### PR TITLE
fix(instructions): exclusive temp write (no symlink follow) and report mixed-encoding runs

### DIFF
--- a/src/instructions.mjs
+++ b/src/instructions.mjs
@@ -21,6 +21,7 @@ import {
   lstatSync,
   realpathSync,
 } from "node:fs";
+import { randomBytes } from "node:crypto";
 import { join, relative, resolve, isAbsolute, dirname, sep } from "node:path";
 import {
   LONG_RUN_RE,
@@ -46,16 +47,25 @@ export function decodeRun(run) {
     .map((cp) => String.fromCharCode(cp - 0xe0000))
     .join("");
 
-  if (tagAscii.length > 0) {
-    return { method: "Unicode tag characters → ASCII", decoded: tagAscii };
-  }
-
   // Zero-width binary encoding: ZWSP=0, ZWNJ=1, ZWJ=group separator.
   const ZW_BIT = new Map([
     [0x200b, "0"],
     [0x200c, "1"],
     [0x200d, "|"],
   ]);
+
+  if (tagAscii.length > 0) {
+    // A run can carry BOTH tag-ASCII and zero-width chars; the strip removes the
+    // whole run regardless, but the operator-facing `decoded` must reflect the
+    // zero-width portion too rather than silently dropping it.
+    const zwCount = cps.filter((cp) => ZW_BIT.has(cp)).length;
+    const note = zwCount > 0 ? ` + ${zwCount} zero-width char(s)` : "";
+    return {
+      method: "Unicode tag characters → ASCII",
+      decoded: `${tagAscii}${note}`,
+    };
+  }
+
   if (cps.every((cp) => ZW_BIT.has(cp))) {
     const bits = cps.map((cp) => ZW_BIT.get(cp)).join("");
     return {
@@ -221,6 +231,34 @@ export function scanInstructionFiles(globs, { cwd = process.cwd() } = {}) {
 }
 
 /**
+ * Atomically replace `absPath`'s contents with `data`, preserving `mode`.
+ *
+ * Writes to a sibling temp in the same directory, then `rename`s it over the
+ * original (same dir => same filesystem => the rename is atomic, not a
+ * cross-device copy). The temp name is UNPREDICTABLE (`tmpName()` defaults to
+ * crypto-random) and the temp is created with the exclusive flag "wx"
+ * (O_CREAT|O_EXCL): if the path already exists — including an attacker-planted
+ * symlink at a guessable temp name — the open fails (EEXIST) and does NOT follow
+ * the link to clobber its target. On the rare collision we fail loud rather than
+ * retry into a different attacker-controlled path. `tmpName` is injectable for
+ * tests to force a known temp path; production callers never pass it.
+ * @param {string} absPath
+ * @param {string} data
+ * @param {number} mode
+ * @param {() => string} [tmpName]
+ */
+export function atomicReplaceFile(
+  absPath,
+  data,
+  mode,
+  tmpName = () => `.${randomBytes(12).toString("hex")}.tmp`,
+) {
+  const tmp = join(dirname(absPath), tmpName());
+  writeFileSync(tmp, data, { mode, flag: "wx" });
+  renameSync(tmp, absPath);
+}
+
+/**
  * Strip payload-capable invisible characters from `absPath` in place. Returns
  * true when the file changed (it held a payload {@link scanText} flags), false
  * when {@link scanText} reports nothing.
@@ -236,9 +274,10 @@ export function scanInstructionFiles(globs, { cwd = process.cwd() } = {}) {
  * symlinked path (which could redirect the write to a target outside the tree)
  * THROWS rather than being written through.
  *
- * The write is atomic: stripped content goes to a temp file in the same
- * directory which is then `rename`d over the original (preserving the original
- * file mode), so a crash mid-write cannot leave a truncated instruction file.
+ * The write is atomic (see {@link atomicReplaceFile}): stripped content goes to
+ * a temp file in the same directory which is then `rename`d over the original
+ * (preserving the original file mode), so a crash mid-write cannot leave a
+ * truncated instruction file.
  *
  * Throws if the file cannot be read or written (the caller decides whether an
  * unwritable contaminated file is fatal or falls back to alerting).
@@ -264,15 +303,9 @@ export function cleanFile(absPath) {
 
   const stripped = stripInvisible(original);
   // info is the lstat above; since the path is confirmed not a symlink, its
-  // mode is the regular file's mode.
-  const mode = info.mode;
-  // Atomic replace: write to a sibling temp (same dir => same filesystem, so
-  // rename is atomic, not a cross-device copy) then rename over the original.
-  // A crash before the rename leaves the original intact; after it, the new
-  // content is fully present. Mode is carried onto the temp so the replacement
-  // keeps the original's permissions. rename errors propagate (fail loud).
-  const tmp = join(dirname(absPath), `.${Date.now()}-${process.pid}.tmp`);
-  writeFileSync(tmp, stripped, { mode });
-  renameSync(tmp, absPath);
+  // mode is the regular file's mode. A crash before the rename inside
+  // atomicReplaceFile leaves the original intact; after it the new content is
+  // fully present. rename/EEXIST errors propagate (fail loud).
+  atomicReplaceFile(absPath, stripped, info.mode);
   return true;
 }

--- a/test/instructions.test.mjs
+++ b/test/instructions.test.mjs
@@ -25,6 +25,7 @@ import {
   findInstructionFiles,
   scanInstructionFiles,
   cleanFile,
+  atomicReplaceFile,
 } from "../src/instructions.mjs";
 import { LONG_RUN_THRESHOLD, SCATTERED_THRESHOLD } from "../src/invisible.mjs";
 import { cp } from "./test-helpers.mjs";
@@ -85,6 +86,29 @@ describe("decodeRun", () => {
     const result = decodeRun(`${cp(0x00ad)}${cp(0x200b)}`);
     assert.match(result.method, /invisible Unicode/);
     assert.equal(result.decoded, "U+00AD U+200B");
+  });
+
+  it("reports the zero-width count for a run mixing tag-ASCII and ZW chars", () => {
+    // A run with tag-encoded "rm -rf" plus 3 ZWSP: the tag branch decodes the
+    // ASCII but must also note the zero-width portion rather than dropping it.
+    const result = decodeRun(`${tagChars("rm -rf")}${zwRun(3)}`);
+    assert.equal(result.method, "Unicode tag characters → ASCII");
+    assert.equal(result.decoded, "rm -rf + 3 zero-width char(s)");
+  });
+
+  it("appends no zero-width note for a pure-tag run", () => {
+    const result = decodeRun(tagChars("payload"));
+    assert.equal(result.method, "Unicode tag characters → ASCII");
+    assert.equal(result.decoded, "payload");
+  });
+
+  it("counts ZWNJ and ZWJ in the mixed-run note, not just ZWSP", () => {
+    // The note counts every ZW-bit char (ZWSP/ZWNJ/ZWJ), so a mix of all three
+    // alongside tag-ASCII reports the full count.
+    const result = decodeRun(
+      `${tagChars("x")}${cp(0x200b)}${cp(0x200c)}${cp(0x200d)}`,
+    );
+    assert.equal(result.decoded, "x + 3 zero-width char(s)");
   });
 });
 
@@ -529,5 +553,56 @@ describe("cleanFile atomic write", () => {
     cleanFile(file);
     // The atomic rename consumes the temp; only the cleaned file remains.
     assert.deepEqual(readdirSync(tmpDir), ["CLAUDE.md"]);
+  });
+
+  it("atomicReplaceFile does NOT write through a pre-planted symlink at the temp path", () => {
+    // R5 invariant, driven through the real code path: atomicReplaceFile creates
+    // its temp with O_CREAT|O_EXCL ("wx"). When the temp path already exists as
+    // an attacker-planted symlink to a victim, the open fails (EEXIST) and the
+    // write does NOT follow the link to clobber the victim. We force a known
+    // temp name via the injectable generator to plant the symlink deterministically.
+    const target = join(tmpDir, "CLAUDE.md");
+    const victim = join(tmpDir, "victim.md");
+    const tmpLeaf = ".attacker-known.tmp";
+    writeFileSync(target, "# replace me\n");
+    writeFileSync(victim, "do not clobber me\n");
+    symlinkSync(victim, join(tmpDir, tmpLeaf), "file");
+    assert.throws(
+      () => atomicReplaceFile(target, "NEW CONTENT", 0o600, () => tmpLeaf),
+      /EEXIST/,
+      "wx must refuse the pre-existing symlinked temp path, not follow it",
+    );
+    assert.equal(
+      readFileSync(victim, "utf-8"),
+      "do not clobber me\n",
+      "the symlink target must be byte-for-byte unchanged",
+    );
+    assert.equal(
+      readFileSync(target, "utf-8"),
+      "# replace me\n",
+      "the original is left intact when the temp write fails",
+    );
+  });
+
+  it("atomicReplaceFile replaces atomically and preserves mode on the happy path", () => {
+    const target = join(tmpDir, "CLAUDE.md");
+    writeFileSync(target, "old\n");
+    atomicReplaceFile(target, "new content\n", 0o640);
+    assert.equal(readFileSync(target, "utf-8"), "new content\n");
+    assert.equal(statSync(target).mode & 0o777, 0o640);
+    assert.deepEqual(readdirSync(tmpDir), ["CLAUDE.md"]);
+  });
+
+  it("cleans a regular file atomically with mode preserved (happy path intact)", () => {
+    const file = join(tmpDir, "AGENTS.md");
+    writeFileSync(file, `# ok\n${tagChars("rm -rf payload here")}\n`);
+    chmodSync(file, 0o644);
+    const before = statSync(file).mode;
+    assert.equal(cleanFile(file), true);
+    const cleaned = readFileSync(file, "utf-8");
+    assert.doesNotMatch(cleaned, /[\u{E0001}-\u{E007F}]/u);
+    assert.match(cleaned, /# ok/);
+    assert.equal(statSync(file).mode, before, "mode preserved across rewrite");
+    assert.deepEqual(readdirSync(tmpDir), ["AGENTS.md"]);
   });
 });


### PR DESCRIPTION
Hardens the instruction auto-cleaner's atomic write and improves its injection report.

**R5 (temp symlink-follow):** `cleanFile`'s temp file used a predictable `.${Date.now()}-${pid}.tmp` name written without an exclusive flag, so an attacker with write access to the instruction file's directory could pre-plant a symlink at that path and have the temp write follow it to clobber a victim file before the rename. The write now goes through a new `atomicReplaceFile` helper using an unpredictable `crypto.randomBytes` name and the exclusive `wx` flag (`O_CREAT|O_EXCL`), which refuses a pre-existing path instead of following it; collisions fail loud. Atomic same-dir rename and mode preservation are retained.

**R6 (mixed-encoding decode):** `decodeRun` no longer drops the zero-width portion of a run that mixes Unicode-tag and zero-width characters — the operator-facing report now notes the zero-width count alongside the decoded ASCII. Strip behavior unchanged.

**Tests:** planted-symlink refusal (victim + original intact) and happy-path atomic replace with mode preserved; mixed/pure decode cases. Red→green confirmed per hunk (reverting `wx` lets the write clobber the symlink target); `instructions.mjs` at 100% coverage; 47 tests pass.

Note: the temp write was extracted into an exported `atomicReplaceFile` with a test-only `tmpName` seam (random default) — the only way to drive the real `wx` path through a deterministically-planted symlink for a non-vacuous test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5rS4SkyGfErQQYMAWd9Ky)_