### PR TITLE
fix(output): bound recursion depth, detect cycles, and flag hidden chars in object keys

### DIFF
--- a/src/output.mjs
+++ b/src/output.mjs
@@ -286,16 +286,54 @@ export async function sanitizeText(text, options = {}) {
 }
 
 /**
+ * Maximum container nesting `sanitizeValue` / `suppressToolOutput` will descend
+ * before failing closed. The JS engine's own call-stack limit is many thousands
+ * of frames deep, so 200 is a wide safety margin below it: a real tool output
+ * never nests this far, while a hostile 200k-deep array (or a self-referential
+ * cycle) would otherwise blow the stack as an UNHANDLED async rejection — the
+ * output then escapes sanitization entirely (fail-open DoS). Past this depth the
+ * subtree is replaced with a placeholder and a warning is recorded, so the
+ * caller still emits a sanitized, flagged result instead of crashing.
+ */
+export const MAX_DEPTH = 200;
+
+const DEPTH_PLACEHOLDER = `[withheld: structured output nested beyond ${MAX_DEPTH} levels]`;
+const CYCLE_PLACEHOLDER = "[withheld: circular reference in structured output]";
+
+/**
  * Sanitize every string leaf of a tool-output value, preserving its shape (a
  * structured tool output whose shape changes would be ignored by a harness,
  * leaking the raw value). Non-string leaves pass through; `warnings`
  * accumulates across leaves. `sgrNote` is the OR across leaves.
+ *
+ * Fails CLOSED on two hostile shapes that would otherwise throw a `RangeError`
+ * as an unhandled async rejection (a DoS that leaves the output un-sanitized):
+ * nesting past {@link MAX_DEPTH}, and a reference cycle. Either replaces the
+ * offending subtree with a placeholder string + a warning, never passing the
+ * raw subtree through. Keys are also screened for hidden chars (see below).
  * @param {any} value
  * @param {SanitizeTextOptions} options
  * @param {string[]} warnings
  * @returns {Promise<{ value: any, modified: boolean, sgrNote: boolean }>}
  */
 export async function sanitizeValue(value, options, warnings) {
+  return sanitizeValueAt(value, options, warnings, 0, new WeakSet());
+}
+
+/**
+ * Recursion core for {@link sanitizeValue}, carrying the current `depth` and the
+ * `seen` set of ancestor containers on the active path (a WeakSet, so a value
+ * reused across sibling branches — legitimate sharing, not a cycle — is not
+ * mistaken for a back-edge; only a true ancestor still on the stack triggers
+ * the cycle guard, and it is removed on the way back up).
+ * @param {any} value
+ * @param {SanitizeTextOptions} options
+ * @param {string[]} warnings
+ * @param {number} depth
+ * @param {WeakSet<object>} seen
+ * @returns {Promise<{ value: any, modified: boolean, sgrNote: boolean }>}
+ */
+async function sanitizeValueAt(value, options, warnings, depth, seen) {
   if (typeof value === "string") {
     const result = await sanitizeText(value, options);
     warnings.push(...result.warnings);
@@ -305,32 +343,76 @@ export async function sanitizeValue(value, options, warnings) {
       sgrNote: result.sgrNote,
     };
   }
-  if (Array.isArray(value)) {
-    const out = [];
-    let modified = false;
-    let sgrNote = false;
-    for (const item of value) {
-      const result = await sanitizeValue(item, options, warnings);
-      out.push(result.value);
-      if (result.modified) modified = true;
-      if (result.sgrNote) sgrNote = true;
-    }
-    return { value: out, modified, sgrNote };
+  const isContainer =
+    Array.isArray(value) || (value !== null && typeof value === "object");
+  if (!isContainer) return { value, modified: false, sgrNote: false };
+
+  // Fail closed before descending into a container: a back-edge to an ancestor
+  // (cycle) or a depth past the cap is replaced with a placeholder, never the
+  // raw subtree. Both set modified so the caller flags the output as sanitized.
+  if (seen.has(value)) {
+    warnings.push("Withheld a circular reference in structured tool output");
+    return { value: CYCLE_PLACEHOLDER, modified: true, sgrNote: false };
   }
-  if (value !== null && typeof value === "object") {
+  if (depth >= MAX_DEPTH) {
+    warnings.push(
+      `Structured tool output nested beyond ${MAX_DEPTH} levels — deeper content withheld`,
+    );
+    return { value: DEPTH_PLACEHOLDER, modified: true, sgrNote: false };
+  }
+
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      const out = [];
+      let modified = false;
+      let sgrNote = false;
+      for (const item of value) {
+        const result = await sanitizeValueAt(
+          item,
+          options,
+          warnings,
+          depth + 1,
+          seen,
+        );
+        out.push(result.value);
+        if (result.modified) modified = true;
+        if (result.sgrNote) sgrNote = true;
+      }
+      return { value: out, modified, sgrNote };
+    }
     /** @type {Record<string, any>} */
     const out = {};
     let modified = false;
     let sgrNote = false;
     for (const [key, item] of Object.entries(value)) {
-      const result = await sanitizeValue(item, options, warnings);
+      // Screen the KEY for hidden chars (Layer 1). We FLAG but do NOT rewrite:
+      // a sanitized key can collide with a sibling key (silently dropping a
+      // field) or break a downstream schema that matches on the exact name, so
+      // precision wins — we keep the original key and warn, letting an operator
+      // decide, rather than mangle the object's shape. (A clean key is silent.)
+      const { cleaned: cleanKey } = applyLayer1(key);
+      if (cleanKey !== key) {
+        modified = true;
+        warnings.push(
+          "An object key in structured tool output carried hidden/invisible characters (key left intact, value sanitized)",
+        );
+      }
+      const result = await sanitizeValueAt(
+        item,
+        options,
+        warnings,
+        depth + 1,
+        seen,
+      );
       out[key] = result.value;
       if (result.modified) modified = true;
       if (result.sgrNote) sgrNote = true;
     }
     return { value: out, modified, sgrNote };
+  } finally {
+    seen.delete(value);
   }
-  return { value, modified: false, sgrNote: false };
 }
 
 /**
@@ -357,20 +439,47 @@ export function composeContext(
  * Replace every string leaf of `value` with `message`, preserving shape so a
  * fail-closed placeholder matches the tool's output schema. Non-string leaves
  * pass through.
+ *
+ * Shares {@link sanitizeValue}'s depth/cycle guard for the same reason: this
+ * runs on the fail-closed path (an already-suspect output), so a 200k-deep or
+ * self-referential value must NOT blow the stack here — that would re-open the
+ * very hole suppression exists to close. Past {@link MAX_DEPTH} or on a cycle it
+ * substitutes `message` for the offending subtree (already the suppression
+ * sentinel, so the placeholder is consistent with the rest of the output).
  * @param {any} value
  * @param {string} message
  * @returns {any}
  */
 export function suppressToolOutput(value, message) {
+  return suppressAt(value, message, 0, new WeakSet());
+}
+
+/**
+ * Recursion core for {@link suppressToolOutput}; see {@link sanitizeValueAt} for
+ * the depth/`seen` bookkeeping rationale.
+ * @param {any} value
+ * @param {string} message
+ * @param {number} depth
+ * @param {WeakSet<object>} seen
+ * @returns {any}
+ */
+function suppressAt(value, message, depth, seen) {
   if (typeof value === "string") return message;
-  if (Array.isArray(value))
-    return value.map((item) => suppressToolOutput(item, message));
-  if (value !== null && typeof value === "object") {
+  const isContainer =
+    Array.isArray(value) || (value !== null && typeof value === "object");
+  if (!isContainer) return value;
+  if (seen.has(value) || depth >= MAX_DEPTH) return message;
+
+  seen.add(value);
+  try {
+    if (Array.isArray(value))
+      return value.map((item) => suppressAt(item, message, depth + 1, seen));
     /** @type {Record<string, any>} */
     const out = {};
     for (const [key, item] of Object.entries(value))
-      out[key] = suppressToolOutput(item, message);
+      out[key] = suppressAt(item, message, depth + 1, seen);
     return out;
+  } finally {
+    seen.delete(value);
   }
-  return value;
 }

--- a/test/output-property.test.mjs
+++ b/test/output-property.test.mjs
@@ -20,6 +20,7 @@ import {
   sanitizeText,
   sanitizeValue,
   deleteVerbatimSpans,
+  MAX_DEPTH,
 } from "../src/output.mjs";
 import { fcRunOptions, cp } from "./test-helpers.mjs";
 
@@ -199,6 +200,40 @@ describe("property: sanitizeValue preserves structure", () => {
         }
         assert.equal(r.modified, changed);
       }),
+      runOptions,
+    );
+  });
+
+  // The depth fail-closed guard (R3) must never throw, regardless of how deep
+  // the random nesting goes. Drive sanitizeValue with an array nested to a
+  // random depth straddling MAX_DEPTH (some runs under, some well over) and
+  // assert it resolves to a string leaf and never blows the stack.
+  it("never throws on arbitrarily deep nesting (straddles MAX_DEPTH)", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.integer({ min: 0, max: MAX_DEPTH * 3 }),
+        async (depth) => {
+          let node = "leaf";
+          for (let i = 0; i < depth; i++) node = [node];
+          const r = await sanitizeValue(node, {}, []);
+          // Descend min(depth, MAX_DEPTH) array levels to the innermost value.
+          let inner = r.value;
+          const levels = Math.min(depth, MAX_DEPTH);
+          for (let i = 0; i < levels; i++) {
+            assert.ok(Array.isArray(inner));
+            inner = inner[0];
+          }
+          assert.equal(typeof inner, "string");
+          // Past the cap the innermost is the withhold placeholder; otherwise
+          // the original (clean) leaf survives.
+          assert.equal(
+            inner,
+            depth > MAX_DEPTH
+              ? "[withheld: structured output nested beyond 200 levels]"
+              : "leaf",
+          );
+        },
+      ),
       runOptions,
     );
   });

--- a/test/output.test.mjs
+++ b/test/output.test.mjs
@@ -21,6 +21,7 @@ import {
   describeWarned,
   needsMarkdownPipeline,
   deleteVerbatimSpans,
+  MAX_DEPTH,
 } from "../src/output.mjs";
 import { cp } from "./test-helpers.mjs";
 
@@ -524,6 +525,120 @@ describe("sanitizeValue", () => {
   });
 });
 
+// ─── sanitizeValue: depth / cycle fail-closed (R3) ───────────────────────────
+
+// Build an array nested `n` deep around a single string leaf, iteratively (a
+// recursive builder would itself blow the stack at 200k). depthArray(2) is
+// [[ "leaf" ]].
+function depthArray(n, leaf = "leaf") {
+  let node = leaf;
+  for (let i = 0; i < n; i++) node = [node];
+  return node;
+}
+
+describe("sanitizeValue depth/cycle guard (R3)", () => {
+  it("does not throw on a 200k-deep array and withholds past the cap", async () => {
+    const warnings = [];
+    const r = await sanitizeValue(depthArray(200_000), {}, warnings);
+    // Descend MAX_DEPTH array levels; the cap placeholder sits at that depth.
+    let node = r.value;
+    for (let i = 0; i < MAX_DEPTH; i++) {
+      assert.ok(Array.isArray(node), `level ${i} should still be an array`);
+      node = node[0];
+    }
+    assert.equal(
+      node,
+      "[withheld: structured output nested beyond 200 levels]",
+    );
+    assert.equal(r.modified, true);
+    assert.ok(
+      warnings.some((w) => w.includes("nested beyond 200 levels")),
+      "a depth warning is recorded",
+    );
+  });
+
+  it("withholds the first container AT MAX_DEPTH; a shallower leaf survives", async () => {
+    // depthArray(n) places its innermost container at depth n-1. The withhold
+    // fires for the first CONTAINER sitting at depth >= MAX_DEPTH, so n must be
+    // MAX_DEPTH+1 for a container to reach depth MAX_DEPTH.
+    const overCap = await sanitizeValue(depthArray(MAX_DEPTH + 1), {}, []);
+    let node = overCap.value;
+    for (let i = 0; i < MAX_DEPTH; i++) node = node[0];
+    assert.equal(
+      node,
+      "[withheld: structured output nested beyond 200 levels]",
+    );
+
+    // Exactly at the boundary (innermost container at depth MAX_DEPTH-1, leaf a
+    // STRING at depth MAX_DEPTH): the string is sanitized normally — the depth
+    // guard only withholds containers, so nothing is withheld here.
+    const warnings = [];
+    const atCap = await sanitizeValue(
+      depthArray(MAX_DEPTH, `mal${ZW}ware`),
+      {},
+      warnings,
+    );
+    let leaf = atCap.value;
+    for (let i = 0; i < MAX_DEPTH; i++) leaf = leaf[0];
+    assert.equal(leaf, "malware");
+    assert.ok(!warnings.some((w) => w.includes("nested beyond")));
+  });
+
+  it("does not throw on a circular object and replaces the back-edge", async () => {
+    const node = { name: "root", child: null };
+    node.child = node; // self-reference
+    const warnings = [];
+    const r = await sanitizeValue(node, {}, warnings);
+    assert.equal(r.value.name, "root");
+    assert.equal(
+      r.value.child,
+      "[withheld: circular reference in structured output]",
+    );
+    assert.equal(r.modified, true);
+    assert.ok(warnings.some((w) => w.includes("circular reference")));
+  });
+
+  it("does not flag a value SHARED across siblings as a cycle (no false back-edge)", async () => {
+    const shared = { v: "x" };
+    const warnings = [];
+    const r = await sanitizeValue([shared, shared], {}, warnings);
+    // Both siblings sanitize as real objects — neither is a cycle placeholder.
+    assert.deepEqual(r.value, [{ v: "x" }, { v: "x" }]);
+    assert.equal(r.modified, false);
+    assert.ok(!warnings.some((w) => w.includes("circular")));
+  });
+});
+
+// ─── sanitizeValue: hidden chars in object KEYS (S5) ─────────────────────────
+
+describe("sanitizeValue key screening (S5)", () => {
+  it("flags a key carrying a ZWSP run + ESC, keeping the original key intact", async () => {
+    const hiddenKey = `std${ZW.repeat(15)}${ESC}[31mout`;
+    const warnings = [];
+    const r = await sanitizeValue({ [hiddenKey]: "clean value" }, {}, warnings);
+    // Key is NOT rewritten (precision: rewriting could collide / break schema).
+    assert.deepEqual(Object.keys(r.value), [hiddenKey]);
+    assert.equal(r.value[hiddenKey], "clean value");
+    assert.equal(r.modified, true);
+    assert.ok(
+      warnings.some((w) => w.includes("object key") && w.includes("hidden")),
+      "a key warning naming hidden chars is recorded",
+    );
+  });
+
+  it("does not flag ordinary keys (negative: clean keys stay silent)", async () => {
+    const warnings = [];
+    const r = await sanitizeValue(
+      { stdout: "ok", code: 0, nested: { a: "b" } },
+      {},
+      warnings,
+    );
+    assert.deepEqual(r.value, { stdout: "ok", code: 0, nested: { a: "b" } });
+    assert.equal(r.modified, false);
+    assert.deepEqual(warnings, []);
+  });
+});
+
 // ─── composeContext ──────────────────────────────────────────────────────────
 
 describe("composeContext", () => {
@@ -572,4 +687,21 @@ describe("suppressToolOutput", () => {
     assert.deepEqual(suppressToolOutput(["a", 1, null], MSG), [MSG, 1, null]));
   it("passes a bare non-string scalar through untouched", () =>
     assert.equal(suppressToolOutput(7, MSG), 7));
+
+  it("does not throw on a 200k-deep array; substitutes the message past the cap", () => {
+    const out = suppressToolOutput(depthArray(200_000, "leak"), MSG);
+    let node = out;
+    for (let i = 0; i < MAX_DEPTH; i++) {
+      assert.ok(Array.isArray(node));
+      node = node[0];
+    }
+    assert.equal(node, MSG);
+  });
+
+  it("does not throw on a circular object; substitutes the back-edge", () => {
+    const node = { a: "leak", self: null };
+    node.self = node;
+    const out = suppressToolOutput(node, MSG);
+    assert.deepEqual(out, { a: MSG, self: MSG });
+  });
 });


### PR DESCRIPTION
Two hardening fixes to the tool-output sanitizer.

## R3 — unbounded recursion (DoS / fail-open)

`sanitizeValue` and `suppressToolOutput` recursed per array element / object entry with no depth bound or cycle detection, so a deeply-nested (e.g. 200k-deep) or circular tool output threw an unhandled `RangeError` — a DoS that also fails **open** (the output skips sanitization entirely). Both now bound recursion at an exported, documented `MAX_DEPTH = 200` and detect cycles with a `WeakSet` of ancestors on the active path (added before descent, removed in a `finally`, so a value legitimately *shared* across sibling branches isn't mistaken for a back-edge). Past the cap or on a cycle they fail **closed**: the offending subtree is replaced with a placeholder + warning (`sanitizeValue`) or the suppression message (`suppressToolOutput`), never passed through raw.

## S5 — object keys unsanitized

Object keys were copied verbatim, so a key carrying a zero-width run + ANSI reached the model with `modified:false` and no warning. Keys are now screened through the existing `applyLayer1`; a key that would change sets `modified=true` and pushes a warning naming hidden chars in a key. Deliberately **flag but do not rewrite** (documented in a comment): a sanitized key can collide with a sibling (silently dropping a field) or break a downstream schema, so precision wins and an operator decides.

## Tests

Example, boundary, and `fast-check` property tests, including the 200k-deep and circular inputs that previously crashed the suite. Red→green confirmed (old code: `RangeError` on deep input; hidden-char key returns `modified:false`/`warnings:[]`). 83 tests pass; `output.mjs` at 100% statements/branches/functions/lines; lint and format clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5rS4SkyGfErQQYMAWd9Ky)_