### PR TITLE
fix(invisible): cap and flag carve-out-preserved joiners to close the zero-width covert channel

### DIFF
--- a/src/invisible.mjs
+++ b/src/invisible.mjs
@@ -154,6 +154,30 @@ const ZWJ = 0x200d;
 // ordinary single linguistic/emoji joiner per word is always preserved.
 export const CONSECUTIVE_JOINER_CAP = 8;
 
+// Max joiners the carve-out will PRESERVE across the WHOLE string, summed over
+// every cluster (unlike CONSECUTIVE_JOINER_CAP, this counter never resets at a
+// gap). It closes a covert channel the consecutive cap alone leaves open: an
+// attacker writes `letter joiner letter letter` repeatedly so each joiner sits
+// between two linguistic letters (preserved) and every cluster is separated by a
+// real gap (resetting joinerRun), threading many one-bit joiners through while
+// staying under SCATTERED_THRESHOLD — so the consecutive cap never trips and
+// `found` stays empty. A document-wide budget catches the aggregate: once more
+// than this many joiners would be preserved, the surplus is stripped as payload
+// AND the category is reported, so the result is never silently carrying a large
+// hidden joiner channel.
+//
+// Sizing (precision over recall — err toward preserving real text): the scatter
+// floor already caps TOTAL invisibles at SCATTERED_THRESHOLD (30); above it the
+// carve-out is off and every joiner is stripped. So the only joiners this budget
+// governs are those in texts with fewer than 30 total invisibles. Within that
+// window, legitimate multilingual prose stays well under 16: a Persian sentence
+// carries a handful of ZWNJ, the longest standard emoji ZWJ sequences three.
+// Genuine text dense enough to need >16 joiners would also push total invisibles
+// past the scatter floor and be handled there. 16 sits comfortably above real
+// usage yet well under the 25-joiner PoC, so honest text is preserved un-flagged
+// while a stuffed channel is capped and surfaced.
+export const TOTAL_PRESERVED_JOINER_BUDGET = 16;
+
 // Scripts whose orthography uses ZWNJ/ZWJ between letters as a rendering
 // control. Single source of truth: LINGUISTIC_LETTER is built from this list,
 // and the test suite drives one preserve-case per entry, so adding a script
@@ -237,9 +261,12 @@ function bulkStrip(body) {
 /**
  * Carve-out strip (a ZWNJ/ZWJ is present): walk code points, preserving a join
  * control only where isPreservedJoiner holds AND the text stays under the
- * scatter floor — otherwise it is stripped like any other payload byte. `found`
- * reports only categories actually removed, so a preserved joiner never makes
- * the caller claim a strip that did not happen.
+ * scatter floor AND neither the per-cluster (CONSECUTIVE_JOINER_CAP) nor the
+ * document-wide (TOTAL_PRESERVED_JOINER_BUDGET) preserve limit is hit —
+ * otherwise it is stripped like any other payload byte. `found` reports only
+ * categories actually removed, so a preserved joiner never makes the caller
+ * claim a strip that did not happen, and a stuffed joiner channel surfaces as
+ * CATEGORY.CF once it overruns the budget.
  * @param {string} body
  * @returns {{ cleaned: string, found: string[] }}
  */
@@ -258,6 +285,11 @@ function carveStrip(body) {
   // genuine gap (two visible chars in a row — see prevVisible) resets it to 0;
   // once it would exceed the cap the surplus joiners are stripped as payload.
   let joinerRun = 0;
+  // Joiners preserved so far across the WHOLE string — never reset at a gap, so
+  // it caps the document-wide channel the per-cluster joinerRun cannot (see
+  // TOTAL_PRESERVED_JOINER_BUDGET). Past the budget a joiner is stripped and its
+  // category reported, even though it is in a per-char linguistic context.
+  let preservedTotal = 0;
   let prevVisible = false;
   for (let i = 0; i < cps.length; i++) {
     const ch = cps[i];
@@ -273,9 +305,11 @@ function carveStrip(body) {
     if (
       allowCarveOut &&
       joinerRun < CONSECUTIVE_JOINER_CAP &&
+      preservedTotal < TOTAL_PRESERVED_JOINER_BUDGET &&
       isPreservedJoiner(ch, cps[i - 1] ?? "", cps[i + 1] ?? "")
     ) {
       joinerRun++;
+      preservedTotal++;
       prevVisible = false; // a joiner keeps the cluster open
       out += ch;
       continue;

--- a/test/invisible-property.test.mjs
+++ b/test/invisible-property.test.mjs
@@ -1,0 +1,97 @@
+/**
+ * Property (fuzz) tests for the ZWNJ/ZWJ carve-out over its real input domain:
+ * random interleavings of joiner-using script letters, emoji parts, and the
+ * joiners themselves. Pins the structural invariants the document-wide budget
+ * must hold against any adversarial arrangement — not just the hand-built PoC.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fc from "fast-check";
+
+import {
+  stripInvisible,
+  stripInvisibleWithReport,
+  TOTAL_PRESERVED_JOINER_BUDGET,
+} from "../src/invisible.mjs";
+import { fcRunOptions, cp } from "./test-helpers.mjs";
+
+const ZWNJ = cp(0x200c);
+const ZWJ = cp(0x200d);
+
+const countOf = (s, ch) => s.split(ch).length - 1;
+const preservedJoiners = (s) => countOf(s, ZWNJ) + countOf(s, ZWJ);
+
+// The carve-out's real domain: letters of joiner-using scripts (Arabic + a
+// Devanagari pair), emoji bases + a skin-tone modifier, the two joiners, and a
+// few plain visible chars to form gaps. No ASCII-only noise — feed the domain
+// the change actually touches.
+const carveChar = fc.constantFrom(
+  cp(0x645), // Arabic
+  cp(0x62e), // Arabic
+  cp(0x915), // Devanagari
+  cp(0x937), // Devanagari
+  cp(0x1f468), // man (pictograph)
+  cp(0x1f469), // woman (pictograph)
+  cp(0x1f3fb), // skin-tone modifier
+  ZWNJ,
+  ZWJ,
+  "a",
+  " ",
+);
+const carveText = fc
+  .array(carveChar, { maxLength: 120 })
+  .map((parts) => parts.join(""));
+
+describe("property: carve-out joiner-budget invariants", () => {
+  it("output is always a subsequence of the input (deletion only)", () => {
+    fc.assert(
+      fc.property(carveText, (text) => {
+        // Per code UNIT (astral chars are two units; the carve-out only ever
+        // deletes whole code points, so a per-unit subsequence check is sound
+        // and stricter than per-code-point here — no lone surrogates injected).
+        const out = stripInvisible(text);
+        let i = 0;
+        for (let k = 0; k < out.length; k++) {
+          const unit = out.charCodeAt(k);
+          while (i < text.length && text.charCodeAt(i) !== unit) i++;
+          assert.ok(i < text.length, "output not a subsequence of input");
+          i++;
+        }
+      }),
+      fcRunOptions(),
+    );
+  });
+
+  it("is idempotent: strip(strip(x)) === strip(x)", () => {
+    fc.assert(
+      fc.property(carveText, (text) => {
+        const once = stripInvisible(text);
+        assert.equal(stripInvisible(once), once);
+      }),
+      fcRunOptions(),
+    );
+  });
+
+  it("preserved-joiner count never exceeds the budget", () => {
+    fc.assert(
+      fc.property(carveText, (text) => {
+        const { cleaned } = stripInvisibleWithReport(text);
+        assert.ok(
+          preservedJoiners(cleaned) <= TOTAL_PRESERVED_JOINER_BUDGET,
+          `preserved ${preservedJoiners(cleaned)} > budget`,
+        );
+      }),
+      fcRunOptions(),
+    );
+  });
+
+  it("`found` is non-empty iff the text actually changed", () => {
+    fc.assert(
+      fc.property(carveText, (text) => {
+        const { cleaned, found } = stripInvisibleWithReport(text);
+        assert.equal(found.length > 0, cleaned !== text);
+      }),
+      fcRunOptions(),
+    );
+  });
+});

--- a/test/invisible.test.mjs
+++ b/test/invisible.test.mjs
@@ -24,6 +24,7 @@ import {
   LONG_RUN_THRESHOLD,
   SCATTERED_THRESHOLD,
   CONSECUTIVE_JOINER_CAP,
+  TOTAL_PRESERVED_JOINER_BUDGET,
   LINGUISTIC_SCRIPTS,
 } from "../src/invisible.mjs";
 import { applyLayer1 } from "../src/layer1.mjs";
@@ -31,6 +32,9 @@ import { fcRunOptions, cp } from "./test-helpers.mjs";
 
 const ZWNJ = cp(0x200c);
 const ZWJ = cp(0x200d);
+
+/** Count occurrences of a single-char needle in a string (joiner counting). */
+const countOf = (s, ch) => s.split(ch).length - 1;
 
 // ─── stripInvisible: core classes ────────────────────────────────────────────
 
@@ -252,35 +256,35 @@ describe("stripInvisible: ZWNJ/ZWJ linguistic carve-out", () => {
     });
   }
 
-  // The scatter floor (SCATTERED_THRESHOLD = 30) is the boundary: 29 invisibles
-  // keep the carve-out enabled, 30 disable it wholesale. Both sides are pinned
-  // so a `<`→`<=`/`>` mutant can't survive. Each joiner sits in its OWN word
-  // (`letter ZWNJ letter` separated by spaces) so the consecutive-joiner cap
-  // resets per word and never confounds the scatter-floor boundary being tested.
-  it(`keeps legit joiners just under the scatter floor (${SCATTERED_THRESHOLD - 1})`, () => {
+  // The scatter floor (SCATTERED_THRESHOLD = 30) is a boundary on TOTAL
+  // invisibles: 29 keep the carve-out enabled, 30 disable it wholesale. Both
+  // sides are pinned so a `<`→`<=`/`>` mutant can't survive. To probe THIS gate
+  // alone we hold the joiner count under TOTAL_PRESERVED_JOINER_BUDGET (so the
+  // budget gate doesn't trip first) and pad the rest of the floor with a
+  // non-joiner invisible class (interior BOMs) the budget never governs. A
+  // single legit Persian word (1 ZWNJ) survives at 29 total, is stripped at 30.
+  const padCount = SCATTERED_THRESHOLD - 2; // + 1 joiner = SCATTERED_THRESHOLD-1
+  const interiorBom = cp(0xfeff); // Cf, strippable, NOT a joiner
+
+  it(`keeps a legit joiner just under the scatter floor (${SCATTERED_THRESHOLD - 1} total)`, () => {
     const word = cp(0x645) + ZWNJ + cp(0x62e);
-    const input = Array.from(
-      { length: SCATTERED_THRESHOLD - 1 },
-      () => word,
-    ).join(" ");
+    // word ends, then a real visible char, then the BOM padding (interior BOMs
+    // are stripped but counted toward the floor): 1 joiner + (floor-2) = floor-1.
+    const input = word + "x" + interiorBom.repeat(padCount);
     const { cleaned, found } = stripInvisibleWithReport(input);
-    assert.equal(cleaned, input);
-    assert.deepEqual(found, []);
+    assert.equal(cleaned, word + "x"); // joiner preserved, interior BOMs gone
+    assert.deepEqual(found, [CATEGORY.CF]); // the BOM padding is reported
+    assert.equal(countOf(cleaned, ZWNJ), 1);
   });
 
-  it("strips ALL joiners once the scatter floor is reached, even legit ones", () => {
+  it("strips the joiner too once the scatter floor is reached", () => {
     const word = cp(0x645) + ZWNJ + cp(0x62e);
-    const stripped = cp(0x645) + cp(0x62e);
-    const input = Array.from({ length: SCATTERED_THRESHOLD }, () => word).join(
-      " ",
-    );
-    const expected = Array.from(
-      { length: SCATTERED_THRESHOLD },
-      () => stripped,
-    ).join(" ");
+    // 1 joiner + (floor-1) BOMs = floor total → carve-out off, joiner stripped.
+    const input = word + "x" + interiorBom.repeat(SCATTERED_THRESHOLD - 1);
     const { cleaned, found } = stripInvisibleWithReport(input);
-    assert.equal(cleaned, expected);
+    assert.equal(cleaned, cp(0x645) + cp(0x62e) + "x");
     assert.deepEqual(found, [CATEGORY.CF]);
+    assert.equal(countOf(cleaned, ZWNJ), 0);
   });
 
   it("counts EVERY invisible class toward the floor, not just joiners", () => {
@@ -394,7 +398,6 @@ describe("zero-width Mn marks", () => {
 describe("consecutive-joiner cap", () => {
   const AR1 = cp(0x645);
   const AR2 = cp(0x62e);
-  const countOf = (s, ch) => s.split(ch).length - 1;
 
   it(`caps preserved ZWNJ in an alternating Arabic run at ${CONSECUTIVE_JOINER_CAP}`, () => {
     const input = (AR1 + ZWNJ).repeat(CONSECUTIVE_JOINER_CAP + 12) + AR2;
@@ -431,6 +434,125 @@ describe("consecutive-joiner cap", () => {
     assert.equal(cleaned, FAMILY);
     assert.deepEqual(found, []);
     assert.equal(countOf(cleaned, ZWJ), 3);
+  });
+});
+
+// ─── Document-wide preserved-joiner budget (covert-channel collapse) ──────────
+// The consecutive cap resets at every genuine gap, so an attacker who puts each
+// joiner in its OWN cluster — `letter joiner letter letter` repeated, double
+// letters forming the gap that resets joinerRun — preserves one joiner per
+// cluster, threading an arbitrary number through while each sits in a per-char
+// "linguistic" context AND the total stays under the scatter floor. That was a
+// silent multi-bit zero-width channel: every joiner preserved, `found` empty.
+// TOTAL_PRESERVED_JOINER_BUDGET caps the document-wide preserved count (never
+// reset at a gap): the surplus is stripped AND reported.
+describe("document-wide preserved-joiner budget", () => {
+  const AR1 = cp(0x645);
+  const AR2 = cp(0x62e);
+
+  // One joiner per cluster, clusters separated by a double-letter gap so the
+  // consecutive cap (per-cluster) never trips — only the document-wide budget
+  // can catch this. N joiners chosen above the budget but below the scatter
+  // floor (so the floor is NOT what trips), proving the budget is the gate.
+  const N = TOTAL_PRESERVED_JOINER_BUDGET + 9; // 25 — the PoC payload size
+  assert.ok(
+    N < SCATTERED_THRESHOLD,
+    "covert-channel case must stay under the scatter floor",
+  );
+  // cluster = `letter joiner letter` then a second letter as the gap opener.
+  const cluster = AR1 + ZWNJ + AR2 + AR2;
+  const covert = cluster.repeat(N);
+
+  it("caps preserved joiners at the budget across separated clusters", () => {
+    const { cleaned, found } = stripInvisibleWithReport(covert);
+    assert.equal(countOf(covert, ZWNJ), N); // input really has N joiners
+    assert.equal(
+      countOf(cleaned, ZWNJ),
+      TOTAL_PRESERVED_JOINER_BUDGET,
+      "preserved joiner count must not exceed the budget",
+    );
+    assert.deepEqual(found, [CATEGORY.CF]); // the surplus strip is reported
+  });
+
+  it("alternating ZWNJ/ZWJ between Arabic letters is capped and flagged", () => {
+    // Closest to the literal PoC: N alternating joiners, each between two Arabic
+    // letters, clusters gap-separated. Mix the two joiner code points to prove
+    // the budget counts both.
+    let s = "";
+    for (let k = 0; k < N; k++) {
+      const j = k % 2 === 0 ? ZWNJ : ZWJ;
+      s += AR1 + j + AR2 + AR2;
+    }
+    const { cleaned, found } = stripInvisibleWithReport(s);
+    const preserved = countOf(cleaned, ZWNJ) + countOf(cleaned, ZWJ);
+    assert.equal(preserved, TOTAL_PRESERVED_JOINER_BUDGET);
+    assert.deepEqual(found, [CATEGORY.CF]);
+  });
+
+  it("preserves exactly the budget at the boundary (none stripped, not flagged)", () => {
+    // Exactly TOTAL_PRESERVED_JOINER_BUDGET joiners, one per gap-separated
+    // cluster: all preserved, nothing reported. Pins the `<` boundary so a
+    // `<`→`<=` mutant (off-by-one over-strip) dies here.
+    const input = cluster.repeat(TOTAL_PRESERVED_JOINER_BUDGET);
+    const { cleaned, found } = stripInvisibleWithReport(input);
+    assert.equal(cleaned, input);
+    assert.deepEqual(found, []);
+    assert.equal(countOf(cleaned, ZWNJ), TOTAL_PRESERVED_JOINER_BUDGET);
+  });
+
+  it("the budget sits below the scatter floor so it is the operative gate", () => {
+    assert.ok(TOTAL_PRESERVED_JOINER_BUDGET < SCATTERED_THRESHOLD);
+  });
+});
+
+// ─── Precision negatives: real multilingual text is preserved un-flagged ──────
+// The budget must NOT mangle or flag legitimate short multilingual content. A
+// handful of genuine joiners — a Persian/Indic compound word, an emoji ZWJ
+// sequence — stay byte-identical with an empty `found`.
+describe("budget precision: legitimate joiners preserved and un-flagged", () => {
+  // A short compound per script (1 joiner) plus a longer one (3 joiners): all
+  // well under the budget, so none is stripped or flagged. Driven off the
+  // LINGUISTIC_SCRIPTS SSOT so a new script without representative letters fails.
+  const SCRIPT_LETTERS = {
+    Arabic: [0x645, 0x62e],
+    Devanagari: [0x915, 0x937],
+    Bengali: [0x995, 0x99a],
+    Gurmukhi: [0x0a15, 0x0a17],
+    Gujarati: [0x0a95, 0x0a97],
+    Oriya: [0x0b15, 0x0b17],
+    Tamil: [0x0b95, 0x0b99],
+    Telugu: [0x0c15, 0x0c17],
+    Kannada: [0x0c95, 0x0c97],
+    Malayalam: [0x0d15, 0x0d17],
+    Sinhala: [0x0d9a, 0x0d9c],
+  };
+  for (const script of LINGUISTIC_SCRIPTS) {
+    const [a, b] = SCRIPT_LETTERS[script];
+    assert.ok(a !== undefined, `no representative letters for ${script}`);
+    it(`a 1-3 joiner ${script} compound is preserved un-flagged`, () => {
+      // " word1 word2 " with 1 then 3 joiners — 4 joiners total, under budget.
+      const w1 = cp(a) + ZWNJ + cp(b);
+      const w2 = cp(a) + ZWNJ + cp(b) + ZWNJ + cp(a) + ZWNJ + cp(b);
+      const input = `${w1} ${w2}`;
+      const { cleaned, found } = stripInvisibleWithReport(input);
+      assert.equal(cleaned, input);
+      assert.deepEqual(found, []);
+    });
+  }
+
+  it("a family emoji ZWJ sequence is preserved un-flagged", () => {
+    const { cleaned, found } = stripInvisibleWithReport(FAMILY);
+    assert.equal(cleaned, FAMILY);
+    assert.deepEqual(found, []);
+  });
+
+  it("several distinct emoji ZWJ sequences together stay under budget", () => {
+    // Three family emoji (9 ZWJ total) separated by spaces: a realistic message,
+    // still under the 16-joiner budget — preserved verbatim, no flag.
+    const input = `${FAMILY} ${FAMILY} ${FAMILY}`;
+    const { cleaned, found } = stripInvisibleWithReport(input);
+    assert.equal(cleaned, input);
+    assert.deepEqual(found, []);
   });
 });
 


### PR DESCRIPTION
## Problem

The ZWNJ/ZWJ linguistic carve-out preserves join controls between two letters of a joiner-using script. `CONSECUTIVE_JOINER_CAP` only limited *consecutive* preserved joiners within one cluster and reset `joinerRun` at any genuine gap, so an attacker could write `letter joiner letter letter` clusters — each joiner in a valid linguistic context, each cluster gap-separated — and thread an arbitrary number of one-bit joiners through while staying under `SCATTERED_THRESHOLD`. Every joiner survived and `found` was **empty**: a silent multi-bit zero-width covert channel.

PoC: 25 alternating ZWNJ/ZWJ between Arabic letters → 25/25 preserved, no signal, full bitstream recoverable.

## Fix

Add a document-wide `TOTAL_PRESERVED_JOINER_BUDGET` (16) that counts every preserved joiner across the whole string and never resets at a gap. Past the budget the surplus joiners are stripped as payload and `CATEGORY.CF` is reported, so the result is never silently carrying a large hidden joiner channel. The budget sits well above legitimate multilingual usage (a Persian sentence's handful of ZWNJ, an emoji sequence's three) but below the scatter floor (30, which already disables the carve-out), so real text is preserved un-flagged while a stuffed channel is capped and surfaced — precision over recall. `bulkStrip` (the no-joiner common path) and the per-cluster cap are unchanged.

## Tests

- Covert-channel case: assert preserved count ≤ budget **and** `found` includes the flag.
- Precision negatives driven from the `LINGUISTIC_SCRIPTS` SSOT: 1–3-joiner compounds and emoji ZWJ sequences preserved un-flagged.
- New `fast-check` property suite over the real joiner-using domain: subsequence / idempotence / budget-cap / `found`⇔change.
- Red→green confirmed (budget gate removed → 25/25 preserved, no flag). 285 tests across consumer suites pass; `src/invisible.mjs` at 100% coverage.

## ⚠️ Behavior change to surface

Two pre-existing scatter-floor tests asserted that **29 separate one-joiner Persian words** are all preserved — but that exact shape *is* the covert channel and is now (correctly) stripped to the budget + flagged. I rewrote them to probe the scatter-floor boundary honestly (hold joiners under the budget, pad to the floor with interior BOMs) so they isolate the floor gate without colliding with the new budget gate. This is the intended new security boundary, not a regression — flagging for your review since it changes a documented preserve-case.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5rS4SkyGfErQQYMAWd9Ky)_