### PR TITLE
fix(layer1): consume OSC payloads, strip zero-width marks, cap joiner runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Commits MUST use [Conventional Commits](https://www.conventionalcommits.org/) (`
 
 Before declaring any non-trivial coding task done, **iteratively critique and fix your own work until you reach a fixed point.** Read what you actually wrote (not what you intended to write) as if it came from a developer you cannot stand—assume it is wrong until proven otherwise.
 
-Each pass, hunt for: bugs, broken or missed edge cases, weakened/skipped/deleted tests, swallowed errors, dead code, unjustified abstractions, premature returns, broken invariants, sloppy naming, fragile assumptions, hidden coupling, scope creep beyond the request, comments that explain _what_ instead of *why*, anything that smells off. State each issue bluntly in one line, then fix it. Then re-review the fix—fixes introduce their own bugs.
+Each pass, hunt for: bugs, broken or missed edge cases, weakened/skipped/deleted tests, swallowed errors, dead code, unjustified abstractions, premature returns, broken invariants, sloppy naming, fragile assumptions, hidden coupling, scope creep beyond the request, comments that explain _what_ instead of _why_, anything that smells off. State each issue bluntly in one line, then fix it. Then re-review the fix—fixes introduce their own bugs.
 
 Stop only when a full pass turns up **nothing** worth changing. Cap at ~5 passes; if you’re still finding real issues at pass 5, say so and ask the user rather than silently giving up. Skip the loop for trivial edits (typo fixes, single-line config tweaks, pure questions)—say so explicitly when you skip.
 

--- a/THREAT-MODEL.md
+++ b/THREAT-MODEL.md
@@ -12,13 +12,13 @@ The three layers are independent; use only the ones your ingress needs.
 
 **What it removes**
 
-| Category                   | Examples                                                       | Why it’s a payload channel                                    |
-| -------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------- |
-| Format chars (`Cf`)        | zero-width space/joiner, bidi overrides, Unicode **tag** chars | render blank but reach the model as bytes; tags smuggle ASCII |
-| Variation selectors        | U+FE00–FE0F, U+E0100–E01EF                                     | not `Cf`; a run encodes a hidden payload                      |
-| Blank-rendering fillers    | Hangul fillers U+115F/1160/3164/FFA0, Braille blank U+2800     | render blank, not `Cf`, so a naive `\p{Cf}` strip misses them |
-| Soft hyphen / interior BOM | U+00AD, interior U+FEFF                                        | either can encode hidden instructions                         |
-| ANSI / SGR escapes         | `ESC[…m`, cursor moves, OSC                                    | repaint or hide what an operator reads in a terminal          |
+| Category                   | Examples                                                                                                       | Why it’s a payload channel                                    |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| Format chars (`Cf`)        | zero-width space/joiner, bidi overrides, Unicode **tag** chars                                                 | render blank but reach the model as bytes; tags smuggle ASCII |
+| Variation selectors        | U+FE00–FE0F, U+E0100–E01EF                                                                                     | not `Cf`; a run encodes a hidden payload                      |
+| Blank-rendering fillers    | Hangul fillers U+115F/1160/3164/FFA0, Braille blank U+2800, zero-width combining marks (`Mn`) U+034F/17B4/17B5 | render blank, not `Cf`, so a naive `\p{Cf}` strip misses them |
+| Soft hyphen / interior BOM | U+00AD, interior U+FEFF                                                                                        | either can encode hidden instructions                         |
+| ANSI / SGR escapes         | `ESC[…m`, cursor moves, OSC                                                                                    | repaint or hide what an operator reads in a terminal          |
 
 **What it preserves**
 
@@ -35,7 +35,11 @@ escape its split had hidden, and removing one ANSI sequence can reconstitute
 another. Layer 1 strips ANSI to a fixed point and then sweeps any residual raw
 control introducer—7-bit ESC (U+001B) or 8-bit C1 CSI (U+009B)—outright, so the
 result carries no raw ANSI introducer for _any_ input and the operation is
-idempotent.
+idempotent. OSC strings (titles, clickable-hyperlink URLs) are consumed as a
+whole, for every terminator form—ST (`ESC\` or 8-bit C1 ST U+009C) and the
+legacy BEL—and for the 8-bit C1 OSC introducer (U+009D); an _unterminated_ OSC
+introducer is dropped through end-of-string (fail-closed), so no OSC body
+survives to carry a payload.
 
 ## Layer 2—hidden HTML (remark/rehype)
 
@@ -105,7 +109,9 @@ payload-capable invisible Unicode and ANSI. A prompt-submission channel usually
 cannot rewrite the prompt in place, so the only neutralization is to block.
 One carve-out: a prompt whose only escape content is display-only SGR color
 passes with a note (pasting colored terminal output is the common case, and SGR
-cannot move the cursor, erase, or carry an OSC payload).
+cannot move the cursor, erase, or carry an OSC payload). The SGR-only test
+recognizes both the 7-bit (`ESC[…m`) and 8-bit C1 (`U+009B…m`) encodings, so a
+C1-introduced cursor-move or erase is never mistaken for benign color.
 
 ## Tool-output pipeline & Layer 5
 

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -364,7 +364,7 @@ const mdParser = unified().use(remarkParse).use(remarkGfm);
  * @param {Array<{start: number, end: number, kind: "comment" | "hidden"}>} ranges
  */
 function collectCommentRanges(value, base, nodeEnd, ranges) {
-  for (let searchFrom = 0; ; ) {
+  for (let searchFrom = 0; ;) {
     const open = value.indexOf("<!--", searchFrom);
     if (open === -1) break;
     const close = value.indexOf("-->", open + 2);

--- a/src/invisible.mjs
+++ b/src/invisible.mjs
@@ -14,11 +14,23 @@ export const VS = [
   .map((codePoint) => String.fromCodePoint(codePoint))
   .join("");
 
+// Combining marks (general category Mn) that carry NO advance width \u2014 they
+// render as nothing on their own, so a run of them is a hidden channel exactly
+// like a zero-width Cf char, yet \p{Cf} misses them (they are Mn). Strictly
+// enumerated, one reason per entry, because MOST Mn marks DO have visible width
+// (accents, vowel signs) and must never be stripped \u2014 only these zero-advance
+// ones qualify. Driven as an SSOT so the test iterates one case per member.
+//   U+034F COMBINING GRAPHEME JOINER \u2014 invisible; affects only collation/shaping
+//   U+17B4 KHMER VOWEL INHERENT AQ   \u2014 zero-width inherent vowel, renders blank
+//   U+17B5 KHMER VOWEL INHERENT AA   \u2014 zero-width inherent vowel, renders blank
+export const ZERO_WIDTH_MN = "\u034F\u17B4\u17B5";
+
 // Code points that render blank / zero-width but are NOT general category Cf,
 // so the \p{Cf} check below misses them: the Hangul fillers (category Lo,
-// U+115F/U+1160/U+3164/U+FFA0) and the Braille blank pattern (category So,
-// U+2800). A run of these carries a hidden payload exactly as zero-widths do.
-export const BLANK_NON_CF = "\u115F\u1160\u3164\uFFA0\u2800";
+// U+115F/U+1160/U+3164/U+FFA0), the Braille blank pattern (category So,
+// U+2800), and the zero-width combining marks above (category Mn). A run of any
+// of these carries a hidden payload exactly as zero-widths do.
+export const BLANK_NON_CF = "\u115F\u1160\u3164\uFFA0\u2800" + ZERO_WIDTH_MN;
 
 const REGEX_FLAGS = "gu";
 
@@ -56,6 +68,11 @@ export const CATEGORY_LABELS = Object.freeze({
 export const CHECKS = [
   [CATEGORY.CF, new RegExp(`\\p{Cf}`, REGEX_FLAGS)],
   [CATEGORY.VARIATION_SELECTORS, new RegExp(`[${VS}]`, REGEX_FLAGS)],
+  // BLANK_NON_CF includes zero-width COMBINING marks (Mn: U+034F/17B4/17B5). In
+  // a `u`-flag class each matches its own single code point — exactly the intent
+  // (we strip the lone mark, never a base+mark grapheme), so the
+  // misleading-character-class heuristic is a false positive here.
+  // eslint-disable-next-line no-misleading-character-class -- single-code-point matches under the u flag are intentional
   [CATEGORY.BLANK_FILLERS, new RegExp(`[${BLANK_NON_CF}]`, REGEX_FLAGS)],
 ];
 
@@ -64,26 +81,36 @@ export const STRIP = new RegExp(
   REGEX_FLAGS,
 );
 
-// SGR (Select Graphic Rendition): ESC [ <digits/semicolons> m — colors, bold,
-// reset. The grammar is closed: params are [0-9;]* and the final byte is `m`,
-// so a match can only restyle text, never reposition the cursor, erase, or
-// smuggle an OSC string. Text is "SGR-only" when removing these leaves no ESC
-// byte at all — a lone or partial escape therefore is not SGR-only.
+// SGR (Select Graphic Rendition): colors, bold, reset. The grammar is closed:
+// params are [0-9;]* and the final byte is `m`, so a match can only restyle
+// text, never reposition the cursor, erase, or smuggle an OSC string. A SGR
+// sequence has TWO encodings: the 7-bit `ESC [ … m` and the 8-bit C1 form where
+// a single U+009B (CSI) replaces `ESC [`. Both must be recognized — otherwise a
+// C1-introduced `U+009B 31m … 0m` is pure color yet is misread as a non-SGR
+// payload (or, worse, mistaken for SGR-only when its introducer was a C1 CSI
+// that isSgrOnly's ESC-only test never saw). Text is "SGR-only" when removing
+// these leaves no ANSI control introducer at all — a lone or partial escape is
+// therefore not SGR-only.
 // eslint-disable-next-line no-control-regex -- matching ESC-led sequences is the point
-export const SGR_RE = /\x1b\[[0-9;]*m/g;
+export const SGR_RE = /(?:\x1b\[|)[0-9;]*m/g;
 
-// eslint-disable-next-line no-control-regex -- ESC (U+001B) is exactly what we test for
-const ESC_RE = /\x1b/;
+// The two raw ANSI control introducers: 7-bit ESC (U+001B) and 8-bit C1 CSI
+// (U+009B). isSgrOnly is honest only if it tests for BOTH — a C1 cursor-move or
+// erase (`U+009B 2J`) leaves a U+009B after SGR removal and must read as NOT
+// SGR-only, exactly as its 7-bit `ESC[2J` twin does.
+// eslint-disable-next-line no-control-regex -- the raw introducers are what we test for
+const CONTROL_INTRODUCER_RE = /[\x1b]/;
 
 /**
- * True when every ESC byte in `text` belongs to a display-only SGR color
- * sequence (so stripping the ANSI removed only cosmetic styling, nothing that
- * could move the cursor, erase, or carry a payload).
+ * True when every ANSI control introducer in `text` belongs to a display-only
+ * SGR color sequence (so stripping the ANSI removed only cosmetic styling,
+ * nothing that could move the cursor, erase, or carry a payload). Recognizes
+ * both the 7-bit `ESC[…m` and 8-bit C1 (`U+009B…m`) SGR encodings.
  * @param {string} text
  * @returns {boolean}
  */
 export function isSgrOnly(text) {
-  return !ESC_RE.test(text.replace(SGR_RE, ""));
+  return !CONTROL_INTRODUCER_RE.test(text.replace(SGR_RE, ""));
 }
 
 export const LONG_RUN_THRESHOLD = 10;
@@ -113,6 +140,19 @@ const BOM = "\uFEFF";
 // clearly belong to the context.
 const ZWNJ = 0x200c;
 const ZWJ = 0x200d;
+
+// Max joiners the carve-out will PRESERVE within one uninterrupted joined
+// sequence (a `letter (joiner letter)*` run, or an emoji ZWJ sequence). A real
+// word or emoji glyph needs only a handful in a row — the longest standard emoji
+// ZWJ sequences (family-of-four, profession+ZWJ) carry three; a Persian
+// compound a couple. Past this many consecutive PRESERVED joiners with no real
+// gap between them, the run is treated as a zero-width payload channel (an
+// attacker alternates `letter joiner letter joiner …` to stay both under the
+// scatter floor AND in a per-joiner "linguistic" context) and the surplus
+// joiners are stripped. The counter resets at any genuine gap — two visible
+// characters in a row, i.e. text that is NOT part of a joined cluster — so an
+// ordinary single linguistic/emoji joiner per word is always preserved.
+export const CONSECUTIVE_JOINER_CAP = 8;
 
 // Scripts whose orthography uses ZWNJ/ZWJ between letters as a rendering
 // control. Single source of truth: LINGUISTIC_LETTER is built from this list,
@@ -214,21 +254,34 @@ function carveStrip(body) {
   const allowCarveOut = invisCount < SCATTERED_THRESHOLD;
   const foundCodes = new Set();
   let out = "";
+  // Joiners preserved so far in the current uninterrupted joined sequence. A
+  // genuine gap (two visible chars in a row — see prevVisible) resets it to 0;
+  // once it would exceed the cap the surplus joiners are stripped as payload.
+  let joinerRun = 0;
+  let prevVisible = false;
   for (let i = 0; i < cps.length; i++) {
     const ch = cps[i];
     const code = classify(ch);
     if (code === null) {
+      // A visible char following another visible char is a real word/segment
+      // boundary, not a join — the joined cluster (if any) ended here.
+      if (prevVisible) joinerRun = 0;
+      prevVisible = true;
       out += ch; // ordinary visible character
       continue;
     }
     if (
       allowCarveOut &&
+      joinerRun < CONSECUTIVE_JOINER_CAP &&
       isPreservedJoiner(ch, cps[i - 1] ?? "", cps[i + 1] ?? "")
     ) {
+      joinerRun++;
+      prevVisible = false; // a joiner keeps the cluster open
       out += ch;
       continue;
     }
     foundCodes.add(code);
+    prevVisible = false; // a stripped invisible neither opens nor closes a gap
   }
   const found = CHECKS.filter(([code]) => foundCodes.has(code)).map(
     ([code]) => code,

--- a/src/layer1.mjs
+++ b/src/layer1.mjs
@@ -15,21 +15,51 @@ import { stripInvisibleWithReport, CATEGORY } from "./invisible.mjs";
 // eslint-disable-next-line no-control-regex -- matching the raw introducers is the point
 const CONTROL_INTRODUCER_RE = /[\u001b\u009b]/g;
 
-// Full ANSI escape grammar (CSI/SGR/OSC-with-BEL), not just SGR: the Layer-1
-// guarantee is that no control introducer survives, and a cursor-move or
-// erase sequence is as much a display-spoofing hazard as a color one.
+// An OSC (Operating System Command) string is `<introducer> … <terminator>`.
+// Introducer: 7-bit `ESC]` or 8-bit C1 OSC (U+009D). Terminator: ST (`ESC\` or
+// 8-bit C1 ST U+009C) OR the legacy BEL (U+0007). The body is everything up to
+// the terminator — a title, a clickable-hyperlink URL, a clipboard write — i.e.
+// attacker-controlled PAYLOAD TEXT. Matching the introducer alone (leaving the
+// body) would let that payload survive into the model's view, so the OSC branch
+// consumes the introducer, the whole body, AND the terminator as one unit.
+//
+// Two alternatives, tried in order: (1) a properly TERMINATED string — a body
+// of bytes that no terminator can start with (the negated class makes that run
+// unambiguous and backtrack-free), then a terminator; (2) anything else from
+// the introducer to END-OF-STRING (`[\s\S]*$`). Alternative 2 is the fail-closed
+// catch-all: an UNTERMINATED introducer, or one whose only "terminator" is an
+// interior bare ESC (which is not a valid ST), drops the entire dangling
+// remainder rather than leaving the C1-OSC introducer (U+009D) and its payload
+// behind for the next pass to mis-handle (that residue broke idempotence). Both
+// alternatives are linear, so the branch stays linear.
+const OSC_INTRO = "(?:\\u001b\\]|\\u009d)";
+const OSC_TERM = "(?:\\u001b\\\\|\\u009c|\\u0007)";
+const OSC_BRANCH = `${OSC_INTRO}(?:[^\\u0007\\u001b\\u009c\\u009d]*${OSC_TERM}|[\\s\\S]*$)`;
+
+// CSI / two-byte ESC sequences (cursor moves, erase, SGR color, charset/DEC
+// selectors): an introducer, a bounded private-intro run, optional numeric
+// params, and a single final byte. Not an enforcement boundary on its own — any
+// introducer this declines to match is still removed by the residual sweep in
+// applyLayer1 — but matching the whole sequence keeps the common case one clean
+// deletion (and avoids a lone-ESC residual on every styled line).
 //
 // The private-intro class is BOUNDED ({0,12}, not *) on purpose: ; and # live
-// in both this class and the parameter groups that follow, so an unbounded *
+// in both this class and the parameter group that follows, so an unbounded *
 // here lets a ;#;#... run be split between the two quantifiers — O(n^2)
 // backtracking on an ESC;#;#... string that never completes a sequence
 // (CodeQL js/polynomial-redos). A constant bound makes the intro a constant
 // factor, so the whole match is linear; a real sequence never carries more than
-// a couple of intro bytes, and any ESC the regex declines to match is still
-// removed by the residual-introducer sweep in applyLayer1.
-// prettier-ignore
-// eslint-disable-next-line no-control-regex -- matching ESC-led sequences is the point
-const ANSI_RE = /[\u001b\u009b][[\]()#;?]{0,12}(?:(?:(?:(?:;[-a-zA-Z\d/#&.:=?%@~_]+)*|[a-zA-Z\d]+(?:;[-a-zA-Z\d/#&.:=?%@~_]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-ntqry=><~]))/g;
+// a couple of intro bytes.
+const CSI_BRANCH =
+  "[\\u001b\\u009b][[()#;?]{0,12}(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~])";
+
+// Full ANSI escape grammar (OSC first so `ESC]` / C1-OSC is consumed as a whole
+// string, not split by the CSI branch), not just SGR: the Layer-1 guarantee is
+// that no control introducer and no OSC payload survives, and a cursor-move or
+// erase sequence is as much a display-spoofing hazard as a color one. Built from
+// `\uXXXX`-escaped string parts via `new RegExp`, so no raw control byte sits in
+// the source (no no-control-regex disable needed).
+const ANSI_RE = new RegExp(`(?:${OSC_BRANCH}|${CSI_BRANCH})`, "gu");
 
 // Unpaired UTF-16 surrogates (high not followed by low, or low not preceded by
 // high). Normalized before any HTML parser, which throws on a stray byte —

--- a/test/invisible.test.mjs
+++ b/test/invisible.test.mjs
@@ -19,11 +19,14 @@ import {
   CATEGORY_LABELS,
   VS,
   BLANK_NON_CF,
+  ZERO_WIDTH_MN,
   LONG_RUN_RE,
   LONG_RUN_THRESHOLD,
   SCATTERED_THRESHOLD,
+  CONSECUTIVE_JOINER_CAP,
   LINGUISTIC_SCRIPTS,
 } from "../src/invisible.mjs";
+import { applyLayer1 } from "../src/layer1.mjs";
 import { fcRunOptions, cp } from "./test-helpers.mjs";
 
 const ZWNJ = cp(0x200c);
@@ -251,19 +254,32 @@ describe("stripInvisible: ZWNJ/ZWJ linguistic carve-out", () => {
 
   // The scatter floor (SCATTERED_THRESHOLD = 30) is the boundary: 29 invisibles
   // keep the carve-out enabled, 30 disable it wholesale. Both sides are pinned
-  // so a `<`→`<=`/`>` mutant can't survive.
+  // so a `<`→`<=`/`>` mutant can't survive. Each joiner sits in its OWN word
+  // (`letter ZWNJ letter` separated by spaces) so the consecutive-joiner cap
+  // resets per word and never confounds the scatter-floor boundary being tested.
   it(`keeps legit joiners just under the scatter floor (${SCATTERED_THRESHOLD - 1})`, () => {
-    const input =
-      (cp(0x645) + ZWNJ).repeat(SCATTERED_THRESHOLD - 1) + cp(0x62e);
+    const word = cp(0x645) + ZWNJ + cp(0x62e);
+    const input = Array.from(
+      { length: SCATTERED_THRESHOLD - 1 },
+      () => word,
+    ).join(" ");
     const { cleaned, found } = stripInvisibleWithReport(input);
     assert.equal(cleaned, input);
     assert.deepEqual(found, []);
   });
 
   it("strips ALL joiners once the scatter floor is reached, even legit ones", () => {
-    const input = (cp(0x645) + ZWNJ).repeat(SCATTERED_THRESHOLD) + cp(0x62e);
+    const word = cp(0x645) + ZWNJ + cp(0x62e);
+    const stripped = cp(0x645) + cp(0x62e);
+    const input = Array.from({ length: SCATTERED_THRESHOLD }, () => word).join(
+      " ",
+    );
+    const expected = Array.from(
+      { length: SCATTERED_THRESHOLD },
+      () => stripped,
+    ).join(" ");
     const { cleaned, found } = stripInvisibleWithReport(input);
-    assert.equal(cleaned, cp(0x645).repeat(SCATTERED_THRESHOLD) + cp(0x62e));
+    assert.equal(cleaned, expected);
     assert.deepEqual(found, [CATEGORY.CF]);
   });
 
@@ -310,6 +326,18 @@ describe("isSgrOnly", () => {
     assert.equal(isSgrOnly(`${cp(0x1b)}[`), false));
   it("SGR_RE matches a color sequence", () =>
     assert.equal(`${cp(0x1b)}[31mx`.replace(SGR_RE, ""), "x"));
+
+  // C1 (8-bit) encodings: a single U+009B (CSI) stands in for `ESC [`. isSgrOnly
+  // must judge these exactly as their 7-bit twins, never letting a C1 introducer
+  // pass unseen (the bug: an ESC-only test was blind to U+009B).
+  it("is true for a C1-introduced SGR color sequence", () =>
+    assert.equal(isSgrOnly(`${cp(0x9b)}31mhi${cp(0x9b)}0m`), true));
+  it("is false for a C1-introduced cursor move", () =>
+    assert.equal(isSgrOnly(`${cp(0x9b)}2J`), false));
+  it("is false for a lone C1 CSI introducer", () =>
+    assert.equal(isSgrOnly(cp(0x9b)), false));
+  it("SGR_RE matches a C1-introduced color sequence", () =>
+    assert.equal(`${cp(0x9b)}31mx`.replace(SGR_RE, ""), "x"));
 });
 
 // ─── LONG_RUN_RE ─────────────────────────────────────────────────────────────
@@ -324,6 +352,171 @@ describe("LONG_RUN_RE", () => {
     assert.equal(
       LONG_RUN_RE.test(cp(0x200b).repeat(LONG_RUN_THRESHOLD - 1)),
       false,
+    );
+  });
+});
+
+// ─── Zero-width combining marks (Mn) ─────────────────────────────────────────
+// These render with no advance width yet are category Mn, so \p{Cf} misses them
+// and only the enumerated ZERO_WIDTH_MN set catches them. One case per member
+// (drive off the SSOT so a dropped entry fails here), plus a guard that a
+// VISIBLE combining mark is never swept.
+describe("zero-width Mn marks", () => {
+  for (const ch of ZERO_WIDTH_MN) {
+    const hex = ch.codePointAt(0).toString(16).toUpperCase().padStart(4, "0");
+    it(`strips zero-width Mn mark U+${hex}`, () => {
+      const { cleaned, found } = stripInvisibleWithReport(`a${ch}b`);
+      assert.equal(cleaned, "ab");
+      assert.deepEqual(found, [CATEGORY.BLANK_FILLERS]);
+    });
+  }
+
+  it("every ZERO_WIDTH_MN member is part of BLANK_NON_CF", () => {
+    for (const ch of ZERO_WIDTH_MN) assert.ok(BLANK_NON_CF.includes(ch));
+  });
+
+  // U+0301 COMBINING ACUTE ACCENT has visible width — it must be left intact;
+  // only zero-advance Mn marks are payload-capable.
+  it("preserves a visible combining mark (U+0301)", () => {
+    const input = `e${cp(0x0301)}`;
+    const { cleaned, found } = stripInvisibleWithReport(input);
+    assert.equal(cleaned, input);
+    assert.deepEqual(found, []);
+  });
+});
+
+// ─── Consecutive-joiner cap (hidden-channel collapse) ────────────────────────
+// An attacker alternates `letter joiner letter joiner …` so every joiner is, in
+// isolation, in a "linguistic" context AND the total stays under the scatter
+// floor — a multi-bit zero-width channel that survived both clean and scan. The
+// cap collapses it: at most CONSECUTIVE_JOINER_CAP joiners survive in one
+// uninterrupted joined run, the surplus stripped as payload.
+describe("consecutive-joiner cap", () => {
+  const AR1 = cp(0x645);
+  const AR2 = cp(0x62e);
+  const countOf = (s, ch) => s.split(ch).length - 1;
+
+  it(`caps preserved ZWNJ in an alternating Arabic run at ${CONSECUTIVE_JOINER_CAP}`, () => {
+    const input = (AR1 + ZWNJ).repeat(CONSECUTIVE_JOINER_CAP + 12) + AR2;
+    const { cleaned, found } = stripInvisibleWithReport(input);
+    assert.equal(countOf(cleaned, ZWNJ), CONSECUTIVE_JOINER_CAP);
+    assert.deepEqual(found, [CATEGORY.CF]);
+  });
+
+  it(`caps preserved ZWJ in an alternating emoji run at ${CONSECUTIVE_JOINER_CAP}`, () => {
+    const input =
+      cp(0x1f468) + (ZWJ + cp(0x1f469)).repeat(CONSECUTIVE_JOINER_CAP + 12);
+    const { cleaned, found } = stripInvisibleWithReport(input);
+    assert.equal(countOf(cleaned, ZWJ), CONSECUTIVE_JOINER_CAP);
+    assert.deepEqual(found, [CATEGORY.CF]);
+  });
+
+  it("preserves exactly CONSECUTIVE_JOINER_CAP joiners (boundary, none stripped)", () => {
+    const input = (AR1 + ZWNJ).repeat(CONSECUTIVE_JOINER_CAP) + AR2;
+    const { cleaned, found } = stripInvisibleWithReport(input);
+    assert.equal(cleaned, input);
+    assert.deepEqual(found, []);
+  });
+
+  it("a single linguistic joiner per word is preserved (cap resets at a gap)", () => {
+    const word = AR1 + ZWNJ + AR2;
+    const input = `${word} ${word} ${word}`;
+    const { cleaned, found } = stripInvisibleWithReport(input);
+    assert.equal(cleaned, input);
+    assert.deepEqual(found, []);
+  });
+
+  it("the four-person family emoji (3 ZWJ) is under the cap and preserved", () => {
+    const { cleaned, found } = stripInvisibleWithReport(FAMILY);
+    assert.equal(cleaned, FAMILY);
+    assert.deepEqual(found, []);
+    assert.equal(countOf(cleaned, ZWJ), 3);
+  });
+});
+
+// ─── Layer 1: OSC strings + C1 sequences (no payload survives) ────────────────
+// OSC strings carry attacker-controlled text (titles, hyperlink URLs) between an
+// introducer and a terminator. The fix consumes the WHOLE string for every
+// terminator form (ST `ESC\`, C1 ST U+009C, legacy BEL) and for the 8-bit C1
+// OSC introducer, and drops an unterminated introducer's remainder (fail-closed).
+describe("applyLayer1: OSC strings and C1 sequences", () => {
+  const ESC = cp(0x1b);
+  const BEL = cp(0x07);
+  const ST = ESC + "\\";
+  const C1_ST = cp(0x9c);
+  const C1_OSC = cp(0x9d);
+  const C1_CSI = cp(0x9b);
+
+  for (const [name, input, expected] of [
+    [
+      "OSC title terminated by ST (ESC\\)",
+      `before${ESC}]0;TITLE${ST}after`,
+      "beforeafter",
+    ],
+    [
+      "OSC title terminated by C1 ST",
+      `before${ESC}]0;TITLE${C1_ST}after`,
+      "beforeafter",
+    ],
+    [
+      "OSC title terminated by BEL",
+      `before${ESC}]0;TITLE${BEL}after`,
+      "beforeafter",
+    ],
+    [
+      "OSC hyperlink (URL payload) terminated by ST",
+      `${ESC}]8;;https://evil/leak${ST}`,
+      "",
+    ],
+    ["unterminated OSC consumes to end-of-string", `${ESC}]0;UNTERMINATED`, ""],
+    [
+      "C1 OSC introducer (U+009D) terminated by C1 ST",
+      `x${C1_OSC}0;SECRET${C1_ST}y`,
+      "xy",
+    ],
+    ["C1 OSC introducer terminated by ST", `x${C1_OSC}0;SECRET${ST}y`, "xy"],
+    ["C1 CSI SGR color sequence", `a${C1_CSI}31mred${C1_CSI}0mb`, "aredb"],
+    ["C1 CSI cursor/erase sequence", `a${C1_CSI}2Jb`, "ab"],
+  ]) {
+    it(`removes the whole sequence: ${name}`, () => {
+      const { cleaned } = applyLayer1(input);
+      assert.equal(cleaned, expected);
+    });
+  }
+
+  it("leaves no raw control introducer for any of the OSC/C1 cases", () => {
+    for (const input of [
+      `${ESC}]0;t${ST}`,
+      `${ESC}]0;t${C1_ST}`,
+      `${ESC}]0;t${BEL}`,
+      `${ESC}]0;unterminated`,
+      `${C1_OSC}0;t${C1_ST}`,
+      `${C1_CSI}31mx${C1_CSI}0m`,
+    ]) {
+      const { cleaned } = applyLayer1(input);
+      assert.ok(!cleaned.includes(cp(0x1b)), "ESC survived");
+      assert.ok(!cleaned.includes(cp(0x9b)), "C1 CSI survived");
+      assert.ok(!cleaned.includes(cp(0x9d)), "C1 OSC survived");
+    }
+  });
+
+  // The deliberate bounded-intro / negated-body design keeps the ANSI grammar
+  // linear; an adversarial never-completing string must not blow up. Assert the
+  // work scales ~linearly (not super-linearly) with input size.
+  it("OSC/CSI stripping stays ~linear on adversarial never-terminating input", () => {
+    const time = (n) => {
+      const input = `${ESC}]` + ";".repeat(n) + `${ESC}[` + ";#".repeat(n);
+      const t0 = process.hrtime.bigint();
+      applyLayer1(input);
+      return Number(process.hrtime.bigint() - t0);
+    };
+    // Warm up, then compare 10x size: linear ⇒ ratio well under quadratic (100x).
+    time(2000);
+    const small = Math.max(time(20000), 1);
+    const big = time(200000);
+    assert.ok(
+      big / small < 40,
+      `super-linear scaling: ${small}ns -> ${big}ns (ratio ${(big / small).toFixed(1)})`,
     );
   });
 });
@@ -456,6 +649,58 @@ describe("property: stripInvisible invariants", () => {
             code === 0x200c || code === 0x200d || (code === 0xfeff && i === 0);
           assert.ok(ok, `unexpected residual invisible U+${code.toString(16)}`);
         }
+      }),
+      fcRunOptions(),
+    );
+  });
+});
+
+// applyLayer1 over a domain that ALSO includes raw ANSI introducers/terminators
+// (ESC, C1 CSI/OSC/ST, BEL, `[`, `]`, `;`, `m`) so the property exercises the
+// OSC/CSI grammar, not just invisible chars.
+const ansiChar = fc.constantFrom(
+  cp(0x1b),
+  cp(0x9b),
+  cp(0x9c),
+  cp(0x9d),
+  cp(0x07),
+  "[",
+  "]",
+  ";",
+  "m",
+  "0",
+);
+const layer1Text = fc
+  .array(fc.oneof(adversarialChar, ansiChar), { maxLength: 80 })
+  .map((parts) => parts.join(""));
+
+describe("property: applyLayer1 invariants", () => {
+  it("never throws on adversarial ANSI + invisible + surrogate input", () => {
+    fc.assert(
+      fc.property(layer1Text, (text) => {
+        const { cleaned } = applyLayer1(text);
+        assert.equal(typeof cleaned, "string");
+      }),
+      fcRunOptions(),
+    );
+  });
+
+  it("no raw ANSI control introducer (ESC / C1 CSI) survives, for any input", () => {
+    fc.assert(
+      fc.property(layer1Text, (text) => {
+        const { cleaned } = applyLayer1(text);
+        assert.ok(!cleaned.includes(cp(0x1b)), "ESC survived");
+        assert.ok(!cleaned.includes(cp(0x9b)), "C1 CSI survived");
+      }),
+      fcRunOptions(),
+    );
+  });
+
+  it("is idempotent: applyLayer1(applyLayer1(x)) === applyLayer1(x)", () => {
+    fc.assert(
+      fc.property(layer1Text, (text) => {
+        const once = applyLayer1(text).cleaned;
+        assert.equal(applyLayer1(once).cleaned, once);
       }),
       fcRunOptions(),
     );

--- a/test/prompt.test.mjs
+++ b/test/prompt.test.mjs
@@ -159,16 +159,18 @@ describe("classifyPrompt: the strip seam runs before the invisible-char count", 
     assert.match(verdict.reason, /Invisible char count: 0/);
   });
 
-  it("the default stripAnsiFully has a stricter OSC grammar, so the run survives and is counted too", () => {
-    // stripAnsiFully's OSC param class does not admit a soft hyphen, so the OSC
-    // is not matched as a unit; the residual ESC is swept but the invisibles
-    // remain — still a block, now flagging BOTH the ANSI escape and the run.
+  it("the default stripAnsiFully consumes the whole OSC, so the embedded run is neutralized before it can be counted", () => {
+    // stripAnsiFully now matches an OSC string as a UNIT (introducer → body →
+    // terminator), so the soft-hyphen run hidden inside the OSC title is removed
+    // with it — exactly like the injected OSC-consuming stripper above. The
+    // prompt is still blocked for the ANSI escape, but no invisible run survives
+    // to count (an OSC body can no longer smuggle a payload past the seam).
     const verdict = classifyPrompt(prompt);
     assert.equal(verdict.action, "block");
-    assert.match(verdict.reason, /Format chars \(Cf\)/);
     assert.match(verdict.reason, /ANSI escapes/);
-    assert.match(verdict.reason, /Long-run sample \(first 16 code points\)/);
-    assert.match(verdict.reason, /U\+00AD/);
+    assert.doesNotMatch(verdict.reason, /Format chars \(Cf\)/);
+    assert.doesNotMatch(verdict.reason, /Long-run sample/);
+    assert.match(verdict.reason, /Invisible char count: 0/);
   });
 
   it("an injected no-op strip leaves the invisibles in place, so the long run is counted too", () => {


### PR DESCRIPTION
## What & why

Layer-1 hardening (`src/invisible.mjs`, `src/layer1.mjs`) from an audit of invisible-character / ANSI handling.

1. **OSC payload leak (HIGH).** `ANSI_RE` only accepted BEL as an OSC terminator, so an OSC string ended with the standard ST (`ESC \`, C1 `U+009C`) or left unterminated kept its **body text** in the output (the residual sweep removed only the bare ESC). Rewrote the grammar into an OSC branch + CSI branch: OSC now consumes introducer→body→terminator as one unit for **every** terminator (ST / C1 ST / BEL) and the C1 OSC introducer `U+009D`; an improperly-terminated OSC is dropped through end-of-string (fail-closed). Linearity preserved (adversarial scaling test added).
2. **Zero-width combining marks (MED).** Added enumerated `ZERO_WIDTH_MN` (`U+034F` CGJ, `U+17B4`, `U+17B5`) to the blank-filler set — these render zero-width but are category Mn, so the `\p{Cf}` pass missed them. Visible combining marks (e.g. `U+0301`) are left intact.
3. **C1 SGR misclassification (MED).** `isSgrOnly`/`SGR_RE` now recognize the 8-bit C1 (`U+009B`) SGR form and test for both introducers, so a C1-introduced color sequence is no longer falsely reported "SGR-only." (Documented boundary: removing the raw `U+009B` byte stays Layer-1's residual-sweep job; only `isSgrOnly`'s honesty was in scope.)
4. **Joiner hidden-channel (MED).** `carveStrip` caps consecutive preserved ZWNJ/ZWJ at 8, collapsing the `letter joiner letter…` zero-width channel (and the ZWJ-between-emoji variant) while the counter resets at a real word gap, so single linguistic/emoji joiners — including 3-ZWJ family emoji — still pass.
5. **THREAT-MODEL.md** — minimal sentence-level updates to the blank-fillers row, the reassembly-hardening OSC sentence, and the SGR-only note.

## How it was tested

- `node --test test/invisible.test.mjs` 143/143; full suite **869/869**; `pnpm lint`, `pnpm check` clean; c8 **100%** on both `invisible.mjs` and `layer1.mjs`.
- Red→green confirmed per bug with explicit codepoints (OSC ST/hyperlink/unterminated leak; `U+009B` survival + `isSgrOnly` lie; the three Mn marks; a 20-joiner run preserved).
- Added fast-check properties over a domain including raw ESC / C1 CSI / OSC / ST / BEL: `applyLayer1` never throws, **no raw ANSI introducer survives for any input**, and is idempotent (this caught a residual `U+009D` bug mid-development, driving the fail-closed redesign).

## Note on a cross-file test change

This PR also updates **one** test in `test/prompt.test.mjs` (16 lines) that previously **asserted the vulnerable behavior** — it expected invisibles hidden inside an OSC title to leak past the ANSI strip and be counted. With the OSC fix the whole sequence is consumed, so the test now asserts the corrected outcome (invisible count 0). Without this the suite stays red.