### PR TITLE
fix(release): declare repository metadata for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,14 @@
   "version": "1.0.1",
   "description": "Defend an agent against hidden-content injection: strip payload-capable invisible Unicode and ANSI, splice out human-invisible HTML, and flag data-exfil URLs in untrusted text before any model sees it.",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alexander-turner/agent-input-sanitizer.git"
+  },
+  "bugs": {
+    "url": "https://github.com/alexander-turner/agent-input-sanitizer/issues"
+  },
+  "homepage": "https://github.com/alexander-turner/agent-input-sanitizer#readme",
   "packageManager": "pnpm@11.8.0",
   "scripts": {
     "postinstall": "git config core.hooksPath .hooks",


### PR DESCRIPTION
## Summary

The `auto-version` release workflow now gets past OIDC trusted publishing, but `pnpm publish --provenance` fails npm's sigstore verification because `package.json` declares no repository:

```
422 Unprocessable Entity ... Error verifying sigstore provenance bundle:
package.json: "repository.url" is "", expected to match
"https://github.com/alexander-turner/agent-input-sanitizer" from provenance
```

npm cross-checks the signed build's source repo against `package.json`; with `repository.url` empty, the publish is rejected.

## Changes

- Add `repository`, `bugs`, and `homepage` fields to `package.json`. The `git+https://github.com/alexander-turner/agent-input-sanitizer.git` URL normalizes to exactly the repo provenance expects, so verification passes.

## Notes

This must land on `main` to take effect — the release workflow only runs on push to `main`. After merge, the workflow should publish `1.0.1` with provenance (the remaining external dependency is that the final `main` commit + tag push uses a token that clears branch protection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017XgtJsTqjafsRQcxX17UHV)_