### PR TITLE
fix(html): route processing-instruction-only documents through the sanitizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .worktrees/
 
 # Dependencies
-node_modules/
+node_modules
 .pnpm-store/
 pnpm-lock.yaml
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ Commits MUST use [Conventional Commits](https://www.conventionalcommits.org/) (`
 
 ## Code Style
 
+- **Favor precision over recall in the detection/transform layers.** A false positive here is a real harm: splicing or rewriting legitimate content removes text the model needed, and a noisy flag trains operators to ignore the signal (alert fatigue). When a heuristic can’t cleanly separate a true payload from benign input, prefer the false negative—let it pass rather than mangle real content—and say so. Concretely: validate against the actual tokenizer/parser, not a hand-rolled approximation; gate keyword matches on the value’s shape, not the name alone; fail _open_ (treat as visible/benign) on an ambiguous `calc()`/unit/encoding you can’t resolve; and pair every new detector with negative tests over a corpus of legitimate inputs asserting zero findings. If a heuristic only adds recall at the cost of precision, drop it.
 - Fail loudly: throw errors over silent warnings; never remove error output unless the user explicitly asks
 - Let exceptions propagate—never use try/except unless there is a specific, necessary recovery action. Default to crashing on unexpected input
 - Un-nest conditionals; combine related checks

--- a/src/gates.mjs
+++ b/src/gates.mjs
@@ -13,10 +13,13 @@
 
 /**
  * Matches any HTML tag-like construct: opening tags, closing tags (`</`),
- * comments (`<!`), and fragments with attributes. Gate for Layer 2 (HTML
- * sanitization) and the HTML img/a exfil path in Layer 3.
+ * comments and bogus declarations (`<!`), and processing instructions / bogus
+ * comments (`<?…?>`, which the HTML tokenizer hides exactly like a comment).
+ * The `<?` arm is what lets a PI-only document reach Layer 2's bogus-comment
+ * splice; without it such a document would skip the pipeline entirely. Gate for
+ * Layer 2 (HTML sanitization) and the HTML img/a exfil path in Layer 3.
  */
-export const HTML_TAG_PRESENT = /<[a-zA-Z/!][^<>]*>/;
+export const HTML_TAG_PRESENT = /<[a-zA-Z/!?][^<>]*>/;
 
 /**
  * Matches markdown link/image syntax (`](`, `![`) and reference link

--- a/test/html.test.mjs
+++ b/test/html.test.mjs
@@ -734,8 +734,9 @@ describe("splice fidelity and regressions", () => {
 // importantly, prove ordinary prose stays BYTE-FOR-BYTE untouched — the
 // false-positive risk a hand-rolled bogus-comment scanner would carry.
 describe("bogus-comment parity in the prose branch", () => {
-  // A `<!` form alone passes the HTML_TAG_PRESENT gate; a `<?` form alone does
-  // not, so it is paired with a `<!` to exercise the `<?` arm of the scan.
+  // `<!`, `<?`, and `<![CDATA[` forms each clear the HTML_TAG_PRESENT gate on
+  // their own (the `<?` arm was added so a PI-only document still reaches the
+  // splice); sanitizeHtml then assigns each the span the tokenizer hides.
   const SPLICED = [
     {
       name: "bogus <!declaration>",
@@ -748,9 +749,14 @@ describe("bogus-comment parity in the prose branch", () => {
       want: `note ${COMMENT_PLACEHOLDER} end`,
     },
     {
-      name: "processing instruction (paired with a <! to clear the gate)",
+      name: "processing instruction beside a bogus declaration",
       input: "x <!a> and <?php evil ?> y",
       want: `x ${COMMENT_PLACEHOLDER} and ${COMMENT_PLACEHOLDER} y`,
+    },
+    {
+      name: "PI-only document (cleared by the <? gate arm)",
+      input: "before <?php evil ?> after",
+      want: `before ${COMMENT_PLACEHOLDER} after`,
     },
     {
       name: "a proper comment beside a bogus one",

--- a/test/output.test.mjs
+++ b/test/output.test.mjs
@@ -34,8 +34,12 @@ describe("needsMarkdownPipeline", () => {
     assert.equal(needsMarkdownPipeline("a <b>x</b> c"), true));
   it("is true for a markdown link hint", () =>
     assert.equal(needsMarkdownPipeline("see [x](https://e.com)"), true));
+  it("is true for a processing instruction / bogus comment (PI-only doc)", () =>
+    assert.equal(needsMarkdownPipeline("before <?php evil ?> after"), true));
   it("is false for plain prose with no tag or link", () =>
     assert.equal(needsMarkdownPipeline("plain prose, nothing here"), false));
+  it("stays false for bare comparison operators (precision)", () =>
+    assert.equal(needsMarkdownPipeline("a < b and c > d, x<3"), false));
 });
 
 // ─── describeRemoved ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up to the bogus-comment fix (#29), closing the known limitation it flagged.

## What & why

**1. `<?…?>`-only documents now reach the sanitizer (the gate fix).** `HTML_TAG_PRESENT` in `gates.mjs` was `/<[a-zA-Z/!][^<>]*>/` — it matched `<!`/`</`/tag forms but **not** `<?`. Since `sanitizeHtml`, `detectExfil`, and the output pipeline's `needsMarkdownPipeline` all gate on this regex, a document whose only hidden construct is a processing-instruction / bogus-comment (`<?php … ?>`) with no `<!` form skipped Layer 2 entirely and the payload reached the model. Added `?` to the class (`/<[a-zA-Z/!?][^<>]*>/`); #29's `bogusCommentEnd` then splices it to the exact span the tokenizer hides.

Precision preserved: the `<?` arm only fires on `<` immediately followed by `?` and a later `>`, so bare comparison operators (`a < b`, `x<3`, `1 < 2 ? a : b` without a closing `>`) don't trip it, and the pipeline's tokenizer-validated splice leaves genuine prose byte-for-byte intact.

**2. Precision policy in `CLAUDE.md`.** Added a Code Style principle: favor precision over recall in the detection/transform layers — a false positive splices legitimate content or causes alert fatigue, so prefer the false negative on ambiguity (validate against the real parser, gate on value shape not name, fail open on unresolvable `calc()`/units/encodings, and pair every detector with a legitimate-input corpus asserting zero findings).

**3. `.gitignore` hardening.** `node_modules/` → `node_modules` so a stray `node_modules` **symlink** (not just the directory) is ignored — prevents the class of accidental commit that breaks CI `pnpm install` with ENOTDIR.

## How it was tested

- Affected suites: `node --test` over html/output/property/corpus/exfil/sanitize/package-exports — 451 pass / 0 fail. `pnpm lint`, `pnpm check` clean.
- Red→green (failing-first): reverting the `?` in the gate reds exactly the two new PI tests — `needsMarkdownPipeline("before <?php evil ?> after") === true` (output.test.mjs) and `applyHtml` splicing a PI-only document (html.test.mjs) — both green with the fix. Added a precision negative (`needsMarkdownPipeline("a < b and c > d, x<3") === false`).

## Note

Stacked on #29 (`claude/fix-html-comment-exfil`) since the splice it relies on lands there; GitHub will retarget this PR's base to `main` when #29 merges.