### PR TITLE
Rename package from llm-text-sanitizer to agent-input-sanitizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# llm-text-sanitizer
+# agent-input-sanitizer
 
-Defend an LLM against hidden-content injection. This library sanitizes untrusted
+Defend an agent against hidden-content injection. This library sanitizes untrusted
 text **before any model sees it**—in an agent, RAG, or tool-use pipeline. It
 has nothing to do with any particular model or provider: it cleans bytes.
 
@@ -52,7 +52,7 @@ See [THREAT-MODEL.md](./THREAT-MODEL.md) for the per-vector detail.
 ## Install
 
 ```sh
-npm install llm-text-sanitizer
+npm install agent-input-sanitizer
 ```
 
 Node ≥ 20. ESM only.
@@ -62,7 +62,7 @@ Node ≥ 20. ESM only.
 ### 1. The convenience function
 
 ```js
-import { sanitize } from "llm-text-sanitizer";
+import { sanitize } from "agent-input-sanitizer";
 
 // Layer 1 only (invisible chars + ANSI), always synchronous work, no heavy deps:
 const { cleaned, found, warnings } = await sanitize(untrustedText);
@@ -83,7 +83,7 @@ is accompanied by at least one entry in `warnings`.
 import {
   stripInvisible,
   stripInvisibleWithReport,
-} from "llm-text-sanitizer/invisible";
+} from "agent-input-sanitizer/invisible";
 
 stripInvisible(text); // -> cleaned string
 const { cleaned, found } = stripInvisibleWithReport(text);
@@ -99,7 +99,7 @@ import {
   sanitizeHtml,
   detectExfil,
   checkExfilUrl,
-} from "llm-text-sanitizer/html";
+} from "agent-input-sanitizer/html";
 
 const layer2 = sanitizeHtml(pageSource); // null when nothing to strip/report
 const threats = detectExfil(pageSource); // null or [{ isImage, reason, target }]
@@ -109,22 +109,22 @@ const reason = checkExfilUrl(oneUrl); // null or a string reason
 > **The HTML entry is heavier—import it only when you need it.** It pulls in
 > the unified/remark/rehype graph (~200 ms of module-load time). The convenience
 > `sanitize` lazy-loads it only on the `{ html: true }` path, so a Layer-1-only
-> caller never pays for it. If you import from `llm-text-sanitizer/html`
+> caller never pays for it. If you import from `agent-input-sanitizer/html`
 > directly, you take that cost at import time.
 
 ## Public surface
 
-`llm-text-sanitizer` (main)—`sanitize`, everything re-exported from
+`agent-input-sanitizer` (main)—`sanitize`, everything re-exported from
 `./invisible`, and the cheap Layer 2/3 pre-gates `HTML_TAG_PRESENT`,
 `MD_LINK_HINT`, `SECRET_HINT`, `SECRET_HINT_EXT`, `matchesSecretHint` (these are
 dependency-free, so re-exporting them never pulls in the heavy HTML graph).
 
-`llm-text-sanitizer/invisible` — `stripInvisible`, `stripInvisibleWithReport`,
+`agent-input-sanitizer/invisible` — `stripInvisible`, `stripInvisibleWithReport`,
 `isSgrOnly`, and the constants `STRIP`, `SGR_RE`, `CHECKS`, `VS`,
 `BLANK_NON_CF`, `LONG_RUN_RE`, `LONG_RUN_THRESHOLD`, `SCATTERED_THRESHOLD`,
 `LINGUISTIC_SCRIPTS`.
 
-`llm-text-sanitizer/html` — `sanitizeHtml`, `scanHtmlFragment`,
+`agent-input-sanitizer/html` — `sanitizeHtml`, `scanHtmlFragment`,
 `looksLikeHtmlSource`, `spliceRanges`, `isHiddenStyle`, `isHiddenElement`,
 `isHiddenOpen`, `closingTagName`, `detectExfil`, `checkExfilUrl`, `urlHost`, the
 constants `REPORTED_TAGS`, `COMMENT_PLACEHOLDER`, `HIDDEN_PLACEHOLDER`,

--- a/THREAT-MODEL.md
+++ b/THREAT-MODEL.md
@@ -1,7 +1,7 @@
 # Threat model
 
-`llm-text-sanitizer` defends the boundary where untrusted text enters an
-LLM-driven pipeline (agent tool output, RAG retrieval, fetched web pages). It is
+`agent-input-sanitizer` defends the boundary where untrusted text enters an
+agent-driven pipeline (agent tool output, RAG retrieval, fetched web pages). It is
 a detect/neutralize layer, not an enforcement boundary: it makes hidden content
 visible-or-gone and surfaces exfil-shaped URLs, so the model and the operator
 see the same thing. Egress controls remain your enforcement layer.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "llm-text-sanitizer",
+  "name": "agent-input-sanitizer",
   "version": "1.0.0",
-  "description": "Defend an LLM against hidden-content injection: strip payload-capable invisible Unicode and ANSI, splice out human-invisible HTML, and flag data-exfil URLs in untrusted text before any model sees it.",
+  "description": "Defend an agent against hidden-content injection: strip payload-capable invisible Unicode and ANSI, splice out human-invisible HTML, and flag data-exfil URLs in untrusted text before any model sees it.",
   "type": "module",
   "packageManager": "pnpm@11.8.0",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "llm-text-sanitizer"
+name = "agent-input-sanitizer"
 version = "0.0.0"
 requires-python = ">=3.10"
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,5 +1,5 @@
 /**
- * Top-level convenience entry for llm-text-sanitizer.
+ * Top-level convenience entry for agent-input-sanitizer.
  *
  * `sanitize` always runs the zero-dependency Layer 1 (invisible-char + ANSI
  * stripping, lone-surrogate normalization) and, when `html` is requested,

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,20 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
+name = "agent-input-sanitizer"
+version = "0.0.0"
+source = { virtual = "." }
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pytest", marker = "extra == 'dev'", specifier = ">=7" }]
+provides-extras = ["dev"]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -31,20 +45,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
-
-[[package]]
-name = "llm-text-sanitizer"
-version = "0.0.0"
-source = { virtual = "." }
-
-[package.optional-dependencies]
-dev = [
-    { name = "pytest" },
-]
-
-[package.metadata]
-requires-dist = [{ name = "pytest", marker = "extra == 'dev'", specifier = ">=7" }]
-provides-extras = ["dev"]
 
 [[package]]
 name = "packaging"


### PR DESCRIPTION
## Summary

Rebrand the package from `llm-text-sanitizer` to `agent-input-sanitizer` to reflect its broader applicability beyond LLM-specific use cases. The library defends any agent-driven pipeline (including RAG, tool-use, and general untrusted input handling) against hidden-content injection.

## Changes

- Updated package name in `package.json` and `pyproject.toml`
- Updated all import statements and references in `README.md` and `THREAT-MODEL.md`
- Updated module-level documentation comments in `src/index.mjs`
- Consistent terminology shift: "LLM" → "agent" throughout user-facing docs and descriptions

## Notes

This is a pure rename with no functional code changes. All public APIs and behavior remain identical; only the package name and documentation strings have been updated.

https://claude.ai/code/session_01DH7DmbYfsqQyiAqPHtdrov