### PR TITLE
fix(cli): harden worker framing, size limits, and error surfaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Commits MUST use [Conventional Commits](https://www.conventionalcommits.org/) (`
 
 Before declaring any non-trivial coding task done, **iteratively critique and fix your own work until you reach a fixed point.** Read what you actually wrote (not what you intended to write) as if it came from a developer you cannot stand—assume it is wrong until proven otherwise.
 
-Each pass, hunt for: bugs, broken or missed edge cases, weakened/skipped/deleted tests, swallowed errors, dead code, unjustified abstractions, premature returns, broken invariants, sloppy naming, fragile assumptions, hidden coupling, scope creep beyond the request, comments that explain _what_ instead of *why*, anything that smells off. State each issue bluntly in one line, then fix it. Then re-review the fix—fixes introduce their own bugs.
+Each pass, hunt for: bugs, broken or missed edge cases, weakened/skipped/deleted tests, swallowed errors, dead code, unjustified abstractions, premature returns, broken invariants, sloppy naming, fragile assumptions, hidden coupling, scope creep beyond the request, comments that explain _what_ instead of _why_, anything that smells off. State each issue bluntly in one line, then fix it. Then re-review the fix—fixes introduce their own bugs.
 
 Stop only when a full pass turns up **nothing** worth changing. Cap at ~5 passes; if you’re still finding real issues at pass 5, say so and ask the user rather than silently giving up. Skip the loop for trivial edits (typo fixes, single-line config tweaks, pure questions)—say so explicitly when you skip.
 

--- a/bin/sanitize-cli.mjs
+++ b/bin/sanitize-cli.mjs
@@ -27,16 +27,58 @@
  *     on stderr — so a scripted caller fails loudly.
  *
  *   worker (`--worker`): read newline-delimited JSON requests until EOF, write
- *     one response line per request, in order. A malformed request yields an
- *     `{ "error" }` line and the worker keeps serving — the specific, necessary
- *     recovery that makes a long-lived process usable across independent
- *     requests (one bad line must not drop the whole pipe). JSON string-encodes
- *     every newline, so one request and one response always occupy one line each.
+ *     EXACTLY one response line per input line, in order — including for a blank
+ *     line (a framing slip on the caller's side), which gets an `{ "error" }`
+ *     line rather than being silently skipped. Skipping a line desyncs every
+ *     later response against a client that reads one response per request. A
+ *     malformed request likewise yields an `{ "error" }` line and the worker
+ *     keeps serving — the specific, necessary recovery that makes a long-lived
+ *     process usable across independent requests (one bad line must not drop the
+ *     whole pipe). JSON string-encodes every newline, so one request and one
+ *     response always occupy one line each.
+ *
+ * Input-size cap: both modes reject a single request larger than
+ * `AGENT_SANITIZER_MAX_INPUT_BYTES` (UTF-8 bytes, default 10 MiB) with a
+ * structured error rather than buffering an unbounded payload into memory —
+ * one-shot exits non-zero, the worker emits an `{ "error" }` line and keeps
+ * serving. Raise or lower the limit via that environment variable.
  */
+import { Buffer } from "node:buffer";
 import process from "node:process";
 import readline from "node:readline";
 
 import { sanitize } from "../src/index.mjs";
+
+/** Largest single request accepted, in UTF-8 bytes. Caps memory per request so
+ * a hostile or runaway caller can't OOM the process; override via the env var. */
+const DEFAULT_MAX_INPUT_BYTES = 10 * 1024 * 1024;
+
+/** Resolve the configured input cap, falling back to the default for an unset,
+ * empty, non-numeric, or non-positive value. */
+function maxInputBytes() {
+  const raw = process.env.AGENT_SANITIZER_MAX_INPUT_BYTES;
+  const parsed = Number(raw);
+  if (
+    raw === undefined ||
+    raw === "" ||
+    !Number.isFinite(parsed) ||
+    parsed <= 0
+  )
+    return DEFAULT_MAX_INPUT_BYTES;
+  return Math.floor(parsed);
+}
+
+/** Throw if `text` exceeds the configured byte cap. The message names the limit
+ * and the env var so a caller can act on it. */
+function enforceSizeLimit(text) {
+  const limit = maxInputBytes();
+  const size = Buffer.byteLength(text, "utf8");
+  if (size > limit)
+    throw new Error(
+      `request too large: ${size} bytes exceeds the ${limit}-byte limit ` +
+        "(raise AGENT_SANITIZER_MAX_INPUT_BYTES to accept it)",
+    );
+}
 
 /** @param {Record<string, unknown>} req @param {string} key */
 function requireString(req, key) {
@@ -103,6 +145,7 @@ const OPS = {
  * @returns {Promise<string>} a single-line JSON response
  */
 async function handle(payload) {
+  enforceSizeLimit(payload);
   const request = JSON.parse(payload);
   const op = request.op ?? "sanitize";
   const run = Object.prototype.hasOwnProperty.call(OPS, op) ? OPS[op] : null;
@@ -110,11 +153,23 @@ async function handle(payload) {
   return JSON.stringify(await run(request));
 }
 
-/** @param {NodeJS.ReadableStream} stream */
+/** Read the whole stream as UTF-8, aborting as soon as the accumulated bytes
+ * exceed the cap so a hostile one-shot caller can't force unbounded buffering.
+ * @param {NodeJS.ReadableStream} stream */
 async function readAll(stream) {
   stream.setEncoding("utf8");
+  const limit = maxInputBytes();
   let text = "";
-  for await (const chunk of stream) text += chunk;
+  let bytes = 0;
+  for await (const chunk of stream) {
+    bytes += Buffer.byteLength(chunk, "utf8");
+    if (bytes > limit)
+      throw new Error(
+        `request too large: input exceeds the ${limit}-byte limit ` +
+          "(raise AGENT_SANITIZER_MAX_INPUT_BYTES to accept it)",
+      );
+    text += chunk;
+  }
   return text;
 }
 
@@ -127,8 +182,14 @@ async function runWorker() {
   // leave in request order. The try/catch is the worker's whole reason to
   // exist: a single malformed request reports an error and the loop continues
   // rather than tearing down a pipe other requests are still using.
+  //
+  // EXACTLY one response line per input line — including a blank/whitespace line
+  // (`handle` lets `JSON.parse` reject it into an `{ error }` line). Skipping it
+  // would emit zero responses for one input line and desync a client that reads
+  // one response per request. `response` never contains a newline: `handle`
+  // returns single-line `JSON.stringify` output, and the error branch
+  // stringifies a one-key object, so the one-line-per-request framing holds.
   for await (const line of rl) {
-    if (line.trim() === "") continue;
     let response;
     try {
       response = await handle(line);
@@ -140,9 +201,19 @@ async function runWorker() {
 }
 
 async function runOneShot() {
-  // No try/catch: a bad request or a (contract-impossible) `sanitize` throw
-  // propagates to a non-zero exit with the stack on stderr — fail loudly.
-  const response = await handle(await readAll(process.stdin));
+  // Fail loudly but cleanly: a bad request (or a contract-impossible `sanitize`
+  // throw) exits non-zero with a one-line reason on stderr — not a raw Node
+  // stack, which leaks internals and is noise for a scripted caller. The
+  // message carries the sanitizer-CLI prefix so a wrapping client can attribute
+  // the failure to this bridge.
+  let response;
+  try {
+    response = await handle(await readAll(process.stdin));
+  } catch (err) {
+    process.stderr.write(`sanitize CLI: ${err?.message ?? String(err)}\n`);
+    process.exitCode = 1;
+    return;
+  }
   process.stdout.write(`${response}\n`);
 }
 

--- a/python/agent_input_sanitizer/__init__.py
+++ b/python/agent_input_sanitizer/__init__.py
@@ -23,11 +23,17 @@ Entry points:
 * :class:`Sanitizer` — an explicitly-scoped long-lived worker (context manager).
 * :func:`shutdown_worker` — tear down the shared worker eagerly (it is also torn
   down at interpreter exit).
+
+The CLI caps a single request at ``AGENT_SANITIZER_MAX_INPUT_BYTES`` UTF-8 bytes
+(default 10 MiB); a larger request fails with a clear error instead of buffering
+an unbounded payload. Set that environment variable in the calling process to
+raise or lower the limit.
 """
 
 import atexit
 import json
 import os
+import signal
 import subprocess
 import tempfile
 import threading
@@ -125,6 +131,23 @@ def _check(response: dict) -> dict:
     return response
 
 
+def _parse_cli_json(output: str) -> dict:
+    """Parse one line of CLI stdout as JSON, wrapping a non-JSON line in a clear
+    error that names the offending output and that it came from the sanitizer CLI.
+
+    Without this, a Node crash or a stray ``console.log`` in the CLI surfaces as
+    a bare ``json.decoder.JSONDecodeError`` with no hint of where the bad bytes
+    came from.
+    """
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError as cause:
+        raise RuntimeError(
+            "sanitize CLI returned non-JSON output (expected one JSON object): "
+            f"{output.strip()!r}"
+        ) from cause
+
+
 def _oneshot(request: dict, node: str) -> dict:
     """One request through a fresh CLI subprocess; returns the response payload."""
     _require_cli()
@@ -142,7 +165,7 @@ def _oneshot(request: dict, node: str) -> dict:
         raise RuntimeError(
             f"sanitize CLI failed (exit {proc.returncode}): {proc.stderr.strip()}"
         )
-    return _check(json.loads(proc.stdout))
+    return _check(_parse_cli_json(proc.stdout))
 
 
 def _dispatch(request: dict, *, persist: bool, node: str) -> dict:
@@ -246,6 +269,12 @@ class Sanitizer:
                 result = s.sanitize(page, html=True)
     """
 
+    # Bound on a single response read. The CLI emits exactly one line per input
+    # line, so a read that never completes means the worker wedged (a CLI bug, or
+    # a process killed/hung mid-response); surfacing it as a timeout beats a
+    # caller hanging forever on an unbounded ``readline``.
+    _READ_TIMEOUT_S = 30.0
+
     def __init__(self, node: str = "node") -> None:
         self._node = node
         self._proc: subprocess.Popen | None = None
@@ -262,6 +291,14 @@ class Sanitizer:
         _require_cli()
         self._pid = os.getpid()
         self._stderr = tempfile.SpooledTemporaryFile(mode="w+", encoding="utf-8")
+        # On POSIX, put the worker in its own process group so a hard-killed
+        # parent's teardown can signal the whole group (the Node process plus any
+        # child it spawned), not just the immediate child — an orphaned worker
+        # otherwise lingers. The worker also exits on stdin EOF, so a clean
+        # parent exit closes stdin and the worker drains and quits on its own.
+        popen_kwargs: dict = {}
+        if hasattr(os, "setsid"):
+            popen_kwargs["start_new_session"] = True
         try:
             self._proc = subprocess.Popen(
                 [self._node, str(_CLI), "--worker"],
@@ -271,6 +308,7 @@ class Sanitizer:
                 text=True,
                 encoding="utf-8",
                 bufsize=1,
+                **popen_kwargs,
             )
         except FileNotFoundError as cause:
             self._stderr.close()
@@ -289,22 +327,64 @@ class Sanitizer:
 
     def request(self, payload: dict) -> dict:
         """Send one request object, return its response payload (raises on error)."""
-        if self._proc is None or self._proc.poll() is not None:
+        if self._proc is None:
             raise RuntimeError("worker is not running (use it as a context manager)")
+        if self._proc.poll() is not None:
+            # Started and since died (killed/crashed mid-use): a "use it as a
+            # context manager" message would lie about it never having run.
+            raise RuntimeError(
+                f"sanitize worker exited unexpectedly: {self._drain_stderr()}"
+            )
         assert self._proc.stdin is not None and self._proc.stdout is not None
-        self._proc.stdin.write(json.dumps(payload) + "\n")
-        self._proc.stdin.flush()
-        # Blocking read with no timeout, under _shared_worker_lock for the shared
-        # worker: the serialized one-line-per-request protocol can't interleave,
-        # but a worker that never answers would wedge every persistent caller.
-        # The CLI emits exactly one line per request, so this is bounded in
-        # practice; a hang means a CLI bug, surfaced as a stuck process.
-        line = self._proc.stdout.readline()
+        # TOCTOU: the worker can die between the poll() above and this write, in
+        # which case the OS raises BrokenPipeError / ValueError (closed file).
+        # Catch both and report the worker's stderr instead of leaking a raw I/O
+        # error with no sanitizer context.
+        try:
+            self._proc.stdin.write(json.dumps(payload) + "\n")
+            self._proc.stdin.flush()
+        except (BrokenPipeError, ValueError, OSError) as cause:
+            raise RuntimeError(
+                f"sanitize worker exited unexpectedly: {self._drain_stderr()}"
+            ) from cause
+        # The serialized one-line-per-request protocol can't interleave (the
+        # shared worker holds _shared_worker_lock across the whole call), and the
+        # CLI emits exactly one line per request — so this read is bounded in
+        # practice. The timeout guards the pathological case (a CLI bug or a
+        # process wedged mid-response) so a missing response surfaces as a clear
+        # error instead of hanging the caller forever.
+        line = self._read_response_line()
         if line == "":
             raise RuntimeError(
                 f"sanitize worker exited unexpectedly: {self._drain_stderr()}"
             )
-        return _check(json.loads(line))
+        return _check(_parse_cli_json(line))
+
+    def _read_response_line(self) -> str:
+        """Read one response line, bounding the wait so a wedged worker surfaces
+        as a clear timeout rather than an unbounded hang.
+
+        ``readline`` can't be interrupted, so it runs on a daemon thread we join
+        with a timeout; on timeout we kill the worker (its response is lost and
+        the protocol is desynced — the worker is unusable) and raise.
+        """
+        assert self._proc is not None and self._proc.stdout is not None
+        result: list[str] = []
+
+        def _read() -> None:
+            assert self._proc is not None and self._proc.stdout is not None
+            result.append(self._proc.stdout.readline())
+
+        reader = threading.Thread(target=_read, daemon=True)
+        reader.start()
+        reader.join(self._READ_TIMEOUT_S)
+        if reader.is_alive():
+            self._terminate_proc()
+            raise RuntimeError(
+                "sanitize worker did not respond within "
+                f"{self._READ_TIMEOUT_S}s and was terminated: {self._drain_stderr()}"
+            )
+        return result[0]
 
     def sanitize(self, text: str, *, html: bool = False) -> SanitizeResult:
         return SanitizeResult(**self.request({"text": text, "html": html}))
@@ -315,15 +395,44 @@ class Sanitizer:
         self._stderr.seek(0)
         return self._stderr.read().strip()
 
+    def _kill_group(self) -> None:
+        """Kill the worker's whole process group (POSIX) so any child it spawned
+        dies with it; fall back to killing just the worker elsewhere or if the
+        group is already gone."""
+        if self._proc is None:
+            return
+        killed_group = False
+        if hasattr(os, "killpg") and hasattr(os, "getpgid"):
+            try:
+                os.killpg(os.getpgid(self._proc.pid), signal.SIGKILL)
+                killed_group = True
+            except (ProcessLookupError, PermissionError):
+                # Group already reaped, or not our group to signal — fall back.
+                pass
+        if not killed_group:
+            self._proc.kill()
+
+    def _terminate_proc(self) -> None:
+        """Force-kill a wedged/unresponsive worker (group and all) and reap it."""
+        if self._proc is None:
+            return
+        self._kill_group()
+        self._proc.wait()
+
     def close(self) -> None:
         if self._proc is None:
             return
+        # Closing stdin is the graceful path: the worker reads EOF and exits on
+        # its own. If it doesn't within the grace window, kill the whole group.
         if self._proc.stdin is not None:
-            self._proc.stdin.close()
+            try:
+                self._proc.stdin.close()
+            except (BrokenPipeError, OSError):
+                pass
         try:
             self._proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
-            self._proc.kill()
+            self._kill_group()
             self._proc.wait()
         if self._proc.stdout is not None:
             self._proc.stdout.close()

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -364,7 +364,7 @@ const mdParser = unified().use(remarkParse).use(remarkGfm);
  * @param {Array<{start: number, end: number, kind: "comment" | "hidden"}>} ranges
  */
 function collectCommentRanges(value, base, nodeEnd, ranges) {
-  for (let searchFrom = 0; ; ) {
+  for (let searchFrom = 0; ;) {
     const open = value.indexOf("<!--", searchFrom);
     if (open === -1) break;
     const close = value.indexOf("-->", open + 2);

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -97,6 +97,79 @@ describe("CLI: worker mode", () => {
     assert.equal(out.split("\n").length, 1);
     assert.deepEqual(JSON.parse(out), envelope(await sanitize(text)));
   });
+
+  it("emits exactly one error line for a blank line, keeping framing", () => {
+    // A blank/whitespace request line must NOT be silently skipped: a skip emits
+    // zero responses for one input line and desyncs every later response against
+    // a one-response-per-request client. We assert one response PER input line
+    // and that the following real request still answers correctly.
+    const input = `\n   \n${JSON.stringify({ text: "ok" })}\n`;
+    const lines = run(["--worker"], input).trim().split("\n");
+    assert.equal(lines.length, 3); // blank, whitespace, real → 3 responses
+    assert.ok(JSON.parse(lines[0]).error);
+    assert.ok(JSON.parse(lines[1]).error);
+    assert.deepEqual(JSON.parse(lines[2]), {
+      cleaned: "ok",
+      found: [],
+      warnings: [],
+    });
+  });
+});
+
+describe("CLI: input-size cap (DoS guard)", () => {
+  const overLimit = JSON.stringify({ text: "A".repeat(200) });
+  const underLimit = JSON.stringify({ text: "ok" });
+
+  it("one-shot rejects an oversized request with a non-zero exit", () => {
+    assert.throws(
+      () =>
+        execFileSync("node", [CLI], {
+          input: overLimit,
+          encoding: "utf8",
+          env: { ...process.env, AGENT_SANITIZER_MAX_INPUT_BYTES: "50" },
+        }),
+      (err) => {
+        assert.equal(err.status, 1);
+        assert.match(String(err.stderr), /request too large/);
+        assert.match(String(err.stderr), /AGENT_SANITIZER_MAX_INPUT_BYTES/);
+        return true;
+      },
+    );
+  });
+
+  it("worker returns an error line for an oversized request and keeps serving", () => {
+    const out = execFileSync("node", [CLI, "--worker"], {
+      input: `${overLimit}\n${underLimit}\n`,
+      encoding: "utf8",
+      env: { ...process.env, AGENT_SANITIZER_MAX_INPUT_BYTES: "50" },
+    });
+    const lines = out.trim().split("\n");
+    assert.equal(lines.length, 2);
+    assert.match(JSON.parse(lines[0]).error, /request too large/);
+    assert.deepEqual(JSON.parse(lines[1]), {
+      cleaned: "ok",
+      found: [],
+      warnings: [],
+    });
+  });
+
+  it("ignores a non-positive / non-numeric limit, using the default", () => {
+    // A bogus override must not disable the cap or set it to zero (which would
+    // reject everything); it falls back to the generous default, so a small
+    // request still succeeds.
+    for (const bogus of ["0", "-1", "notanumber", ""]) {
+      const out = execFileSync("node", [CLI], {
+        input: underLimit,
+        encoding: "utf8",
+        env: { ...process.env, AGENT_SANITIZER_MAX_INPUT_BYTES: bogus },
+      });
+      assert.deepEqual(JSON.parse(out), {
+        cleaned: "ok",
+        found: [],
+        warnings: [],
+      });
+    }
+  });
 });
 
 describe("CLI: one-shot fails loudly on a bad request", () => {

--- a/tests/test_python_client.py
+++ b/tests/test_python_client.py
@@ -7,11 +7,13 @@ verdicts themselves are owned by the JS suite — here the CLI is the source of
 truth and the client must faithfully relay it.
 """
 
+import json
 import os
 import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -189,11 +191,21 @@ def test_drain_stderr_reads_back_worker_stderr() -> None:
 
 
 def test_killed_worker_raises_loudly_on_next_use() -> None:
+    # A worker that WAS started then died mid-use must not claim it was never
+    # used as a context manager — it reports the unexpected exit (bug #2).
     with Sanitizer() as worker:
         worker._proc.kill()
         worker._proc.wait()
-        with pytest.raises(RuntimeError, match="worker is not running"):
+        with pytest.raises(RuntimeError, match="worker exited unexpectedly"):
             worker.sanitize("x")
+
+
+def test_never_started_worker_says_use_as_context_manager() -> None:
+    # The original message is still correct for a worker that genuinely never
+    # ran: distinguish "not started" from "started then died".
+    worker = Sanitizer()
+    with pytest.raises(RuntimeError, match="use it as a context manager"):
+        worker.request({"text": "x"})
 
 
 def test_shared_worker_not_shared_across_fork() -> None:
@@ -269,3 +281,96 @@ def test_scan_and_clean_instruction_files(tmp_path: Path) -> None:
 def test_sanitize_text_uses_shared_worker_for_html() -> None:
     sanitize_text(HIDDEN_HTML, html=True)
     assert ais._worker is not None and ais._worker.is_alive()
+
+
+# ─── Robustness: framing, concurrency, death, DoS, error surfaces ─────────────
+
+
+def test_blank_request_does_not_hang_and_framing_survives() -> None:
+    # A blank request line must come back as a single structured error, never a
+    # silent skip that leaves the client's readline waiting forever. We bound the
+    # read so the unfixed worker (which skips the blank line, emitting nothing)
+    # fails fast as a timeout instead of hanging the whole suite.
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(Sanitizer, "_READ_TIMEOUT_S", 8.0)
+        with Sanitizer() as worker:
+            # A literally blank request line: the worker must answer it (with a
+            # structured error), not skip it and leave the read hanging.
+            worker._proc.stdin.write("\n")
+            worker._proc.stdin.flush()
+            line = worker._read_response_line()
+            assert line != ""
+            assert "error" in json.loads(line)
+            # Framing intact: a normal request right after still answers.
+            assert worker.sanitize(f"a{ZERO_WIDTH_SPACE}b").cleaned == "ab"
+
+
+def test_concurrent_threads_get_uncorrupted_responses() -> None:
+    # Drive the SHARED persistent worker from many threads at once: the
+    # per-request lock must serialize each write+read so no response is
+    # interleaved with another's, and every thread gets exactly its own answer.
+    inputs = [f"thread-{i}{ZERO_WIDTH_SPACE}" for i in range(40)]
+    results: dict[int, str] = {}
+    errors: list[Exception] = []
+    barrier = threading.Barrier(len(inputs))
+
+    def worker(i: int) -> None:
+        try:
+            barrier.wait()  # maximize contention: all fire together
+            results[i] = sanitize(inputs[i], persist=True).cleaned
+        except Exception as exc:  # noqa: BLE001 — collect for assertion
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(len(inputs))]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+    # Each thread's cleaned text must be exactly its own input minus the ZWS — a
+    # corrupted/interleaved response would mismatch.
+    assert results == {i: f"thread-{i}" for i in range(len(inputs))}
+
+
+def test_killed_worker_includes_stderr_not_raw_ioerror() -> None:
+    # A worker killed mid-use must raise a clear sanitizer error carrying its
+    # stderr — never a bare ValueError/BrokenPipeError leaking I/O internals.
+    with Sanitizer() as worker:
+        worker._proc.kill()
+        worker._proc.wait()
+        with pytest.raises(RuntimeError, match="worker exited unexpectedly"):
+            worker.sanitize("x")
+
+
+def test_oversized_input_oneshot_raises_clear_error() -> None:
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setenv("AGENT_SANITIZER_MAX_INPUT_BYTES", "100")
+        with pytest.raises(RuntimeError, match="request too large"):
+            sanitize("A" * 500, persist=False)
+
+
+def test_oversized_input_worker_raises_clear_error() -> None:
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setenv("AGENT_SANITIZER_MAX_INPUT_BYTES", "100")
+        with Sanitizer() as worker:
+            with pytest.raises(RuntimeError, match="request too large"):
+                worker.sanitize("A" * 500)
+            # Worker survives the oversized request and still serves.
+            assert worker.sanitize("ok").cleaned == "ok"
+
+
+def test_non_json_stdout_raises_wrapped_error() -> None:
+    # A CLI (or fake) that prints non-JSON must surface as a clear sanitizer
+    # error naming the offending output, not a bare json.JSONDecodeError.
+    node = shutil.which("node")
+    assert node is not None
+    fake_cli = Path(tempfile.mkdtemp()) / "fake-cli.mjs"
+    fake_cli.write_text(
+        "process.stdin.resume();\nconsole.log('not json at all');\n",
+        encoding="utf-8",
+    )
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(ais, "_CLI", fake_cli)
+        with pytest.raises(RuntimeError, match="non-JSON output"):
+            sanitize("x", persist=False)


### PR DESCRIPTION
## What & why

Robustness fixes to the cross-language bridge (`bin/sanitize-cli.mjs`, `python/agent_input_sanitizer/__init__.py`), found during an audit of the non-JS path.

1. **Worker hang (HIGH).** The `--worker` loop did `if (line.trim()==="") continue`, emitting *no* response for a blank/whitespace request while the Python client did an unbounded `readline()` — one framing slip desynced every later response and could hang forever. The worker now emits **exactly one single-line JSON response per input line** (a blank line → `{"error":"Unexpected end of JSON input"}`); the Python side adds a bounded read as defense-in-depth.
2. **TOCTOU + misleading death message (MED).** `request()` wraps write/flush to catch `BrokenPipeError`/`ValueError`/`OSError` and raise `worker exited unexpectedly: <stderr>`; a started-then-crashed worker no longer falsely claims it was never used as a context manager (that message is reserved for a never-started worker).
3. **Input-size cap (MED).** Both modes enforce `AGENT_SANITIZER_MAX_INPUT_BYTES` (UTF-8 bytes, default **10 MiB**); one-shot aborts buffering mid-stream and exits non-zero, the worker returns an error line and keeps serving. Bad overrides fall back to the default.
4. **Orphan worker (LOW).** Worker started with `start_new_session=True`; `close()`/timeout `killpg` the group; it still exits on stdin EOF for clean teardown.
5. **Confusing error surfaces (LOW).** Python wraps non-JSON CLI stdout (`sanitize CLI returned non-JSON output … <repr>`); the one-shot CLI writes a one-line `sanitize CLI: <reason>` to stderr instead of a raw Node stack.

## Framing guarantee

The worker writes exactly one single-line JSON response per input line — `JSON.stringify` escapes any newline in the text, and the error branch stringifies a one-key object — so no response ever contains a literal newline. Requests are one JSON object per line, so newlines inside `text` arrive JSON-escaped.

## How it was tested (real subprocesses, un-mocked)

- `node --test test/cli.test.mjs` 21/21; pytest `tests/test_python_client.py` 35/35; eslint, tsc, ruff all clean.
- Red→green: JS blank-line/oversized-one-shot/oversized-worker tests and Python blank-no-hang / killed-includes-stderr / oversized (both modes) / non-JSON-stdout tests all RED on stashed source, GREEN after. The blank-line test uses a timeout so the unfixed worker's hang surfaces as a failure.

## Known limitation

In worker mode `readline` buffers a full line before the size check, so an oversized single line is briefly held in memory before the structured error — true streaming line-length capping isn't readily available via `readline`; the post-buffer check still satisfies the structured-error contract.