### PR TITLE
fix(html): detect more CSS hiding techniques in isHiddenStyle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Commits MUST use [Conventional Commits](https://www.conventionalcommits.org/) (`
 
 Before declaring any non-trivial coding task done, **iteratively critique and fix your own work until you reach a fixed point.** Read what you actually wrote (not what you intended to write) as if it came from a developer you cannot stand—assume it is wrong until proven otherwise.
 
-Each pass, hunt for: bugs, broken or missed edge cases, weakened/skipped/deleted tests, swallowed errors, dead code, unjustified abstractions, premature returns, broken invariants, sloppy naming, fragile assumptions, hidden coupling, scope creep beyond the request, comments that explain _what_ instead of *why*, anything that smells off. State each issue bluntly in one line, then fix it. Then re-review the fix—fixes introduce their own bugs.
+Each pass, hunt for: bugs, broken or missed edge cases, weakened/skipped/deleted tests, swallowed errors, dead code, unjustified abstractions, premature returns, broken invariants, sloppy naming, fragile assumptions, hidden coupling, scope creep beyond the request, comments that explain _what_ instead of _why_, anything that smells off. State each issue bluntly in one line, then fix it. Then re-review the fix—fixes introduce their own bugs.
 
 Stop only when a full pass turns up **nothing** worth changing. Cap at ~5 passes; if you’re still finding real issues at pass 5, say so and ask the user rather than silently giving up. Skip the loop for trivial edits (typo fixes, single-line config tweaks, pure questions)—say so explicitly when you skip.
 

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -45,15 +45,130 @@ export {
 
 // ─── Layer 2: hidden-content detection ───────────────────────────────────────
 
+// A length/opacity/size is "near zero" when its magnitude is below this — a
+// browser renders 0.0001px text or 0.001 opacity as effectively invisible, so
+// requiring an exact 0 lets a trivially-perturbed value slip through.
+const NEAR_ZERO_EPSILON = 0.01;
+
+/** @param {string} value @returns {boolean} */
+function isNearZeroLength(value) {
+  if (!value) return false;
+  const number = parseFloat(value);
+  return Number.isFinite(number) && Math.abs(number) < NEAR_ZERO_EPSILON;
+}
+
+// A negative offset is "offscreen" once it pushes content past the viewport
+// edge — but how far that is depends on the unit. An absolute unit (px and the
+// font/char units) needs a large magnitude (~-900px); a viewport/percent unit
+// pushes a full screen-width with a single-digit-ish magnitude (-50vw, -100%
+// clear the viewport), so it gets a small threshold. `calc(...)` and other
+// un-parseable offscreen-shaped values fail closed (treated as hidden).
+const OFFSCREEN_ABSOLUTE_THRESHOLD = -900;
+const OFFSCREEN_VIEWPORT_THRESHOLD = -50;
+const ABSOLUTE_UNIT_RE = /^-?\d*\.?\d+\s*(?:px|em|rem|ex|ch|pt|pc|in|cm|mm)?$/;
+const VIEWPORT_UNIT_RE = /^-?\d*\.?\d+\s*(?:vw|vh|vmin|vmax|%)$/;
+
+/** @param {string} value @returns {boolean} */
+function isOffscreenOffset(value) {
+  if (!value) return false;
+  if (ABSOLUTE_UNIT_RE.test(value))
+    return parseFloat(value) < OFFSCREEN_ABSOLUTE_THRESHOLD;
+  if (VIEWPORT_UNIT_RE.test(value))
+    return parseFloat(value) <= OFFSCREEN_VIEWPORT_THRESHOLD;
+  // `calc(-100vw)` / `calc(-9999px - 1em)` and other complex expressions: a
+  // unit-blind parseFloat can't resolve them, so fail closed when the value is
+  // shaped like an offscreen push (contains a large-ish negative number).
+  const calcMatch = value.match(/calc\([^)]*\)/);
+  if (calcMatch) return /-\s*\d/.test(calcMatch[0]);
+  return false;
+}
+
+/**
+ * A `transform` that renders text invisible: scaled to (near) nothing, rotated
+ * edge-on (a quarter turn around X or Y leaves a zero-area projection), or
+ * translated far off any viewport.
+ * @param {string} transform
+ * @returns {boolean}
+ */
+function isHidingTransform(transform) {
+  if (!transform) return false;
+  // scale()/matrix() with a (near-)zero factor.
+  const scale = transform.match(
+    /\b(?:scale|scale3d|scalex|scaley|matrix|matrix3d)\(\s*(-?\d*\.?\d+)/,
+  );
+  if (scale && Math.abs(parseFloat(scale[1])) < NEAR_ZERO_EPSILON) return true;
+  // rotateX/rotateY by an odd multiple of 90deg turns the box edge-on (zero
+  // projected area). Only the axis-specific rotations collapse to a line; a
+  // plain rotate()/rotateZ() spins in-plane and stays visible.
+  const rotate = transform.match(/\brotate[xy]\(\s*(-?\d*\.?\d+)deg/i);
+  if (rotate) {
+    const degrees = ((parseFloat(rotate[1]) % 360) + 360) % 360;
+    if (degrees === 90 || degrees === 270) return true;
+  }
+  // translateX/translateY/translate far off-screen.
+  for (const match of transform.matchAll(/\btranslate(?:[xy])?\(\s*([^,)]+)/gi))
+    if (isOffscreenOffset(match[1].trim())) return true;
+  return false;
+}
+
 /** @param {(key: string) => string} val */
 function isPositionedOffscreen(val) {
   if (!/\babsolute\b|\bfixed\b/.test(val("position"))) return false;
-  for (const side of ["left", "top", "right", "bottom"]) {
-    const value = val(side);
-    if (value && parseFloat(value) < -900) return true;
-  }
+  for (const side of ["left", "top", "right", "bottom"])
+    if (isOffscreenOffset(val(side))) return true;
   const clip = val("clip");
   return Boolean(clip && /rect\s*\(\s*0/.test(clip));
+}
+
+// CSS named colors that participate in a white-on-white / black-on-black style
+// of hiding. The full named-color set is unnecessary — only colors that
+// commonly back hidden text need a canonical form for the equality compare.
+/** @type {Record<string, string>} */
+const NAMED_COLORS = {
+  white: "#ffffff",
+  black: "#000000",
+  red: "#ff0000",
+  transparent: "transparent",
+};
+
+/**
+ * Canonicalize a CSS color to lowercase `#rrggbb` so `white`, `#FFF`,
+ * `#ffffff`, and `rgb(255, 255, 255)` all compare equal. Returns the trimmed
+ * lowercased input unchanged when it is not a form we recognize (so two
+ * identical unknown notations still compare equal, and a mismatch never
+ * falsely reads as same-color).
+ * @param {string} raw
+ * @returns {string}
+ */
+function canonicalizeColor(raw) {
+  const value = raw.trim().toLowerCase();
+  if (!value) return "";
+  if (value in NAMED_COLORS) return NAMED_COLORS[value];
+  const shortHex = value.match(/^#([0-9a-f])([0-9a-f])([0-9a-f])$/);
+  if (shortHex)
+    return `#${shortHex[1]}${shortHex[1]}${shortHex[2]}${shortHex[2]}${shortHex[3]}${shortHex[3]}`;
+  if (/^#[0-9a-f]{6}$/.test(value)) return value;
+  const rgb = value.match(
+    /^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*(?:,[^)]*)?\)$/,
+  );
+  if (rgb) {
+    /** @param {string} n */
+    const hex = (n) => Number(n).toString(16).padStart(2, "0");
+    return `#${hex(rgb[1])}${hex(rgb[2])}${hex(rgb[3])}`;
+  }
+  return value;
+}
+
+// The leading color token of a `background` shorthand (the first token that
+// canonicalizes to a real color), so `background:#fff url(x)` still compares.
+/** @param {string} shorthand @returns {string} */
+function backgroundColor(shorthand) {
+  for (const token of shorthand.split(/\s+/)) {
+    const color = canonicalizeColor(token);
+    if (color && (color.startsWith("#") || color === "transparent"))
+      return color;
+  }
+  return "";
 }
 
 /** @param {(key: string) => string} val */
@@ -101,52 +216,45 @@ export function isHiddenStyle(styleStr) {
   const val = (key) => (props[key] || "").toString().trim().toLowerCase();
 
   if (val("display") === "none") return true;
-  if (val("visibility") === "hidden") return true;
+  if (val("visibility") === "hidden" || val("visibility") === "collapse")
+    return true;
 
-  const opacity = parseFloat(val("opacity"));
-  if (val("opacity") !== "" && opacity === 0) return true;
+  const opacity = val("opacity");
+  if (opacity !== "" && Math.abs(parseFloat(opacity)) < NEAR_ZERO_EPSILON)
+    return true;
 
-  for (const dim of ["height", "width", "font-size"]) {
-    const value = val(dim);
-    if (value && parseFloat(value) === 0) return true;
-  }
+  for (const dim of ["height", "width", "font-size"])
+    if (isNearZeroLength(val(dim))) return true;
 
   if (isPositionedOffscreen(val)) return true;
 
-  const textIndent = val("text-indent");
-  if (textIndent && parseFloat(textIndent) < -900) return true;
+  if (isOffscreenOffset(val("text-indent"))) return true;
 
-  // Clipped or scaled to nothing: modern equivalents of the legacy
-  // `clip: rect(0…)` above. Only the clip shapes that collapse the box to
-  // nothing are flagged — the canonical "visually hidden" utilities
-  // (`inset(50%)`…`inset(100%)`, `circle(0)`) abused to hide injected text.
-  // Decorative clips (`circle(50%)`, partial `inset`s, polygon shapes) render
-  // visible content and are left alone. A zero scale collapses the box too.
+  // Clipped to nothing: the modern equivalent of the legacy `clip: rect(0…)`.
+  // `inset(50%)`…`inset(100%)` (including fractional `inset(99.9%)`) collapse
+  // the box, as does `circle(0)`. Decorative clips (`circle(50%)`, small
+  // `inset`s, polygons) render visible content and are left alone.
   const clipPath = val("clip-path");
   if (
     clipPath &&
-    /\b(?:inset\(\s{0,8}(?:[5-9][0-9]|100)%|circle\(\s{0,8}0(?![.\d]))/.test(
+    /\b(?:inset\(\s{0,8}(?:[5-9]\d(?:\.\d+)?|100)%|circle\(\s{0,8}0(?![.\d]))/.test(
       clipPath,
     )
   )
     return true;
-  const transform = val("transform");
-  if (
-    transform &&
-    /\b(?:scale|scale3d|scalex|scaley|matrix|matrix3d)\(\s{0,8}0(?![.\d])/.test(
-      transform,
-    )
-  )
-    return true;
+  if (isHidingTransform(val("transform"))) return true;
 
   // Same-color text on its background (white-on-white) and fully transparent
-  // text are invisible to a human but plain text to the model.
-  const color = val("color");
+  // text are invisible to a human but plain text to the model. Colors are
+  // canonicalized so `white`/`#fff`/`rgb(255,255,255)` mixes still compare.
+  const color = canonicalizeColor(val("color"));
   if (color === "transparent") return true;
-  const background = val("background-color") || val("background");
-  // The `background` guard also rejects the both-absent case: two empty values
-  // are equal, so without it an unstyled element would read as hidden.
-  if (background && color === background) return true;
+  const background =
+    canonicalizeColor(val("background-color")) ||
+    backgroundColor(val("background"));
+  // Require a real (non-empty) canonical color on both sides: two empty values
+  // are equal, so without this an unstyled element would read as hidden.
+  if (color && background && color === background) return true;
 
   return isOverflowHidden(val);
 }
@@ -364,7 +472,7 @@ const mdParser = unified().use(remarkParse).use(remarkGfm);
  * @param {Array<{start: number, end: number, kind: "comment" | "hidden"}>} ranges
  */
 function collectCommentRanges(value, base, nodeEnd, ranges) {
-  for (let searchFrom = 0; ; ) {
+  for (let searchFrom = 0; ;) {
     const open = value.indexOf("<!--", searchFrom);
     if (open === -1) break;
     const close = value.indexOf("-->", open + 2);

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -57,14 +57,16 @@ function isNearZeroLength(value) {
   return Number.isFinite(number) && Math.abs(number) < NEAR_ZERO_EPSILON;
 }
 
-// A negative offset is "offscreen" once it pushes content past the viewport
-// edge — but how far that is depends on the unit. An absolute unit (px and the
-// font/char units) needs a large magnitude (~-900px); a viewport/percent unit
-// pushes a full screen-width with a single-digit-ish magnitude (-50vw, -100%
-// clear the viewport), so it gets a small threshold. `calc(...)` and other
-// un-parseable offscreen-shaped values fail closed (treated as hidden).
+// A negative offset is "offscreen" only when it pushes the element ENTIRELY
+// past the viewport edge — the magnitude that takes depends on the unit. An
+// absolute unit (px and the font/char units) needs a large magnitude
+// (< -900px). A viewport/percent unit clears the screen only at a full
+// viewport-width: -100vw / -100% push a normal-width element fully out, but
+// -50vw / -50% leave roughly half of it on screen, so the threshold is a full
+// -100, not a partial shift. Flagging a partial shift would splice visible
+// text, so this errs toward false-negative.
 const OFFSCREEN_ABSOLUTE_THRESHOLD = -900;
-const OFFSCREEN_VIEWPORT_THRESHOLD = -50;
+const OFFSCREEN_VIEWPORT_THRESHOLD = -100;
 const ABSOLUTE_UNIT_RE = /^-?\d*\.?\d+\s*(?:px|em|rem|ex|ch|pt|pc|in|cm|mm)?$/;
 const VIEWPORT_UNIT_RE = /^-?\d*\.?\d+\s*(?:vw|vh|vmin|vmax|%)$/;
 
@@ -75,11 +77,11 @@ function isOffscreenOffset(value) {
     return parseFloat(value) < OFFSCREEN_ABSOLUTE_THRESHOLD;
   if (VIEWPORT_UNIT_RE.test(value))
     return parseFloat(value) <= OFFSCREEN_VIEWPORT_THRESHOLD;
-  // `calc(-100vw)` / `calc(-9999px - 1em)` and other complex expressions: a
-  // unit-blind parseFloat can't resolve them, so fail closed when the value is
-  // shaped like an offscreen push (contains a large-ish negative number).
-  const calcMatch = value.match(/calc\([^)]*\)/);
-  if (calcMatch) return /-\s*\d/.test(calcMatch[0]);
+  // `calc(...)` is deliberately NOT treated as offscreen. Resolving a calc
+  // needs the layout context (`calc(100% - 5px)` is an ordinary in-flow
+  // position), and a unit-blind "contains a negative number" guess flags those
+  // benign expressions — which would splice visible text. Ambiguity must fail
+  // OPEN (visible), so unresolved calc is left alone.
   return false;
 }
 

--- a/test/html-corpus.test.mjs
+++ b/test/html-corpus.test.mjs
@@ -48,12 +48,51 @@ const CORPUS = {
       input: hidden("overflow:hidden;max-width:0"),
     },
     { name: "font-size-zero", input: hidden("font-size:0") },
+    { name: "font-size-near-zero", input: hidden("font-size:0.0001px") },
     { name: "clip-path-inset", input: hidden("clip-path:inset(50%)") },
+    {
+      name: "clip-path-inset-fractional",
+      input: hidden("clip-path:inset(99.9%)"),
+    },
+    { name: "visibility-collapse", input: hidden("visibility:collapse") },
+    { name: "opacity-near-zero", input: hidden("opacity:0.001") },
     { name: "transform-scale-zero", input: hidden("transform:scale(0)") },
+    {
+      name: "transform-scale-near-zero",
+      input: hidden("transform:scale(0.0001)"),
+    },
+    {
+      name: "transform-rotatey-edge-on",
+      input: hidden("transform:rotateY(90deg)"),
+    },
+    {
+      name: "transform-rotatex-edge-on",
+      input: hidden("transform:rotateX(90deg)"),
+    },
+    {
+      name: "transform-translate-offscreen",
+      input: hidden("transform:translateX(-9999px)"),
+    },
+    {
+      name: "offscreen-left-vw",
+      input: hidden("position:absolute;left:-50vw"),
+    },
+    {
+      name: "offscreen-left-calc",
+      input: hidden("position:fixed;left:calc(-100vw)"),
+    },
     { name: "transparent-text", input: hidden("color:transparent") },
     {
       name: "white-on-white",
       input: hidden("color:white;background-color:white"),
+    },
+    {
+      name: "white-on-white-mixed-notation",
+      input: hidden("color:#FFFFFF;background-color:rgb(255, 255, 255)"),
+    },
+    {
+      name: "black-on-black-shorthand",
+      input: hidden("color:#000;background:rgb(0,0,0) url(x)"),
     },
     {
       name: "aria-hidden-span",

--- a/test/html-corpus.test.mjs
+++ b/test/html-corpus.test.mjs
@@ -75,11 +75,7 @@ const CORPUS = {
     },
     {
       name: "offscreen-left-vw",
-      input: hidden("position:absolute;left:-50vw"),
-    },
-    {
-      name: "offscreen-left-calc",
-      input: hidden("position:fixed;left:calc(-100vw)"),
+      input: hidden("position:absolute;left:-100vw"),
     },
     { name: "transparent-text", input: hidden("color:transparent") },
     {
@@ -315,6 +311,44 @@ const CORPUS = {
       input: "https://ok.example/the-" + "quick-".repeat(40) + "end",
     },
   ],
+  // Visible content that earlier over-eager hiding heuristics could splice. A
+  // false positive here DELETES legitimate text the model needed, so each row
+  // pins that the canary SURVIVES — the precision counterpart to `hidden`.
+  visible: [
+    {
+      name: "small-negative-left",
+      input: hidden("position:absolute;left:-5px"),
+    },
+    {
+      name: "half-shift-vw",
+      input: hidden("position:absolute;left:-50vw"),
+    },
+    {
+      name: "half-shift-percent",
+      input: hidden("position:absolute;left:-50%"),
+    },
+    {
+      name: "in-flow-calc-left",
+      input: hidden("position:absolute;left:calc(100% - 5px)"),
+    },
+    {
+      name: "negative-viewport-calc",
+      input: hidden("position:fixed;left:calc(-100vw)"),
+    },
+    { name: "hanging-text-indent", input: hidden("text-indent:-0.5em") },
+    { name: "dim-opacity", input: hidden("opacity:0.15") },
+    { name: "small-font", input: hidden("font-size:11px") },
+    { name: "mild-scale", input: hidden("transform:scale(0.8)") },
+    { name: "near-edge-rotate", input: hidden("transform:rotateY(89deg)") },
+    { name: "in-plane-rotate", input: hidden("transform:rotate(90deg)") },
+    { name: "partial-clip-inset", input: hidden("clip-path:inset(10%)") },
+    { name: "color-without-bg", input: hidden("color:white") },
+    {
+      name: "near-white-mismatch",
+      input: hidden("color:white;background:#fefefe"),
+    },
+    { name: "distinct-grays", input: hidden("color:#777;background:#888") },
+  ],
 };
 
 describe("corpus: hidden content never survives sanitizeHtml", () => {
@@ -322,6 +356,15 @@ describe("corpus: hidden content never survives sanitizeHtml", () => {
     it(`removes ${name}`, () => {
       const out = sanitizeHtml(input)?.text ?? input;
       assert.equal(out.includes(CANARY), false, `survived: ${name}`);
+    });
+  }
+});
+
+describe("corpus: visible content is never spliced (precision)", () => {
+  for (const { name, input } of CORPUS.visible) {
+    it(`keeps ${name}`, () => {
+      const out = sanitizeHtml(input)?.text ?? input;
+      assert.equal(out.includes(CANARY), true, `spliced visible: ${name}`);
     });
   }
 });

--- a/test/html-property.test.mjs
+++ b/test/html-property.test.mjs
@@ -165,6 +165,50 @@ describe("property: hidden-style variants flagged by isHiddenStyle", () => {
   }
 });
 
+// Ordinary visible declarations a real page emits. isHiddenStyle splices the
+// element's content out of the model's view, so flagging any of these would
+// DELETE legitimate text — a curated allowlist pins that none ever reads as
+// hidden, even wrapped in the same whitespace/!important/case noise the
+// positive fuzz uses.
+const visibleDeclaration = fc.constantFrom(
+  "opacity: 0.15",
+  "opacity: 0.5",
+  "opacity: 1",
+  "font-size: 11px",
+  "font-size: 0.9em",
+  "font-size: 14px",
+  "transform: scale(0.8)",
+  "transform: rotateY(45deg)",
+  "transform: rotateY(89deg)",
+  "transform: rotate(90deg)",
+  "transform: translateX(-5px)",
+  "position: absolute; left: -5px",
+  "position: absolute; top: -1px",
+  "position: absolute; left: -50vw",
+  "position: absolute; left: -50%",
+  "position: absolute; left: -10%",
+  "position: absolute; left: calc(100% - 5px)",
+  "margin-left: -2em",
+  "text-indent: -0.5em",
+  "clip-path: inset(10%)",
+  "clip-path: circle(50%)",
+  "color: white",
+  "color: white; background: #fefefe",
+  "color: #777; background: #888",
+  "color: red",
+);
+
+describe("property: ordinary visible styles are never flagged hidden", () => {
+  it("no curated visible declaration reads as hidden under noise", () =>
+    checkProperty(wrapWithNoise(visibleDeclaration), (styleString) =>
+      assert.equal(
+        isHiddenStyle(styleString),
+        false,
+        `false positive: ${JSON.stringify(styleString)}`,
+      ),
+    ));
+});
+
 describe("property: isHiddenStyle never throws on arbitrary input", () => {
   it("returns a boolean for any string", () =>
     checkProperty(fc.string(), (styleString) => {

--- a/test/html-property.test.mjs
+++ b/test/html-property.test.mjs
@@ -165,6 +165,38 @@ describe("property: hidden-style variants flagged by isHiddenStyle", () => {
   }
 });
 
+describe("property: isHiddenStyle never throws on arbitrary input", () => {
+  it("returns a boolean for any string", () =>
+    checkProperty(fc.string(), (styleString) => {
+      assert.equal(typeof isHiddenStyle(styleString), "boolean");
+    }));
+  it("returns a boolean for plausibly-CSS strings", () => {
+    const cssLike = fc
+      .array(
+        fc
+          .tuple(
+            fc.constantFrom(
+              "color",
+              "opacity",
+              "transform",
+              "clip-path",
+              "left",
+              "font-size",
+              "background",
+              "visibility",
+            ),
+            fc.string({ maxLength: 20 }),
+          )
+          .map(([prop, value]) => `${prop}:${value}`),
+        { maxLength: 5 },
+      )
+      .map((decls) => decls.join(";"));
+    checkProperty(cssLike, (styleString) => {
+      assert.equal(typeof isHiddenStyle(styleString), "boolean");
+    });
+  });
+});
+
 // ─── 3. URL exfil monotonicity ───────────────────────────────────────────────
 
 const base64Char = fc.constantFrom(

--- a/test/html.test.mjs
+++ b/test/html.test.mjs
@@ -43,6 +43,7 @@ const HIDDEN_STYLE_CASES = [
   ["opacity:0", true],
   ["opacity:0.001", true], // near-zero (bug: only ===0 caught)
   ["opacity:0.009", true],
+  ["opacity:0.15", false], // dim but readable — epsilon must stay tight
   ["opacity:0.5", false],
   ["opacity:1", false],
   ["opacity:5", false],
@@ -53,6 +54,8 @@ const HIDDEN_STYLE_CASES = [
   ["font-size:0.0001px", true], // sub-epsilon (bug: required exact 0)
   ["font-size:0.005em", true],
   ["height:5px", false],
+  ["font-size:11px", false],
+  ["font-size:0.9em", false], // ordinary relative size
   ["font-size:14px", false],
   // ── positioned offscreen, any unit ──
   ["position:absolute;left:-9999px", true],
@@ -60,14 +63,20 @@ const HIDDEN_STYLE_CASES = [
   ["position:fixed;right:-9999px", true],
   ["position:absolute;bottom:-9999px", true],
   ["position:absolute;left:-901px", true],
-  ["position:absolute;left:-50vw", true], // viewport unit (bug: px-only)
+  ["position:absolute;left:-100vw", true], // a full viewport-width fully clears the screen
   ["position:absolute;left:-100%", true],
-  ["position:fixed;left:calc(-100vw)", true], // calc offscreen (bug: not parsed)
   ["clip:rect(0,0,0,0);position:absolute", true],
   ["position:absolute;left:10px", false],
   ["position:absolute;left:-900px", false],
   ["position:absolute;left:-10px", false],
+  ["position:absolute;left:-5px", false], // small negative is ordinary layout
   ["position:absolute;left:-5vw", false],
+  ["position:absolute;left:-50vw", false], // half-shift leaves it on screen (precision: was over-flagged)
+  ["position:absolute;left:-50%", false], // half-shift leaves it on screen
+  ["position:absolute;left:-10%", false],
+  ["position:absolute;top:-1px", false],
+  ["position:absolute;left:calc(-100vw)", false], // unresolvable calc fails open (precision)
+  ["position:absolute;left:calc(100% - 5px)", false], // ordinary in-flow calc must not splice
   ["position:static;left:-9999px", false],
   ["position:absolute;left:auto", false], // non-length offset is not offscreen
   ["position:absolute;clip:rect(1,1,1,1)", false],
@@ -75,6 +84,8 @@ const HIDDEN_STYLE_CASES = [
   ["text-indent:-9999px", true],
   ["text-indent:-100vw", true],
   ["text-indent:-900px", false],
+  ["text-indent:-0.5em", false], // ordinary hanging indent is not offscreen
+  ["text-indent:calc(2em - 1px)", false], // calc indent fails open
   // ── overflow + zero box ──
   ["overflow:hidden;max-width:0", true],
   ["overflow:hidden;max-height:0", true],
@@ -87,6 +98,7 @@ const HIDDEN_STYLE_CASES = [
   ["clip-path:circle(0)", true],
   ["clip-path:none", false],
   ["clip-path:circle(50%)", false],
+  ["clip-path:inset(10%)", false], // partial inset still shows content
   ["clip-path:inset(10px)", false],
   // ── transform: scale / rotate edge-on / translate offscreen ──
   ["transform:scale(0)", true],
@@ -98,12 +110,15 @@ const HIDDEN_STYLE_CASES = [
   ["transform:rotateY(-90deg)", true],
   ["transform:rotateX(270deg)", true],
   ["transform:translateX(-9999px)", true], // offscreen via transform (bug: position-only)
-  ["transform:translatex(-50vw)", true],
+  ["transform:translatex(-100vw)", true], // a full viewport-width clears the screen
+  ["transform:translatex(-50vw)", false], // half-shift stays partly visible (precision)
   ["transform:scale(0.5)", false],
+  ["transform:scale(0.8)", false], // mild shrink stays readable
   ["transform:translatex(5px)", false],
-  ["transform:rotate(90deg)", false], // in-plane spin stays visible
+  ["transform:rotate(90deg)", false], // 2D in-plane spin stays visible
   ["transform:rotateZ(90deg)", false],
   ["transform:rotateY(45deg)", false],
+  ["transform:rotateY(89deg)", false], // near-edge-on but still projects area
   // ── same-color text/background across notations ──
   ["color:transparent", true],
   ["color:white;background-color:white", true],
@@ -114,6 +129,9 @@ const HIDDEN_STYLE_CASES = [
   ["color:#000;background:rgb(0,0,0)", true], // black on black
   ["color:white;background:#fff url(x) no-repeat", true], // background shorthand carries the color
   ["color:red", false],
+  ["color:white", false], // color alone, no background — never infer the page bg
+  ["color:white;background:#fefefe", false], // near-white but not equal
+  ["color:#777;background:#888", false], // distinct grays
   ["color:white;background-color:black", false],
   ["background-color:white", false], // color absent — not same-color
   ["color:rgb(0,0,0);background:rgb(255,255,255)", false],

--- a/test/html.test.mjs
+++ b/test/html.test.mjs
@@ -26,66 +26,106 @@ import {
 
 const applyHtml = (text) => sanitizeHtml(text)?.text ?? text;
 
+// SSOT for the hidden-style unit cases: one row per hiding technique (and per
+// near-boundary visible counter-example). Driving the loop from this array
+// means adding a technique without a row fails to register a case. Each
+// `expectedHidden` is the exact verdict for that `style`.
+const HIDDEN_STYLE_CASES = [
+  // ── display / visibility ──
+  ["display:none", true],
+  ["DISPLAY:NONE", true],
+  ["display:none !important", true],
+  ["display:block", false],
+  ["visibility:hidden", true],
+  ["visibility:collapse", true], // collapse hides like hidden (bug: only hidden checked)
+  ["visibility:visible", false],
+  // ── opacity (epsilon, not exact 0) ──
+  ["opacity:0", true],
+  ["opacity:0.001", true], // near-zero (bug: only ===0 caught)
+  ["opacity:0.009", true],
+  ["opacity:0.5", false],
+  ["opacity:1", false],
+  ["opacity:5", false],
+  // ── zero / near-zero size (epsilon) ──
+  ["height:0", true],
+  ["width:0", true],
+  ["font-size:0", true],
+  ["font-size:0.0001px", true], // sub-epsilon (bug: required exact 0)
+  ["font-size:0.005em", true],
+  ["height:5px", false],
+  ["font-size:14px", false],
+  // ── positioned offscreen, any unit ──
+  ["position:absolute;left:-9999px", true],
+  ["position:fixed;top:-10000px", true],
+  ["position:fixed;right:-9999px", true],
+  ["position:absolute;bottom:-9999px", true],
+  ["position:absolute;left:-901px", true],
+  ["position:absolute;left:-50vw", true], // viewport unit (bug: px-only)
+  ["position:absolute;left:-100%", true],
+  ["position:fixed;left:calc(-100vw)", true], // calc offscreen (bug: not parsed)
+  ["clip:rect(0,0,0,0);position:absolute", true],
+  ["position:absolute;left:10px", false],
+  ["position:absolute;left:-900px", false],
+  ["position:absolute;left:-10px", false],
+  ["position:absolute;left:-5vw", false],
+  ["position:static;left:-9999px", false],
+  ["position:absolute;left:auto", false], // non-length offset is not offscreen
+  ["position:absolute;clip:rect(1,1,1,1)", false],
+  // ── text-indent offscreen ──
+  ["text-indent:-9999px", true],
+  ["text-indent:-100vw", true],
+  ["text-indent:-900px", false],
+  // ── overflow + zero box ──
+  ["overflow:hidden;max-width:0", true],
+  ["overflow:hidden;max-height:0", true],
+  ["overflow:visible;max-width:0", false],
+  ["overflow:hidden;max-width:5px", false],
+  // ── clip-path (fractional percentages) ──
+  ["clip-path:inset(50%)", true],
+  ["clip-path:inset(100%)", true],
+  ["clip-path:inset(99.9%)", true], // fractional (bug: regex missed it)
+  ["clip-path:circle(0)", true],
+  ["clip-path:none", false],
+  ["clip-path:circle(50%)", false],
+  ["clip-path:inset(10px)", false],
+  // ── transform: scale / rotate edge-on / translate offscreen ──
+  ["transform:scale(0)", true],
+  ["transform:scale( 0)", true],
+  ["transform:scale(0.0001)", true], // near-zero scale (bug: exact 0 only)
+  ["transform:matrix(0,0,0,0,0,0)", true],
+  ["transform:rotateY(90deg)", true], // edge-on (bug: not detected)
+  ["transform:rotateX(90deg)", true],
+  ["transform:rotateY(-90deg)", true],
+  ["transform:rotateX(270deg)", true],
+  ["transform:translateX(-9999px)", true], // offscreen via transform (bug: position-only)
+  ["transform:translatex(-50vw)", true],
+  ["transform:scale(0.5)", false],
+  ["transform:translatex(5px)", false],
+  ["transform:rotate(90deg)", false], // in-plane spin stays visible
+  ["transform:rotateZ(90deg)", false],
+  ["transform:rotateY(45deg)", false],
+  // ── same-color text/background across notations ──
+  ["color:transparent", true],
+  ["color:white;background-color:white", true],
+  ["color:#fff;background:#fff", true],
+  ["color:#FFFFFF;background-color:white", true], // hex vs named (bug: notation mismatch)
+  ["color:rgb(255,255,255);background:white", true], // rgb vs named
+  ["color:white;background-color:rgb(255, 255, 255)", true],
+  ["color:#000;background:rgb(0,0,0)", true], // black on black
+  ["color:white;background:#fff url(x) no-repeat", true], // background shorthand carries the color
+  ["color:red", false],
+  ["color:white;background-color:black", false],
+  ["background-color:white", false], // color absent — not same-color
+  ["color:rgb(0,0,0);background:rgb(255,255,255)", false],
+  // ── degenerate / invalid input ──
+  ["", false],
+  ["a{b:c}", false],
+];
+
 describe("unit: isHiddenStyle exact verdicts", () => {
-  const HIDDEN = [
-    "display:none",
-    "DISPLAY:NONE",
-    "display:none !important",
-    "visibility:hidden",
-    "opacity:0",
-    "height:0",
-    "width:0",
-    "font-size:0",
-    "position:absolute;left:-9999px",
-    "position:fixed;top:-10000px",
-    "position:fixed;right:-9999px",
-    "position:absolute;bottom:-9999px",
-    "position:absolute;left:-901px",
-    "clip:rect(0,0,0,0);position:absolute",
-    "text-indent:-9999px",
-    "overflow:hidden;max-width:0",
-    "overflow:hidden;max-height:0",
-    "clip-path:inset(50%)",
-    "clip-path:inset(100%)",
-    "clip-path:circle(0)",
-    "transform:scale(0)",
-    "transform:scale( 0)",
-    "transform:matrix(0,0,0,0,0,0)",
-    "color:transparent",
-    "color:white;background-color:white",
-    "color:#fff;background:#fff",
-  ];
-  const VISIBLE = [
-    "display:block",
-    "visibility:visible",
-    "opacity:0.5",
-    "opacity:1",
-    "opacity:5",
-    "height:5px",
-    "position:absolute;left:10px",
-    "position:absolute;left:-900px",
-    "position:static;left:-9999px",
-    "position:absolute;clip:rect(1,1,1,1)",
-    "text-indent:-900px",
-    "overflow:visible;max-width:0",
-    "overflow:hidden;max-width:5px",
-    "color:red",
-    "clip-path:none",
-    "clip-path:circle(50%)",
-    "clip-path:inset(10px)",
-    "transform:scale(0.5)",
-    "transform:translatex(5px)",
-    "color:white;background-color:black",
-    "background-color:white",
-    "",
-    "a{b:c}",
-  ];
-  for (const style of HIDDEN)
-    it(`flags ${JSON.stringify(style)}`, () =>
-      assert.equal(isHiddenStyle(style), true));
-  for (const style of VISIBLE)
-    it(`leaves ${JSON.stringify(style)}`, () =>
-      assert.equal(isHiddenStyle(style), false));
+  for (const [style, expectedHidden] of HIDDEN_STYLE_CASES)
+    it(`${expectedHidden ? "flags" : "leaves"} ${JSON.stringify(style)}`, () =>
+      assert.equal(isHiddenStyle(style), expectedHidden));
 });
 
 describe("unit: isHiddenElement exact verdicts", () => {


### PR DESCRIPTION
## What & why

`isHiddenStyle` (Layer 2) decides whether an inline style renders an element invisible to a human, so its content gets spliced out before the model reads it. An audit found many browser-invisible techniques it classified as *visible*, letting hidden instructions through. All verified to return "visible" before this change:

- `transform:rotateX/rotateY(90deg)` (edge-on), `transform:scale(0.0001)`, `transform:translateX(-9999px)` (offscreen via transform — only `position` offsets were checked)
- `font-size:0.0001px` and other sub-epsilon sizes (only exact `0` caught)
- `opacity:0.001` (only `=== 0`)
- `clip-path:inset(99.9%)` (regex only matched `[5-9][0-9]|100`)
- `visibility:collapse` (only `hidden`)
- white-on-white across notations: `color:white;background:#fff`, `#FFFFFF`/`white`, `rgb(255,255,255)` (raw-string compare missed these)
- offscreen offsets in viewport/percent units (the `-900` threshold assumed px)

## What changed

Extended `isHiddenStyle` with small, named helpers: color canonicalization (named/hex/rgb → canonical, both colors required and never inferred) before the white-on-white compare and `background`-shorthand handling; a near-zero numeric check with a tight epsilon; offscreen-in-any-unit. Existing genuinely-visible cases still pass.

## Precision pass (high-precision, no false positives)

Because a `true` from `isHiddenStyle` **deletes the element's content from the model's view**, a false positive is a real harm. A second pass audited and tightened every new rule toward false-negatives on ambiguity:

- **`calc(...)` now fails open (visible).** The first cut flagged any `calc()` with a negative-looking term, so `position:absolute;left:calc(100% - 5px)` (ordinary in-flow) was spliced. Resolving a `calc` needs layout context, so it is no longer treated as offscreen at all.
- **Viewport/percent threshold tightened `-50` → `-100`.** `left:-50vw`/`-50%` leave ~half the element on screen; only a full viewport-width (`-100vw`/`-100%`) clears it.
- Confirmed-already-precise rules got regression guards rather than code changes: small absolute negatives (`-5px`, `-0.5em`, `-1px`), epsilon (`opacity:0.15/0.5`, `font-size:11px/0.9em`, `scale(0.8)`), rotate (`rotateY(45/89deg)`, 2D `rotate(90deg)`), white-on-white (`color:white` alone, `white`/`#fefefe`, `#777`/`#888`), `clip-path:inset(10%)`.

**Deliberate false-negatives (precision wins):** a negative `calc()` offset and a `-50vw`/`-50%` half-shift are no longer treated as hidden. Genuine full-viewport offscreen (`-100vw`) and large absolute offsets (`-9999px`) still assert removal.

## How it was tested

- `node --test` (3 files) 321 pass / 0 fail; full `pnpm test` **915 pass**; `pnpm lint`, `pnpm check` clean; c8 **100%** on `src/html.mjs`.
- Red→green: the original 34 technique cases red on unfixed source; the 6 new precision cases (`-50vw`, `-50%`, `calc(-100vw)`, `calc(100% - 5px)`, `calc(2em - 1px)`, `translateX(-50vw)`) fail on the pre-precision source for over-flagging visible content, pass after.
- Hidden-style cases driven from a `HIDDEN_STYLE_CASES` SSOT (positives + near-boundary visible counter-examples), a new `CORPUS.visible` survival section, and a fast-check property over 25 ordinary visible declarations (500 runs) that never read as hidden.

## Note

A sibling PR (`fix(html): bogus-comment + EXFIL value-gating`) also edits `src/html.mjs` in a different region (comment/exfil, not `isHiddenStyle`); a small merge-time conflict is expected.