### PR TITLE
fix(confusables): fold search-tool fields and fail loud on bad scanner offsets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Commits MUST use [Conventional Commits](https://www.conventionalcommits.org/) (`
 
 Before declaring any non-trivial coding task done, **iteratively critique and fix your own work until you reach a fixed point.** Read what you actually wrote (not what you intended to write) as if it came from a developer you cannot stand—assume it is wrong until proven otherwise.
 
-Each pass, hunt for: bugs, broken or missed edge cases, weakened/skipped/deleted tests, swallowed errors, dead code, unjustified abstractions, premature returns, broken invariants, sloppy naming, fragile assumptions, hidden coupling, scope creep beyond the request, comments that explain _what_ instead of *why*, anything that smells off. State each issue bluntly in one line, then fix it. Then re-review the fix—fixes introduce their own bugs.
+Each pass, hunt for: bugs, broken or missed edge cases, weakened/skipped/deleted tests, swallowed errors, dead code, unjustified abstractions, premature returns, broken invariants, sloppy naming, fragile assumptions, hidden coupling, scope creep beyond the request, comments that explain _what_ instead of _why_, anything that smells off. State each issue bluntly in one line, then fix it. Then re-review the fix—fixes introduce their own bugs.
 
 Stop only when a full pass turns up **nothing** worth changing. Cap at ~5 passes; if you’re still finding real issues at pass 5, say so and ask the user rather than silently giving up. Skip the loop for trivial edits (typo fixes, single-line config tweaks, pure questions)—say so explicitly when you skip.
 

--- a/src/confusables.mjs
+++ b/src/confusables.mjs
@@ -35,6 +35,9 @@ export const DEFAULT_FIELDS = {
   Read: ["file_path"],
   MultiEdit: ["file_path"],
   NotebookEdit: ["notebook_path"],
+  Grep: ["pattern", "path"],
+  Glob: ["pattern", "path"],
+  LS: ["path"],
 };
 
 /**
@@ -95,11 +98,21 @@ function describeFolds(findings) {
  */
 export function foldConfusables(text, findings) {
   let folded = text;
-  for (const finding of [...findings].sort((lhs, rhs) => rhs.index - lhs.index))
+  for (const finding of [...findings].sort(
+    (lhs, rhs) => rhs.index - lhs.index,
+  )) {
+    // Fail loud on a finding that does not match the actual bytes at its offset:
+    // a buggy/adversarial scanner reporting a wrong char/index would otherwise
+    // silently corrupt the path/command, defeating the deny-rule protection.
+    if (!folded.startsWith(finding.char, finding.index))
+      throw new Error(
+        `Confusable finding does not match input at index ${finding.index}: expected ${JSON.stringify(finding.char)}`,
+      );
     folded =
       folded.slice(0, finding.index) +
       finding.latinEquivalent +
       folded.slice(finding.index + finding.char.length);
+  }
   return folded;
 }
 

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -364,7 +364,7 @@ const mdParser = unified().use(remarkParse).use(remarkGfm);
  * @param {Array<{start: number, end: number, kind: "comment" | "hidden"}>} ranges
  */
 function collectCommentRanges(value, base, nodeEnd, ranges) {
-  for (let searchFrom = 0; ; ) {
+  for (let searchFrom = 0; ;) {
     const open = value.indexOf("<!--", searchFrom);
     if (open === -1) break;
     const close = value.indexOf("-->", open + 2);

--- a/test/confusables-property.test.mjs
+++ b/test/confusables-property.test.mjs
@@ -134,6 +134,32 @@ describe("foldConfusables (property)", () => {
       assert.equal(foldConfusables(once, scan(once).findings), once);
     });
   });
+
+  it("is a no-op on all-ASCII input (an honest scanner flags nothing)", () => {
+    const asciiText = fc
+      .array(fc.integer({ min: 0x20, max: 0x7e }), { maxLength: 60 })
+      .map((codes) => codes.map((c) => String.fromCharCode(c)).join(""));
+    check(asciiText, (t) => {
+      assert.equal(foldConfusables(t, scan(t).findings), t);
+    });
+  });
+
+  it("throws when a finding's char does not match the bytes at its index", () => {
+    // Build an honest finding, then corrupt its char so it no longer matches the
+    // input at the reported offset: the fail-loud guard must reject it anywhere.
+    const withConfusable = text.filter((t) => scan(t).findings.length > 0);
+    check(withConfusable, (t) => {
+      const findings = scan(t).findings;
+      const corrupted = findings.map((f) => ({
+        ...f,
+        char: `/${f.char}`, // prefix the char so startsWith(char, index) fails
+      }));
+      assert.throws(
+        () => foldConfusables(t, corrupted),
+        /does not match input at index/,
+      );
+    });
+  });
 });
 
 describe("normalizeConfusables (property)", () => {
@@ -164,7 +190,7 @@ describe("normalizeConfusables (property)", () => {
   it("ignores tools with no mapped field", () => {
     check(text, (value) =>
       assert.equal(
-        normalizeConfusables("Grep", { pattern: value }, { scan }),
+        normalizeConfusables("WebSearch", { query: value }, { scan }),
         null,
       ),
     );

--- a/test/confusables.test.mjs
+++ b/test/confusables.test.mjs
@@ -124,6 +124,27 @@ describe("foldConfusables", () => {
     ];
     assert.equal(foldConfusables(text, findings), "ao");
   });
+
+  it("throws when a finding's char does not match the bytes at its index", () => {
+    // Adversarial scanner: claims a 2-char glyph "аа" at index 1 of "/xyz".
+    // Splicing blindly would corrupt to "/Zz"; the guard must fail loud instead.
+    assert.throws(
+      () =>
+        foldConfusables("/xyz", [
+          { index: 1, char: `${CYR_A}${CYR_A}`, latinEquivalent: "Z" },
+        ]),
+      /does not match input at index 1/,
+    );
+  });
+
+  it("does not throw when a correct finding matches the bytes at its index", () => {
+    assert.equal(
+      foldConfusables(`/${CYR_A}`, [
+        { index: 1, char: CYR_A, latinEquivalent: "a" },
+      ]),
+      "/a",
+    );
+  });
 });
 
 // ─── normalizeConfusables: folding positive cases ────────────────────────────
@@ -179,20 +200,38 @@ describe("normalizeConfusables: folding", () => {
     });
   }
 
-  // Each handled tool folds its own path/command field — and only that one.
-  for (const [tool, field] of Object.entries(DEFAULT_FIELDS)) {
-    it(`folds the ${field[0]} field of ${tool}`, () => {
-      const key = field[0];
-      const result = normalizeConfusables(
-        tool,
-        { [key]: `/p${CYR_A}th` },
-        { scan },
-      );
-      assert.deepEqual(result, {
-        updatedInput: { [key]: "/path" },
-        normalized: [`${key} (U+0430 → "a")`],
-      });
+  // The read/search/list tools must be covered: a Cyrillic homoglyph in a
+  // Grep/Glob pattern is exactly the CVE-2025-54794 cross-script deny-rule
+  // bypass this module exists to close. Pin the required (tool → fields) set so
+  // dropping any of them from DEFAULT_FIELDS fails here, not silently.
+  for (const [tool, expectedFields] of [
+    ["Grep", ["pattern", "path"]],
+    ["Glob", ["pattern", "path"]],
+    ["Read", ["file_path"]],
+    ["LS", ["path"]],
+  ]) {
+    it(`covers ${tool} with fields ${expectedFields.join(", ")}`, () => {
+      assert.deepEqual(DEFAULT_FIELDS[tool], expectedFields);
     });
+  }
+
+  // SSOT-driven: every field of every tool in DEFAULT_FIELDS must be folded.
+  // Iterating per (tool, field) means adding a tool/field without a test is
+  // impossible — the loop generates a case for it automatically.
+  for (const [tool, fieldList] of Object.entries(DEFAULT_FIELDS)) {
+    for (const key of fieldList) {
+      it(`folds the ${key} field of ${tool}`, () => {
+        const result = normalizeConfusables(
+          tool,
+          { [key]: `/p${CYR_A}th` },
+          { scan },
+        );
+        assert.deepEqual(result, {
+          updatedInput: { [key]: "/path" },
+          normalized: [`${key} (U+0430 → "a")`],
+        });
+      });
+    }
   }
 
   it("names each fold (code point → ASCII) so a broken legit path is explainable", () => {


### PR DESCRIPTION
## What & why

Two fixes in `src/confusables.mjs`, found during a security audit of the package.

**1. `DEFAULT_FIELDS` omitted read/search tools (MED).** The shipped default folded confusables only in `Bash`/`Edit`/`Write`/`Read`/`MultiEdit`/`NotebookEdit`. A Cyrillic homoglyph in a `Grep` or `Glob` *pattern* — the exact CVE-2025-54794 cross-script deny-rule bypass this module exists to close — was never folded (`normalizeConfusables("Grep", {pattern: "rm -rf /а"}, {scan})` returned `null`). Added `Grep: ["pattern","path"]`, `Glob: ["pattern","path"]`, `LS: ["path"]`. Callers can still override `fields`.

**2. `foldConfusables` blindly trusted scanner-supplied offsets (LOW).** It spliced `slice(0,index) + latin + slice(index + char.length)` without verifying the text actually held `char` at `index`, so a buggy or adversarial injected scanner could silently corrupt path/command bytes. It now asserts `startsWith(char, index)` before each splice and throws a descriptive error on mismatch — fail-loud, matching the project's posture.

## How it was tested

- `node --test` 66 pass / 0 fail; `pnpm lint`, `pnpm check` (tsc), prettier all clean; c8 100% lines/branches/functions on `confusables.mjs`.
- Red→green confirmed by reverting each source hunk: dropping the `DEFAULT_FIELDS` additions reds 3 SSOT contract cases; removing the offset guard reds the unit + property tests.
- The per-`(tool, field)` folding test now iterates **every** field of every `DEFAULT_FIELDS` entry (was only `field[0]`), so adding a tool/field without coverage fails.

## Notes for the maintainer

Out of scope but worth a look: `lint-staged` in `package.json` matches `*.{js,jsx,ts,tsx}` but **not** `*.mjs`, so the source files (all `.mjs`) are never auto-formatted on commit — prettier only catches them via the `format` script / CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_014aAhQZu5pmhbvDFeK9mdqg)_