### PR TITLE
fix(cli): bound worker-mode per-line buffering to the input size cap

### DIFF
--- a/bin/sanitize-cli.mjs
+++ b/bin/sanitize-cli.mjs
@@ -45,7 +45,7 @@
  */
 import { Buffer } from "node:buffer";
 import process from "node:process";
-import readline from "node:readline";
+import { pathToFileURL } from "node:url";
 
 import { sanitize } from "../src/index.mjs";
 
@@ -173,31 +173,137 @@ async function readAll(stream) {
   return text;
 }
 
-async function runWorker() {
-  const rl = readline.createInterface({
-    input: process.stdin,
-    crlfDelay: Infinity,
+/**
+ * Streaming newline-splitter that never buffers a line past the byte `limit`.
+ *
+ * Fed raw stdin chunks one at a time, it yields a sequence of events the worker
+ * turns into exactly one response line each. The reason this exists instead of
+ * `readline`: `readline` buffers an entire newline-less line into memory before
+ * handing it over, so a hostile caller streaming a multi-gigabyte line with no
+ * `\n` defeats the size cap (the cap only fires once the whole line is already
+ * resident). Here the running byte length of the CURRENT unterminated line is
+ * tracked as bytes arrive; the instant it exceeds `limit` the partial buffer is
+ * dropped and the splitter enters a "resync" state that discards every byte up
+ * to (and including) the next `\n`, so peak buffering for one line is bounded by
+ * `limit` plus one chunk — never the whole line.
+ *
+ * Events: `{ kind: "line", text }` for a complete in-cap line (trailing `\r`
+ * stripped, matching `readline`'s `crlfDelay: Infinity` CRLF handling), and
+ * `{ kind: "oversize" }` for a line whose bytes crossed `limit` (emitted once,
+ * at the newline that terminates the discarded line). The worker maps the
+ * former through `handle` and the latter to a "request too large" error line, so
+ * the one-response-per-input-line framing holds even for a dropped line.
+ *
+ * @param {number} limit  per-line byte cap (`maxInputBytes()`)
+ */
+function createLineSplitter(limit) {
+  // `buffer` holds the bytes of the current line while it's still under the cap.
+  // The moment appending the next segment would push its byte length over
+  // `limit`, `buffer` is freed and `discarding` flips: from there we scan only
+  // for the terminating `\n`, never re-accumulating, so peak buffering for one
+  // line is bounded by `limit` regardless of how long the line runs.
+  let buffer = Buffer.alloc(0);
+  let discarding = false;
+
+  /** Strip one trailing `\r` so CRLF input frames identically to LF. */
+  const toLine = (buf) => {
+    const stripCr = buf.length > 0 && buf[buf.length - 1] === 0x0d;
+    return buf.toString("utf8", 0, stripCr ? buf.length - 1 : buf.length);
+  };
+
+  // Fold one segment (the bytes of the current line seen so far in this chunk)
+  // into `buffer`, flipping to `discarding` if it would breach the cap. Applies
+  // identically to a newline-terminated segment and to the unterminated tail, so
+  // an oversize line is caught WITHIN a chunk, not only at its trailing edge.
+  const accumulate = (segment) => {
+    if (discarding) return;
+    if (buffer.length + segment.length > limit) {
+      buffer = Buffer.alloc(0);
+      discarding = true;
+      return;
+    }
+    if (segment.length > 0) buffer = Buffer.concat([buffer, segment]);
+  };
+
+  /** Feed one chunk, returning the events it completes (newline-terminated). */
+  const push = (chunk) => {
+    const events = [];
+    let start = 0;
+    for (let i = 0; i < chunk.length; i++) {
+      if (chunk[i] !== 0x0a) continue;
+      accumulate(chunk.subarray(start, i));
+      if (discarding) {
+        events.push({ kind: "oversize" });
+        discarding = false;
+      } else {
+        events.push({ kind: "line", text: toLine(buffer) });
+      }
+      buffer = Buffer.alloc(0);
+      start = i + 1;
+    }
+    accumulate(chunk.subarray(start));
+    return events;
+  };
+
+  /**
+   * Flush at EOF. A final line with no trailing `\n` is still a request, so it
+   * gets a response — matching `readline`, which emits its last line on `close`.
+   * An empty tail (stream ended on a `\n`, or was empty) yields nothing.
+   */
+  push.end = () => {
+    if (discarding) {
+      discarding = false;
+      return [{ kind: "oversize" }];
+    }
+    if (buffer.length === 0) return [];
+    const event = { kind: "line", text: toLine(buffer) };
+    buffer = Buffer.alloc(0);
+    return [event];
+  };
+
+  return push;
+}
+
+const OVERSIZE_ERROR = (limit) =>
+  JSON.stringify({
+    error:
+      `request too large: input exceeds the ${limit}-byte limit ` +
+      "(raise AGENT_SANITIZER_MAX_INPUT_BYTES to accept it)",
   });
-  // `for await` drives lines sequentially, awaiting each `handle`, so responses
-  // leave in request order. The try/catch is the worker's whole reason to
-  // exist: a single malformed request reports an error and the loop continues
-  // rather than tearing down a pipe other requests are still using.
-  //
-  // EXACTLY one response line per input line — including a blank/whitespace line
-  // (`handle` lets `JSON.parse` reject it into an `{ error }` line). Skipping it
-  // would emit zero responses for one input line and desync a client that reads
-  // one response per request. `response` never contains a newline: `handle`
-  // returns single-line `JSON.stringify` output, and the error branch
-  // stringifies a one-key object, so the one-line-per-request framing holds.
-  for await (const line of rl) {
+
+async function runWorker() {
+  // Stream raw bytes (no encoding) so the splitter tracks UTF-8 byte length, not
+  // decoded characters, and a multi-gigabyte newline-less line is discarded as
+  // it streams rather than buffered whole the way `readline` would.
+  const limit = maxInputBytes();
+  const split = createLineSplitter(limit);
+
+  // EXACTLY one response line per input line. A complete in-cap line goes
+  // through `handle`; its try/catch is the worker's reason to exist — a single
+  // malformed request reports an error and serving continues rather than
+  // tearing down a pipe other requests still use. An oversize line (its bytes
+  // crossed the cap, so it was discarded unbuffered) gets the same structured
+  // "request too large" error a one-shot caller sees. `response` never holds a
+  // newline: `JSON.stringify` of the result or of a one-key error object is
+  // single-line, so the one-line-per-request framing holds.
+  const respond = async (event) => {
+    if (event.kind === "oversize") {
+      process.stdout.write(`${OVERSIZE_ERROR(limit)}\n`);
+      return;
+    }
     let response;
     try {
-      response = await handle(line);
+      response = await handle(event.text);
     } catch (err) {
       response = JSON.stringify({ error: err?.message ?? String(err) });
     }
     process.stdout.write(`${response}\n`);
+  };
+
+  for await (const chunk of process.stdin) {
+    for (const event of split(Buffer.from(chunk))) await respond(event);
   }
+  for (const event of split.end()) await respond(event);
 }
 
 async function runOneShot() {
@@ -217,4 +323,12 @@ async function runOneShot() {
   process.stdout.write(`${response}\n`);
 }
 
-await (process.argv.includes("--worker") ? runWorker() : runOneShot());
+// Run only when invoked as a script, not when imported (a unit test imports
+// `createLineSplitter` directly and must not have the worker consume its stdin).
+const invokedAsScript =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedAsScript)
+  await (process.argv.includes("--worker") ? runWorker() : runOneShot());
+
+export { createLineSplitter };

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -10,7 +10,8 @@
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
+import { Buffer } from "node:buffer";
 import { fileURLToPath } from "node:url";
 import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -21,6 +22,7 @@ import { sanitize } from "../src/index.mjs";
 import { classifyPrompt } from "../src/prompt.mjs";
 import { sanitizeText } from "../src/output.mjs";
 import { scanInstructionFiles } from "../src/instructions.mjs";
+import { createLineSplitter } from "../bin/sanitize-cli.mjs";
 import { fcRunOptions } from "./test-helpers.mjs";
 
 const ESC = "\u001b";
@@ -378,5 +380,276 @@ describe("CLI: unknown op fails loudly", () => {
       found: [],
       warnings: [],
     });
+  });
+});
+
+// ─── Worker per-line memory cap (streaming) ─────────────────────────
+//
+// The header docstring promises the worker rejects an oversized request "rather
+// than buffering an unbounded payload into memory." A `readline`-based loop
+// can't honor that: it buffers a whole newline-less line before the size check
+// runs. These tests pin the streaming behavior — an oversize line is discarded
+// AS IT STREAMS (peak buffering bounded by the cap), the worker emits one error
+// line for it, and the framing resyncs so the NEXT request still answers.
+
+/**
+ * Drive the worker by streaming raw chunks on stdin, collecting response lines.
+ * @param {Buffer[]} chunks   written in order, then stdin is closed
+ * @param {number} capBytes   AGENT_SANITIZER_MAX_INPUT_BYTES for the child
+ * @returns {Promise<{ lines: string[], peakRssBytes: number }>}
+ */
+const runWorkerStreaming = (chunks, capBytes) =>
+  new Promise((resolve, reject) => {
+    const child = spawn("node", [CLI, "--worker"], {
+      env: {
+        ...process.env,
+        AGENT_SANITIZER_MAX_INPUT_BYTES: String(capBytes),
+      },
+    });
+    let out = "";
+    let peakRssBytes = 0;
+    child.stdout.on("data", (d) => (out += d));
+    child.on("error", reject);
+    // Sample the child's resident set so the test can assert the oversize line
+    // never made it into memory whole. /proc is Linux-only; elsewhere the RSS
+    // assertion is skipped and only the functional framing checks run.
+    const sample = () => {
+      try {
+        const statm = readFileSync(`/proc/${child.pid}/statm`, "utf8");
+        peakRssBytes = Math.max(
+          peakRssBytes,
+          Number(statm.split(" ")[1]) * 4096,
+        );
+      } catch {
+        // child gone or non-Linux /proc absent — nothing to sample
+      }
+    };
+    const sampler = setInterval(sample, 5);
+    child.on("close", () => {
+      clearInterval(sampler);
+      resolve({
+        lines: out.length === 0 ? [] : out.trim().split("\n"),
+        peakRssBytes,
+      });
+    });
+
+    (async () => {
+      for (const chunk of chunks) {
+        if (!child.stdin.write(chunk))
+          await new Promise((r) => child.stdin.once("drain", r));
+      }
+      child.stdin.end();
+    })().catch(reject);
+  });
+
+describe("CLI: worker bounds per-line buffering to the input cap", () => {
+  it("discards an oversized no-newline line, errors once, and resyncs", async () => {
+    const cap = 1024;
+    const okBefore = Buffer.from(`${JSON.stringify({ text: "a" })}\n`);
+    // A single line FAR larger than Node's interpreter baseline, NO interior
+    // newline, streamed in 1 MiB chunks: a buffering implementation must hold the
+    // whole payload before the cap fires, so its peak RSS rises by ~payloadBytes.
+    // The bound code discards each chunk past the cap, so RSS stays near baseline.
+    const payloadBytes = 256 * 1024 * 1024;
+    const chunkSize = 1024 * 1024;
+    const bigChunk = Buffer.from("X".repeat(chunkSize));
+    const bigChunks = Array.from(
+      { length: payloadBytes / chunkSize },
+      () => bigChunk,
+    );
+    const okAfter = Buffer.from(`\n${JSON.stringify({ text: "b" })}\n`);
+
+    // Baseline: peak RSS of a worker that only handles two tiny requests. The
+    // streaming run's peak must not exceed this by anything close to payloadBytes.
+    const baseline = await runWorkerStreaming(
+      [okBefore, Buffer.from(`${JSON.stringify({ text: "b" })}\n`)],
+      cap,
+    );
+    const { lines, peakRssBytes } = await runWorkerStreaming(
+      [okBefore, ...bigChunks, okAfter],
+      cap,
+    );
+
+    // Exactly one response per input line, framing intact across the discard.
+    assert.equal(lines.length, 3);
+    assert.deepEqual(JSON.parse(lines[0]), {
+      cleaned: "a",
+      found: [],
+      warnings: [],
+    });
+    assert.match(JSON.parse(lines[1]).error, /request too large/);
+    assert.match(JSON.parse(lines[1]).error, /AGENT_SANITIZER_MAX_INPUT_BYTES/);
+    // The resync proof: the request AFTER the discarded line still answers.
+    assert.deepEqual(JSON.parse(lines[2]), {
+      cleaned: "b",
+      found: [],
+      warnings: [],
+    });
+
+    // Memory proof: peak RSS over baseline must stay a small fraction of the
+    // 256 MiB payload. A buffering impl would add ~payloadBytes here; the bound
+    // adds only the cap plus transient chunk/GC slack. The 1/4-payload ceiling
+    // sits far below a buffering peak yet comfortably above GC headroom, so the
+    // assertion separates the two implementations without flaking. /proc-less
+    // hosts report 0 for both; skip the bound only then.
+    if (peakRssBytes > 0 && baseline.peakRssBytes > 0)
+      assert.ok(
+        peakRssBytes - baseline.peakRssBytes < payloadBytes / 4,
+        `peak RSS grew by ${peakRssBytes - baseline.peakRssBytes} bytes over ` +
+          `baseline ${baseline.peakRssBytes}; a bounded worker stays well under ` +
+          `${payloadBytes / 4} for a ${payloadBytes}-byte streamed line`,
+      );
+  });
+
+  it("a line exactly at the cap succeeds; one byte over errors", async () => {
+    // The request is `{"text":"<pad>"}`; size the pad so the whole line lands
+    // exactly on / one past the cap, pinning the boundary.
+    const make = (capExact) => {
+      const envelopeBytes = Buffer.byteLength('{"text":""}');
+      const text = "a".repeat(capExact - envelopeBytes);
+      return JSON.stringify({ text });
+    };
+    const cap = 256;
+    const atCap = make(cap);
+    assert.equal(Buffer.byteLength(atCap), cap);
+    const overCap = make(cap + 1);
+    assert.equal(Buffer.byteLength(overCap), cap + 1);
+
+    const input = Buffer.from(`${atCap}\n${overCap}\n`);
+    const { lines } = await runWorkerStreaming([input], cap);
+    assert.equal(lines.length, 2);
+    assert.ok(!("error" in JSON.parse(lines[0])), "at-cap line should succeed");
+    assert.match(JSON.parse(lines[1]).error, /request too large/);
+  });
+});
+
+// ─── Splitter unit + property tests ────────────────────────────────────
+//
+// `createLineSplitter` is the pure heart of the fix — it decides, byte by byte,
+// which line is in-cap (a `line` event) and which overflowed (an `oversize`
+// event), independent of how stdin chunks the bytes. Unit-test it directly so a
+// member-drop (CRLF handling, the at-cap boundary, mid-chunk overflow, the EOF
+// flush) is caught without spawning a process.
+
+/** Feed `input` to a fresh splitter as the given `chunkSize` (or all at once),
+ * returning every event including the EOF flush. */
+const splitAll = (input, cap, chunkSize) => {
+  const split = createLineSplitter(cap);
+  const buf = Buffer.from(input, "utf8");
+  const events = [];
+  if (chunkSize === undefined) events.push(...split(buf));
+  else
+    for (let i = 0; i < buf.length; i += chunkSize)
+      events.push(...split(buf.subarray(i, i + chunkSize)));
+  events.push(...split.end());
+  return events;
+};
+
+describe("createLineSplitter", () => {
+  it("emits one in-cap line per newline, text decoded", () => {
+    assert.deepEqual(splitAll("hi\nthere\n", 100), [
+      { kind: "line", text: "hi" },
+      { kind: "line", text: "there" },
+    ]);
+  });
+
+  it("strips a trailing CR (CRLF frames like LF)", () => {
+    assert.deepEqual(splitAll("a\r\nb\r\n", 100), [
+      { kind: "line", text: "a" },
+      { kind: "line", text: "b" },
+    ]);
+  });
+
+  it("emits a blank line for an empty input line (no skip)", () => {
+    assert.deepEqual(splitAll("\n \n", 100), [
+      { kind: "line", text: "" },
+      { kind: "line", text: " " },
+    ]);
+  });
+
+  it("flushes an unterminated final line at EOF", () => {
+    assert.deepEqual(splitAll("done", 100), [{ kind: "line", text: "done" }]);
+    assert.deepEqual(splitAll("", 100), []);
+    assert.deepEqual(splitAll("x\n", 100), [{ kind: "line", text: "x" }]);
+  });
+
+  it("a line exactly at the cap is in-cap; one over is oversize", () => {
+    assert.deepEqual(splitAll("AAAA\n", 4), [{ kind: "line", text: "AAAA" }]);
+    assert.deepEqual(splitAll("AAAAA\n", 4), [{ kind: "oversize" }]);
+  });
+
+  it("discards an oversize line then resyncs on the next", () => {
+    assert.deepEqual(splitAll("AAAAAAAA\nok\n", 4), [
+      { kind: "oversize" },
+      { kind: "line", text: "ok" },
+    ]);
+  });
+
+  it("flushes an unterminated oversize tail as one oversize event", () => {
+    assert.deepEqual(splitAll("AAAAAAAA", 4), [{ kind: "oversize" }]);
+  });
+
+  it("detects overflow mid-chunk, not only at the trailing edge", () => {
+    // Whole input in ONE chunk: the oversize MIDDLE line must still be caught
+    // (the bug the fix targets — size-checking only the chunk's tail misses it).
+    assert.deepEqual(splitAll("a\nBBBBBBBB\nc\n", 4), [
+      { kind: "line", text: "a" },
+      { kind: "oversize" },
+      { kind: "line", text: "c" },
+    ]);
+  });
+
+  it("classification is identical however the bytes are chunked", () => {
+    // The same logical lines fed as one chunk vs. byte-by-byte vs. odd splits
+    // must yield the SAME event sequence — chunk boundaries are not request
+    // boundaries. (Decoded text can differ when a split lands mid-UTF-8 char, so
+    // compare the kind/oversize structure, which is what framing depends on.)
+    const cap = 8;
+    const input = "ok\nWAYTOOLONGLINE\n\nfin";
+    const kinds = (cs) =>
+      splitAll(input, cap, cs).map((e) =>
+        e.kind === "oversize" ? "oversize" : "line",
+      );
+    const oneShot = kinds(undefined);
+    assert.deepEqual(oneShot, ["line", "oversize", "line", "line"]);
+    for (const cs of [1, 2, 3, 5, 7, 13]) assert.deepEqual(kinds(cs), oneShot);
+  });
+
+  it("property: # line events == # in-cap lines; framing chunk-invariant", () => {
+    // Domain: random lines (some > cap), joined by \\n, fed at random chunk
+    // sizes. INVARIANTS: (1) total events == number of input lines (one response
+    // per line, no skips/dupes); (2) a line's event kind matches whether its
+    // BYTE length is within the cap; (3) the event SEQUENCE is invariant to how
+    // the byte stream is chunked. Never throws on any input.
+    const cap = 16;
+    fc.assert(
+      fc.property(
+        fc.array(fc.string({ maxLength: 40 }), { minLength: 1, maxLength: 12 }),
+        fc.integer({ min: 1, max: 20 }),
+        (rawLines, chunkSize) => {
+          // A line can't contain its own delimiter; \\r is stripped, so exclude
+          // both to keep the expected framing unambiguous. Terminate EVERY line
+          // with \\n (trailing newline included) so each modeled line is framed —
+          // an unterminated empty tail is genuinely zero lines, not one, which
+          // would desync the count.
+          const lines = rawLines.map((l) => l.replace(/[\n\r]/g, ""));
+          const input = `${lines.join("\n")}\n`;
+          const expected = lines.map((l) =>
+            Buffer.byteLength(l, "utf8") > cap ? "oversize" : "line",
+          );
+
+          const kindsAt = (cs) =>
+            splitAll(input, cap, cs).map((e) =>
+              e.kind === "oversize" ? "oversize" : "line",
+            );
+          const got = kindsAt(chunkSize);
+          assert.equal(got.length, lines.length);
+          assert.deepEqual(got, expected);
+          // Chunk-invariance: same sequence fed all-at-once.
+          assert.deepEqual(kindsAt(undefined), expected);
+        },
+      ),
+      fcRunOptions({ numRuns: 200 }),
+    );
   });
 });


### PR DESCRIPTION
## Problem

Worker mode (`--worker`) used `readline`, which buffers an entire newline-less line into memory **before** `enforceSizeLimit` runs. So a hostile caller could stream a multi-gigabyte line with no `\n` and defeat `AGENT_SANITIZER_MAX_INPUT_BYTES` — contradicting the header docstring's promise that *both* modes reject oversized requests "rather than buffering an unbounded payload into memory." (One-shot's `readAll` already aborts mid-stream.)

## Fix

Replace the `readline` loop with a streaming, byte-bounded splitter (`createLineSplitter(limit)`): it consumes raw stdin chunks, tracks the running byte length of the current unterminated line, and the instant appending the next segment would exceed the cap it frees the buffer and enters a "discard until next `\n`" resync state — emitting one `request too large` error line, then serving the next request normally. Overflow is detected *within* a chunk (not just at the trailing edge), so an oversized line that arrives in a single read is caught too.

All existing worker semantics are preserved: exactly one response line per input line (blank lines included), in order; malformed line → `{error}` line and keep serving; CRLF normalized; unterminated final line flushed at EOF. One-shot mode is unchanged. The worker/one-shot now runs only when invoked as a script (`import.meta.url` vs `argv[1]`) so the splitter is unit-testable without consuming the test's stdin.

## Verification

- A subprocess test streams a 256 MiB no-newline line (1 MiB chunks, 1 KiB cap) and samples the child's peak RSS via `/proc`. Non-vacuity is concrete: the **old** readline worker peaks at **612 MiB** (would fail the bound), the **new** splitter peaks at **89 MiB** (~20 MiB over baseline) — both still emit 3 correctly-framed response lines.
- A `fast-check` property asserts one event per line, kind matching whether each line is within the cap, and chunk-invariance (same events however the byte stream is split).
- 33 tests / 10 suites pass; lint, format, and `tsc` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5rS4SkyGfErQQYMAWd9Ky)_