### PR TITLE
refactor: expose Layer 2/3 pre-gates from the root without breaking lazy-load

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,6 +8,8 @@ on:
       - "**/*.tsx"
       - "**/*.js"
       - "**/*.jsx"
+      - "**/*.mjs"
+      - "**/*.cjs"
       - "package.json"
       - ".github/workflows/lint.yaml"
   pull_request:
@@ -16,6 +18,8 @@ on:
       - "**/*.tsx"
       - "**/*.js"
       - "**/*.jsx"
+      - "**/*.mjs"
+      - "**/*.cjs"
       - "package.json"
       - ".github/workflows/lint.yaml"
 

--- a/.github/workflows/node-tests.yaml
+++ b/.github/workflows/node-tests.yaml
@@ -8,6 +8,8 @@ on:
       - "**/*.tsx"
       - "**/*.js"
       - "**/*.jsx"
+      - "**/*.mjs"
+      - "**/*.cjs"
       - "package.json"
       - ".github/workflows/node-tests.yaml"
   pull_request:
@@ -16,6 +18,8 @@ on:
       - "**/*.tsx"
       - "**/*.js"
       - "**/*.jsx"
+      - "**/*.mjs"
+      - "**/*.cjs"
       - "package.json"
       - ".github/workflows/node-tests.yaml"
 

--- a/README.md
+++ b/README.md
@@ -114,8 +114,10 @@ const reason = checkExfilUrl(oneUrl); // null or a string reason
 
 ## Public surface
 
-`llm-text-sanitizer` (main)—`sanitize`, plus everything re-exported from
-`./invisible`.
+`llm-text-sanitizer` (main)—`sanitize`, everything re-exported from
+`./invisible`, and the cheap Layer 2/3 pre-gates `HTML_TAG_PRESENT`,
+`MD_LINK_HINT`, `SECRET_HINT`, `SECRET_HINT_EXT`, `matchesSecretHint` (these are
+dependency-free, so re-exporting them never pulls in the heavy HTML graph).
 
 `llm-text-sanitizer/invisible` — `stripInvisible`, `stripInvisibleWithReport`,
 `isSgrOnly`, and the constants `STRIP`, `SGR_RE`, `CHECKS`, `VS`,
@@ -124,9 +126,10 @@ const reason = checkExfilUrl(oneUrl); // null or a string reason
 
 `llm-text-sanitizer/html` — `sanitizeHtml`, `scanHtmlFragment`,
 `looksLikeHtmlSource`, `spliceRanges`, `isHiddenStyle`, `isHiddenElement`,
-`isHiddenOpen`, `closingTagName`, `detectExfil`, `checkExfilUrl`, `urlHost`, and
-the constants `REPORTED_TAGS`, `COMMENT_PLACEHOLDER`, `HIDDEN_PLACEHOLDER`,
-`DATA_URI_LENGTH_THRESHOLD`.
+`isHiddenOpen`, `closingTagName`, `detectExfil`, `checkExfilUrl`, `urlHost`, the
+constants `REPORTED_TAGS`, `COMMENT_PLACEHOLDER`, `HIDDEN_PLACEHOLDER`,
+`DATA_URI_LENGTH_THRESHOLD`, and the pre-gates `HTML_TAG_PRESENT`,
+`MD_LINK_HINT`, `SECRET_HINT`, `SECRET_HINT_EXT`, `matchesSecretHint`.
 
 ## Development
 

--- a/src/gates.mjs
+++ b/src/gates.mjs
@@ -1,0 +1,54 @@
+/**
+ * Cheap, dependency-free pre-gates shared by the HTML layer (Layers 2 & 3) and
+ * re-exported from both the package root and the `./html` subpath.
+ *
+ * These are pulled out of `html.mjs` so the package root can re-export them
+ * without dragging in the heavy remark/rehype/unified graph: a static
+ * `export … from "./html.mjs"` would eagerly evaluate that ~200ms module on
+ * every root import, defeating the lazy-load design. This module imports
+ * nothing, so re-exporting it is free.
+ */
+
+// ─── Cheap pre-gates ─────────────────────────────────────────────────────────
+
+/**
+ * Matches any HTML tag-like construct: opening tags, closing tags (`</`),
+ * comments (`<!`), and fragments with attributes. Gate for Layer 2 (HTML
+ * sanitization) and the HTML img/a exfil path in Layer 3.
+ */
+export const HTML_TAG_PRESENT = /<[a-zA-Z/!][^<>]*>/;
+
+/**
+ * Matches markdown link/image syntax (`](`, `![`) and reference link
+ * definitions (`[label]: url` at line start). Gate for Layer 3 (markdown
+ * exfiltration detection).
+ */
+export const MD_LINK_HINT = /\]\(|!\[|^[ \t]*\[[^[\]\n]+\]:\s/m;
+
+// ─── Secret-shape pre-gate (Layer 3 URL-param reuse) ─────────────────────────
+// Cheap shape match that decides whether a URL parameter value carries a
+// credential (Layer 3). Split across TWO regexes, combined by matchesSecretHint:
+// one alternation of every arm makes a redos analyzer see cross-arm polynomial
+// backtracking (each arm is linear alone, but the union was a 3rd-degree
+// polynomial on a long alnum run). Testing two independently-safe literals with
+// || is linear and keeps each under the analyzer's bar. The `(?<!...)`
+// lookbehinds on the EXT run-matching arms pin them to a token boundary so they
+// can't be retried at every offset; the atlasv1 arm in SECRET_HINT does the same.
+export const SECRET_HINT =
+  /secret|token|password|passwd|pwd|bearer|credential|authorization|contrase[nñ]a|-----BEGIN|(?:api|auth|service|account|db|database|priv|private|client|access)[_-]?key|(?:db|database|key)[_-]?pass|(?:A3T|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}|gh[pousr]_[A-Za-z0-9]|github_pat_|gl[a-z]{2,12}-[0-9A-Za-z_-]{20}|sk-ant-|AIza[0-9A-Za-z_-]{35}|sk_live_|sk_test_|rk_live_|rk_test_|xox[bpasr]-|eyJ[A-Za-z0-9]|do[opr]_v1_[a-f0-9]{16}|v1\.0-[a-f0-9]{24}-|hv[sb]\.[A-Za-z0-9_-]{20}|(?<![a-z0-9])[a-z0-9]{14}\.atlasv1\.|sk-or-v1-[0-9a-f]{16}|gsk_[A-Za-z0-9]{16}|xai-[A-Za-z0-9]{16}|r8_[A-Za-z0-9]{16}/i;
+
+// Second alternation (see SECRET_HINT): kept a separate literal so a redos
+// analyzer vets each alternation in isolation.
+export const SECRET_HINT_EXT =
+  /(?:AC|SK)[a-z0-9]{32}|SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}|sq0csp-[0-9A-Za-z_-]{43}|(?<![0-9])[0-9]{8,10}:[0-9A-Za-z_-]{35}|(?<![0-9a-z])[0-9a-z]{32}-us[0-9]{1,2}|(?<![A-Za-z0-9_-])[MNO][A-Za-z0-9_-]{23,25}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27}|T3BlbkFJ|pypi-AgE|(?<![A-Za-z0-9])AKC[A-Za-z0-9]{10}|(?<![A-Za-z0-9])AP[0-9A-Fa-f][A-Za-z0-9]{8}|:\/\/[^\s:/@]{1,64}:[^\s:/@]{1,64}@|(?:key|pw|pass)["']?[\s:=>]+["']?[A-Za-z0-9_/+-]{20}/i;
+
+/**
+ * True when either pre-gate alternation shape-matches `text`. Split into two
+ * literals (see SECRET_HINT) and OR'd so neither grows into a
+ * polynomial-backtracking shape.
+ * @param {string} text
+ * @returns {boolean}
+ */
+export function matchesSecretHint(text) {
+  return SECRET_HINT.test(text) || SECRET_HINT_EXT.test(text);
+}

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -24,50 +24,24 @@ import remarkGfm from "remark-gfm";
 import rehypeParse from "rehype-parse";
 import { visit, SKIP, EXIT } from "unist-util-visit";
 import styleToObject from "style-to-object";
+import {
+  HTML_TAG_PRESENT,
+  MD_LINK_HINT,
+  SECRET_HINT,
+  SECRET_HINT_EXT,
+  matchesSecretHint,
+} from "./gates.mjs";
 
-// ─── Cheap pre-gates ─────────────────────────────────────────────────────────
-
-/**
- * Matches any HTML tag-like construct: opening tags, closing tags (`</`),
- * comments (`<!`), and fragments with attributes. Gate for Layer 2 (HTML
- * sanitization) and the HTML img/a exfil path in Layer 3.
- */
-const HTML_TAG_PRESENT = /<[a-zA-Z/!][^<>]*>/;
-
-/**
- * Matches markdown link/image syntax (`](`, `![`) and reference link
- * definitions (`[label]: url` at line start). Gate for Layer 3 (markdown
- * exfiltration detection).
- */
-const MD_LINK_HINT = /\]\(|!\[|^[ \t]*\[[^[\]\n]+\]:\s/m;
-
-// ─── Secret-shape pre-gate (Layer 3 URL-param reuse) ─────────────────────────
-// Cheap shape match that decides whether a URL parameter value carries a
-// credential (Layer 3). Split across TWO regexes, combined by matchesSecretHint:
-// one alternation of every arm makes a redos analyzer see cross-arm polynomial
-// backtracking (each arm is linear alone, but the union was a 3rd-degree
-// polynomial on a long alnum run). Testing two independently-safe literals with
-// || is linear and keeps each under the analyzer's bar. The `(?<!...)`
-// lookbehinds on the EXT run-matching arms pin them to a token boundary so they
-// can't be retried at every offset; the atlasv1 arm in SECRET_HINT does the same.
-const SECRET_HINT =
-  /secret|token|password|passwd|pwd|bearer|credential|authorization|contrase[nñ]a|-----BEGIN|(?:api|auth|service|account|db|database|priv|private|client|access)[_-]?key|(?:db|database|key)[_-]?pass|(?:A3T|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}|gh[pousr]_[A-Za-z0-9]|github_pat_|gl[a-z]{2,12}-[0-9A-Za-z_-]{20}|sk-ant-|AIza[0-9A-Za-z_-]{35}|sk_live_|sk_test_|rk_live_|rk_test_|xox[bpasr]-|eyJ[A-Za-z0-9]|do[opr]_v1_[a-f0-9]{16}|v1\.0-[a-f0-9]{24}-|hv[sb]\.[A-Za-z0-9_-]{20}|(?<![a-z0-9])[a-z0-9]{14}\.atlasv1\.|sk-or-v1-[0-9a-f]{16}|gsk_[A-Za-z0-9]{16}|xai-[A-Za-z0-9]{16}|r8_[A-Za-z0-9]{16}/i;
-
-// Second alternation (see SECRET_HINT): kept a separate literal so a redos
-// analyzer vets each alternation in isolation.
-const SECRET_HINT_EXT =
-  /(?:AC|SK)[a-z0-9]{32}|SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}|sq0csp-[0-9A-Za-z_-]{43}|(?<![0-9])[0-9]{8,10}:[0-9A-Za-z_-]{35}|(?<![0-9a-z])[0-9a-z]{32}-us[0-9]{1,2}|(?<![A-Za-z0-9_-])[MNO][A-Za-z0-9_-]{23,25}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27}|T3BlbkFJ|pypi-AgE|(?<![A-Za-z0-9])AKC[A-Za-z0-9]{10}|(?<![A-Za-z0-9])AP[0-9A-Fa-f][A-Za-z0-9]{8}|:\/\/[^\s:/@]{1,64}:[^\s:/@]{1,64}@|(?:key|pw|pass)["']?[\s:=>]+["']?[A-Za-z0-9_/+-]{20}/i;
-
-/**
- * True when either pre-gate alternation shape-matches `text`. Split into two
- * literals (see SECRET_HINT) and OR'd so neither grows into a
- * polynomial-backtracking shape.
- * @param {string} text
- * @returns {boolean}
- */
-function matchesSecretHint(text) {
-  return SECRET_HINT.test(text) || SECRET_HINT_EXT.test(text);
-}
+// The cheap pre-gates live in the dependency-free `./gates.mjs` so the package
+// root can re-export them without eagerly loading this module's remark/rehype
+// graph. Re-exported here too so the `./html` subpath keeps exposing them.
+export {
+  HTML_TAG_PRESENT,
+  MD_LINK_HINT,
+  SECRET_HINT,
+  SECRET_HINT_EXT,
+  matchesSecretHint,
+};
 
 // ─── Layer 2: hidden-content detection ───────────────────────────────────────
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -26,6 +26,19 @@ export {
   SCATTERED_THRESHOLD,
 } from "./invisible.mjs";
 
+// Layer 2/3 cheap pre-gates. Re-exported from the dependency-free `./gates.mjs`
+// (not `./html.mjs`) so consumers can share the exact HTML-tag/markdown-link
+// hints and secret-shape pre-gate without duplicating the regexes — and without
+// pulling in the heavy remark/rehype graph that a re-export from `./html.mjs`
+// would eagerly load on every root import.
+export {
+  HTML_TAG_PRESENT,
+  MD_LINK_HINT,
+  SECRET_HINT,
+  SECRET_HINT_EXT,
+  matchesSecretHint,
+} from "./gates.mjs";
+
 // The two raw control introducers an ANSI sequence can start with: 7-bit
 // ESC (U+001B) and the 8-bit C1 CSI (U+009B). Both are category Cc, so the
 // invisible-char pass (which targets Cf / variation / blank fillers) never

--- a/test/lazy-load.test.mjs
+++ b/test/lazy-load.test.mjs
@@ -23,12 +23,16 @@ import os from "node:os";
 const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
   encoding: "utf8",
 }).trim();
-const srcUrl = (file) =>
-  new URL(`../src/${file}`, import.meta.url).href.replace(/"/g, '\\"');
+const srcUrl = (file) => new URL(`../src/${file}`, import.meta.url).href;
 
-// The heavy graph that the Layer-1 path must never trigger: the lazy `html.mjs`
-// module itself and every dependency only it pulls in.
-const HEAVY = /(?:\/html\.mjs$)|remark|rehype|unified|unist|style-to-object/;
+// What the Layer-1 root path must never trigger. The root re-exports only the
+// zero-dependency `invisible.mjs` and `gates.mjs`, so its graph is expected to
+// be dependency-free: ANY `node_modules` resolution is a leak, robust to future
+// dependency renames (a brittle package-name allowlist would miss a heavy
+// transitive copied straight into the root). The `html.mjs` arm names the one
+// module that bridges the root to the heavy graph, for a clearer failure.
+const LEAKED = (url) =>
+  url.includes("/node_modules/") || /\/html\.mjs$/.test(url);
 
 // Run `import(entryUrl)` in a fresh process under a resolve hook that appends
 // every resolved module URL to `outPath`. The hook runs off-thread, but module
@@ -55,13 +59,13 @@ function resolvedGraph(entryUrl) {
     "  parentURL: import.meta.url,",
     `  data: { outPath: ${JSON.stringify(outPath)} },`,
     "});",
-    `await import("${entryUrl}");`,
+    `await import(${JSON.stringify(entryUrl)});`,
   ].join("\n");
-  execFileSync(process.execPath, ["--input-type=module", "-e", runner], {
-    cwd: repoRoot,
-    encoding: "utf8",
-  });
   try {
+    execFileSync(process.execPath, ["--input-type=module", "-e", runner], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    });
     return readFileSync(outPath, "utf8").split("\n").filter(Boolean);
   } finally {
     rmSync(outPath, { force: true });
@@ -81,7 +85,7 @@ describe("lazy-load invariant", () => {
       graph.some((url) => url.endsWith("/gates.mjs")),
       "root did not load gates.mjs — pre-gate re-export path changed",
     );
-    const leaked = graph.filter((url) => HEAVY.test(url));
+    const leaked = graph.filter(LEAKED);
     assert.deepEqual(
       leaked,
       [],
@@ -89,11 +93,11 @@ describe("lazy-load invariant", () => {
     );
   });
 
-  it("importing the HTML subpath DOES load the remark graph (negative test is not vacuous)", () => {
+  it("importing the HTML subpath DOES load the heavy graph (negative test is not vacuous)", () => {
     const graph = resolvedGraph(srcUrl("html.mjs"));
     assert.ok(
-      graph.some((url) => HEAVY.test(url)),
-      "html.mjs loaded none of the heavy deps — the leak detector can never fire, so the root test would pass vacuously",
+      graph.some(LEAKED),
+      "html.mjs loaded nothing LEAKED flags — the detector can never fire, so the root test would pass vacuously",
     );
   });
 });

--- a/test/lazy-load.test.mjs
+++ b/test/lazy-load.test.mjs
@@ -1,0 +1,99 @@
+/**
+ * Lazy-load invariant: importing the package root (`index.mjs`) must NOT pull
+ * in the heavy HTML layer (`html.mjs` and its remark/rehype/unified graph,
+ * ~200ms of module-load time). The root only `await import()`s that module
+ * inside `sanitize({ html: true })`; everything it re-exports at module scope —
+ * including the Layer 2/3 pre-gates — comes from the dependency-free
+ * `gates.mjs`, never from `html.mjs`.
+ *
+ * This is the entire rationale for extracting `gates.mjs`, so it gets a
+ * behavioral guard: a future `export … from "./html.mjs"` slipped into
+ * `index.mjs` would silently reintroduce the eager load, and only this test
+ * would catch it. We record the real module-resolution graph via a `module`
+ * customization hook rather than grepping source, so the assertion tracks what
+ * actually loads, not what the imports happen to look like.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync, rmSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+  encoding: "utf8",
+}).trim();
+const srcUrl = (file) =>
+  new URL(`../src/${file}`, import.meta.url).href.replace(/"/g, '\\"');
+
+// The heavy graph that the Layer-1 path must never trigger: the lazy `html.mjs`
+// module itself and every dependency only it pulls in.
+const HEAVY = /(?:\/html\.mjs$)|remark|rehype|unified|unist|style-to-object/;
+
+// Run `import(entryUrl)` in a fresh process under a resolve hook that appends
+// every resolved module URL to `outPath`. The hook runs off-thread, but module
+// resolution is awaited by the importer, so once `await import()` returns the
+// file holds the complete graph — no timing race.
+function resolvedGraph(entryUrl) {
+  const outPath = path.join(
+    os.tmpdir(),
+    `llm-sanitizer-graph-${process.pid}-${Math.random().toString(36).slice(2)}.txt`,
+  );
+  const hookSrc = [
+    'import { appendFileSync } from "node:fs";',
+    "let outPath;",
+    "export async function initialize(data) { outPath = data.outPath; }",
+    "export async function resolve(specifier, context, next) {",
+    "  const result = await next(specifier, context);",
+    "  appendFileSync(outPath, result.url + String.fromCharCode(10));",
+    "  return result;",
+    "}",
+  ].join("\n");
+  const runner = [
+    'import { register } from "node:module";',
+    `register("data:text/javascript,${encodeURIComponent(hookSrc)}", {`,
+    "  parentURL: import.meta.url,",
+    `  data: { outPath: ${JSON.stringify(outPath)} },`,
+    "});",
+    `await import("${entryUrl}");`,
+  ].join("\n");
+  execFileSync(process.execPath, ["--input-type=module", "-e", runner], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  try {
+    return readFileSync(outPath, "utf8").split("\n").filter(Boolean);
+  } finally {
+    rmSync(outPath, { force: true });
+  }
+}
+
+describe("lazy-load invariant", () => {
+  it("importing the package root does not load the HTML/remark graph", () => {
+    const graph = resolvedGraph(srcUrl("index.mjs"));
+    // Positive markers: the recorder works and the root graph really loaded —
+    // so a clean negative result below is "heavy graph absent", not "hook dead".
+    assert.ok(
+      graph.some((url) => url.endsWith("/index.mjs")),
+      "recorder saw no index.mjs — the resolve hook is not working",
+    );
+    assert.ok(
+      graph.some((url) => url.endsWith("/gates.mjs")),
+      "root did not load gates.mjs — pre-gate re-export path changed",
+    );
+    const leaked = graph.filter((url) => HEAVY.test(url));
+    assert.deepEqual(
+      leaked,
+      [],
+      `package root eagerly loaded the heavy HTML graph: ${leaked.join(", ")}`,
+    );
+  });
+
+  it("importing the HTML subpath DOES load the remark graph (negative test is not vacuous)", () => {
+    const graph = resolvedGraph(srcUrl("html.mjs"));
+    assert.ok(
+      graph.some((url) => HEAVY.test(url)),
+      "html.mjs loaded none of the heavy deps — the leak detector can never fire, so the root test would pass vacuously",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Downstream consumers (e.g. the sanitizer hooks) want to reuse the exact Layer 2/3 pre-gate shapes — the HTML-tag/markdown-link hints and the secret-shape pre-gate — instead of duplicating those regexes locally. This exposes them from the package **root** (and keeps them on `./html`) with **no duplication**.
- The obvious way to do that — `export … from "./html.mjs"` in `index.mjs` — would have broken the package's core performance invariant: `html.mjs` statically imports the remark/rehype/unified graph (~200 ms), and the root deliberately `await import()`s it only on the `{ html: true }` path. A static re-export re-evaluates `html.mjs` on **every** root import, eagerly loading that graph.
- Resolved by extracting the five dependency-free primitives into a new `src/gates.mjs` and re-exporting from there, so the root surface grows without the heavy graph coming along.
- While shipping this, found the CI test/lint jobs never ran on this PR — their `paths` filters omit `**/*.mjs`, and the whole codebase is `.mjs`. Fixed so the correctness gates actually fire.

## Changes

- **`src/gates.mjs`** (new): the five dependency-free pre-gates — `HTML_TAG_PRESENT`, `MD_LINK_HINT`, `SECRET_HINT`, `SECRET_HINT_EXT`, `matchesSecretHint`. Regex literals are byte-identical to the originals (verified against `origin/main`).
- **`src/html.mjs`**: imports the gates from `./gates.mjs` and re-exports them, so the `./html` subpath surface is unchanged.
- **`src/index.mjs`**: re-exports the gates from the zero-dep `./gates.mjs` (never from `./html.mjs`); its only reference to `html.mjs` remains the dynamic `await import()` inside `sanitize()`.
- **`test/lazy-load.test.mjs`** (new): records the real module-resolution graph via a `module.register` resolve hook in a child process and asserts the root import pulls in **zero** `node_modules` (and no `html.mjs`). A companion test imports `./html` and asserts the heavy graph *does* load, so the negative assertion can't pass vacuously.
- **`.github/workflows/{node-tests,lint}.yaml`**: add `**/*.mjs` and `**/*.cjs` to the `push` and `pull_request` `paths` filters (previously `.js`/`.ts` only).
- **`README.md`**: public-surface docs updated to list the pre-gates under both the root and `./html`.

## Testing

- `pnpm test` — 379 passing, 100% line/branch/function coverage (including `gates.mjs`).
- `pnpm check` (tsc) and `pnpm lint` (eslint) clean; `pnpm build:types` emits `types/gates.d.mts` and the re-exports resolve.
- Mutation-checked the new guard: swapping `index.mjs`'s gate re-export to `./html.mjs` makes `lazy-load.test.mjs` fail as intended; reverting makes it pass.
- The workflow `paths` fix means `node-tests` and `lint` now execute on this PR (they were skipped on the initial push).

## Lessons Learned

- **What**: Add `**/*.mjs` and `**/*.cjs` to the `paths` filters (both `push` and `pull_request`) of any path-gated JS workflow that currently lists only `**/*.js`/`**/*.jsx`/`**/*.ts`/`**/*.tsx`.
- **Where**: the template's `.github/workflows/node-tests.yaml` and `.github/workflows/lint.yaml` (and any sibling JS-gated workflow).
- **Why**: ESM packages whose source is `.mjs` get a silent false-green — a PR touching only `.mjs` files matches no path, so the test/lint jobs never run yet the PR reports all checks passing.

- **What**: Widen the `lint-staged` JS/TS glob from `*.{js,jsx,ts,tsx}` to also match `*.{mjs,cjs}`.
- **Where**: the template's `package.json` `lint-staged` config.
- **Why**: the same `.mjs` blind spot at commit time — `.mjs`-only commits log "could not find any staged files matching configured tasks" and Prettier/ESLint never run on them via the hook.