### PR TITLE
fix(html): strip bogus comments in prose branch and value-gate exfil keywords

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/user/agent-input-sanitizer/node_modules

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -264,6 +264,11 @@ export function spliceRanges(text, ranges) {
     const last = merged[merged.length - 1];
     if (last && range.start < last.end) {
       if (range.end > last.end) last.end = range.end;
+      // A hidden range absorbed into a comment range (the comment sorts first
+      // on a tie) must keep the hidden label — hidden content placeholdered as
+      // "[HTML comment removed]" would understate what was stripped. Hidden
+      // dominates: if either side is hidden, the union is hidden.
+      if (range.kind === "hidden") last.kind = "hidden";
     } else {
       merged.push({ ...range });
     }
@@ -352,35 +357,82 @@ export function scanHtmlFragment(html) {
 
 const mdParser = unified().use(remarkParse).use(remarkGfm);
 
+// A markup-declaration-open (`<!`) or processing-instruction-ish (`<?`) start.
+// Inside an inline html node these begin a *bogus comment* unless they open a
+// proper `<!--…-->` comment (handled on the fast path) — `<!bogus>`, `<?php?>`,
+// `<![CDATA[…]]>` all tokenize to comments the HTML-source branch already
+// strips. The prose branch matched only literal `<!--`, so the bogus forms
+// leaked through; this finds the candidates to validate.
+const BOGUS_COMMENT_OPEN_RE = /<[!?]/g;
+
+/**
+ * If `value.slice(at)` begins with an HTML comment (proper or bogus), return
+ * the comment's end offset *within `value`* (exclusive); else null. Validated
+ * against the real HTML tokenizer rather than a hand-rolled bogus-comment state
+ * machine, so we splice exactly what a browser would hide and never a `<Foo>`
+ * element, a `<!doctype>`, or visible prose.
+ * @param {string} value
+ * @param {number} at offset of a candidate `<!`/`<?` within `value`
+ * @returns {number | null}
+ */
+function bogusCommentEnd(value, at) {
+  const tree = /** @type {any} */ (
+    unified().use(rehypeParse, { fragment: true }).parse(value.slice(at))
+  );
+  // The slice starts at the candidate `<!`/`<?`, and an inline html node value
+  // is a single construct, so the first parsed child IS that construct: a
+  // `comment` node iff it tokenized to a (bogus) comment. A `<Foo>` element, a
+  // `<!doctype>` (dropped, leaving following text), or nothing else qualifies.
+  const first = tree.children[0];
+  if (!first || first.type !== "comment") return null;
+  return at + first.position.end.offset;
+}
+
 /**
  * Append comment ranges found in `value` to `ranges`.
  *
- * indexOf scanning is linear (a lazy `<!--[\s\S]*?-->` regex backtracks
- * polynomially on crafted input); the close search starts 2 chars in so
- * spec-abrupt closes (`<!-->`, `<!--->`) terminate their own comment.
+ * Proper `<!--…-->` comments are located with linear indexOf scanning (a lazy
+ * `<!--[\s\S]*?-->` regex backtracks polynomially on crafted input); the close
+ * search starts 2 chars in so spec-abrupt closes (`<!-->`, `<!--->`) terminate
+ * their own comment. Other `<!`/`<?` starts are bogus comments, spliced to the
+ * exact span the HTML tokenizer assigns them so the prose branch reaches parity
+ * with the HTML-source branch (which strips them via parse5).
  * @param {string} value
  * @param {number} base absolute offset of the start of `value`
  * @param {number} nodeEnd absolute offset of the end of the containing node
  * @param {Array<{start: number, end: number, kind: "comment" | "hidden"}>} ranges
  */
 function collectCommentRanges(value, base, nodeEnd, ranges) {
-  for (let searchFrom = 0; ; ) {
-    const open = value.indexOf("<!--", searchFrom);
-    if (open === -1) break;
-    const close = value.indexOf("-->", open + 2);
-    /* c8 ignore start -- micromark only tokenizes inline comments WITH a
-       terminator (an unterminated `<!--` in phrasing context stays literal
-       text, visible to a human reader), so this is fail-closed
-       defense-in-depth against a future tokenizer change. Unterminated
-       comments in flow blocks are covered — parse5 handles them in
-       scanHtmlFragment. */
-    if (close === -1) {
-      ranges.push({ start: base + open, end: nodeEnd, kind: "comment" });
-      break;
+  BOGUS_COMMENT_OPEN_RE.lastIndex = 0;
+  for (let match; (match = BOGUS_COMMENT_OPEN_RE.exec(value));) {
+    const open = match.index;
+    if (value.startsWith("<!--", open)) {
+      const close = value.indexOf("-->", open + 2);
+      /* c8 ignore start -- micromark only tokenizes inline comments WITH a
+         terminator (an unterminated `<!--` in phrasing context stays literal
+         text, visible to a human reader), so this is fail-closed
+         defense-in-depth against a future tokenizer change. Unterminated
+         comments in flow blocks are covered — parse5 handles them in
+         scanHtmlFragment. */
+      if (close === -1) {
+        ranges.push({ start: base + open, end: nodeEnd, kind: "comment" });
+        break;
+      }
+      /* c8 ignore stop */
+      ranges.push({
+        start: base + open,
+        end: base + close + 3,
+        kind: "comment",
+      });
+      BOGUS_COMMENT_OPEN_RE.lastIndex = close + 3;
+      continue;
     }
-    /* c8 ignore stop */
-    ranges.push({ start: base + open, end: base + close + 3, kind: "comment" });
-    searchFrom = close + 3;
+    const end = bogusCommentEnd(value, open);
+    // Not a comment (a `<Foo>` element, a `<!doctype>`, visible prose): leave
+    // it untouched and resume scanning just past this `<`.
+    if (end === null) continue;
+    ranges.push({ start: base + open, end: base + end, kind: "comment" });
+    BOGUS_COMMENT_OPEN_RE.lastIndex = end;
   }
 }
 
@@ -558,19 +610,29 @@ export function sanitizeHtml(text) {
 
 // ─── Layer 3: markdown/URL exfiltration detection ────────────────────────────
 
-// High-precision raw-string indicators, applied to the whole URL so they fire
-// even when it is too malformed for `new URL()` to parse (e.g. a non-ASCII
-// host). The `#` in the delimiter class extends keyword detection to the
-// fragment, an exfil channel the param walk would otherwise miss (`…#token=…`).
-// The generic "long base64/hex value" arm that once lived here moved into the
-// per-parameter walk (paramExfilReason) so it can skip request-signing,
-// pagination, and analytics parameters that legitimately carry long opaque
-// values — see BENIGN_BLOB_PARAM_RE.
-const EXFIL_INDICATORS = [
-  /[?&#](?:data|d|payload|exfil|leak|steal|secret|token|key|env|password|pwd|cookie|session|auth)=/i,
-  /\$\{[^{}]+\}/,
-  /\{\{[^{}]+\}\}/,
-];
+// Template-injection indicators, applied to the whole URL so they fire even
+// when it is too malformed for `new URL()` to parse (e.g. a non-ASCII host).
+// These are name-independent shapes — server-/client-side template syntax that
+// only appears in a URL when something is interpolating untrusted data — so
+// they carry signal on their own and need no value-shape gate.
+//
+// Keyword-PARAM detection (`?token=…`, `…#secret=…`) was REMOVED from this list
+// (finding #20): firing on the parameter NAME alone flagged every `?session=ok`
+// / `?key=pk_public_mapkey` / `?d=3`, drowning the real signal. A keyword
+// param is now flagged only when its VALUE is payload-shaped, via the
+// value-gated raw scan below (rawUrlKeywordExfil) which reuses the same
+// blob/credential shape test as the post-parse param walk — see
+// paramExfilReason. The raw scan keeps the pre-parse / fragment coverage the
+// old name arm had (an unparseable host means `new URL()` throws and the
+// post-parse walk never runs).
+const EXFIL_INDICATORS = [/\$\{[^{}]+\}/, /\{\{[^{}]+\}\}/];
+
+// Parameter NAMES whose presence used to flag on sight; now they only gate
+// WHICH raw params the value-shape test is applied to before the URL is parsed.
+// Kept narrow (the historically over-eager set) so the raw pre-parse pass stays
+// cheap; any non-keyword param is still value-gated post-parse by the walk.
+const KEYWORD_PARAM_NAME_RE =
+  /^(?:data|d|payload|exfil|leak|steal|secret|token|key|env|password|pwd|cookie|session|auth)$/i;
 
 const LONG_QUERY_THRESHOLD = 200;
 
@@ -677,6 +739,32 @@ function paramExfilReason(name, value) {
 }
 
 /**
+ * Pre-parse, value-GATED keyword-parameter scan over the RAW URL string. Splits
+ * off the query (`?…`) and fragment (`#…`) and applies the same blob/credential
+ * value-shape test as the post-parse walk, but only to keyword-named params
+ * (KEYWORD_PARAM_NAME_RE). This is the precision fix for finding #20: a keyword
+ * param flags only when its value is actually payload-shaped, so `?session=ok`
+ * and `?key=pk_public_mapkey` no longer fire. It runs BEFORE `new URL()` so a
+ * blob in an unparseable-host URL (which the post-parse walk never reaches) is
+ * still caught, preserving the coverage the old name-only arm had.
+ * @param {string} url
+ * @returns {string | null}
+ */
+function rawUrlKeywordExfil(url) {
+  // Strip the scheme+authority+path prefix: everything up to the first `?`/`#`.
+  const qIdx = url.search(/[?#]/);
+  if (qIdx === -1) return null;
+  for (const segment of url.slice(qIdx + 1).split("#")) {
+    for (const [name, value] of rawParams(segment)) {
+      if (!KEYWORD_PARAM_NAME_RE.test(name)) continue;
+      const reason = paramExfilReason(name, value);
+      if (reason) return reason;
+    }
+  }
+  return null;
+}
+
+/**
  * True when every parameter of the parsed URL's query is in the benign
  * allowlist. Used to suppress the coarse long-query-string heuristic for
  * signed-CDN links, which are long by design. Only ever called once the query
@@ -738,6 +826,10 @@ export function checkExfilUrl(url) {
   if (SCRIPT_URI_RE.test(url)) return "script-executing URI";
   if (EXFIL_INDICATORS.some((pattern) => pattern.test(url)))
     return "suspicious query parameter";
+  // Value-gated keyword params, scanned on the RAW string so a blob in an
+  // unparseable-host URL is caught before `new URL()` would throw.
+  const keywordReason = rawUrlKeywordExfil(url);
+  if (keywordReason) return keywordReason;
   // Userinfo and an oversized fragment are exfil channels the param walk misses:
   // credentials smuggled as `user:secret@host`, or a payload tucked in `#<blob>`.
   // Parse against a sentinel base so relative URLs don't throw.

--- a/test/html-corpus.test.mjs
+++ b/test/html-corpus.test.mjs
@@ -124,14 +124,16 @@ const CORPUS = {
   ],
   exfil: [
     {
+      // A payload-shaped (44-char base64) value: a SHORT keyword-param value
+      // like `payload=QUJDRE…` no longer flags on the name alone (finding #20).
       name: "link-query-base64",
-      input: "[c](https://evil.example/t?payload=QUJDREVGR0hJSktMTU5P)",
+      input: `[c](https://evil.example/t?payload=${"A".repeat(44)})`,
       reason: "suspicious query parameter",
       isImage: false,
     },
     {
       name: "image-query-base64",
-      input: "![i](https://evil.example/p.png?data=QUJDREVGR0hJSktM)",
+      input: `![i](https://evil.example/p.png?data=${"A".repeat(44)})`,
       reason: "suspicious query parameter",
       isImage: true,
     },
@@ -175,8 +177,10 @@ const CORPUS = {
   ],
   url: [
     {
+      // A keyword param flags only when its value is payload-shaped: a 44-char
+      // base64 blob in `token=` is exfil; a short `?token=abc` is not (#20).
       name: "token-query-param",
-      input: `https://evil.example/log?token=${NEEDLE}`,
+      input: `https://evil.example/log?token=${"A".repeat(44)}`,
       reason: "suspicious query parameter",
     },
     {
@@ -191,7 +195,7 @@ const CORPUS = {
     },
     {
       name: "fragment-keyword-exfil",
-      input: `https://ok.example/p#token=${NEEDLE}`,
+      input: `https://ok.example/p#token=${"a".repeat(64)}`,
       reason: "suspicious query parameter",
     },
     {
@@ -210,8 +214,10 @@ const CORPUS = {
       reason: "suspicious query parameter",
     },
     {
+      // One benign param (`page=2`) plus one payload-shaped keyword param: a
+      // SHORT `session=abcdef` no longer flags on the name alone (#20).
       name: "multi-param-one-exfil",
-      input: "https://ok.example/p?page=2&session=abcdef",
+      input: `https://ok.example/p?page=2&session=${"A".repeat(44)}`,
       reason: "suspicious query parameter",
     },
     {
@@ -249,10 +255,31 @@ const CORPUS = {
       input: "https://ok.example/p?a=1#x=" + "a".repeat(64),
       reason: "suspicious query parameter",
     },
+    {
+      // Retained true positive for finding #20: a long high-entropy value in a
+      // keyword param IS payload-shaped and still flags after the name-only arm
+      // was replaced by value-gating.
+      name: "keyword-data-blob-retained",
+      input: "https://evil.example/c?data=" + "A".repeat(64),
+      reason: "suspicious query parameter",
+    },
   ],
   urlBenign: [
     { name: "fragment-anchor", input: "https://ok.example/page#section-2" },
     { name: "safe-query", input: "https://ok.example/safe?q=hello" },
+    // Finding #20 precision corpus: keyword-named params whose VALUE is short /
+    // low-entropy must NOT flag on the param name alone. Each of these used to
+    // fire ("?key=", "?d=", "?session=", "?auth=") and drowned the real signal.
+    { name: "keyword-utm-source", input: "https://e.com/p?utm_source=news" },
+    { name: "keyword-short-gclid", input: "https://e.com/p?gclid=Cj0short" },
+    { name: "keyword-d-3", input: "https://e.com/p?d=3" },
+    {
+      name: "keyword-public-mapkey",
+      input: "https://e.com/p?key=pk_public_mapkey",
+    },
+    { name: "keyword-session-ok", input: "https://e.com/p?session=ok" },
+    { name: "keyword-cursor-abc", input: "https://e.com/p?cursor=abc" },
+    { name: "keyword-auth-ok", input: "https://e.com/p?auth=ok" },
     { name: "small-data-image", input: "data:image/png;base64,iVBORw0KGgo=" },
     {
       name: "signed-cdn-link",

--- a/test/html.test.mjs
+++ b/test/html.test.mjs
@@ -5,7 +5,9 @@
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import fc from "fast-check";
 
+import { fcRunOptions } from "./test-helpers.mjs";
 import {
   sanitizeHtml,
   detectExfil,
@@ -394,6 +396,28 @@ describe("unit: spliceRanges exact behavior", () => {
     ));
   it("returns the text unchanged for no ranges", () =>
     assert.equal(spliceRanges(text, []), text));
+  it("a hidden range merged into a comment range keeps the hidden label (#21)", () =>
+    // The comment sorts first on the start tie, so the naive merge kept its
+    // kind and labeled the union "[HTML comment removed]" — understating that
+    // actively-hidden content was stripped. Hidden must dominate the union.
+    assert.equal(
+      spliceRanges(text, [
+        { start: 2, end: 5, kind: "comment" },
+        { start: 4, end: 8, kind: "hidden" },
+      ]),
+      `01${HIDDEN_PLACEHOLDER}89`,
+    ));
+  it("hidden dominates an equal-start comment that sorts first (#21)", () =>
+    // Equal starts sort by end ascending, so the SHORT comment range becomes
+    // `last` and the longer hidden range is absorbed into it — the kind must
+    // still flip to hidden.
+    assert.equal(
+      spliceRanges(text, [
+        { start: 2, end: 4, kind: "comment" },
+        { start: 2, end: 7, kind: "hidden" },
+      ]),
+      `01${HIDDEN_PLACEHOLDER}789`,
+    ));
 });
 
 describe("unit: scanHtmlFragment exact verdicts", () => {
@@ -632,8 +656,140 @@ describe("splice fidelity and regressions", () => {
       ),
       "embedded credentials",
     ));
-  it("flags a keyword exfil parameter in the fragment", () =>
-    assert.notEqual(checkExfilUrl("https://ok.example/#token=abc"), null));
+  it("flags a payload-shaped keyword param in the fragment", () =>
+    assert.notEqual(
+      checkExfilUrl(`https://ok.example/#token=${"a".repeat(64)}`),
+      null,
+    ));
+  it("does not flag a SHORT keyword fragment param on its name alone (#20)", () =>
+    assert.equal(checkExfilUrl("https://ok.example/#token=abc"), null));
   it("leaves a benign fragment anchor alone", () =>
     assert.equal(checkExfilUrl("https://ok.example/page#section-2"), null));
+});
+
+// ─── Bogus-comment parity (finding: prose branch matched only `<!--`) ─────────
+//
+// The HTML-source branch (parse5/rehype) strips not just proper comments but the
+// HTML tokenizer's *bogus comments* (`<!…>` that is not a comment/doctype,
+// `<?…>`, `<![CDATA[…]]>`). The prose/markdown branch used to scan literal
+// `<!--` only, so the bogus forms survived. These cases pin the parity AND, more
+// importantly, prove ordinary prose stays BYTE-FOR-BYTE untouched — the
+// false-positive risk a hand-rolled bogus-comment scanner would carry.
+describe("bogus-comment parity in the prose branch", () => {
+  // A `<!` form alone passes the HTML_TAG_PRESENT gate; a `<?` form alone does
+  // not, so it is paired with a `<!` to exercise the `<?` arm of the scan.
+  const SPLICED = [
+    {
+      name: "bogus <!declaration>",
+      input: "text <!bogus secret> OK",
+      want: `text ${COMMENT_PLACEHOLDER} OK`,
+    },
+    {
+      name: "CDATA section",
+      input: "note <![CDATA[ secret ]]> end",
+      want: `note ${COMMENT_PLACEHOLDER} end`,
+    },
+    {
+      name: "processing instruction (paired with a <! to clear the gate)",
+      input: "x <!a> and <?php evil ?> y",
+      want: `x ${COMMENT_PLACEHOLDER} and ${COMMENT_PLACEHOLDER} y`,
+    },
+    {
+      name: "a proper comment beside a bogus one",
+      input: "x <!bogus> y <!-- c --> z",
+      want: `x ${COMMENT_PLACEHOLDER} y ${COMMENT_PLACEHOLDER} z`,
+    },
+  ];
+  for (const { name, input, want } of SPLICED)
+    it(`splices ${name}`, () => assert.equal(applyHtml(input), want));
+
+  // The precision counter-examples. Every one of these is visible text a browser
+  // renders; not a single byte may be touched. (Several never produce an inline
+  // html node at all — micromark leaves them literal — which is exactly why the
+  // scan is safe; the assertion pins that end-to-end.)
+  const UNTOUCHED = [
+    "a < b",
+    "x<3",
+    "if (x<y) {",
+    "1<2 && 3>2",
+    "<not a tag",
+    "a bare < here",
+    "see <https://example.com> for more",
+    "use the `<Foo>` component in a code span",
+    "<Foo>visible element body</Foo>",
+    "a doctype <!DOCTYPE html> is dropped by the parser, not spliced",
+  ];
+  for (const input of UNTOUCHED)
+    it(`leaves ${JSON.stringify(input)} byte-for-byte`, () =>
+      assert.equal(applyHtml(input), input));
+});
+
+// ─── looksLikeHtmlSource branch-parity (finding #2) ──────────────────────────
+//
+// `sanitizeHtml` routes through one of two scanners — `scanHtmlFragment`
+// (parse5, when `looksLikeHtmlSource` is true) or `scanMarkdown` (remark, the
+// prose branch) — based on a coarse 30%-of-lines heuristic. After the
+// bogus-comment parity fix, the SAME hidden/bogus construct must be stripped no
+// matter which branch the heuristic happens to pick; otherwise an attacker tunes
+// the surrounding line-shape to dodge whichever branch is weaker. This property
+// embeds one construct (carrying a canary) in BOTH a tag-dense doc (forces the
+// source branch) and a prose doc (forces the markdown branch) and asserts the
+// canary dies in both while a visible marker survives in both.
+describe("property: hidden/bogus content is stripped on either branch (#2)", () => {
+  const CANARY = "CANARY_PARITY";
+  const MARKER = "VISIBLE_MARKER";
+
+  // Each builds a fragment that hides CANARY; the HTML-source branch already
+  // strips all of these, so the property pins the prose branch up to parity.
+  const hiddenConstruct = fc.constantFrom(
+    `<!-- ${CANARY} -->`,
+    `<!bogus ${CANARY}>`,
+    `<![CDATA[${CANARY}]]>`,
+    `<span style="display:none">${CANARY}</span>`,
+    `<div hidden>${CANARY}</div>`,
+    `<span aria-hidden="true">${CANARY}</span>`,
+  );
+
+  it("the canary never survives, the visible marker always does", () => {
+    let sawSourceBranch = 0;
+    let sawProseBranch = 0;
+    fc.assert(
+      fc.property(hiddenConstruct, (construct) => {
+        // Tag-dense doc: ≥5 lines, >30% tag-shaped → source branch.
+        const sourceDoc = [
+          "<section>",
+          "<p>intro</p>",
+          `<p>${MARKER}</p>`,
+          construct,
+          "<p>outro</p>",
+          "</section>",
+        ].join("\n");
+        // Prose doc: a single paragraph of plain text → markdown branch.
+        const proseDoc = `Here is ${MARKER} then ${construct} and more prose.`;
+
+        assert.equal(looksLikeHtmlSource(sourceDoc), true);
+        assert.equal(looksLikeHtmlSource(proseDoc), false);
+        if (looksLikeHtmlSource(sourceDoc)) sawSourceBranch += 1;
+        if (!looksLikeHtmlSource(proseDoc)) sawProseBranch += 1;
+
+        for (const doc of [sourceDoc, proseDoc]) {
+          const out = applyHtml(doc);
+          assert.equal(
+            out.includes(CANARY),
+            false,
+            `canary survived: ${JSON.stringify(doc)} -> ${JSON.stringify(out)}`,
+          );
+          assert.ok(
+            out.includes(MARKER),
+            `visible marker lost: ${JSON.stringify(doc)} -> ${JSON.stringify(out)}`,
+          );
+        }
+      }),
+      fcRunOptions({ numRuns: 200 }),
+    );
+    assert.ok(
+      sawSourceBranch > 0 && sawProseBranch > 0,
+      "a branch was never exercised",
+    );
+  });
 });


### PR DESCRIPTION
## What & why

Two precision-focused Layer-2/3 fixes in `src/html.mjs` (plus a count-accuracy fix). Scoped deliberately to changes that **don't add false positives** — recall-oriented heuristics were considered and dropped (see below).

**1. Bogus-comment parity (HIGH — a real hidden-instruction bypass).** The prose/markdown branch of `collectCommentRanges` scanned only literal `<!-- … -->`, so `<!bogus …>`, `<?… ?>`, and `<[CDATA[ … ]]>` — which the HTML tokenizer classifies as (bogus) comments and a browser hides, and which the HTML-**source** branch already strips via parse5 — leaked through as visible-looking text in prose. The prose branch now splices exactly the span the tokenizer assigns each construct, **validated against rehype (the real tokenizer)** via a `bogusCommentEnd` helper rather than a hand-rolled matcher. Ordinary prose stays **byte-for-byte untouched**: micromark only emits inline `html` nodes for genuine HTML constructs, and each candidate is validated — `a < b`, `x<3`, `if (x<y)`, `1<2 && 3>2`, a bare `<`, markdown autolinks, and JSX-ish text in code spans are all left intact (counter-example tests included).

**2. `looksLikeHtmlSource` branch-parity.** A property test asserts the same hidden/bogus construct is stripped on either branch (HTML-source vs. prose) while a visible marker survives in both, so the routing heuristic can't reopen the gap. Routing was not broadened.

**3. `EXFIL_INDICATORS` value-gating (finding #20 — reduces false positives).** Keyword params (`?token=`, `?session=`, `?key=`, `?d=`, …) were flagged on the parameter **name alone**, drowning the real signal. The name-only arm is replaced with a check that only flags when the **value** is payload-shaped (reusing the existing blob/credential gate). **Strictly fewer findings.**

**4. `spliceRanges` count fix (#21).** When a hidden range merges into an overlapping comment range, the placeholder now reads `[hidden HTML removed]` and the `removed.hidden`/`removed.comments` counts stay accurate (previously the first range's kind dominated).

## Deliberately NOT added (out of scope — false-positive risk)

base64url-blob widening, benign-named-param blob detection, and aggregate/split-payload entropy. These raise recall at the cost of precision; per the high-precision goal they are omitted.

## Precision corpus (all return no finding)

`?utm_source=news`, `?gclid=Cj0short`, `?d=3`, `?key=pk_public_mapkey`, `?session=ok`, `?cursor=abc`, `?auth=ok` — with retained true positives (`data=`/`payload=`/`token=` carrying a 44–64-char blob still flag).

## How it was tested

- `node --test` (3 target files) 256 pass / 0 fail; full suite **864 / 0**; `pnpm lint`, `pnpm check` clean; c8 **100%** on `src/html.mjs`.
- Red→green (failing-first): bogus-comment splice + parity tests red when the bogus branch is stubbed (prose FP cases stay green); `#21` merge tests red when the `kind = "hidden"` line is removed; the value-gating corpus reds 4 cases (`d=3`, `key=…`, `session=ok`, `auth=ok`) when the old name-only arm is reinstated.

## Known limitation (follow-up)

A `<?…?>`-only document never reaches the sanitizer because the cheap `HTML_TAG_PRESENT` pre-gate in `gates.mjs` (out of scope for this PR) doesn't include `<?`; the new `<?` handling is exercised whenever a document also contains a `<!` form, and the HTML-source branch handles it regardless. Letting PI-only documents through the gate is a one-line `gates.mjs` change best done separately.

## Note

A sibling PR (`fix(html): isHiddenStyle precision`) also edits `src/html.mjs` in a different region; a small merge-time conflict is expected.