### PR TITLE
fix(rehydrate): fail closed on empty old_string instead of throwing RangeError

### DIFF
--- a/src/rehydrate.mjs
+++ b/src/rehydrate.mjs
@@ -114,6 +114,11 @@ async function rehydrateEdit(
   hint,
 ) {
   const oldS = ti.old_string;
+  // An empty old_string is not a view span the model copied — in real Edit it
+  // is the create/insert-at-anchor case, which Edit handles itself. There is
+  // nothing to re-anchor; pass through (null) so Edit surfaces its own
+  // behavior and the empty needle never reaches occurrences.
+  if (oldS === "") return null;
   // Resolve against the VIEW first — it is the only thing the model can have
   // copied from. A verbatim disk match is only trusted when the view has no
   // match: on a divergent file, raw bytes can contain an accidental match

--- a/src/view-map.mjs
+++ b/src/view-map.mjs
@@ -19,13 +19,16 @@
  * @returns {number[]}
  */
 export function occurrences(haystack, needle) {
+  // An empty needle has no meaningful occurrence here, and `indexOf("", k)`
+  // clamps to `haystack.length` rather than returning -1, so stepping by the
+  // needle length (0) would loop forever and grow `out` until a RangeError.
+  // Callers must never act on a zero-length match; return none.
+  if (needle === "") return [];
   const out = [];
   let i = haystack.indexOf(needle);
   while (i !== -1) {
     out.push(i);
-    // max(len, 1) so an empty needle (never produced here, but cheap to
-    // harden against) cannot loop forever.
-    i = haystack.indexOf(needle, i + Math.max(needle.length, 1));
+    i = haystack.indexOf(needle, i + needle.length);
   }
   return out;
 }

--- a/test/rehydrate.test.mjs
+++ b/test/rehydrate.test.mjs
@@ -570,6 +570,52 @@ describe("rehydrate: stripped-character re-anchoring", () => {
     );
   });
 
+  it("fails closed (null, no throw) on an empty old_string against a divergent-view file", async () => {
+    // A stripped ANSI run makes the Layer-1 view diverge from disk, so this
+    // Edit reaches rehydrateEdit. An empty old_string would otherwise hit
+    // occurrences(view.text, "") — which used to loop until a RangeError.
+    // Edit's own create/anchor handling owns the empty case, so pass through.
+    const content = `${GREEN}green${RESET} text\n`;
+    let out;
+    await assert.doesNotReject(async () => {
+      out = await rehydrateRedacted(
+        "Edit",
+        { file_path: "/f", old_string: "", new_string: "inserted" },
+        liveIo(content),
+      );
+    });
+    assert.equal(out, null);
+  });
+
+  it("returns null (not a misleading deny) for an empty old_string whose new_string carries a placeholder", async () => {
+    // Without the empty-old_string guard, occurrences("") returns [] and the
+    // call falls into the literal/empty-span resolver, which — because
+    // new_string names a redacted secret outside the (empty) span — emits the
+    // "extend old_string to cover that secret" deny. That guidance is nonsense
+    // for an empty old_string (Edit's create case), so the guard must short
+    // out to null first. This case fails (deny, not null) if the guard is
+    // removed, so it pins the guard's behavior, not just the no-throw fix.
+    const content = `${GREEN}green${RESET}\nPASSWORD=${SECRET_A}\n`;
+    const out = await rehydrateRedacted(
+      "Edit",
+      { file_path: "/f", old_string: "", new_string: `X=${PH}` },
+      liveIo(content, [{ value: SECRET_A, placeholder: PH }], reRedact),
+    );
+    assert.equal(out, null);
+  });
+
+  it("fails closed (null) on an empty old_string against a zero-width-divergent file", async () => {
+    // Second divergence flavor (stripped invisible char) to prove the guard is
+    // not specific to ANSI.
+    const content = `note${ZW}here\n`;
+    const out = await rehydrateRedacted(
+      "Edit",
+      { file_path: "/f", old_string: "", new_string: "x" },
+      liveIo(content),
+    );
+    assert.equal(out, null);
+  });
+
   it("passes through a hint-free stale old_string on a divergent file", async () => {
     const content = `${ZW}note\n`;
     const out = await rehydrateRedacted(

--- a/test/view-map-property.test.mjs
+++ b/test/view-map-property.test.mjs
@@ -146,6 +146,32 @@ describe("occurrences (property)", () => {
         assert.deepEqual(occurrences(haystack, needle), occ(haystack, needle)),
     );
   });
+
+  it("never throws over arbitrary (haystack, needle), incl. empty/multi-char", () => {
+    // An empty needle previously looped forever and grew the result until a
+    // RangeError; assert it yields [] and that any non-empty needle returns
+    // real, in-bounds match indices. Needle length 0..6 covers empty and
+    // multi-char.
+    check(
+      fc.tuple(fc.string({ maxLength: 40 }), fc.string({ maxLength: 6 })),
+      ([haystack, needle]) => {
+        const out = occurrences(haystack, needle);
+        if (needle === "") {
+          assert.deepEqual(out, []);
+          return;
+        }
+        assert.deepEqual(out, occ(haystack, needle));
+        for (const idx of out)
+          assert.equal(haystack.slice(idx, idx + needle.length), needle);
+      },
+    );
+  });
+
+  it("returns [] for an empty needle regardless of haystack", () => {
+    check(fc.string({ maxLength: 40 }), (haystack) =>
+      assert.deepEqual(occurrences(haystack, ""), []),
+    );
+  });
 });
 
 // ─── alignDeletions ──────────────────────────────────────────────────────────


### PR DESCRIPTION
`occurrences(haystack, needle)` threw `RangeError: Invalid array length` on an empty needle — the `Math.max(needle.length, 1)` comment claimed to harden against this but didn't (`indexOf("", i+1)` clamps to length rather than returning -1, so the loop never terminates and grows the result array unbounded). This is reachable from `rehydrateRedacted("Edit", {old_string: ""})` against any file whose Layer-1 view diverges from disk, turning ordinary model/attacker input into a crash instead of a fail-closed verdict (the module promises "throws only on internal error").

The fix makes `occurrences` return `[]` for an empty needle (and replaces the false comment with the real reason) and adds an explicit `old_string === "" → null` guard in `rehydrateEdit`, so the empty (create/anchor) case passes through to Edit cleanly rather than producing a misleading deny.

**Tests:** `fast-check` property that `occurrences` never throws over arbitrary `(haystack, needle)` incl. `""`; rehydrate cases for empty `old_string` against ANSI- and zero-width-divergent files (null, no throw) and a killing null-not-deny case. Red→green confirmed per hunk; both `view-map.mjs` and `rehydrate.mjs` at 100% coverage; 106 tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5rS4SkyGfErQQYMAWd9Ky)_