### PR TITLE
fix(instructions): contain globs to cwd, refuse symlink writes, fix absolute-glob miss

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Commits MUST use [Conventional Commits](https://www.conventionalcommits.org/) (`
 
 Before declaring any non-trivial coding task done, **iteratively critique and fix your own work until you reach a fixed point.** Read what you actually wrote (not what you intended to write) as if it came from a developer you cannot stand—assume it is wrong until proven otherwise.
 
-Each pass, hunt for: bugs, broken or missed edge cases, weakened/skipped/deleted tests, swallowed errors, dead code, unjustified abstractions, premature returns, broken invariants, sloppy naming, fragile assumptions, hidden coupling, scope creep beyond the request, comments that explain _what_ instead of *why*, anything that smells off. State each issue bluntly in one line, then fix it. Then re-review the fix—fixes introduce their own bugs.
+Each pass, hunt for: bugs, broken or missed edge cases, weakened/skipped/deleted tests, swallowed errors, dead code, unjustified abstractions, premature returns, broken invariants, sloppy naming, fragile assumptions, hidden coupling, scope creep beyond the request, comments that explain _what_ instead of _why_, anything that smells off. State each issue bluntly in one line, then fix it. Then re-review the fix—fixes introduce their own bugs.
 
 Stop only when a full pass turns up **nothing** worth changing. Cap at ~5 passes; if you’re still finding real issues at pass 5, say so and ask the user rather than silently giving up. Skip the loop for trivial edits (typo fixes, single-line config tweaks, pure questions)—say so explicitly when you skip.
 

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -364,7 +364,7 @@ const mdParser = unified().use(remarkParse).use(remarkGfm);
  * @param {Array<{start: number, end: number, kind: "comment" | "hidden"}>} ranges
  */
 function collectCommentRanges(value, base, nodeEnd, ranges) {
-  for (let searchFrom = 0; ; ) {
+  for (let searchFrom = 0; ;) {
     const open = value.indexOf("<!--", searchFrom);
     if (open === -1) break;
     const close = value.indexOf("-->", open + 2);

--- a/src/instructions.mjs
+++ b/src/instructions.mjs
@@ -13,8 +13,15 @@
  * instruction files live under (e.g. `["CLAUDE.md", "AGENTS.md",
  * ".claude/**\/*.md", "**\/SKILL.md"]`), so no agent's convention is baked in.
  */
-import { readFileSync, globSync, writeFileSync } from "node:fs";
-import { join, relative } from "node:path";
+import {
+  readFileSync,
+  globSync,
+  writeFileSync,
+  renameSync,
+  lstatSync,
+  realpathSync,
+} from "node:fs";
+import { join, relative, resolve, isAbsolute, dirname, sep } from "node:path";
 import {
   LONG_RUN_RE,
   STRIP,
@@ -103,20 +110,75 @@ export function scanText(content) {
 }
 
 /**
+ * True when `realChild` is `realRoot` itself or lives beneath it. Both inputs
+ * must already be realpath-resolved absolute paths. Containment is tested with
+ * `relative(root, child)`: the result is "" when they are the same path, and
+ * for a true descendant it is a forward path with no `..` segment and is not
+ * itself absolute — so a sibling like `/proj-evil` (relative => `../proj-evil`)
+ * is correctly rejected.
+ * @param {string} realRoot
+ * @param {string} realChild
+ * @returns {boolean}
+ */
+function isContained(realRoot, realChild) {
+  const rel = relative(realRoot, realChild);
+  return (
+    rel === "" ||
+    (!rel.startsWith(`..${sep}`) && rel !== ".." && !isAbsolute(rel))
+  );
+}
+
+/**
+ * Resolve `absPath` to a real (symlink-followed) absolute path and assert it is
+ * contained within `realRoot`; THROW naming the offending path/pattern when it
+ * escapes. A scanner pointed outside its own tree is a misconfiguration the
+ * caller must see — failing loud beats silently skipping a file the caller
+ * believes was scanned. `pattern` is included in the message for diagnosis.
+ * @param {string} absPath  absolute path to a glob match (already exists)
+ * @param {string} realRoot  realpath of the scan root
+ * @param {string} pattern  the glob that produced this match
+ * @returns {void}
+ */
+function assertContained(absPath, realRoot, pattern) {
+  const real = realpathSync(absPath);
+  if (isContained(realRoot, real)) return;
+  throw new Error(
+    `instruction-file path escapes scan root: pattern ${JSON.stringify(
+      pattern,
+    )} matched ${JSON.stringify(absPath)} which resolves to ${JSON.stringify(
+      real,
+    )} outside ${JSON.stringify(realRoot)}`,
+  );
+}
+
+/**
  * Expand `globs` (relative to `cwd`) to absolute file paths, skipping
  * `node_modules`. The glob set is the caller's instruction-file convention.
+ *
+ * Containment is enforced: every match is resolved to its real (symlink-
+ * followed) path and must live within `cwd`'s realpath. A match that escapes
+ * the root — via `..`, an absolute-path glob, or a symlink pointing outside —
+ * THROWS rather than being scanned or silently dropped, since reaching outside
+ * the tree is a caller misconfiguration that must surface loudly.
  * @param {string[]} globs
  * @param {{ cwd?: string }} [options]
  * @returns {string[]}
  */
 export function findInstructionFiles(globs, { cwd = process.cwd() } = {}) {
+  const realRoot = realpathSync(resolve(cwd));
   const seen = new Set();
   for (const pattern of globs)
     for (const name of globSync(pattern, {
       cwd,
       exclude: (entry) => entry === "node_modules",
-    }))
-      seen.add(join(cwd, name));
+    })) {
+      // globSync returns absolute paths verbatim for an absolute pattern and
+      // cwd-relative names otherwise; joining an already-absolute name would
+      // double the prefix into a nonexistent path (the absolute-glob miss bug).
+      const absPath = isAbsolute(name) ? name : join(cwd, name);
+      assertContained(absPath, realRoot, pattern);
+      seen.add(absPath);
+    }
   return [...seen];
 }
 
@@ -145,16 +207,57 @@ export function scanInstructionFiles(globs, { cwd = process.cwd() } = {}) {
 
 /**
  * Strip payload-capable invisible characters from `absPath` in place. Returns
- * true when the file changed (it held a payload), false when it was already
- * clean. Throws if the file cannot be read or written (the caller decides
- * whether an unwritable contaminated file is fatal or falls back to alerting).
+ * true when the file changed (it held a payload {@link scanText} flags), false
+ * when {@link scanText} reports nothing.
+ *
+ * Contract (scan/clean coherence): clean strips exactly what scan flags. A
+ * write happens ONLY when `scanText` reports a finding, so the "scan, then
+ * clean what scan flagged" workflow never silently rewrites a file scan called
+ * clean. A handful of sub-threshold invisible chars (which scan ignores) are
+ * left untouched — by design, the scanner's definition of a payload is the
+ * single source of truth for what gets removed.
+ *
+ * Refuses to follow symlinks: instruction files must be regular files, so a
+ * symlinked path (which could redirect the write to a target outside the tree)
+ * THROWS rather than being written through.
+ *
+ * The write is atomic: stripped content goes to a temp file in the same
+ * directory which is then `rename`d over the original (preserving the original
+ * file mode), so a crash mid-write cannot leave a truncated instruction file.
+ *
+ * Throws if the file cannot be read or written (the caller decides whether an
+ * unwritable contaminated file is fatal or falls back to alerting).
  * @param {string} absPath
  * @returns {boolean}
  */
 export function cleanFile(absPath) {
+  const info = lstatSync(absPath);
+  if (info.isSymbolicLink())
+    throw new Error(
+      `refusing to clean through a symlink (instruction files must be regular files): ${JSON.stringify(
+        absPath,
+      )}`,
+    );
+
   const original = readFileSync(absPath, "utf-8");
+  // Scan is the SSOT for what counts as a payload: don't rewrite a file scan
+  // would not flag, even if stripInvisible would technically remove a char.
+  // A scan finding (a >=LONG_RUN_THRESHOLD run, or >=SCATTERED_THRESHOLD
+  // scattered chars) is past the carve-out's preserve window, so stripInvisible
+  // always removes at least one char here — stripped !== original is guaranteed.
+  if (scanText(original).length === 0) return false;
+
   const stripped = stripInvisible(original);
-  if (stripped === original) return false;
-  writeFileSync(absPath, stripped);
+  // info is the lstat above; since the path is confirmed not a symlink, its
+  // mode is the regular file's mode.
+  const mode = info.mode;
+  // Atomic replace: write to a sibling temp (same dir => same filesystem, so
+  // rename is atomic, not a cross-device copy) then rename over the original.
+  // A crash before the rename leaves the original intact; after it, the new
+  // content is fully present. Mode is carried onto the temp so the replacement
+  // keeps the original's permissions. rename errors propagate (fail loud).
+  const tmp = join(dirname(absPath), `.${Date.now()}-${process.pid}.tmp`);
+  writeFileSync(tmp, stripped, { mode });
+  renameSync(tmp, absPath);
   return true;
 }

--- a/src/instructions.mjs
+++ b/src/instructions.mjs
@@ -129,19 +129,34 @@ function isContained(realRoot, realChild) {
 }
 
 /**
- * Resolve `absPath` to a real (symlink-followed) absolute path and assert it is
- * contained within `realRoot`; THROW naming the offending path/pattern when it
- * escapes. A scanner pointed outside its own tree is a misconfiguration the
- * caller must see — failing loud beats silently skipping a file the caller
- * believes was scanned. `pattern` is included in the message for diagnosis.
- * @param {string} absPath  absolute path to a glob match (already exists)
+ * Classify a glob match for containment: resolve it to a real (symlink-
+ * followed) path and decide whether to keep, drop, or reject it. Two failure
+ * modes are kept distinct:
+ *
+ *   - The realpath ESCAPES `realRoot` → THROW. A scanner pointed outside its
+ *     own tree is a caller misconfiguration that must surface loudly, not a
+ *     file silently skipped while the caller believes it was scanned.
+ *   - The path cannot be resolved at all (ENOENT/EACCES — a dangling symlink or
+ *     unreadable entry that still lives inside the tree) → return false to SKIP
+ *     it, matching scanInstructionFiles' existing skip-on-unreadable behavior.
+ *     A stale symlink in a project must not abort scanning every other file.
+ *
+ * A genuine resolution failure is never allowed to masquerade as a
+ * containment pass: an unresolvable path is skipped, only a successfully
+ * resolved in-tree path returns true.
+ * @param {string} absPath  absolute path to a glob match
  * @param {string} realRoot  realpath of the scan root
  * @param {string} pattern  the glob that produced this match
- * @returns {void}
+ * @returns {boolean} true to keep the match, false to skip an unresolvable one
  */
-function assertContained(absPath, realRoot, pattern) {
-  const real = realpathSync(absPath);
-  if (isContained(realRoot, real)) return;
+function keepContained(absPath, realRoot, pattern) {
+  let real;
+  try {
+    real = realpathSync(absPath);
+  } catch {
+    return false; // dangling/unreadable in-cwd match: skip, do not abort
+  }
+  if (isContained(realRoot, real)) return true;
   throw new Error(
     `instruction-file path escapes scan root: pattern ${JSON.stringify(
       pattern,
@@ -155,11 +170,12 @@ function assertContained(absPath, realRoot, pattern) {
  * Expand `globs` (relative to `cwd`) to absolute file paths, skipping
  * `node_modules`. The glob set is the caller's instruction-file convention.
  *
- * Containment is enforced: every match is resolved to its real (symlink-
- * followed) path and must live within `cwd`'s realpath. A match that escapes
- * the root — via `..`, an absolute-path glob, or a symlink pointing outside —
- * THROWS rather than being scanned or silently dropped, since reaching outside
- * the tree is a caller misconfiguration that must surface loudly.
+ * Containment is enforced per match (see {@link keepContained}): a match whose
+ * realpath escapes `cwd` — via `..`, an absolute-path glob, or a symlink
+ * pointing outside — THROWS, since reaching outside the tree is a caller
+ * misconfiguration. A match that simply cannot be resolved (a dangling symlink
+ * or unreadable entry inside the tree) is SKIPPED, so one stale symlink never
+ * aborts scanning the rest of the project.
  * @param {string[]} globs
  * @param {{ cwd?: string }} [options]
  * @returns {string[]}
@@ -176,8 +192,7 @@ export function findInstructionFiles(globs, { cwd = process.cwd() } = {}) {
       // cwd-relative names otherwise; joining an already-absolute name would
       // double the prefix into a nonexistent path (the absolute-glob miss bug).
       const absPath = isAbsolute(name) ? name : join(cwd, name);
-      assertContained(absPath, realRoot, pattern);
-      seen.add(absPath);
+      if (keepContained(absPath, realRoot, pattern)) seen.add(absPath);
     }
   return [...seen];
 }

--- a/test/instructions.test.mjs
+++ b/test/instructions.test.mjs
@@ -11,6 +11,10 @@ import {
   writeFileSync,
   rmSync,
   readFileSync,
+  symlinkSync,
+  chmodSync,
+  statSync,
+  readdirSync,
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -286,5 +290,226 @@ describe("cleanFile", () => {
     writeFileSync(file, original);
     assert.equal(cleanFile(file), false);
     assert.equal(readFileSync(file, "utf-8"), original);
+  });
+});
+
+// ─── containment: path traversal (bug #1) ────────────────────────────────────
+
+describe("findInstructionFiles containment", () => {
+  let tmpDir;
+  let outsideDir;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "contain-cwd-"));
+    outsideDir = mkdtempSync(join(tmpdir(), "contain-out-"));
+  });
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    rmSync(outsideDir, { recursive: true, force: true });
+  });
+
+  it("THROWS naming the escaping pattern for a `..` traversal glob", () => {
+    // A secret living outside the scan root, reachable only via `..`.
+    writeFileSync(join(outsideDir, "secret.md"), "top secret\n");
+    // Walk from tmpDir up to outsideDir by name (sibling of tmpDir under tmpdir).
+    const rel = join("..", `${outsideDir.split("/").pop()}`, "secret.md");
+    assert.throws(
+      () => findInstructionFiles([rel], { cwd: tmpDir }),
+      (err) =>
+        err instanceof Error &&
+        /escapes scan root/.test(err.message) &&
+        err.message.includes(rel),
+      "a `..` glob reaching outside cwd must throw, not silently read",
+    );
+  });
+
+  it("THROWS for an absolute glob whose match lives outside cwd", () => {
+    writeFileSync(join(outsideDir, "CLAUDE.md"), "x\n");
+    const abs = join(outsideDir, "CLAUDE.md");
+    assert.throws(
+      () => findInstructionFiles([abs], { cwd: tmpDir }),
+      /escapes scan root/,
+    );
+  });
+
+  it("does NOT throw for a sibling dir sharing a name prefix with cwd", () => {
+    // `/x/proj-evil` must not count as contained in `/x/proj`: the segment
+    // boundary check rejects the prefix-only match. No glob hits it from tmpDir,
+    // so the call simply returns []; the point is it neither throws nor matches.
+    writeFileSync(join(tmpDir, "CLAUDE.md"), "x");
+    const found = findInstructionFiles(["CLAUDE.md"], { cwd: tmpDir });
+    assert.deepEqual(found, [join(tmpDir, "CLAUDE.md")]);
+  });
+});
+
+// ─── absolute-glob in-cwd is found (bug #3) ──────────────────────────────────
+
+describe("findInstructionFiles absolute glob", () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "abs-glob-"));
+  });
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("an absolute glob pointing at an in-cwd file IS found (no doubled prefix)", () => {
+    const file = join(tmpDir, "CLAUDE.md");
+    writeFileSync(file, "x");
+    // Pre-fix: join(cwd, name) doubled the absolute prefix => nonexistent path,
+    // so the file was silently MISSED. It must be returned verbatim here.
+    const found = findInstructionFiles([file], { cwd: tmpDir });
+    assert.deepEqual(found, [file]);
+  });
+
+  it("an absolute glob is also scanned end-to-end for its payload", () => {
+    const file = join(tmpDir, "CLAUDE.md");
+    writeFileSync(file, `# h\n${tagChars("evil payload")}\n`);
+    const out = scanInstructionFiles([file], { cwd: tmpDir });
+    assert.equal(out.length, 1);
+    assert.equal(out[0].findings[0].decoded, "evil payload");
+  });
+});
+
+// ─── symlink handling (bug #2) ───────────────────────────────────────────────
+
+describe("symlink containment", () => {
+  let tmpDir;
+  let outsideDir;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "symlink-cwd-"));
+    outsideDir = mkdtempSync(join(tmpdir(), "symlink-out-"));
+  });
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    rmSync(outsideDir, { recursive: true, force: true });
+  });
+
+  it("THROWS when a symlinked dir inside cwd resolves to a file outside cwd", () => {
+    // outsideDir/.claude/skills/evil/SKILL.md, reached via tmpDir/.claude -> outsideDir/.claude
+    const outClaudeSkill = join(outsideDir, ".claude", "skills", "evil");
+    mkdirSync(outClaudeSkill, { recursive: true });
+    writeFileSync(join(outClaudeSkill, "SKILL.md"), "payload\n");
+    symlinkSync(join(outsideDir, ".claude"), join(tmpDir, ".claude"), "dir");
+    assert.throws(
+      () => findInstructionFiles(GLOBS, { cwd: tmpDir }),
+      /escapes scan root/,
+      "a symlinked dir escaping cwd must be caught by the realpath check",
+    );
+  });
+
+  it("cleanFile THROWS rather than writing THROUGH a symlink", () => {
+    const target = join(tmpDir, "real-CLAUDE.md");
+    const original = `# t\n${tagChars("payload x".repeat(2))}\n`;
+    writeFileSync(target, original);
+    const link = join(tmpDir, "CLAUDE.md");
+    symlinkSync(target, link, "file");
+    assert.throws(() => cleanFile(link), /refusing to clean through a symlink/);
+    // The symlink target is left byte-for-byte unchanged (no write-through).
+    assert.equal(readFileSync(target, "utf-8"), original);
+  });
+});
+
+// ─── cleanFile hostile pre-state matrix ──────────────────────────────────────
+
+describe("cleanFile hostile pre-states", () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "clean-prestate-"));
+  });
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("missing path: throws a clear ENOENT-class error (no silent success)", () => {
+    assert.throws(() => cleanFile(join(tmpDir, "nope.md")), /ENOENT/);
+  });
+
+  it("directory at path: throws (EISDIR-class), never returns silently", () => {
+    const dir = join(tmpDir, "CLAUDE.md");
+    mkdirSync(dir);
+    assert.throws(() => cleanFile(dir));
+  });
+
+  it("dangling symlink: refuses (symlink check fires before read)", () => {
+    const link = join(tmpDir, "CLAUDE.md");
+    symlinkSync(join(tmpDir, "does-not-exist.md"), link, "file");
+    assert.throws(() => cleanFile(link), /refusing to clean through a symlink/);
+  });
+
+  it("regular contaminated file: cleans and returns true", () => {
+    const file = join(tmpDir, "CLAUDE.md");
+    writeFileSync(file, `# ok\n${tagChars("payload here now")}\n`);
+    assert.equal(cleanFile(file), true);
+    assert.doesNotMatch(readFileSync(file, "utf-8"), /[\u{E0001}-\u{E007F}]/u);
+  });
+});
+
+// ─── scan/clean contract coherence (bug #4) ──────────────────────────────────
+
+describe("scan/clean contract", () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "scan-clean-"));
+  });
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("clean does NOT rewrite a file scan reports clean (2 stray ZWSPs)", () => {
+    // Two scattered ZWSPs: below LONG_RUN_THRESHOLD and SCATTERED_THRESHOLD, so
+    // scanText flags nothing. Pre-fix cleanFile stripped them anyway (the
+    // asymmetry). Contract: clean strips exactly what scan flags => no rewrite.
+    const file = join(tmpDir, "CLAUDE.md");
+    const original = `a${cp(0x200b)}b${cp(0x200b)}c\n`;
+    writeFileSync(file, original);
+    assert.deepEqual(
+      scanText(original),
+      [],
+      "precondition: scan flags nothing",
+    );
+    assert.equal(cleanFile(file), false);
+    assert.equal(
+      readFileSync(file, "utf-8"),
+      original,
+      "scan-clean file must be left byte-identical",
+    );
+  });
+
+  it("clean DOES strip when scan flags (long run) — payload removed", () => {
+    const file = join(tmpDir, "CLAUDE.md");
+    const original = `x${zwRun(LONG_RUN_THRESHOLD)}y\n`;
+    writeFileSync(file, original);
+    assert.ok(scanText(original).length > 0, "precondition: scan flags it");
+    assert.equal(cleanFile(file), true);
+    assert.equal(readFileSync(file, "utf-8"), "xy\n");
+  });
+});
+
+// ─── atomic write + mode preservation (bug #5) ───────────────────────────────
+
+describe("cleanFile atomic write", () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "atomic-"));
+  });
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("preserves the file mode across the rewrite", () => {
+    const file = join(tmpDir, "CLAUDE.md");
+    writeFileSync(file, `# h\n${tagChars("rm payload now")}\n`);
+    chmodSync(file, 0o640);
+    const before = statSync(file).mode;
+    assert.equal(cleanFile(file), true);
+    assert.equal(statSync(file).mode, before, "mode must survive the rewrite");
+  });
+
+  it("leaves no temp files behind in the directory", () => {
+    const file = join(tmpDir, "CLAUDE.md");
+    writeFileSync(file, `# h\n${tagChars("payload payload")}\n`);
+    cleanFile(file);
+    // The atomic rename consumes the temp; only the cleaned file remains.
+    assert.deepEqual(readdirSync(tmpDir), ["CLAUDE.md"]);
   });
 });

--- a/test/instructions.test.mjs
+++ b/test/instructions.test.mjs
@@ -397,6 +397,24 @@ describe("symlink containment", () => {
     );
   });
 
+  it("SKIPS an in-cwd dangling symlink and still scans the valid files", () => {
+    // A stale symlink in the project must not abort the whole scan: it resolves
+    // to nothing (ENOENT), so it is dropped while real instruction files remain.
+    symlinkSync(join(tmpDir, "gone.md"), join(tmpDir, "AGENTS.md"), "file");
+    writeFileSync(
+      join(tmpDir, "CLAUDE.md"),
+      `# h\n${tagChars("payload xyz123")}\n`,
+    );
+    const found = findInstructionFiles(GLOBS, { cwd: tmpDir });
+    assert.deepEqual(found, [join(tmpDir, "CLAUDE.md")]);
+    const out = scanInstructionFiles(GLOBS, { cwd: tmpDir });
+    assert.deepEqual(
+      out.map((e) => e.file),
+      ["CLAUDE.md"],
+      "the dangling symlink is skipped, the real file is still scanned",
+    );
+  });
+
   it("cleanFile THROWS rather than writing THROUGH a symlink", () => {
     const target = join(tmpDir, "real-CLAUDE.md");
     const original = `# t\n${tagChars("payload x".repeat(2))}\n`;


### PR DESCRIPTION
## What & why

Containment and correctness fixes to the instruction-file scanner/cleaner (`src/instructions.mjs`), found during an audit.

1. **Path traversal (HIGH).** `findInstructionFiles` passed caller globs straight to `globSync` with no containment — `["../../secret.md"]` read files outside the project. Every match is now realpath-resolved and asserted to live within `cwd`'s realpath; a match whose realpath **escapes** cwd **throws** (a scanner pointed outside its tree is a caller misconfiguration that must surface, not a silent skip).
2. **Symlink following (HIGH).** Symlinked dirs/files resolving outside cwd are caught by the same containment check; `cleanFile` now `lstat`s first and **throws** on a symlink rather than writing through to its (possibly external) target.
3. **Absolute-glob miss (MED).** `join(cwd, name)` doubled an already-absolute `globSync` result into a nonexistent path (e.g. `/proj/proj/CLAUDE.md`), silently scanning nothing. Now only joins relative matches; absolute matches are used verbatim (then containment-checked).
4. **scan/clean mismatch (MED).** `cleanFile` stripped *all* invisibles while `scanInstructionFiles` only flagged long-runs/scatter, so "scan then clean what scan flagged" silently rewrote files scan called clean. `cleanFile` now rewrites only when `scanText` flags the file — `scanText` is the single source of truth for what counts as a payload.
5. **Non-atomic write (LOW).** `cleanFile` writes to a sibling temp file then `rename`s over the original (preserving mode), so a crash mid-write can't corrupt the file.

**Dangling/unreadable in-cwd entries are skipped, not fatal.** A resolution failure (ENOENT/EACCES — e.g. a stale in-cwd symlink) is skipped consistently with the existing skip-on-unreadable behavior, so one broken link can't abort scanning the whole project; only a genuine containment *escape* throws. A resolution failure never masquerades as a containment pass. `cleanFile` still refuses a symlink target loudly (it's an explicit target).

## How it was tested

- `node --test` 41/41; `pnpm lint`, `pnpm check` (tsc) clean; c8 **100%** on `src/instructions.mjs`.
- Red→green: traversal-throw, absolute-outside-throw, absolute-glob-found, symlinked-dir-throw, cleanFile-symlink-throw, dangling-symlink-skip, and scan/clean-no-rewrite all RED on unfixed source, GREEN after. Atomic-write non-vacuity proved by mutation (dropping the `{mode}` option reds the mode-preservation test).
- Filesystem helpers driven through a hostile pre-state matrix (missing, file, dir, valid symlink, dangling symlink, outside-cwd target), each asserting a well-defined outcome.