### PR TITLE
fix(cli): run the bin when launched through a node_modules/.bin symlink

### DIFF
--- a/bin/sanitize-cli.mjs
+++ b/bin/sanitize-cli.mjs
@@ -44,8 +44,9 @@
  * serving. Raise or lower the limit via that environment variable.
  */
 import { Buffer } from "node:buffer";
+import { realpathSync } from "node:fs";
 import process from "node:process";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 
 import { sanitize } from "../src/index.mjs";
 
@@ -325,10 +326,24 @@ async function runOneShot() {
 
 // Run only when invoked as a script, not when imported (a unit test imports
 // `createLineSplitter` directly and must not have the worker consume its stdin).
-const invokedAsScript =
-  process.argv[1] !== undefined &&
-  import.meta.url === pathToFileURL(process.argv[1]).href;
-if (invokedAsScript)
+// Compare REAL paths: the published bin is launched through a
+// `node_modules/.bin/sanitize-cli` symlink, so `process.argv[1]` is the symlink
+// path while `import.meta.url` is this module's real file — a raw URL compare
+// would be false and the CLI would silently produce no output. `realpathSync`
+// resolves both to the same on-disk file. A non-existent `argv[1]` (e.g. an
+// `--eval` entry) throws ENOENT and is treated as "not our script".
+function invokedAsScript() {
+  if (process.argv[1] === undefined) return false;
+  try {
+    return (
+      realpathSync(process.argv[1]) ===
+      realpathSync(fileURLToPath(import.meta.url))
+    );
+  } catch {
+    return false;
+  }
+}
+if (invokedAsScript())
   await (process.argv.includes("--worker") ? runWorker() : runOneShot());
 
 export { createLineSplitter };

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -13,7 +13,7 @@ import assert from "node:assert/strict";
 import { execFileSync, spawn } from "node:child_process";
 import { Buffer } from "node:buffer";
 import { fileURLToPath } from "node:url";
-import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import fc from "fast-check";
@@ -56,6 +56,27 @@ const CASES = [
     html: true,
   },
 ];
+
+describe("CLI: invoked through a symlinked bin (published-package shape)", () => {
+  // npm installs the `sanitize-cli` bin as a symlink under node_modules/.bin,
+  // so a consumer launches the CLI via a path that is NOT this module's real
+  // file. The script-detection guard must resolve real paths; a raw URL compare
+  // makes `invokedAsScript` false and the CLI emits nothing (silent break).
+  it("runs and returns a response when launched through a symlink", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "ais-cli-bin-"));
+    const link = path.join(dir, "sanitize-cli");
+    symlinkSync(CLI, link);
+    const out = execFileSync("node", [link], {
+      input: '{"text":"a​b"}',
+      encoding: "utf8",
+    });
+    assert.deepEqual(JSON.parse(out), {
+      cleaned: "ab",
+      found: ["cf-format"],
+      warnings: ["Stripped: Format chars (Cf)"],
+    });
+  });
+});
 
 describe("CLI: one-shot mode mirrors sanitize()", () => {
   for (const { name, text, html } of CASES) {


### PR DESCRIPTION
## Regression (shipped in 1.2.x)

The CLI's script-detection guard compared `import.meta.url` to `pathToFileURL(process.argv[1])` verbatim. npm installs the `sanitize-cli` bin as a **symlink** under `node_modules/.bin`, so when a consumer invokes it, `process.argv[1]` is the *symlink* path while `import.meta.url` is the module's *real* file — the guard is false, neither `runWorker` nor `runOneShot` runs, and the CLI emits **nothing**. The published `sanitize-cli` (and therefore the Python client, which shells out to it) is broken on any normal install.

The in-repo tests invoke `node bin/sanitize-cli.mjs` directly (where `argv[1]` already equals the real path), so they passed — the gap that the new **pack-and-install smoke test (#41)** caught end-to-end.

## Fix

Resolve **both** sides with `realpathSync` before comparing, so a symlinked launch path maps to the same on-disk file. A non-existent `argv[1]` (e.g. an `--eval` entry) is caught and treated as "not our script", preserving the import-safety the guard exists for (a unit test importing `createLineSplitter` must not start the worker).

## Test

`test/cli.test.mjs` now invokes the CLI through a freshly-created symlink (the published-bin shape) and asserts a correct response. Verified red→green: on the old guard the symlinked invocation returns `''`; on the fix it returns the proper envelope. 34 CLI tests pass; eslint/prettier clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5rS4SkyGfErQQYMAWd9Ky)_