### PR TITLE
fix(packaging): repair consumer npm install and stop shipping build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ __pycache__/
 *.pyc
 .venv/
 .uv/
+*.egg-info/
 
 # Stryker mutation testing
 .stryker-tmp/

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "sanitize-cli": "bin/sanitize-cli.mjs"
   },
   "scripts": {
-    "postinstall": "git config core.hooksPath .hooks",
+    "prepare": "if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then git config core.hooksPath .hooks; fi",
     "test": "c8 node --test",
     "coverage": "c8 node --test",
     "check": "tsc --noEmit",
@@ -134,7 +134,7 @@
     }
   },
   "files": [
-    "src",
+    "src/*.mjs",
     "bin/sanitize-cli.mjs",
     "types",
     "LICENSE",


### PR DESCRIPTION
## Problem

`package.json` ran `postinstall: "git config core.hooksPath .hooks"` in **every consumer** `npm install`. That command exits **128** outside a git repository, so `npm install agent-input-sanitizer` fails for all downstream users — the README's very first instruction is broken.

```
npm error code 128
npm error command sh -c git config core.hooksPath .hooks
npm error fatal: not in a git directory
```

Separately, `files: ["src", …]` globbed the whole `src/` directory, so stray Python build artifacts (`src/agent_input_sanitizer.egg-info/*`, including a `Version: 0.0.0` PKG-INFO) were swept into the published npm tarball.

## Fix

- Move hook wiring from `postinstall` to a `prepare` script — `prepare` runs on a local dev install and before pack/publish, but **not** when the package is installed as a dependency — guarded by `git rev-parse --is-inside-work-tree` so it no-ops outside a repo and fails loud only on a genuine in-repo `git config` error (no `|| true` swallow).
- Narrow the `files` allowlist from `src` to `src/*.mjs`.
- Add `*.egg-info/` to `.gitignore`.

## Verification

- With an `egg-info` directory planted in `src/`, `npm pack --dry-run` now ships only the 11 `.mjs` modules — zero egg-info entries.
- The `prepare` guard exits `0` when run outside a git repo (the consumer-install case), and still wires `core.hooksPath` inside a checkout.

## Notes

A follow-up CI job that packs the tarball and installs it as a consumer (root + every subpath import, `npx sanitize-cli`) would have caught both issues and guards against regressions — tracked separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5rS4SkyGfErQQYMAWd9Ky)_