### PR TITLE
Add ci-truth-serum checks and fix workflow path filters

### DIFF
--- a/.claude/hooks/safe-launch.sh
+++ b/.claude/hooks/safe-launch.sh
@@ -24,7 +24,9 @@
 set -uo pipefail
 
 target="${1:-}"
-shift || true
+# Drop the target arg only when present; `shift` with no args fails under
+# `set -u`. Branch on $# instead of `shift || true`, which would swallow it.
+[ "$#" -eq 0 ] || shift
 
 if [ -z "$target" ] || [ ! -f "$target" ]; then
   echo "safe-launch: missing target hook: $target" >&2

--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -33,6 +33,9 @@ webi_install_if_missing() {
   if ! command -v "$cmd" &>/dev/null; then
     local installer
     installer=$(mktemp "${TMPDIR:-/tmp}/webi-${cmd}-XXXXXX.sh")
+    # webi.sh serves a per-request generated installer with no published
+    # checksum/signature; we pin HTTPS and validate the shebang below.
+    # pin-exempt: no stable digest to verify against for a dynamic installer.
     if curl --proto '=https' -fsSL "https://webi.sh/$pkg" -o "$installer" 2>/dev/null; then
       if head -n 1 "$installer" | grep -q '^#!'; then
         sh "$installer" >/dev/null 2>&1 || warn "Failed to install $cmd"

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -13,15 +13,19 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
+# Least privilege at the top: the reporter job needs nothing. Write scopes are
+# granted only to the auto-merge job that actually merges/comments.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: github.event.pull_request.user.login == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Dependabot metadata
         id: metadata
@@ -43,3 +47,17 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Stable reporter: runs even when `auto-merge` is gated out on non-dependabot
+  # PRs (its result is then `skipped`, not a failure), so if this check is ever
+  # marked Required a protected branch never gets stuck on a status that never
+  # reports. Mirrors the *-passed gate every other workflow here uses.
+  dependabot-auto-merge-passed:
+    if: always()
+    needs: [auto-merge]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fail if any required job did not pass
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/hook-lifecycle.yaml
+++ b/.github/workflows/hook-lifecycle.yaml
@@ -17,18 +17,9 @@ on:
       - ".pre-commit-config.yaml"
       - ".github/scripts/run-hook-lifecycle.sh"
       - ".github/workflows/hook-lifecycle.yaml"
-  pull_request: # not-required-check
-    paths:
-      - ".claude/hooks/**"
-      - ".hooks/**"
-      - "setup.sh"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pyproject.toml"
-      - "uv.lock"
-      - ".pre-commit-config.yaml"
-      - ".github/scripts/run-hook-lifecycle.sh"
-      - ".github/workflows/hook-lifecycle.yaml"
+  # No paths filter on pull_request: a workflow-level filter skips the whole
+  # workflow (so it never reports) on PRs that don't match, stranding the check.
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/hook-lifecycle.yaml
+++ b/.github/workflows/hook-lifecycle.yaml
@@ -17,7 +17,7 @@ on:
       - ".pre-commit-config.yaml"
       - ".github/scripts/run-hook-lifecycle.sh"
       - ".github/workflows/hook-lifecycle.yaml"
-  pull_request:
+  pull_request: # not-required-check
     paths:
       - ".claude/hooks/**"
       - ".hooks/**"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,16 +12,11 @@ on:
       - "**/*.cjs"
       - "package.json"
       - ".github/workflows/lint.yaml"
+  # No paths filter on pull_request: this is a Required check, and a workflow-level
+  # path filter would skip the whole workflow (including the lint-passed reporter)
+  # on PRs that don't touch these paths, stranding the check at "Expected — Waiting".
+  # The job below cheaply no-ops via script-configured.sh when nothing applies.
   pull_request:
-    paths:
-      - "**/*.ts"
-      - "**/*.tsx"
-      - "**/*.js"
-      - "**/*.jsx"
-      - "**/*.mjs"
-      - "**/*.cjs"
-      - "package.json"
-      - ".github/workflows/lint.yaml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/node-tests.yaml
+++ b/.github/workflows/node-tests.yaml
@@ -12,16 +12,11 @@ on:
       - "**/*.cjs"
       - "package.json"
       - ".github/workflows/node-tests.yaml"
+  # No paths filter on pull_request: this is a Required check, and a workflow-level
+  # path filter would skip the whole workflow (including the node-tests-passed
+  # reporter) on PRs that don't touch these paths, stranding the check at
+  # "Expected — Waiting". The job below cheaply no-ops via script-configured.sh.
   pull_request:
-    paths:
-      - "**/*.ts"
-      - "**/*.tsx"
-      - "**/*.js"
-      - "**/*.jsx"
-      - "**/*.mjs"
-      - "**/*.cjs"
-      - "package.json"
-      - ".github/workflows/node-tests.yaml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/validate-config.yaml
+++ b/.github/workflows/validate-config.yaml
@@ -8,14 +8,11 @@ on:
       - "tests/**"
       - "pyproject.toml"
       - "uv.lock"
+  # No paths filter on pull_request: this is a Required check, and a workflow-level
+  # path filter would skip the whole workflow (including the validate-config-passed
+  # reporter) on PRs that don't touch these paths, stranding the check at
+  # "Expected — Waiting".
   pull_request:
-    paths:
-      - ".claude/**"
-      - ".hooks/**"
-      - ".github/workflows/**"
-      - "tests/**"
-      - "pyproject.toml"
-      - "uv.lock"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -7,9 +7,9 @@ on:
     branches: ["main"]
     paths:
       - ".github/**"
-  pull_request: # not-required-check
-    paths:
-      - ".github/**"
+  # No paths filter on pull_request: a workflow-level filter skips the whole
+  # workflow (so it never reports) on PRs that don't match, stranding the check.
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -7,7 +7,7 @@ on:
     branches: ["main"]
     paths:
       - ".github/**"
-  pull_request:
+  pull_request: # not-required-check
     paths:
       - ".github/**"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,33 @@ repos:
         args: [--fix]
       - id: ruff-format
 
+  # ci-truth-serum: catch CI "lies" — pipelines that report success while the
+  # real work failed, required checks that silently never report, and artifacts
+  # pinned to mutable names. No published tag yet, so rev is the main HEAD SHA
+  # (pinned per the "SHA-pin third-party sources" rule). ALL hooks enabled:
+  # Tier 1 (honesty + identity), Tier 2 (opinionated — this repo follows the
+  # decide/reporter + cancel-in-progress conventions they assume), and Extras.
+  - repo: https://github.com/alexander-turner/ci-truth-serum
+    rev: 0d932b98e1384685ec289b8f7bb2df760ebfb8af # main (no tagged release yet)
+    hooks:
+      # Tier 1 · Honesty
+      - id: check-workflow-pipefail
+      - id: check-exit-suppression
+      - id: check-stderr-suppression
+      - id: check-pr-paths
+      # Tier 1 · Identity
+      - id: check-pinned-base-images
+      - id: check-pinned-downloads
+      # Tier 2 · Opinionated
+      - id: check-always-reporter
+      - id: check-inline-run-length
+      - id: check-concurrency
+      - id: check-static-concurrency
+      # Extras
+      - id: check-symlinks
+      - id: check-unnamed-regex-groups
+      - id: check-global-stdio-swap
+
   - repo: local
     hooks:
       - id: zizmor


### PR DESCRIPTION
Adds CI integrity checks and fixes a critical issue where required workflows could get stuck in "Expected — Waiting" status on PRs that don't touch certain paths.

## Changes

- **Add ci-truth-serum pre-commit hooks** to catch CI pipeline failures that silently report success, unpinned artifacts, and other integrity issues. Enables all three tiers: Honesty (pipefail, exit/stderr suppression), Identity (pinned images/downloads), and Opinionated (reporter stability, concurrency conventions).

- **Remove `paths` filters from `pull_request` triggers** in `lint.yaml`, `node-tests.yaml`, and `validate-config.yaml`. These are Required checks; a workflow-level path filter skips the entire workflow (including the reporter job) on PRs that don't touch those paths, leaving the check stranded at "Expected — Waiting". The jobs now run cheaply via `script-configured.sh` when nothing applies.

- **Add stable reporter jobs** (`dependabot-auto-merge-passed`, etc.) that run even when gated jobs are skipped, preventing Required checks from getting stuck. Uses `if: always()` and `needs: [...]` to report pass/fail correctly.

- **Tighten permissions** in `dependabot-auto-merge.yaml`: move write scopes to the job that needs them, leaving the workflow-level permission read-only. Adds a reporter job that ensures the check never silently skips.

- **Fix shell script safety** in `safe-launch.sh`: replace `shift || true` with `[ "$#" -eq 0 ] || shift` to avoid silently swallowing errors under `set -u`.

- **Document webi.sh exemption** in `session-setup.sh`: add a pin-exempt comment explaining why the dynamic installer has no stable digest to verify.

- **Mark non-required workflows** (`hook-lifecycle.yaml`, `zizmor.yaml`) with `# not-required-check` comments to clarify they won't block merges.

## Implementation Notes

The path filter removal is safe because:
- `push` triggers still have path filters (no change to push behavior)
- Jobs use `script-configured.sh` to no-op when paths don't apply
- Reporter jobs ensure the check always reports a result, preventing "Expected — Waiting" hangs

The ci-truth-serum hooks are pinned to the main HEAD SHA (no tagged release yet) per the "SHA-pin third-party sources" rule.

https://claude.ai/code/session_01EYv7FvMGar2S6SGarW4fog