### PR TITLE
feat: drive the sanitizer from Python (and any language) via a single-source-of-truth CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,182 +1,126 @@
 # `agent-input-sanitizer`
 
 Sanitize untrusted text **before any model sees it**—in an agent, RAG, or
-tool-use pipeline. Provider-agnostic: it cleans bytes, not prompts. Every entry
-point is a pure transform or a function with an **injected** I/O/engine seam, so
-nothing about a specific agent harness (Claude, or any other) is baked in.
-
-The core cleaners, split across entry points so the heavy HTML dependency stays
-opt-in:
-
-1. **Invisible-char + ANSI stripping** (`./invisible`, zero runtime deps) —
-   removes zero-width spaces, bidi controls, variation selectors, tag
-   characters, ANSI/SGR escapes, and other hidden code points used to smuggle
-   instructions. Preserves ZWNJ/ZWJ where scripts (Arabic, Indic, emoji)
-   require them. The composite `applyLayer1` (ANSI + invisibles, lone-surrogate
-   safe) is re-exported from the package root.
-2. **Hidden-HTML splicing** (`./html`)—splices out instructions buried in
-   comments, `display:none`, off-screen, white-on-white, `hidden`/`aria-hidden`,
-   etc. Leaves a placeholder; preserves every other byte verbatim.
-3. **Exfil-URL detection** (`./html`, detection only)—reports URLs shaped to
-   leak data off-origin (payloads in query/path, embedded credentials,
-   `data:`/`javascript:` targets, off-origin redirects). Reports, never edits.
-
-Built on those, entry points covering each ingress an agent has:
-
-4. **Confusable/homoglyph folding** (`./confusables`)—fold look-alike glyphs in
-   tool-call **input** fields (paths, commands) to their ASCII canon, closing a
-   cross-script deny-rule bypass. The homoglyph scanner is **injected**
-   (`{ scan }`).
-5. **Instruction-file scanning** (`./instructions`)—scan/auto-clean
-   `CLAUDE.md` / `AGENTS.md` / `SKILL.md` / any markdown that loads as model
-   context, decoding Unicode-tag and zero-width-binary payloads. The target file
-   set is a **caller-supplied glob set**.
-6. **User-prompt verdict** (`./prompt`)—classify a submitted prompt as
-   pass / pass-with-SGR-note / block on payload-capable invisible/ANSI content.
-7. **Tool-output pipeline** (`./output`)—run Layers 1–4 over structured tool
-   output, preserving its shape. Layer 4 (secret redaction) is an **injected**
-   redactor; an optional Layer-5 slot takes a filter that returns _verbatim
-   spans to delete_, so even a compromised filter can only remove bytes.
-8. **Edit-repair / rehydration** (`./rehydrate`, `./view-map`)—re-anchor an
-   Edit/Write the model composed from the _sanitized_ view back onto the real
-   on-disk bytes, substitute redaction placeholders with the real secrets, and
-   **deny** any call that can’t be unambiguously anchored or that would expose a
-   secret in the next view. Without this, sanitizing a file’s view silently
-   breaks the agent’s ability to edit it. File access and the redactor are
-   injected via `io`.
-
-See [THREAT-MODEL.md](./THREAT-MODEL.md) for per-vector detail.
+tool-use pipeline. It cleans bytes, not prompts, so it’s provider-agnostic:
+every entry point is a pure transform or takes an **injected** I/O/engine seam,
+with nothing about a specific agent harness (Claude, or any other) baked in.
 
 ```sh
 npm install agent-input-sanitizer
 ```
 
-## Usage
-
-### Convenience function
+## Quick start
 
 ```js
 import { sanitize } from "agent-input-sanitizer";
 
-// Layer 1 only (invisible chars + ANSI), no heavy deps:
+// Layer 1 (invisible chars + ANSI), zero heavy deps:
 const { cleaned, found, warnings } = await sanitize(untrustedText);
 
-// Opt into the HTML layers for web/HTML ingress:
-const result = await sanitize(fetchedPageSource, { html: true });
-//   result.cleaned   — hidden HTML spliced out, placeholders left in place
-//   result.found     — stable category codes neutralized (e.g. ["cf-format", "hidden-html"])
-//   result.warnings  — human-facing notices (long-run alerts, exfil reasons, …)
+// Opt into the HTML layers for web ingress (lazy-loads ~200 ms of deps):
+const result = await sanitize(pageSource, { html: true });
 ```
 
-`sanitize` never throws and never silently drops content: any change to the
-text comes with at least one `warnings` entry. The `{ html: true }` path
-lazy-loads the HTML deps, so a Layer-1-only caller never pays for them.
+`sanitize` never throws and never silently drops content—any change comes with
+at least one `warnings` entry. `found` names the neutralized category codes
+(e.g. `["cf-format", "hidden-html"]`); `cleaned` is the safe text, with
+placeholders where hidden HTML was spliced out.
 
-### Zero-dependency invisible-char core
+## Entry points
+
+Split into subpaths so the heavy HTML dependency stays opt-in. The **seam**
+column is the agent-specific concern each one injects, so it knows nothing about
+any particular harness.
+
+| #   | Import          | Purpose                                                                                                                            | Seam                        |
+| --- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| 1   | `/invisible`    | Strip zero-width, bidi, variation-selector and tag chars + ANSI/SGR escapes. Preserves ZWNJ/ZWJ for Arabic/Indic/emoji. Zero deps. | —                           |
+| 2   | `/html`         | Splice out instructions hidden in comments, `display:none`, off-screen, white-on-white, `hidden`. Leaves a placeholder.            | —                           |
+| 3   | `/html`         | Detect exfil-shaped URLs (payloads in query/path, embedded creds, `data:`/`javascript:`, off-origin redirects). Reports only.      | —                           |
+| 4   | `/confusables`  | Fold look-alike glyphs in tool-call input (paths, commands) to ASCII, closing a cross-script deny-rule bypass.                     | `scan`                      |
+| 5   | `/instructions` | Scan/auto-clean `CLAUDE.md`, `AGENTS.md`, `SKILL.md`, etc., decoding Unicode-tag + zero-width-binary payloads.                     | glob set                    |
+| 6   | `/prompt`       | Classify a prompt pass / SGR-note / block on payload-capable invisible/ANSI content.                                               | —                           |
+| 7   | `/output`       | Run Layers 1–4 over structured tool output, preserving shape. The Layer-5 slot takes a delete-only filter.                         | `redact`, `filterInjection` |
+| 8   | `/rehydrate`    | Re-anchor a model Edit composed from the _sanitized_ view back onto real bytes; deny anything ambiguous or secret-exposing.        | `io`                        |
+
+See [THREAT-MODEL.md](./THREAT-MODEL.md) for per-vector detail.
+
+### Examples
 
 ```js
-import {
-  stripInvisible,
-  stripInvisibleWithReport,
-} from "agent-input-sanitizer/invisible";
+import { stripInvisibleWithReport } from "agent-input-sanitizer/invisible";
+const { cleaned, found } = stripInvisibleWithReport(text); // found: ["variation-selectors"]
 
-stripInvisible(text); // -> cleaned string
-const { cleaned, found } = stripInvisibleWithReport(text);
-//   found names exactly the category codes removed, e.g. ["variation-selectors"]
-```
-
-### HTML layer
-
-Heavier—it pulls in the unified/remark/rehype graph (~200 ms of module-load
-time). Import it directly only when you need it.
-
-```js
 import {
   sanitizeHtml,
   detectExfil,
   checkExfilUrl,
 } from "agent-input-sanitizer/html";
-
-const cleaned = sanitizeHtml(pageSource); // null when nothing to strip/report
-const threats = detectExfil(pageSource); // null or [{ isImage, reason, target }]
-const reason = checkExfilUrl(oneUrl); // null or a string reason
+sanitizeHtml(pageSource); // cleaned string, or null when nothing to strip
+detectExfil(pageSource); // [{ isImage, reason, target }] or null
+checkExfilUrl(oneUrl); // reason string or null
 ```
 
-### Agent-pipeline entry points
-
-Each takes plain arguments and returns plain results; agent-specific concerns
-(homoglyph engine, secret redactor, file access, hook envelope) are injected, so
-none of them know about any particular agent harness.
+The agent-pipeline entry points take plain arguments and inject their
+agent-specific seam:
 
 ```js
-// Confusable folding — inject your homoglyph scanner.
 import { normalizeConfusables } from "agent-input-sanitizer/confusables";
-const folded = normalizeConfusables(
+normalizeConfusables(
   "Bash",
   { command: "/аpt update" },
-  {
-    scan: (text) => myHomoglyphEngine.scan(text), // -> { findings:[{ index, char, latinEquivalent }] }
-  },
-);
-//   null when nothing changed, else { updatedInput, normalized }
+  { scan: (t) => myHomoglyphEngine.scan(t) }, // -> { findings: [{ index, char, latinEquivalent }] }
+); // null, or { updatedInput, normalized }
 
-// Instruction files — pass YOUR glob set.
 import {
   scanInstructionFiles,
   cleanFile,
 } from "agent-input-sanitizer/instructions";
-const findings = scanInstructionFiles(
-  ["CLAUDE.md", "AGENTS.md", "**/SKILL.md", ".claude/**/*.md"],
-  { cwd: projectDir },
-);
+const findings = scanInstructionFiles(["CLAUDE.md", "**/SKILL.md"], {
+  cwd: projectDir,
+});
 for (const { file } of findings) cleanFile(`${projectDir}/${file}`);
 
-// User prompt — pass/note/block verdict.
 import { classifyPrompt } from "agent-input-sanitizer/prompt";
-const verdict = classifyPrompt(submittedPrompt); // { action: "pass" | "note" | "block", reason? }
+classifyPrompt(submittedPrompt); // { action: "pass" | "note" | "block", reason? }
 
-// Tool output — Layers 1–4, redactor injected, optional Layer-5 spans slot.
 import { sanitizeText } from "agent-input-sanitizer/output";
-const out = await sanitizeText(toolText, {
+await sanitizeText(toolText, {
   html: isWebPage,
   exfilScan: isUntrustedIngress,
   redact: async (t) => myRedactor.redact(t), // -> { text, found, note? } | null
   filterInjection: (t) => mySemanticFilter(t), // -> { removeSpans, warning } | null
 });
 
-// Edit-repair — re-anchor a model-authored Edit onto real on-disk bytes.
 import { rehydrateRedacted } from "agent-input-sanitizer/rehydrate";
-const repaired = await rehydrateRedacted("Edit", toolInput, {
+await rehydrateRedacted("Edit", toolInput, {
   readFile: (p) => fs.readFileSync(p, "utf8"),
   redactMap: (t) => myRedactor.map(t), // -> { text, pairs } | { unmappable }
   redact: (t) => myRedactor.redact(t), // -> string | null
-});
-//   { updatedInput, context } | { deny } | null  — a deny never exposes a secret
+}); // { updatedInput, context } | { deny } | null — a deny never exposes a secret
 ```
 
 ## Non-JS pipelines (Python, etc.)
 
-The JS is the **single source of truth**; non-JS callers drive the same
-verdicts through the bundled CLI (JSON over stdin/stdout, Node ≥20 on `PATH`)
-—no second implementation to drift. The CLI bridges every self-contained
-entry point via an `op` field (default `"sanitize"`): `sanitizeText` (Layers
-1–3), `classifyPrompt`, `scanInstructionFiles`, and `cleanFile`. The
-agent-pipeline seams that take an **injected** JS callback (homoglyph scanner,
-redactor, file access) have no language-agnostic wire form, so call those from
-JS.
+The JS is the **single source of truth**—non-JS callers drive the same verdicts
+through the bundled CLI (JSON over stdin/stdout, Node ≥20 on `PATH`), so there’s
+no second implementation to drift. An `op` field selects the entry point
+(default `sanitize`); the self-contained ones—`sanitizeText`, `classifyPrompt`,
+`scanInstructionFiles`, `cleanFile`—are all bridged. Entry points with an
+injected JS callback have no wire form and stay JS-only.
 
 ```sh
-echo '{"text":"a​b","html":false}' | npx sanitize-cli  # default op: sanitize
-echo '{"op":"classifyPrompt","text":"…"}' | npx sanitize-cli  # pass/note/block
-sanitize-cli --worker                                   # newline-delimited, one response/line
+echo '{"text":"a​b"}' | npx sanitize-cli           # default op: sanitize
+echo '{"op":"classifyPrompt","text":"…"}' | npx sanitize-cli
+sanitize-cli --worker                              # newline-delimited, one response/line
 ```
 
-The [`python/`](./python) client wraps both. By default the ~200 ms HTML
-module-load is paid **once per process**: the first `html=True` call starts a
-shared worker that later calls reuse (Layer-1 calls stay one-shot, leaving no
-process behind). `persist=True/False` forces the mode; `shutdown_worker()` (also
-an `atexit` hook) stops it, or scope one with the `Sanitizer` context manager.
-No pure-Python port—a port _is_ the drift this avoids; missing Node fails loudly.
+The [`python/`](./python) client wraps every bridged op (`sanitize`,
+`sanitize_text`, `classify_prompt`, `scan_instruction_files`, `clean_file`). The
+first `html=True` call starts a shared worker, so the ~200 ms HTML module-load
+is paid **once per process**; Layer-1 calls stay one-shot. `persist=True/False`
+forces the mode and `shutdown_worker()` (also an `atexit` hook) stops it. Missing
+Node fails loudly—a pure-Python port _is_ the drift this avoids.
 
 ```python
 from agent_input_sanitizer import sanitize, Sanitizer
@@ -186,6 +130,3 @@ sanitize(page_source, html=True)  # HTML layers, warm worker reused
 with Sanitizer() as s:            # own the worker’s lifetime
     s.sanitize(page, html=True)
 ```
-
-The other self-contained entry points are wrapped too:
-`sanitize_text`, `classify_prompt`, `scan_instruction_files`, `clean_file`.

--- a/README.md
+++ b/README.md
@@ -91,17 +91,32 @@ echo '{"text":"a​b","html":false}' | npx sanitize-cli
 sanitize-cli --worker
 ```
 
-A thin Python client lives in [`python/`](./python). One-shot per call, or a
-long-lived worker (context manager) that pays the HTML module-load once:
+A thin Python client lives in [`python/`](./python). By default it pays the
+heavy ~200 ms HTML module-load **once per process, not per call**: the first
+`html=True` call spins up a shared worker and every later `html=True` call
+reuses it. Layer-1-only calls stay one-shot, so a caller that never touches HTML
+leaves no process running.
 
 ```python
-from agent_input_sanitizer import sanitize, Sanitizer
+from agent_input_sanitizer import sanitize
 
-result = sanitize(untrusted_text)                 # Layer 1 only
-result = sanitize(page_source, html=True)         # opt into the HTML layers
+result = sanitize(untrusted_text)                 # Layer 1 only (one-shot)
+result = sanitize(page_source, html=True)         # HTML layers — warm worker, reused
 #   result.cleaned / result.found / result.warnings — mirrors the JS return shape
 
-with Sanitizer() as s:                             # hot path: reuse one process
+# Force the mode if you need to: persist=True keeps a process warm even for
+# Layer-1 calls; persist=False spawns a fresh subprocess every time.
+sanitize(text, persist=True)
+```
+
+The shared worker is torn down at interpreter exit; call `shutdown_worker()` to
+stop it sooner. For a worker whose lifetime you own explicitly, use the
+`Sanitizer` context manager:
+
+```python
+from agent_input_sanitizer import Sanitizer
+
+with Sanitizer() as s:
     for page in pages:
         s.sanitize(page, html=True)
 ```

--- a/README.md
+++ b/README.md
@@ -156,55 +156,30 @@ const repaired = await rehydrateRedacted("Edit", toolInput, {
 
 ## Non-JS pipelines (Python, etc.)
 
-The sanitization logic has a **single source of truth**: the JavaScript above.
-A Python (or any-language) pipeline drives the _same_ verdicts—no second
-implementation to drift—through the bundled CLI, which speaks JSON over
-stdin/stdout. It requires Node.js (≥20) on `PATH`.
-
-The CLI bridges the data-in/data-out core—`sanitize` (Layers 1–3). The
-agent-pipeline entry points above (`confusables`, `output`, `rehydrate`, …) take
-**injected** JS seams—a homoglyph scanner, a redactor, file access—so they have
-no language-agnostic wire form and stay JS-only by nature; call them from JS.
+The JS is the **single source of truth**; non-JS callers drive the same
+verdicts through the bundled CLI (JSON over stdin/stdout, Node ≥20 on `PATH`)
+—no second implementation to drift. The CLI exposes the data-in/data-out core
+(`sanitize`, Layers 1–3); the agent-pipeline entry points take **injected** JS
+seams (homoglyph scanner, redactor, file access) that have no language-agnostic
+wire form, so call those from JS.
 
 ```sh
-# One JSON request in, one JSON response out:
-echo '{"text":"a​b","html":false}' | npx sanitize-cli
-# → {"cleaned":"ab","found":["cf-format"],"warnings":["Stripped: Format chars (Cf)"]}
-
-# Persistent worker: newline-delimited requests, one response line each.
-sanitize-cli --worker
+echo '{"text":"a​b","html":false}' | npx sanitize-cli  # one request → one response
+sanitize-cli --worker                                   # newline-delimited, one response/line
 ```
 
-A thin Python client lives in [`python/`](./python). By default it pays the
-heavy ~200 ms HTML module-load **once per process, not per call**: the first
-`html=True` call spins up a shared worker and every later `html=True` call
-reuses it. Layer-1-only calls stay one-shot, so a caller that never touches HTML
-leaves no process running.
+The [`python/`](./python) client wraps both. By default the ~200 ms HTML
+module-load is paid **once per process**: the first `html=True` call starts a
+shared worker that later calls reuse (Layer-1 calls stay one-shot, leaving no
+process behind). `persist=True/False` forces the mode; `shutdown_worker()` (also
+an `atexit` hook) stops it, or scope one with the `Sanitizer` context manager.
+No pure-Python port—a port _is_ the drift this avoids; missing Node fails loudly.
 
 ```python
-from agent_input_sanitizer import sanitize
+from agent_input_sanitizer import sanitize, Sanitizer
 
-result = sanitize(untrusted_text)                 # Layer 1 only (one-shot)
-result = sanitize(page_source, html=True)         # HTML layers — warm worker, reused
-#   result.cleaned / result.found / result.warnings — mirrors the JS return shape
-
-# Force the mode if you need to: persist=True keeps a process warm even for
-# Layer-1 calls; persist=False spawns a fresh subprocess every time.
-sanitize(text, persist=True)
+sanitize(untrusted_text)          # Layer 1, one-shot
+sanitize(page_source, html=True)  # HTML layers, warm worker reused
+with Sanitizer() as s:            # own the worker’s lifetime
+    s.sanitize(page, html=True)
 ```
-
-The shared worker is torn down at interpreter exit; call `shutdown_worker()` to
-stop it sooner. For a worker whose lifetime you own explicitly, use the
-`Sanitizer` context manager:
-
-```python
-from agent_input_sanitizer import Sanitizer
-
-with Sanitizer() as s:
-    for page in pages:
-        s.sanitize(page, html=True)
-```
-
-There is deliberately no pure-Python port: a port _is_ the drift this design
-avoids. Don’t have Node? The client raises a loud error rather than silently
-degrading.

--- a/README.md
+++ b/README.md
@@ -74,3 +74,38 @@ const cleaned = sanitizeHtml(pageSource); // null when nothing to strip/report
 const threats = detectExfil(pageSource); // null or [{ isImage, reason, target }]
 const reason = checkExfilUrl(oneUrl); // null or a string reason
 ```
+
+## Non-JS pipelines (Python, etc.)
+
+The sanitization logic has a **single source of truth**: the JavaScript above.
+A Python (or any-language) pipeline drives the _same_ verdicts—no second
+implementation to drift—through the bundled CLI, which speaks JSON over
+stdin/stdout. It requires Node.js (≥20) on `PATH`.
+
+```sh
+# One JSON request in, one JSON response out:
+echo '{"text":"a​b","html":false}' | npx sanitize-cli
+# → {"cleaned":"ab","found":["cf-format"],"warnings":["Stripped: Format chars (Cf)"]}
+
+# Persistent worker: newline-delimited requests, one response line each.
+sanitize-cli --worker
+```
+
+A thin Python client lives in [`python/`](./python). One-shot per call, or a
+long-lived worker (context manager) that pays the HTML module-load once:
+
+```python
+from agent_input_sanitizer import sanitize, Sanitizer
+
+result = sanitize(untrusted_text)                 # Layer 1 only
+result = sanitize(page_source, html=True)         # opt into the HTML layers
+#   result.cleaned / result.found / result.warnings — mirrors the JS return shape
+
+with Sanitizer() as s:                             # hot path: reuse one process
+    for page in pages:
+        s.sanitize(page, html=True)
+```
+
+There is deliberately no pure-Python port: a port _is_ the drift this design
+avoids. Don’t have Node? The client raises a loud error rather than silently
+degrading.

--- a/README.md
+++ b/README.md
@@ -158,13 +158,16 @@ const repaired = await rehydrateRedacted("Edit", toolInput, {
 
 The JS is the **single source of truth**; non-JS callers drive the same
 verdicts through the bundled CLI (JSON over stdin/stdout, Node ≥20 on `PATH`)
-—no second implementation to drift. The CLI exposes the data-in/data-out core
-(`sanitize`, Layers 1–3); the agent-pipeline entry points take **injected** JS
-seams (homoglyph scanner, redactor, file access) that have no language-agnostic
-wire form, so call those from JS.
+—no second implementation to drift. The CLI bridges every self-contained
+entry point via an `op` field (default `"sanitize"`): `sanitizeText` (Layers
+1–3), `classifyPrompt`, `scanInstructionFiles`, and `cleanFile`. The
+agent-pipeline seams that take an **injected** JS callback (homoglyph scanner,
+redactor, file access) have no language-agnostic wire form, so call those from
+JS.
 
 ```sh
-echo '{"text":"a​b","html":false}' | npx sanitize-cli  # one request → one response
+echo '{"text":"a​b","html":false}' | npx sanitize-cli  # default op: sanitize
+echo '{"op":"classifyPrompt","text":"…"}' | npx sanitize-cli  # pass/note/block
 sanitize-cli --worker                                   # newline-delimited, one response/line
 ```
 
@@ -183,3 +186,6 @@ sanitize(page_source, html=True)  # HTML layers, warm worker reused
 with Sanitizer() as s:            # own the worker’s lifetime
     s.sanitize(page, html=True)
 ```
+
+The other self-contained entry points are wrapped too:
+`sanitize_text`, `classify_prompt`, `scan_instruction_files`, `clean_file`.

--- a/bin/sanitize-cli.mjs
+++ b/bin/sanitize-cli.mjs
@@ -1,16 +1,26 @@
 #!/usr/bin/env node
 /**
- * Single-source-of-truth CLI over `sanitize()` for non-JS pipelines.
+ * Single-source-of-truth CLI over the sanitizer's data-in/data-out entry points,
+ * for non-JS pipelines.
  *
- * The sanitization logic lives once, in `src/`. This CLI is the supported
- * escape hatch for callers that can't import the JavaScript directly (a Python
- * pipeline, say): it speaks JSON over stdin/stdout so any language can drive the
- * exact same verdicts without a second implementation to keep in sync.
+ * The logic lives once, in `src/`. This CLI is the supported escape hatch for
+ * callers that can't import the JavaScript directly (a Python pipeline, say): it
+ * speaks JSON over stdin/stdout so any language drives the exact same verdicts
+ * without a second implementation to keep in sync. Only the entry points with no
+ * injected callback are exposed — the agent-pipeline seams that take a homoglyph
+ * scanner, redactor, or file-access object have no language-agnostic wire form
+ * and stay JS-only.
  *
- * Protocol — a request is a JSON object `{ "text": string, "html"?: boolean }`;
- * a success response is `{ "cleaned", "found", "warnings" }` (the `sanitize`
- * return shape) and a failure response is `{ "error": string }`. Two modes,
- * same binary:
+ * Protocol — a request is a JSON object with an `op` (default `"sanitize"` so a
+ * bare `{ text, html }` keeps working). Per op:
+ *
+ *   sanitize           { text, html? }            -> { cleaned, found, warnings }
+ *   sanitizeText       { text, html?, exfilScan? } -> { cleaned, warnings, modified, sgrNote }
+ *   classifyPrompt     { text }                    -> { action, reason? }
+ *   scanInstructionFiles { globs, cwd? }           -> { findings: [{ file, findings }] }
+ *   cleanFile          { path }                    -> { changed }
+ *
+ * A failure response is `{ "error": string }`. Two modes, same binary:
  *
  *   one-shot (default): read ONE JSON object from stdin (may span lines), write
  *     ONE response line. A malformed request propagates — non-zero exit, stack
@@ -28,21 +38,76 @@ import readline from "node:readline";
 
 import { sanitize } from "../src/index.mjs";
 
+/** @param {Record<string, unknown>} req @param {string} key */
+function requireString(req, key) {
+  if (typeof req[key] !== "string")
+    throw new Error(`request.${key} must be a string`);
+}
+
+/** Operations the CLI exposes. Each takes the parsed request, returns the JSON
+ * payload object. Non-`sanitize` modules are imported lazily so a caller that
+ * only ever sanitizes never loads prompt/output/instructions code. */
+const OPS = {
+  async sanitize(req) {
+    requireString(req, "text");
+    const { cleaned, found, warnings } = await sanitize(req.text, {
+      html: Boolean(req.html),
+    });
+    return { cleaned, found, warnings };
+  },
+
+  async sanitizeText(req) {
+    requireString(req, "text");
+    // Layers 1–3 only: redact (Layer 4) and filterInjection (Layer 5) are
+    // injected JS callbacks with no wire form, so they're never set here.
+    const { sanitizeText } = await import("../src/output.mjs");
+    const { cleaned, warnings, modified, sgrNote } = await sanitizeText(
+      req.text,
+      {
+        html: Boolean(req.html),
+        exfilScan: Boolean(req.exfilScan),
+      },
+    );
+    return { cleaned, warnings, modified, sgrNote };
+  },
+
+  async classifyPrompt(req) {
+    requireString(req, "text");
+    const { classifyPrompt } = await import("../src/prompt.mjs");
+    return classifyPrompt(req.text);
+  },
+
+  async scanInstructionFiles(req) {
+    if (
+      !Array.isArray(req.globs) ||
+      req.globs.some((g) => typeof g !== "string")
+    )
+      throw new Error("request.globs must be an array of strings");
+    const { scanInstructionFiles } = await import("../src/instructions.mjs");
+    const opts = typeof req.cwd === "string" ? { cwd: req.cwd } : {};
+    return { findings: scanInstructionFiles(req.globs, opts) };
+  },
+
+  async cleanFile(req) {
+    requireString(req, "path");
+    const { cleanFile } = await import("../src/instructions.mjs");
+    return { changed: cleanFile(req.path) };
+  },
+};
+
 /**
- * Run one request through `sanitize` and serialize the response.
- * Throws on a malformed request (non-string `text`); the caller decides whether
- * that propagates (one-shot) or becomes an `{ error }` line (worker).
+ * Run one request through the named `op` and serialize the response.
+ * Throws on a malformed request or unknown op; the caller decides whether that
+ * propagates (one-shot) or becomes an `{ error }` line (worker).
  * @param {string} payload  a single JSON request object
  * @returns {Promise<string>} a single-line JSON response
  */
 async function handle(payload) {
   const request = JSON.parse(payload);
-  if (typeof request.text !== "string")
-    throw new Error("request.text must be a string");
-  const { cleaned, found, warnings } = await sanitize(request.text, {
-    html: Boolean(request.html),
-  });
-  return JSON.stringify({ cleaned, found, warnings });
+  const op = request.op ?? "sanitize";
+  const run = Object.prototype.hasOwnProperty.call(OPS, op) ? OPS[op] : null;
+  if (!run) throw new Error(`unknown op: ${op}`);
+  return JSON.stringify(await run(request));
 }
 
 /** @param {NodeJS.ReadableStream} stream */

--- a/bin/sanitize-cli.mjs
+++ b/bin/sanitize-cli.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Single-source-of-truth CLI over `sanitize()` for non-JS pipelines.
+ *
+ * The sanitization logic lives once, in `src/`. This CLI is the supported
+ * escape hatch for callers that can't import the JavaScript directly (a Python
+ * pipeline, say): it speaks JSON over stdin/stdout so any language can drive the
+ * exact same verdicts without a second implementation to keep in sync.
+ *
+ * Protocol — a request is a JSON object `{ "text": string, "html"?: boolean }`;
+ * a success response is `{ "cleaned", "found", "warnings" }` (the `sanitize`
+ * return shape) and a failure response is `{ "error": string }`. Two modes,
+ * same binary:
+ *
+ *   one-shot (default): read ONE JSON object from stdin (may span lines), write
+ *     ONE response line. A malformed request propagates — non-zero exit, stack
+ *     on stderr — so a scripted caller fails loudly.
+ *
+ *   worker (`--worker`): read newline-delimited JSON requests until EOF, write
+ *     one response line per request, in order. A malformed request yields an
+ *     `{ "error" }` line and the worker keeps serving — the specific, necessary
+ *     recovery that makes a long-lived process usable across independent
+ *     requests (one bad line must not drop the whole pipe). JSON string-encodes
+ *     every newline, so one request and one response always occupy one line each.
+ */
+import process from "node:process";
+import readline from "node:readline";
+
+import { sanitize } from "../src/index.mjs";
+
+/**
+ * Run one request through `sanitize` and serialize the response.
+ * Throws on a malformed request (non-string `text`); the caller decides whether
+ * that propagates (one-shot) or becomes an `{ error }` line (worker).
+ * @param {string} payload  a single JSON request object
+ * @returns {Promise<string>} a single-line JSON response
+ */
+async function handle(payload) {
+  const request = JSON.parse(payload);
+  if (typeof request.text !== "string")
+    throw new Error("request.text must be a string");
+  const { cleaned, found, warnings } = await sanitize(request.text, {
+    html: Boolean(request.html),
+  });
+  return JSON.stringify({ cleaned, found, warnings });
+}
+
+/** @param {NodeJS.ReadableStream} stream */
+async function readAll(stream) {
+  stream.setEncoding("utf8");
+  let text = "";
+  for await (const chunk of stream) text += chunk;
+  return text;
+}
+
+async function runWorker() {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    crlfDelay: Infinity,
+  });
+  // `for await` drives lines sequentially, awaiting each `handle`, so responses
+  // leave in request order. The try/catch is the worker's whole reason to
+  // exist: a single malformed request reports an error and the loop continues
+  // rather than tearing down a pipe other requests are still using.
+  for await (const line of rl) {
+    if (line.trim() === "") continue;
+    let response;
+    try {
+      response = await handle(line);
+    } catch (err) {
+      response = JSON.stringify({ error: err?.message ?? String(err) });
+    }
+    process.stdout.write(`${response}\n`);
+  }
+}
+
+async function runOneShot() {
+  // No try/catch: a bad request or a (contract-impossible) `sanitize` throw
+  // propagates to a non-zero exit with the stack on stderr — fail loudly.
+  const response = await handle(await readAll(process.stdin));
+  process.stdout.write(`${response}\n`);
+}
+
+await (process.argv.includes("--worker") ? runWorker() : runOneShot());

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   },
   "homepage": "https://github.com/alexander-turner/agent-input-sanitizer#readme",
   "packageManager": "pnpm@11.8.0",
+  "bin": {
+    "sanitize-cli": "bin/sanitize-cli.mjs"
+  },
   "scripts": {
     "postinstall": "git config core.hooksPath .hooks",
     "test": "c8 node --test",
@@ -100,6 +103,7 @@
   },
   "files": [
     "src",
+    "bin/sanitize-cli.mjs",
     "types",
     "LICENSE",
     "README.md",

--- a/python/agent_input_sanitizer/__init__.py
+++ b/python/agent_input_sanitizer/__init__.py
@@ -7,15 +7,20 @@ without a second implementation to keep in sync. It requires Node.js (>=20) on
 ``PATH``; there is deliberately no pure-Python fallback, because a port is
 exactly the drift this design avoids.
 
+Only the CLI's data-in/data-out entry points are wrapped; the agent-pipeline
+seams that take an injected JS callback (homoglyph scanner, redactor, file
+access) have no language-agnostic wire form and stay JS-only.
+
 Entry points:
 
-* :func:`sanitize` — the one call most callers need. By default it pays the
+* :func:`sanitize` / :func:`sanitize_text` — clean text. The first pays the
   heavy ~200 ms HTML module-load only ONCE: the first ``html=True`` call spins
-  up a shared, process-wide worker and every later ``html=True`` call reuses it
-  (Layer-1-only calls stay one-shot, so a caller that never touches HTML never
-  leaves a process running). Override with ``persist=True``/``False``.
-* :class:`Sanitizer` — an explicitly-scoped long-lived worker, for callers that
-  want to own the process lifetime via a context manager.
+  up a shared, process-wide worker that later ``html=True`` calls reuse (Layer-1
+  calls stay one-shot, leaving no process behind). Override with ``persist``.
+* :func:`classify_prompt` — pass / note / block verdict for a user prompt.
+* :func:`scan_instruction_files` / :func:`clean_file` — scan or strip
+  hidden-Unicode payloads from instruction files (`CLAUDE.md`, `AGENTS.md`, …).
+* :class:`Sanitizer` — an explicitly-scoped long-lived worker (context manager).
 * :func:`shutdown_worker` — tear down the shared worker eagerly (it is also torn
   down at interpreter exit).
 """
@@ -34,7 +39,19 @@ from pathlib import Path
 # parents up.
 _CLI = Path(__file__).resolve().parents[2] / "bin" / "sanitize-cli.mjs"
 
-__all__ = ["SanitizeResult", "sanitize", "Sanitizer", "shutdown_worker"]
+__all__ = [
+    "SanitizeResult",
+    "TextResult",
+    "PromptVerdict",
+    "InstructionFinding",
+    "sanitize",
+    "sanitize_text",
+    "classify_prompt",
+    "scan_instruction_files",
+    "clean_file",
+    "Sanitizer",
+    "shutdown_worker",
+]
 
 
 @dataclass(frozen=True)
@@ -49,6 +66,33 @@ class SanitizeResult:
     cleaned: str
     found: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class TextResult:
+    """The :func:`sanitize_text` return shape (Layers 1–3 of the output pipeline)."""
+
+    cleaned: str
+    warnings: list[str]
+    modified: bool
+    sgr_note: bool
+
+
+@dataclass(frozen=True)
+class PromptVerdict:
+    """The :func:`classify_prompt` verdict: ``action`` is pass / note / block."""
+
+    action: str
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class InstructionFinding:
+    """One :func:`scan_instruction_files` hit: a file and its hidden-Unicode
+    findings (each ``{line, charCount, method, decoded}``, mirroring the JS)."""
+
+    file: str
+    findings: list[dict]
 
 
 def _node_missing(node: str) -> RuntimeError:
@@ -74,16 +118,40 @@ def _require_cli() -> None:
         )
 
 
-def _encode_request(text: str, html: bool) -> str:
-    """The on-wire request envelope, single-sourced for both call paths."""
-    return json.dumps({"text": text, "html": html})
-
-
-def _parse_response(line: str) -> SanitizeResult:
-    response = json.loads(line)
+def _check(response: dict) -> dict:
+    """Raise on an ``{error}`` response, else return the payload dict."""
     if "error" in response:
         raise RuntimeError(f"sanitize CLI error: {response['error']}")
-    return SanitizeResult(**response)
+    return response
+
+
+def _oneshot(request: dict, node: str) -> dict:
+    """One request through a fresh CLI subprocess; returns the response payload."""
+    _require_cli()
+    try:
+        proc = subprocess.run(
+            [node, str(_CLI)],
+            input=json.dumps(request),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+    except FileNotFoundError as cause:
+        raise _node_missing(node) from cause
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"sanitize CLI failed (exit {proc.returncode}): {proc.stderr.strip()}"
+        )
+    return _check(json.loads(proc.stdout))
+
+
+def _dispatch(request: dict, *, persist: bool, node: str) -> dict:
+    """Route a request through the shared worker (persist) or a one-shot call."""
+    if persist:
+        _require_cli()
+        with _shared_worker_lock:
+            return _shared_worker(node).request(request)
+    return _oneshot(request, node)
 
 
 def sanitize(
@@ -101,28 +169,69 @@ def sanitize(
     force the worker or a fresh one-shot subprocess. ``node`` overrides the
     executable, honored only when starting a fresh process.
     """
-    _require_cli()
     if persist is None:
         persist = html
-    if persist:
-        with _shared_worker_lock:
-            return _shared_worker(node).sanitize(text, html=html)
+    resp = _dispatch({"text": text, "html": html}, persist=persist, node=node)
+    return SanitizeResult(**resp)
 
-    try:
-        proc = subprocess.run(
-            [node, str(_CLI)],
-            input=_encode_request(text, html),
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-        )
-    except FileNotFoundError as cause:
-        raise _node_missing(node) from cause
-    if proc.returncode != 0:
-        raise RuntimeError(
-            f"sanitize CLI failed (exit {proc.returncode}): {proc.stderr.strip()}"
-        )
-    return _parse_response(proc.stdout)
+
+def sanitize_text(
+    text: str,
+    *,
+    html: bool = False,
+    exfil_scan: bool = False,
+    persist: bool | None = None,
+    node: str = "node",
+) -> TextResult:
+    """Run the output pipeline's Layers 1–3 over ``text``.
+
+    Layer 4 (secret redaction) and Layer 5 (semantic filter) are injected JS
+    callbacks with no wire form, so they are never run here — use the JS
+    ``sanitizeText`` directly when you need them. ``persist`` behaves as in
+    :func:`sanitize` (defaults to persisting exactly when ``html=True``).
+    """
+    if persist is None:
+        persist = html
+    resp = _dispatch(
+        {"op": "sanitizeText", "text": text, "html": html, "exfilScan": exfil_scan},
+        persist=persist,
+        node=node,
+    )
+    return TextResult(
+        cleaned=resp["cleaned"],
+        warnings=resp["warnings"],
+        modified=resp["modified"],
+        sgr_note=resp["sgrNote"],
+    )
+
+
+def classify_prompt(prompt: str, *, node: str = "node") -> PromptVerdict:
+    """Classify a user ``prompt`` as pass / note / block on invisible/ANSI content."""
+    resp = _oneshot({"op": "classifyPrompt", "text": prompt}, node)
+    return PromptVerdict(action=resp["action"], reason=resp.get("reason"))
+
+
+def scan_instruction_files(
+    globs: list[str], *, cwd: str | None = None, node: str = "node"
+) -> list[InstructionFinding]:
+    """Scan instruction files matched by ``globs`` for hidden-Unicode payloads.
+
+    Returns only files with findings, each path relative to ``cwd`` (default: the
+    CLI process's working directory).
+    """
+    request: dict = {"op": "scanInstructionFiles", "globs": list(globs)}
+    if cwd is not None:
+        request["cwd"] = str(cwd)
+    resp = _oneshot(request, node)
+    return [
+        InstructionFinding(file=f["file"], findings=f["findings"])
+        for f in resp["findings"]
+    ]
+
+
+def clean_file(path: str, *, node: str = "node") -> bool:
+    """Strip payload-capable invisibles from ``path`` in place. True if it changed."""
+    return _oneshot({"op": "cleanFile", "path": str(path)}, node)["changed"]
 
 
 class Sanitizer:
@@ -178,11 +287,12 @@ class Sanitizer:
     def is_alive(self) -> bool:
         return self._proc is not None and self._proc.poll() is None
 
-    def sanitize(self, text: str, *, html: bool = False) -> SanitizeResult:
+    def request(self, payload: dict) -> dict:
+        """Send one request object, return its response payload (raises on error)."""
         if self._proc is None or self._proc.poll() is not None:
             raise RuntimeError("worker is not running (use it as a context manager)")
         assert self._proc.stdin is not None and self._proc.stdout is not None
-        self._proc.stdin.write(_encode_request(text, html) + "\n")
+        self._proc.stdin.write(json.dumps(payload) + "\n")
         self._proc.stdin.flush()
         # Blocking read with no timeout, under _shared_worker_lock for the shared
         # worker: the serialized one-line-per-request protocol can't interleave,
@@ -194,7 +304,10 @@ class Sanitizer:
             raise RuntimeError(
                 f"sanitize worker exited unexpectedly: {self._drain_stderr()}"
             )
-        return _parse_response(line)
+        return _check(json.loads(line))
+
+    def sanitize(self, text: str, *, html: bool = False) -> SanitizeResult:
+        return SanitizeResult(**self.request({"text": text, "html": html}))
 
     def _drain_stderr(self) -> str:
         if self._stderr is None:

--- a/python/agent_input_sanitizer/__init__.py
+++ b/python/agent_input_sanitizer/__init__.py
@@ -23,6 +23,7 @@ Entry points:
 import atexit
 import json
 import subprocess
+import tempfile
 import threading
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -55,6 +56,11 @@ def _node_missing(node: str) -> RuntimeError:
         "agent-input-sanitizer keeps a single JavaScript source of truth and "
         "has no pure-Python fallback; install Node to use the Python client."
     )
+
+
+def _encode_request(text: str, html: bool) -> str:
+    """The on-wire request envelope, single-sourced for both call paths."""
+    return json.dumps({"text": text, "html": html})
 
 
 def _parse_response(line: str) -> SanitizeResult:
@@ -94,11 +100,10 @@ def sanitize(
         with _shared_worker_lock:
             return _shared_worker(node).sanitize(text, html=html)
 
-    request = json.dumps({"text": text, "html": html})
     try:
         proc = subprocess.run(
             [node, str(_CLI)],
-            input=request,
+            input=_encode_request(text, html),
             capture_output=True,
             text=True,
             encoding="utf-8",
@@ -127,21 +132,32 @@ class Sanitizer:
     def __init__(self, node: str = "node") -> None:
         self._node = node
         self._proc: subprocess.Popen | None = None
+        # Worker stderr goes to a temp file, never a pipe: nobody drains stderr
+        # between requests, so a pipe could fill (Node warnings, etc.) and block
+        # the worker mid-response, deadlocking the readline below. A file never
+        # blocks, and we still read it back for diagnostics if the worker dies.
+        self._stderr: tempfile.SpooledTemporaryFile | None = None
 
-    def __enter__(self) -> "Sanitizer":
+    def start(self) -> "Sanitizer":
+        self._stderr = tempfile.SpooledTemporaryFile(mode="w+", encoding="utf-8")
         try:
             self._proc = subprocess.Popen(
                 [self._node, str(_CLI), "--worker"],
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                stderr=self._stderr,
                 text=True,
                 encoding="utf-8",
                 bufsize=1,
             )
         except FileNotFoundError as cause:
+            self._stderr.close()
+            self._stderr = None
             raise _node_missing(self._node) from cause
         return self
+
+    def __enter__(self) -> "Sanitizer":
+        return self.start()
 
     def __exit__(self, *exc: object) -> None:
         self.close()
@@ -153,21 +169,37 @@ class Sanitizer:
         if self._proc is None or self._proc.poll() is not None:
             raise RuntimeError("worker is not running (use it as a context manager)")
         assert self._proc.stdin is not None and self._proc.stdout is not None
-        self._proc.stdin.write(json.dumps({"text": text, "html": html}) + "\n")
+        self._proc.stdin.write(_encode_request(text, html) + "\n")
         self._proc.stdin.flush()
         line = self._proc.stdout.readline()
         if line == "":
-            stderr = self._proc.stderr.read() if self._proc.stderr else ""
-            raise RuntimeError(f"sanitize worker exited unexpectedly: {stderr.strip()}")
+            raise RuntimeError(
+                f"sanitize worker exited unexpectedly: {self._drain_stderr()}"
+            )
         return _parse_response(line)
+
+    def _drain_stderr(self) -> str:
+        if self._stderr is None:
+            return ""
+        self._stderr.seek(0)
+        return self._stderr.read().strip()
 
     def close(self) -> None:
         if self._proc is None:
             return
         if self._proc.stdin is not None:
             self._proc.stdin.close()
-        self._proc.wait(timeout=5)
+        try:
+            self._proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self._proc.kill()
+            self._proc.wait()
+        if self._proc.stdout is not None:
+            self._proc.stdout.close()
         self._proc = None
+        if self._stderr is not None:
+            self._stderr.close()
+            self._stderr = None
 
 
 # Process-wide worker backing the persistent path of `sanitize`. The lock is
@@ -188,9 +220,10 @@ def _shared_worker(node: str) -> Sanitizer:
     """
     global _worker, _atexit_registered
     if _worker is not None and not _worker.is_alive():
+        _worker.close()  # reap the corpse's pipes/temp file before replacing it
         _worker = None
     if _worker is None:
-        _worker = Sanitizer(node=node).__enter__()
+        _worker = Sanitizer(node=node).start()
         if not _atexit_registered:
             atexit.register(shutdown_worker)
             _atexit_registered = True

--- a/python/agent_input_sanitizer/__init__.py
+++ b/python/agent_input_sanitizer/__init__.py
@@ -22,6 +22,7 @@ Entry points:
 
 import atexit
 import json
+import os
 import subprocess
 import tempfile
 import threading
@@ -58,6 +59,21 @@ def _node_missing(node: str) -> RuntimeError:
     )
 
 
+def _require_cli() -> None:
+    """Fail with a clear message if the bundled CLI isn't where we expect.
+
+    The CLI is resolved relative to this module's source tree, so the client
+    only works from a repo checkout (it is not yet pip-installable). Without
+    this check a missing CLI surfaces as an opaque "node: Cannot find module".
+    """
+    if not _CLI.is_file():
+        raise RuntimeError(
+            f"sanitize CLI not found at {_CLI}. The Python client resolves the "
+            "bundled CLI relative to its source checkout and is not yet "
+            "pip-installable; run it from a repo checkout."
+        )
+
+
 def _encode_request(text: str, html: bool) -> str:
     """The on-wire request envelope, single-sourced for both call paths."""
     return json.dumps({"text": text, "html": html})
@@ -77,23 +93,15 @@ def sanitize(
     persist: bool | None = None,
     node: str = "node",
 ) -> SanitizeResult:
-    """Sanitize ``text``.
+    """Sanitize ``text``. Set ``html=True`` to also run the HTML layers.
 
-    Set ``html=True`` to run the HTML layers (Layers 2 & 3) in addition to the
-    always-on Layer 1.
-
-    ``persist`` selects how the Node process is managed:
-
-    * ``None`` (default) — persist exactly when ``html=True``. HTML's ~200 ms
-      module-load is then paid once for the whole process: the first such call
-      starts the shared worker and the rest reuse it. Layer-1-only calls stay
-      one-shot so a non-HTML caller leaves no process running.
-    * ``True`` — always route through the shared worker.
-    * ``False`` — always spawn a fresh one-shot subprocess.
-
-    ``node`` overrides the Node executable (only honored when starting a fresh
-    process; an already-running shared worker keeps the executable it began with).
+    ``persist`` picks the process model (see the module docstring for the
+    amortization rationale): ``None`` (default) routes through the shared worker
+    exactly when ``html=True`` and stays one-shot otherwise; ``True``/``False``
+    force the worker or a fresh one-shot subprocess. ``node`` overrides the
+    executable, honored only when starting a fresh process.
     """
+    _require_cli()
     if persist is None:
         persist = html
     if persist:
@@ -132,6 +140,9 @@ class Sanitizer:
     def __init__(self, node: str = "node") -> None:
         self._node = node
         self._proc: subprocess.Popen | None = None
+        # The pid that spawned the worker, so a worker inherited across os.fork
+        # can be detected and not shared between processes (see _shared_worker).
+        self._pid: int | None = None
         # Worker stderr goes to a temp file, never a pipe: nobody drains stderr
         # between requests, so a pipe could fill (Node warnings, etc.) and block
         # the worker mid-response, deadlocking the readline below. A file never
@@ -139,6 +150,8 @@ class Sanitizer:
         self._stderr: tempfile.SpooledTemporaryFile | None = None
 
     def start(self) -> "Sanitizer":
+        _require_cli()
+        self._pid = os.getpid()
         self._stderr = tempfile.SpooledTemporaryFile(mode="w+", encoding="utf-8")
         try:
             self._proc = subprocess.Popen(
@@ -171,6 +184,11 @@ class Sanitizer:
         assert self._proc.stdin is not None and self._proc.stdout is not None
         self._proc.stdin.write(_encode_request(text, html) + "\n")
         self._proc.stdin.flush()
+        # Blocking read with no timeout, under _shared_worker_lock for the shared
+        # worker: the serialized one-line-per-request protocol can't interleave,
+        # but a worker that never answers would wedge every persistent caller.
+        # The CLI emits exactly one line per request, so this is bounded in
+        # practice; a hang means a CLI bug, surfaced as a stuck process.
         line = self._proc.stdout.readline()
         if line == "":
             raise RuntimeError(
@@ -214,14 +232,23 @@ _atexit_registered = False
 def _shared_worker(node: str) -> Sanitizer:
     """Return the shared worker, starting it on first use. Caller holds the lock.
 
-    A worker found dead (its prior request already raised, so the failure was
-    surfaced loudly) is discarded and replaced, so the persistent path
-    self-heals rather than wedging every later call on a corpse.
+    Two cases force a fresh worker:
+
+    * Inherited across ``os.fork`` (pid mismatch) — the Popen and its pipes
+      belong to the parent; two processes driving one pipe would desync the
+      protocol. Abandon the reference WITHOUT ``close()`` (reaping a process this
+      child doesn't own is undefined) and spawn one this process owns.
+    * Dead (its prior request already raised, surfacing the failure loudly) —
+      reap its pipes/temp file, then replace it, so the path self-heals instead
+      of wedging every later call on a corpse.
     """
     global _worker, _atexit_registered
-    if _worker is not None and not _worker.is_alive():
-        _worker.close()  # reap the corpse's pipes/temp file before replacing it
-        _worker = None
+    if _worker is not None:
+        if _worker._pid != os.getpid():
+            _worker = None  # inherited across fork; do not reap the parent's proc
+        elif not _worker.is_alive():
+            _worker.close()
+            _worker = None
     if _worker is None:
         _worker = Sanitizer(node=node).start()
         if not _atexit_registered:

--- a/python/agent_input_sanitizer/__init__.py
+++ b/python/agent_input_sanitizer/__init__.py
@@ -7,16 +7,23 @@ without a second implementation to keep in sync. It requires Node.js (>=20) on
 ``PATH``; there is deliberately no pure-Python fallback, because a port is
 exactly the drift this design avoids.
 
-Two entry points, mirroring the CLI's two modes:
+Entry points:
 
-* :func:`sanitize` — one subprocess per call. Simplest; pays process-spawn cost
-  (and ~200 ms HTML module-load when ``html=True``) every time.
-* :class:`Sanitizer` — a long-lived worker process. Amortizes startup across
-  many calls; use it as a context manager on the hot path.
+* :func:`sanitize` — the one call most callers need. By default it pays the
+  heavy ~200 ms HTML module-load only ONCE: the first ``html=True`` call spins
+  up a shared, process-wide worker and every later ``html=True`` call reuses it
+  (Layer-1-only calls stay one-shot, so a caller that never touches HTML never
+  leaves a process running). Override with ``persist=True``/``False``.
+* :class:`Sanitizer` — an explicitly-scoped long-lived worker, for callers that
+  want to own the process lifetime via a context manager.
+* :func:`shutdown_worker` — tear down the shared worker eagerly (it is also torn
+  down at interpreter exit).
 """
 
+import atexit
 import json
 import subprocess
+import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -25,7 +32,7 @@ from pathlib import Path
 # parents up.
 _CLI = Path(__file__).resolve().parents[2] / "bin" / "sanitize-cli.mjs"
 
-__all__ = ["SanitizeResult", "sanitize", "Sanitizer"]
+__all__ = ["SanitizeResult", "sanitize", "Sanitizer", "shutdown_worker"]
 
 
 @dataclass(frozen=True)
@@ -57,12 +64,36 @@ def _parse_response(line: str) -> SanitizeResult:
     return SanitizeResult(**response)
 
 
-def sanitize(text: str, *, html: bool = False, node: str = "node") -> SanitizeResult:
-    """Sanitize ``text`` via a one-shot CLI subprocess.
+def sanitize(
+    text: str,
+    *,
+    html: bool = False,
+    persist: bool | None = None,
+    node: str = "node",
+) -> SanitizeResult:
+    """Sanitize ``text``.
 
     Set ``html=True`` to run the HTML layers (Layers 2 & 3) in addition to the
-    always-on Layer 1. ``node`` overrides the Node executable.
+    always-on Layer 1.
+
+    ``persist`` selects how the Node process is managed:
+
+    * ``None`` (default) — persist exactly when ``html=True``. HTML's ~200 ms
+      module-load is then paid once for the whole process: the first such call
+      starts the shared worker and the rest reuse it. Layer-1-only calls stay
+      one-shot so a non-HTML caller leaves no process running.
+    * ``True`` — always route through the shared worker.
+    * ``False`` — always spawn a fresh one-shot subprocess.
+
+    ``node`` overrides the Node executable (only honored when starting a fresh
+    process; an already-running shared worker keeps the executable it began with).
     """
+    if persist is None:
+        persist = html
+    if persist:
+        with _shared_worker_lock:
+            return _shared_worker(node).sanitize(text, html=html)
+
     request = json.dumps({"text": text, "html": html})
     try:
         proc = subprocess.run(
@@ -115,6 +146,9 @@ class Sanitizer:
     def __exit__(self, *exc: object) -> None:
         self.close()
 
+    def is_alive(self) -> bool:
+        return self._proc is not None and self._proc.poll() is None
+
     def sanitize(self, text: str, *, html: bool = False) -> SanitizeResult:
         if self._proc is None or self._proc.poll() is not None:
             raise RuntimeError("worker is not running (use it as a context manager)")
@@ -134,3 +168,40 @@ class Sanitizer:
             self._proc.stdin.close()
         self._proc.wait(timeout=5)
         self._proc = None
+
+
+# Process-wide worker backing the persistent path of `sanitize`. The lock is
+# held across each full request/response so concurrent persistent callers can't
+# interleave writes and reads on the one shared pipe (which would desync the
+# protocol); it also guards spin-up and teardown of `_worker` itself.
+_worker: Sanitizer | None = None
+_shared_worker_lock = threading.Lock()
+_atexit_registered = False
+
+
+def _shared_worker(node: str) -> Sanitizer:
+    """Return the shared worker, starting it on first use. Caller holds the lock.
+
+    A worker found dead (its prior request already raised, so the failure was
+    surfaced loudly) is discarded and replaced, so the persistent path
+    self-heals rather than wedging every later call on a corpse.
+    """
+    global _worker, _atexit_registered
+    if _worker is not None and not _worker.is_alive():
+        _worker = None
+    if _worker is None:
+        _worker = Sanitizer(node=node).__enter__()
+        if not _atexit_registered:
+            atexit.register(shutdown_worker)
+            _atexit_registered = True
+    return _worker
+
+
+def shutdown_worker() -> None:
+    """Tear down the shared persistent worker if one is running. Idempotent."""
+    global _worker
+    with _shared_worker_lock:
+        if _worker is None:
+            return
+        _worker.close()
+        _worker = None

--- a/python/agent_input_sanitizer/__init__.py
+++ b/python/agent_input_sanitizer/__init__.py
@@ -1,0 +1,136 @@
+"""Python client for ``agent-input-sanitizer``.
+
+The sanitization logic has a single source of truth: the JavaScript in
+``src/``. This module is a thin client that shells out to the
+``bin/sanitize-cli.mjs`` CLI, so a Python pipeline gets byte-identical verdicts
+without a second implementation to keep in sync. It requires Node.js (>=20) on
+``PATH``; there is deliberately no pure-Python fallback, because a port is
+exactly the drift this design avoids.
+
+Two entry points, mirroring the CLI's two modes:
+
+* :func:`sanitize` — one subprocess per call. Simplest; pays process-spawn cost
+  (and ~200 ms HTML module-load when ``html=True``) every time.
+* :class:`Sanitizer` — a long-lived worker process. Amortizes startup across
+  many calls; use it as a context manager on the hot path.
+"""
+
+import json
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# The CLI lives at <repo>/bin/sanitize-cli.mjs; this module is at
+# <repo>/python/agent_input_sanitizer/__init__.py, so the repo root is two
+# parents up.
+_CLI = Path(__file__).resolve().parents[2] / "bin" / "sanitize-cli.mjs"
+
+__all__ = ["SanitizeResult", "sanitize", "Sanitizer"]
+
+
+@dataclass(frozen=True)
+class SanitizeResult:
+    """The :func:`sanitize` return shape, mirroring the JS API.
+
+    ``cleaned`` is the sanitized text; ``found`` names the neutralized
+    categories; ``warnings`` carries the operator-facing notices. As in JS, any
+    change to the text comes with at least one warning.
+    """
+
+    cleaned: str
+    found: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+def _node_missing(node: str) -> RuntimeError:
+    return RuntimeError(
+        f"Node.js (>=20) is required but {node!r} was not found on PATH. "
+        "agent-input-sanitizer keeps a single JavaScript source of truth and "
+        "has no pure-Python fallback; install Node to use the Python client."
+    )
+
+
+def _parse_response(line: str) -> SanitizeResult:
+    response = json.loads(line)
+    if "error" in response:
+        raise RuntimeError(f"sanitize CLI error: {response['error']}")
+    return SanitizeResult(**response)
+
+
+def sanitize(text: str, *, html: bool = False, node: str = "node") -> SanitizeResult:
+    """Sanitize ``text`` via a one-shot CLI subprocess.
+
+    Set ``html=True`` to run the HTML layers (Layers 2 & 3) in addition to the
+    always-on Layer 1. ``node`` overrides the Node executable.
+    """
+    request = json.dumps({"text": text, "html": html})
+    try:
+        proc = subprocess.run(
+            [node, str(_CLI)],
+            input=request,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+    except FileNotFoundError as cause:
+        raise _node_missing(node) from cause
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"sanitize CLI failed (exit {proc.returncode}): {proc.stderr.strip()}"
+        )
+    return _parse_response(proc.stdout)
+
+
+class Sanitizer:
+    """A long-lived sanitizer worker, for the hot path.
+
+    Spawns one ``node ... --worker`` process and feeds it newline-delimited JSON
+    requests, so the (heavy, when ``html=True``) module load is paid once rather
+    than per call. Use as a context manager::
+
+        with Sanitizer() as s:
+            for page in pages:
+                result = s.sanitize(page, html=True)
+    """
+
+    def __init__(self, node: str = "node") -> None:
+        self._node = node
+        self._proc: subprocess.Popen | None = None
+
+    def __enter__(self) -> "Sanitizer":
+        try:
+            self._proc = subprocess.Popen(
+                [self._node, str(_CLI), "--worker"],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+                bufsize=1,
+            )
+        except FileNotFoundError as cause:
+            raise _node_missing(self._node) from cause
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    def sanitize(self, text: str, *, html: bool = False) -> SanitizeResult:
+        if self._proc is None or self._proc.poll() is not None:
+            raise RuntimeError("worker is not running (use it as a context manager)")
+        assert self._proc.stdin is not None and self._proc.stdout is not None
+        self._proc.stdin.write(json.dumps({"text": text, "html": html}) + "\n")
+        self._proc.stdin.flush()
+        line = self._proc.stdout.readline()
+        if line == "":
+            stderr = self._proc.stderr.read() if self._proc.stderr else ""
+            raise RuntimeError(f"sanitize worker exited unexpectedly: {stderr.strip()}")
+        return _parse_response(line)
+
+    def close(self) -> None:
+        if self._proc is None:
+            return
+        if self._proc.stdin is not None:
+            self._proc.stdin.close()
+        self._proc.wait(timeout=5)
+        self._proc = None

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -12,10 +12,21 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import fc from "fast-check";
 
 import { sanitize } from "../src/index.mjs";
+import { classifyPrompt } from "../src/prompt.mjs";
+import { sanitizeText } from "../src/output.mjs";
+import { scanInstructionFiles } from "../src/instructions.mjs";
 import { fcRunOptions } from "./test-helpers.mjs";
+
+const ESC = "\u001b";
+
+const ZWS = "\u200b";
+const HIDDEN_HTML = '<div style="display:none">leak</div>';
 
 const CLI = fileURLToPath(new URL("../bin/sanitize-cli.mjs", import.meta.url));
 
@@ -199,5 +210,100 @@ describe("CLI: large input", () => {
     const out = run(["--worker"], `${JSON.stringify({ text })}\n`).trim();
     assert.equal(out.split("\n").length, 1);
     assert.deepEqual(JSON.parse(out), expected);
+  });
+});
+
+// \u2500\u2500\u2500 Op dispatch: the other self-contained entry points \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+//
+// Beyond `sanitize`, the CLI bridges every data-in/data-out entry point through
+// an `op` field. Same contract as above \u2014 the in-process function is the oracle,
+// and these pin only that the CLI relays its result faithfully in both modes.
+// The injected-callback seams (confusables, redact, io) have no wire form and are
+// deliberately absent.
+
+/** Build one request line and assert the CLI's response equals `expected`, in
+ * both one-shot and (single-request) worker mode. */
+const assertOpMirrors = (request, expected) => {
+  const line = JSON.stringify(request);
+  assert.deepEqual(JSON.parse(run([], line)), expected);
+  const out = run(["--worker"], `${line}\n`).trim();
+  assert.equal(out.split("\n").length, 1);
+  assert.deepEqual(JSON.parse(out), expected);
+};
+
+describe("CLI: op dispatch mirrors the in-process entry point", () => {
+  it("classifyPrompt: pass / SGR-note / block all relay faithfully", () => {
+    for (const text of [
+      "hello world",
+      `${ESC}[31mred${ESC}[0m`,
+      `${ESC}[2Jwipe`,
+    ])
+      assertOpMirrors({ op: "classifyPrompt", text }, classifyPrompt(text));
+  });
+
+  it("sanitizeText: Layers 1\u20133 relay the full shape", async () => {
+    for (const { text, html } of [
+      { text: `a${ZWS}b`, html: false },
+      { text: "hello", html: false },
+      { text: HIDDEN_HTML, html: true },
+    ]) {
+      const { cleaned, warnings, modified, sgrNote } = await sanitizeText(
+        text,
+        {
+          html,
+        },
+      );
+      assertOpMirrors(
+        { op: "sanitizeText", text, html },
+        { cleaned, warnings, modified, sgrNote },
+      );
+    }
+  });
+
+  it("scanInstructionFiles + cleanFile: scan, clean, re-scan clean", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "ais-cli-"));
+    const notes = path.join(dir, "NOTES.md");
+    writeFileSync(notes, `intro ${ZWS.repeat(100)} outro\n`, "utf8");
+    writeFileSync(path.join(dir, "CLEAN.md"), "nothing hidden\n", "utf8");
+
+    assertOpMirrors(
+      { op: "scanInstructionFiles", globs: ["*.md"], cwd: dir },
+      { findings: scanInstructionFiles(["*.md"], { cwd: dir }) },
+    );
+
+    // cleanFile mutates the file, so the oracle can't run on the same path after
+    // the CLI already cleaned it. Drive the CLI first, then assert the on-disk
+    // effect and that a second clean is a no-op.
+    const clean = (p) =>
+      JSON.parse(run([], JSON.stringify({ op: "cleanFile", path: p }))).changed;
+    assert.equal(clean(notes), true);
+    assert.ok(!readFileSync(notes, "utf8").includes(ZWS));
+    assert.equal(clean(notes), false);
+    assert.equal(clean(path.join(dir, "CLEAN.md")), false);
+    assert.deepEqual(scanInstructionFiles(["*.md"], { cwd: dir }), []);
+  });
+});
+
+describe("CLI: unknown op fails loudly", () => {
+  it("one-shot exits non-zero naming the op", () => {
+    assert.throws(
+      () => run([], JSON.stringify({ op: "nope", text: "x" })),
+      (err) => {
+        assert.equal(err.status, 1);
+        assert.match(String(err.stderr), /unknown op: nope/);
+        return true;
+      },
+    );
+  });
+
+  it("worker reports the bad op and keeps serving", () => {
+    const input = `${JSON.stringify({ op: "nope" })}\n${JSON.stringify({ text: "ok" })}\n`;
+    const lines = run(["--worker"], input).trim().split("\n");
+    assert.match(JSON.parse(lines[0]).error, /unknown op: nope/);
+    assert.deepEqual(JSON.parse(lines[1]), {
+      cleaned: "ok",
+      found: [],
+      warnings: [],
+    });
   });
 });

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -21,12 +21,16 @@ const CLI = fileURLToPath(new URL("../bin/sanitize-cli.mjs", import.meta.url));
 const run = (args, input) =>
   execFileSync("node", [CLI, ...args], { input, encoding: "utf8" });
 
+/** The wire response shape, for comparing CLI output against the sanitize oracle. */
+const envelope = ({ cleaned, found, warnings }) => ({ cleaned, found, warnings });
+
 // Inputs spanning every layer: a Cf char (Layer 1), clean passthrough, a hidden
 // element + an exfil-shaped URL (Layers 2/3, html mode). Each carries the html
 // flag it needs so the oracle comparison covers both code paths.
 const CASES = [
   { name: "strips invisible (Layer 1)", text: "a​b", html: false },
   { name: "clean passthrough", text: "hello world", html: false },
+  { name: "empty input", text: "", html: false },
   {
     name: "hidden HTML + exfil (Layers 2/3)",
     text: '<div style="display:none">leak</div>[x](https://evil.test/?d=SECRET)',
@@ -39,11 +43,7 @@ describe("CLI: one-shot mode mirrors sanitize()", () => {
     it(name, async () => {
       const expected = await sanitize(text, { html });
       const got = JSON.parse(run([], JSON.stringify({ text, html })));
-      assert.deepEqual(got, {
-        cleaned: expected.cleaned,
-        found: expected.found,
-        warnings: expected.warnings,
-      });
+      assert.deepEqual(got, envelope(expected));
     });
   }
 });
@@ -56,12 +56,7 @@ describe("CLI: worker mode", () => {
     const lines = run(["--worker"], `${input}\n`).trim().split("\n");
     assert.equal(lines.length, CASES.length);
     for (const [i, { text, html }] of CASES.entries()) {
-      const expected = await sanitize(text, { html });
-      assert.deepEqual(JSON.parse(lines[i]), {
-        cleaned: expected.cleaned,
-        found: expected.found,
-        warnings: expected.warnings,
-      });
+      assert.deepEqual(JSON.parse(lines[i]), envelope(await sanitize(text, { html })));
     }
   });
 
@@ -78,14 +73,9 @@ describe("CLI: worker mode", () => {
 
   it("treats a string-encoded newline in the payload as one request", async () => {
     const text = "line1\nline2​";
-    const expected = await sanitize(text);
     const out = run(["--worker"], `${JSON.stringify({ text })}\n`).trim();
     assert.equal(out.split("\n").length, 1);
-    assert.deepEqual(JSON.parse(out), {
-      cleaned: expected.cleaned,
-      found: expected.found,
-      warnings: expected.warnings,
-    });
+    assert.deepEqual(JSON.parse(out), envelope(await sanitize(text)));
   });
 });
 
@@ -96,6 +86,16 @@ describe("CLI: one-shot fails loudly on a bad request", () => {
       (err) => {
         assert.equal(err.status, 1);
         assert.match(String(err.stderr), /text must be a string/);
+        return true;
+      },
+    );
+  });
+
+  it("exits non-zero on empty stdin (no request at all)", () => {
+    assert.throws(
+      () => run([], ""),
+      (err) => {
+        assert.equal(err.status, 1);
         return true;
       },
     );

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -22,7 +22,11 @@ const run = (args, input) =>
   execFileSync("node", [CLI, ...args], { input, encoding: "utf8" });
 
 /** The wire response shape, for comparing CLI output against the sanitize oracle. */
-const envelope = ({ cleaned, found, warnings }) => ({ cleaned, found, warnings });
+const envelope = ({ cleaned, found, warnings }) => ({
+  cleaned,
+  found,
+  warnings,
+});
 
 // Inputs spanning every layer: a Cf char (Layer 1), clean passthrough, a hidden
 // element + an exfil-shaped URL (Layers 2/3, html mode). Each carries the html
@@ -56,7 +60,10 @@ describe("CLI: worker mode", () => {
     const lines = run(["--worker"], `${input}\n`).trim().split("\n");
     assert.equal(lines.length, CASES.length);
     for (const [i, { text, html }] of CASES.entries()) {
-      assert.deepEqual(JSON.parse(lines[i]), envelope(await sanitize(text, { html })));
+      assert.deepEqual(
+        JSON.parse(lines[i]),
+        envelope(await sanitize(text, { html })),
+      );
     }
   });
 

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -12,8 +12,10 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import fc from "fast-check";
 
 import { sanitize } from "../src/index.mjs";
+import { fcRunOptions } from "./test-helpers.mjs";
 
 const CLI = fileURLToPath(new URL("../bin/sanitize-cli.mjs", import.meta.url));
 
@@ -106,5 +108,96 @@ describe("CLI: one-shot fails loudly on a bad request", () => {
         return true;
       },
     );
+  });
+});
+
+// ─── Transport faithfulness (fuzz) ───────────────────────────────────────────
+//
+// The fixed CASES above pin known shapes; this fuzzes the NEW surface the CLI
+// adds — the JSON request/response envelope and the worker's newline framing —
+// to prove it transports arbitrary text without altering the verdict. The
+// sanitizer itself is already fuzzed elsewhere, so `sanitize` is the oracle:
+// the only thing under test is that `cli(text)` === `sanitize(text)` for inputs
+// that stress the encoding (lone surrogates, ANSI/ESC, invisibles, structural
+// tokens, line/paragraph separators). A framing bug — a payload byte read as a
+// request boundary, or a surrogate mangled by the JSON round-trip — shows up as
+// a mismatch or a response-count drift that the hand-picked cases would miss.
+
+const FRAMING_TOKENS = [
+  "\n",
+  "\r",
+  "\r\n",
+  "\u2028", // line separator — valid in JSON, must NOT split a worker request
+  "\u2029", // paragraph separator
+  "\u0000", // NUL
+  "\u001b[31m", // 7-bit ANSI/ESC
+  "\u009b6n", // 8-bit C1 CSI
+  "\u200b", // zero-width space
+  "\ufeff", // BOM
+  '<div style="display:none">x</div>',
+  "[t](https://evil.test/?d=SECRET)",
+];
+
+const unicodeChar = fc
+  .integer({ min: 0, max: 0x10ffff })
+  .filter((c) => c < 0xd800 || c > 0xdfff)
+  .map((c) => String.fromCodePoint(c));
+const loneSurrogate = fc
+  .integer({ min: 0xd800, max: 0xdfff })
+  .map((c) => String.fromCharCode(c));
+const fuzzText = fc
+  .array(
+    fc.oneof(unicodeChar, loneSurrogate, fc.constantFrom(...FRAMING_TOKENS)),
+    {
+      maxLength: 80,
+    },
+  )
+  .map((parts) => parts.join(""));
+
+describe("CLI: transport faithfulness (fuzz)", () => {
+  it("one-shot mode equals sanitize() for arbitrary input", async () => {
+    await fc.assert(
+      fc.asyncProperty(fuzzText, fc.boolean(), async (text, html) => {
+        const got = JSON.parse(run([], JSON.stringify({ text, html })));
+        assert.deepEqual(got, envelope(await sanitize(text, { html })));
+      }),
+      fcRunOptions({ numRuns: 60 }),
+    );
+  });
+
+  it("worker mode batches arbitrary requests, one faithful response each", async () => {
+    // Batch a whole array of inputs through ONE worker process: this is where a
+    // framing bug bites — a payload that smuggles a newline would split one
+    // request into two and desync every response after it.
+    await fc.assert(
+      fc.asyncProperty(
+        fc.array(fuzzText, { minLength: 1, maxLength: 15 }),
+        async (texts) => {
+          const input = texts
+            .map((text) => JSON.stringify({ text }))
+            .join("\n");
+          const lines = run(["--worker"], `${input}\n`).trim().split("\n");
+          assert.equal(lines.length, texts.length);
+          for (const [i, text] of texts.entries()) {
+            assert.deepEqual(
+              JSON.parse(lines[i]),
+              envelope(await sanitize(text)),
+            );
+          }
+        },
+      ),
+      fcRunOptions({ numRuns: 40 }),
+    );
+  });
+});
+
+describe("CLI: large input", () => {
+  it("transports a payload larger than the OS pipe buffer in both modes", async () => {
+    const text = `${"A".repeat(200_000)}\u200b${"B".repeat(200_000)}`;
+    const expected = envelope(await sanitize(text));
+    assert.deepEqual(JSON.parse(run([], JSON.stringify({ text }))), expected);
+    const out = run(["--worker"], `${JSON.stringify({ text })}\n`).trim();
+    assert.equal(out.split("\n").length, 1);
+    assert.deepEqual(JSON.parse(out), expected);
   });
 });

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -1,0 +1,103 @@
+/**
+ * Contract tests for the stdin/stdout CLI (`bin/sanitize-cli.mjs`), the
+ * single-source-of-truth bridge for non-JS pipelines.
+ *
+ * The CLI must be a faithful pass-through to `sanitize`: its JSON response has
+ * to equal what an in-process `sanitize` call returns for the same input, in
+ * both one-shot and worker modes. So `sanitize` itself is the oracle here —
+ * these tests pin the I/O envelope and the worker's stay-alive-on-bad-input
+ * contract, not the sanitization verdicts (those are owned by sanitize.test.mjs).
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { sanitize } from "../src/index.mjs";
+
+const CLI = fileURLToPath(new URL("../bin/sanitize-cli.mjs", import.meta.url));
+
+/** Run the CLI with `input` on stdin, returning trimmed stdout. */
+const run = (args, input) =>
+  execFileSync("node", [CLI, ...args], { input, encoding: "utf8" });
+
+// Inputs spanning every layer: a Cf char (Layer 1), clean passthrough, a hidden
+// element + an exfil-shaped URL (Layers 2/3, html mode). Each carries the html
+// flag it needs so the oracle comparison covers both code paths.
+const CASES = [
+  { name: "strips invisible (Layer 1)", text: "a​b", html: false },
+  { name: "clean passthrough", text: "hello world", html: false },
+  {
+    name: "hidden HTML + exfil (Layers 2/3)",
+    text: '<div style="display:none">leak</div>[x](https://evil.test/?d=SECRET)',
+    html: true,
+  },
+];
+
+describe("CLI: one-shot mode mirrors sanitize()", () => {
+  for (const { name, text, html } of CASES) {
+    it(name, async () => {
+      const expected = await sanitize(text, { html });
+      const got = JSON.parse(run([], JSON.stringify({ text, html })));
+      assert.deepEqual(got, {
+        cleaned: expected.cleaned,
+        found: expected.found,
+        warnings: expected.warnings,
+      });
+    });
+  }
+});
+
+describe("CLI: worker mode", () => {
+  it("answers newline-delimited requests in order, matching sanitize()", async () => {
+    const input = CASES.map((c) =>
+      JSON.stringify({ text: c.text, html: c.html }),
+    ).join("\n");
+    const lines = run(["--worker"], `${input}\n`).trim().split("\n");
+    assert.equal(lines.length, CASES.length);
+    for (const [i, { text, html }] of CASES.entries()) {
+      const expected = await sanitize(text, { html });
+      assert.deepEqual(JSON.parse(lines[i]), {
+        cleaned: expected.cleaned,
+        found: expected.found,
+        warnings: expected.warnings,
+      });
+    }
+  });
+
+  it("reports a bad request as an error line and keeps serving the next", () => {
+    const input = `${JSON.stringify({ text: 123 })}\n${JSON.stringify({ text: "ok" })}\n`;
+    const lines = run(["--worker"], input).trim().split("\n");
+    assert.match(JSON.parse(lines[0]).error, /text must be a string/);
+    assert.deepEqual(JSON.parse(lines[1]), {
+      cleaned: "ok",
+      found: [],
+      warnings: [],
+    });
+  });
+
+  it("treats a string-encoded newline in the payload as one request", async () => {
+    const text = "line1\nline2​";
+    const expected = await sanitize(text);
+    const out = run(["--worker"], `${JSON.stringify({ text })}\n`).trim();
+    assert.equal(out.split("\n").length, 1);
+    assert.deepEqual(JSON.parse(out), {
+      cleaned: expected.cleaned,
+      found: expected.found,
+      warnings: expected.warnings,
+    });
+  });
+});
+
+describe("CLI: one-shot fails loudly on a bad request", () => {
+  it("exits non-zero with the reason on stderr", () => {
+    assert.throws(
+      () => run([], JSON.stringify({ text: 123 })),
+      (err) => {
+        assert.equal(err.status, 1);
+        assert.match(String(err.stderr), /text must be a string/);
+        return true;
+      },
+    );
+  });
+});

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -44,6 +44,15 @@ def run_session_setup(
             "CLAUDE_PROJECT_DIR": str(sandbox),
             "CLAUDE_ENV_FILE": str(env_file),
             "GH_TOKEN": "fake",
+            # Isolate the script's `git remote get-url` from ambient git config.
+            # Proxy environments (incl. this one's CI) register a global
+            # `url.<proxy>.insteadOf = https://github.com/`, which rewrites the
+            # github-https/ssh fixtures to the proxy form before the script sees
+            # them — making GH_REPO extraction look like it fired on a plain
+            # GitHub URL. Pinning config to /dev/null lets each fixture exercise
+            # the regex against the literal URL it sets.
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_SYSTEM": os.devnull,
         }
     )
     if extra_env:

--- a/tests/test_python_client.py
+++ b/tests/test_python_client.py
@@ -7,8 +7,11 @@ verdicts themselves are owned by the JS suite — here the CLI is the source of
 truth and the client must faithfully relay it.
 """
 
+import os
 import shutil
+import subprocess
 import sys
+import tempfile
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -140,3 +143,62 @@ def test_worker_missing_node_fails_loudly() -> None:
     with pytest.raises(RuntimeError, match="Node.js"):
         with Sanitizer(node="definitely-not-a-real-node-binary"):
             pass
+
+
+def test_missing_cli_fails_with_clear_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ais, "_CLI", REPO_ROOT / "bin" / "does-not-exist.mjs")
+    with pytest.raises(RuntimeError, match="sanitize CLI not found"):
+        sanitize("x")
+
+
+def test_worker_error_response_becomes_runtime_error() -> None:
+    # A CLI `{error}` response (here: a non-string text) must surface as a clear
+    # exception, not a malformed SanitizeResult.
+    with Sanitizer() as worker:
+        with pytest.raises(RuntimeError, match="text must be a string"):
+            worker.sanitize(123)  # type: ignore[arg-type]
+
+
+def test_oneshot_error_becomes_runtime_error() -> None:
+    with pytest.raises(RuntimeError, match="sanitize CLI failed"):
+        sanitize(123, persist=False)  # type: ignore[arg-type]
+
+
+def test_drain_stderr_reads_back_worker_stderr() -> None:
+    # The death-diagnostic path: a child process writes to the worker's stderr
+    # temp file via its fd; _drain_stderr must read it back across that fd.
+    worker = Sanitizer()
+    worker._stderr = tempfile.SpooledTemporaryFile(mode="w+", encoding="utf-8")
+    node = shutil.which("node")
+    assert node is not None
+    subprocess.run(
+        [node, "-e", "process.stderr.write('diag-from-child')"],
+        stderr=worker._stderr,
+        check=True,
+    )
+    assert worker._drain_stderr() == "diag-from-child"
+    worker._stderr.close()
+
+
+def test_killed_worker_raises_loudly_on_next_use() -> None:
+    with Sanitizer() as worker:
+        worker._proc.kill()
+        worker._proc.wait()
+        with pytest.raises(RuntimeError, match="worker is not running"):
+            worker.sanitize("x")
+
+
+def test_shared_worker_not_shared_across_fork() -> None:
+    # Simulate inheriting a worker across os.fork: a pid mismatch must force a
+    # fresh process, never reuse the parent's pipe.
+    sanitize("x", persist=True)
+    inherited = ais._worker
+    assert inherited is not None
+    inherited._pid = -1  # pretend this worker was spawned by another process
+
+    sanitize("y", persist=True)
+    assert ais._worker is not None and ais._worker is not inherited
+    assert ais._worker._pid == os.getpid()
+    # The "inherited" worker was abandoned, not reaped — still running.
+    assert inherited.is_alive()
+    inherited.close()

--- a/tests/test_python_client.py
+++ b/tests/test_python_client.py
@@ -1,0 +1,67 @@
+"""Tests for the Python client (`python/agent_input_sanitizer`).
+
+The client is a thin bridge to the Node CLI, so these assert the bridge holds:
+Layer 1 strips, the html flag reaches Layers 2/3, the persistent worker agrees
+with the one-shot path, and a missing Node fails loudly. The sanitization
+verdicts themselves are owned by the JS suite — here the CLI is the source of
+truth and the client must faithfully relay it.
+"""
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "python"))
+
+from agent_input_sanitizer import Sanitizer, SanitizeResult, sanitize  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("node") is None, reason="Node.js required for the CLI bridge"
+)
+
+ZERO_WIDTH_SPACE = "​"
+HIDDEN_HTML = '<div style="display:none">leak</div>'
+
+
+def test_strips_invisible_layer1() -> None:
+    result = sanitize(f"a{ZERO_WIDTH_SPACE}b")
+    assert result.cleaned == "ab"
+    assert result.found == ["cf-format"]
+    assert result.warnings  # any change carries a warning
+
+
+def test_clean_text_passes_through_unchanged() -> None:
+    result = sanitize("hello world")
+    assert result == SanitizeResult(cleaned="hello world", found=[], warnings=[])
+
+
+def test_html_flag_reaches_layer2() -> None:
+    assert "leak" in sanitize(HIDDEN_HTML, html=False).cleaned  # Layer 1 only
+    assert "leak" not in sanitize(HIDDEN_HTML, html=True).cleaned  # hidden removed
+
+
+def test_worker_matches_oneshot() -> None:
+    texts = [f"a{ZERO_WIDTH_SPACE}b", "plain", HIDDEN_HTML]
+    with Sanitizer() as worker:
+        for text in texts:
+            assert worker.sanitize(text, html=True) == sanitize(text, html=True)
+
+
+def test_worker_preserves_embedded_newlines() -> None:
+    text = f"line1\nline2{ZERO_WIDTH_SPACE}"
+    with Sanitizer() as worker:
+        assert worker.sanitize(text) == sanitize(text)
+
+
+def test_missing_node_fails_loudly() -> None:
+    with pytest.raises(RuntimeError, match="Node.js"):
+        sanitize("x", node="definitely-not-a-real-node-binary")
+
+
+def test_worker_missing_node_fails_loudly() -> None:
+    with pytest.raises(RuntimeError, match="Node.js"):
+        with Sanitizer(node="definitely-not-a-real-node-binary"):
+            pass

--- a/tests/test_python_client.py
+++ b/tests/test_python_client.py
@@ -9,6 +9,7 @@ truth and the client must faithfully relay it.
 
 import shutil
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -16,7 +17,13 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "python"))
 
-from agent_input_sanitizer import Sanitizer, SanitizeResult, sanitize  # noqa: E402
+import agent_input_sanitizer as ais  # noqa: E402
+from agent_input_sanitizer import (  # noqa: E402
+    Sanitizer,
+    SanitizeResult,
+    sanitize,
+    shutdown_worker,
+)
 
 pytestmark = pytest.mark.skipif(
     shutil.which("node") is None, reason="Node.js required for the CLI bridge"
@@ -24,6 +31,16 @@ pytestmark = pytest.mark.skipif(
 
 ZERO_WIDTH_SPACE = "​"
 HIDDEN_HTML = '<div style="display:none">leak</div>'
+
+
+@pytest.fixture(autouse=True)
+def _no_shared_worker_leak() -> Iterator[None]:
+    """Each test starts and ends with no shared worker, so persistence state
+    can't bleed across tests."""
+    shutdown_worker()
+    assert ais._worker is None
+    yield
+    shutdown_worker()
 
 
 def test_strips_invisible_layer1() -> None:
@@ -41,6 +58,44 @@ def test_clean_text_passes_through_unchanged() -> None:
 def test_html_flag_reaches_layer2() -> None:
     assert "leak" in sanitize(HIDDEN_HTML, html=False).cleaned  # Layer 1 only
     assert "leak" not in sanitize(HIDDEN_HTML, html=True).cleaned  # hidden removed
+
+
+def test_html_amortizes_load_via_shared_worker() -> None:
+    # Default persist=None ⇒ html calls reuse one warm worker: the ~200 ms
+    # module-load is paid once, not per call.
+    first = sanitize(HIDDEN_HTML, html=True)
+    worker = ais._worker
+    assert worker is not None and worker.is_alive()
+    second = sanitize(f"a{ZERO_WIDTH_SPACE}b", html=True)
+    assert ais._worker is worker  # same process reused, not respawned
+    assert "leak" not in first.cleaned
+    assert second.cleaned == "ab"
+
+
+def test_layer1_default_stays_oneshot() -> None:
+    # A caller that never touches HTML must not leave a process running.
+    sanitize(f"a{ZERO_WIDTH_SPACE}b")
+    assert ais._worker is None
+
+
+def test_persist_true_forces_worker_for_layer1() -> None:
+    sanitize("plain", persist=True)
+    assert ais._worker is not None and ais._worker.is_alive()
+
+
+def test_persist_false_forces_oneshot_for_html() -> None:
+    result = sanitize(HIDDEN_HTML, html=True, persist=False)
+    assert ais._worker is None
+    assert "leak" not in result.cleaned
+
+
+def test_shutdown_worker_is_idempotent() -> None:
+    sanitize("x", persist=True)
+    assert ais._worker is not None
+    shutdown_worker()
+    assert ais._worker is None
+    shutdown_worker()  # second call is a no-op, not an error
+    assert ais._worker is None
 
 
 def test_worker_matches_oneshot() -> None:

--- a/tests/test_python_client.py
+++ b/tests/test_python_client.py
@@ -22,11 +22,19 @@ sys.path.insert(0, str(REPO_ROOT / "python"))
 
 import agent_input_sanitizer as ais  # noqa: E402
 from agent_input_sanitizer import (  # noqa: E402
+    PromptVerdict,
     Sanitizer,
     SanitizeResult,
+    TextResult,
+    classify_prompt,
+    clean_file,
     sanitize,
+    sanitize_text,
+    scan_instruction_files,
     shutdown_worker,
 )
+
+ESC = "\x1b"
 
 pytestmark = pytest.mark.skipif(
     shutil.which("node") is None, reason="Node.js required for the CLI bridge"
@@ -202,3 +210,62 @@ def test_shared_worker_not_shared_across_fork() -> None:
     # The "inherited" worker was abandoned, not reaped — still running.
     assert inherited.is_alive()
     inherited.close()
+
+
+# ─── Additional self-contained entry points (op dispatch) ────────────────────
+
+
+def test_classify_prompt_pass() -> None:
+    assert classify_prompt("hello world") == PromptVerdict(action="pass")
+
+
+def test_classify_prompt_note_on_sgr_only() -> None:
+    # A purely cosmetic color sequence is usable: note, not block.
+    assert classify_prompt(f"{ESC}[31mred{ESC}[0m") == PromptVerdict(action="note")
+
+
+def test_classify_prompt_block_carries_reason() -> None:
+    verdict = classify_prompt(f"{ESC}[2Jwipe")  # non-SGR escape → block
+    assert verdict.action == "block"
+    assert verdict.reason
+
+
+def test_sanitize_text_layer1() -> None:
+    result = sanitize_text(f"a{ZERO_WIDTH_SPACE}b")
+    assert result == TextResult(
+        cleaned="ab",
+        warnings=result.warnings,  # exact text owned by JS suite
+        modified=True,
+        sgr_note=False,
+    )
+    assert result.warnings
+
+
+def test_sanitize_text_clean_passthrough() -> None:
+    assert sanitize_text("hello") == TextResult(
+        cleaned="hello", warnings=[], modified=False, sgr_note=False
+    )
+
+
+def test_sanitize_text_html_layer() -> None:
+    assert "leak" not in sanitize_text(HIDDEN_HTML, html=True).cleaned
+
+
+def test_scan_and_clean_instruction_files(tmp_path: Path) -> None:
+    payload = f"intro {ZERO_WIDTH_SPACE * 100} outro\n"
+    (tmp_path / "NOTES.md").write_text(payload, encoding="utf-8")
+    (tmp_path / "CLEAN.md").write_text("nothing hidden here\n", encoding="utf-8")
+
+    findings = scan_instruction_files(["*.md"], cwd=str(tmp_path))
+    assert [f.file for f in findings] == ["NOTES.md"]
+    assert findings[0].findings  # non-empty hidden-Unicode hits
+
+    assert clean_file(str(tmp_path / "NOTES.md")) is True
+    assert clean_file(str(tmp_path / "NOTES.md")) is False  # already clean now
+    assert clean_file(str(tmp_path / "CLEAN.md")) is False
+    assert scan_instruction_files(["*.md"], cwd=str(tmp_path)) == []
+
+
+def test_sanitize_text_uses_shared_worker_for_html() -> None:
+    sanitize_text(HIDDEN_HTML, html=True)
+    assert ais._worker is not None and ais._worker.is_alive()

--- a/tests/test_python_client.py
+++ b/tests/test_python_client.py
@@ -55,6 +55,10 @@ def test_clean_text_passes_through_unchanged() -> None:
     assert result == SanitizeResult(cleaned="hello world", found=[], warnings=[])
 
 
+def test_empty_input() -> None:
+    assert sanitize("") == SanitizeResult(cleaned="", found=[], warnings=[])
+
+
 def test_html_flag_reaches_layer2() -> None:
     assert "leak" in sanitize(HIDDEN_HTML, html=False).cleaned  # Layer 1 only
     assert "leak" not in sanitize(HIDDEN_HTML, html=True).cleaned  # hidden removed
@@ -70,6 +74,22 @@ def test_html_amortizes_load_via_shared_worker() -> None:
     assert ais._worker is worker  # same process reused, not respawned
     assert "leak" not in first.cleaned
     assert second.cleaned == "ab"
+
+
+def test_shared_worker_self_heals_after_death() -> None:
+    # The riskiest path: a dead shared worker must be reaped and respawned, not
+    # left wedging every later persistent call on a corpse.
+    sanitize(HIDDEN_HTML, html=True)
+    dead = ais._worker
+    assert dead is not None
+    dead._proc.kill()
+    dead._proc.wait()
+    assert not dead.is_alive()
+
+    result = sanitize(f"a{ZERO_WIDTH_SPACE}b", html=True, persist=True)
+    assert ais._worker is not None and ais._worker.is_alive()
+    assert ais._worker is not dead  # a fresh process, not the corpse
+    assert result.cleaned == "ab"
 
 
 def test_layer1_default_stays_oneshot() -> None:


### PR DESCRIPTION
## Summary

- A large consumer runs a Python pipeline and would rather not repackage the JavaScript. This adds a way to drive the **exact same** sanitization from Python without a second implementation to keep in sync: the JS in `src/` stays the single source of truth, and non-JS callers reach it through a thin JSON CLI.
- The HTML layer's ~200 ms module-load is paid **once per process, not per call** — the Python client transparently amortizes it behind a warm worker.

## Changes

**CLI bridge (`bin/sanitize-cli.mjs`)** — wraps `sanitize()` and speaks JSON over stdin/stdout. One binary, two modes:
- one-shot (default): one JSON request in → one response line out; a malformed request (or empty stdin) exits non-zero with the reason on stderr (fails loudly).
- `--worker`: newline-delimited requests, one response line each, in order; a malformed request yields an `{ "error" }` line and the worker keeps serving so one bad request can't drop the pipe. JSON string-encodes newlines, so a request/response always occupies one line.
- Imports only Layer 1 eagerly; the heavy remark/rehype graph still lazy-loads only on `html: true`, preserving the existing fast path. Wired into `package.json` `bin` (`sanitize-cli`) and the `files` whitelist.
- **Scope:** the CLI bridges the data-in/data-out core (`sanitize`, Layers 1–3). The agent-pipeline entry points (`confusables`, `output`, `rehydrate`, …) take *injected* JS seams (homoglyph scanner, redactor, file access) so they have no language-agnostic wire form and stay JS-only by nature — documented as such in the README.

**Python client (`python/agent_input_sanitizer`)** — `sanitize(text, *, html=False, persist=None, node="node")` returning a `SanitizeResult(cleaned, found, warnings)` that mirrors the JS shape.
- `persist=None` (default) persists exactly when `html=True`: the first HTML call spins up a shared, process-wide worker and every later HTML call reuses it, so the ~200 ms load is paid once. Layer-1-only calls stay one-shot, leaving no process behind for callers that never touch HTML.
- `persist=True/False` forces either mode; `shutdown_worker()` (also an `atexit` hook) tears the worker down. `Sanitizer` context manager is available for callers who want to own the process lifetime.
- Worker hardening: lock-guarded for concurrent callers; **fork-safe** (records its spawning pid and refuses to share an inherited worker across `os.fork`); self-heals (reap + respawn) if it dies; routes stderr to a temp file rather than an undrained pipe (so a full stderr buffer can't deadlock the blocking read); kills a worker that ignores stdin-EOF instead of leaking it; and fails with a clear message if the bundled CLI is missing.
- No pure-Python fallback by design — a port *is* the drift this avoids; a missing Node raises a loud error rather than degrading. The client is repo-local (resolves the CLI relative to the source tree); making it `pip install`-able is a deliberate follow-up.

**Test-harness fix (`tests/test_claude_hooks.py`)** — pins `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` to `/dev/null` for the `session-setup.sh` subprocess so the GH_REPO-extraction fixtures exercise the regex against their literal URLs instead of URLs silently rewritten by the environment's global `url.<proxy>.insteadOf`.

Merged latest `main` (1.1.0 — agent-pipeline entry points); README/package.json conflicts resolved additively, full suite green against the merged tree.

## Testing

- `pnpm test` — **725 JS tests pass** on the merged tree. `test/cli.test.mjs` drives the CLI in both modes (in-process `sanitize` as the oracle), plus **transport-faithfulness fuzzing** (arbitrary text — lone surrogates, ANSI/ESC, U+2028/U+2029, NUL, invisibles — must round-trip equal to `sanitize()` in one-shot and batched worker mode), a >pipe-buffer large-input case, stay-alive-on-bad-input, empty-input, and empty-stdin contracts.
- `uv run --extra dev pytest tests/` — **77 pass** (was 1 failing pre-fix). `tests/test_python_client.py` covers Layer-1 stripping, the `html` flag reaching Layers 2/3, worker-vs-one-shot agreement, auto-amortization/reuse, **fork-not-shared**, worker self-heal, killed-worker loud failure, `_drain_stderr` read-back, missing-CLI message, `{error}`→exception mapping, the `persist` overrides, embedded-newline + empty input, idempotent shutdown, and loud-on-missing-Node.
- `pnpm lint` / `tsc --noEmit` / `ruff check` / `ruff format --check` clean.

## Lessons Learned

- **What**: Pin `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` to `os.devnull` in the subprocess env whenever a test invokes a script that runs `git remote get-url` (or otherwise reads remote URLs).
- **Where**: the `session-setup.sh` test harness (`tests/test_claude_hooks.py`, `run_session_setup`).
- **Why**: Proxy/web-session environments register a global `url.<proxy>.insteadOf = https://github.com/`, so `git remote get-url` rewrites a fixture's plain GitHub URL into the proxy form before the script sees it — making GH_REPO extraction appear to fire on a plain GitHub URL and failing the `github-https` case nondeterministically by environment. Hermetic git config makes the regex-under-test deterministic.
