### PR TITLE
fix: harden ReDoS timing guard, close isSgrOnly C1-OSC gap, broaden secret negatives, ship types on git installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "sanitize-cli": "bin/sanitize-cli.mjs"
   },
   "scripts": {
-    "prepare": "if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then git config core.hooksPath .hooks; fi",
+    "prepare": "pnpm build:types; if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then git config core.hooksPath .hooks; fi",
     "test": "c8 node --test",
     "coverage": "c8 node --test",
     "check": "tsc --noEmit",

--- a/src/invisible.mjs
+++ b/src/invisible.mjs
@@ -94,12 +94,15 @@ export const STRIP = new RegExp(
 // eslint-disable-next-line no-control-regex -- matching ESC-led sequences is the point
 export const SGR_RE = /(?:\x1b\[|)[0-9;]*m/g;
 
-// The two raw ANSI control introducers: 7-bit ESC (U+001B) and 8-bit C1 CSI
-// (U+009B). isSgrOnly is honest only if it tests for BOTH — a C1 cursor-move or
-// erase (`U+009B 2J`) leaves a U+009B after SGR removal and must read as NOT
-// SGR-only, exactly as its 7-bit `ESC[2J` twin does.
+// The raw ANSI control introducers isSgrOnly must treat as NON-SGR after SGR
+// removal: 7-bit ESC (U+001B), 8-bit C1 CSI (U+009B), and 8-bit C1 OSC
+// (U+009D). isSgrOnly is honest only if it tests for ALL THREE — a C1
+// cursor-move or erase (`U+009B 2J`) leaves a U+009B, and a C1-OSC string
+// (`U+009D … BEL`) leaves a U+009D, after SGR removal; both must read as NOT
+// SGR-only, exactly as their 7-bit `ESC[2J` / `ESC]…` twins do. Omitting
+// U+009D would let a residual C1-OSC introducer be misread as SGR-only.
 // eslint-disable-next-line no-control-regex -- the raw introducers are what we test for
-const CONTROL_INTRODUCER_RE = /[\x1b]/;
+const CONTROL_INTRODUCER_RE = /[\x1b\x9b\x9d]/;
 
 /**
  * True when every ANSI control introducer in `text` belongs to a display-only

--- a/test/invisible.test.mjs
+++ b/test/invisible.test.mjs
@@ -342,6 +342,16 @@ describe("isSgrOnly", () => {
     assert.equal(isSgrOnly(cp(0x9b)), false));
   it("SGR_RE matches a C1-introduced color sequence", () =>
     assert.equal(`${cp(0x9b)}31mx`.replace(SGR_RE, ""), "x"));
+
+  // C1 OSC (U+009D) is an Operating System Command string, not SGR. A residual
+  // C1-OSC introducer must read as NOT SGR-only (the S1 residual: the test only
+  // knew U+009B, so a string whose sole introducer was U+009D slipped through as
+  // "SGR-only"). The paired SGR case stays true to prove the widening did not
+  // over-reject genuine color.
+  it("is false for a C1-OSC (U+009D) string", () =>
+    assert.equal(isSgrOnly(`${cp(0x9d)}0;title${cp(0x07)}`), false));
+  it("stays true for a genuine 7-bit SGR color string", () =>
+    assert.equal(isSgrOnly(`${cp(0x1b)}[31mred${cp(0x1b)}[0m`), true));
 });
 
 // ─── LONG_RUN_RE ─────────────────────────────────────────────────────────────

--- a/test/invisible.test.mjs
+++ b/test/invisible.test.mjs
@@ -633,22 +633,28 @@ describe("applyLayer1: OSC strings and C1 sequences", () => {
   });
 
   // The deliberate bounded-intro / negated-body design keeps the ANSI grammar
-  // linear; an adversarial never-completing string must not blow up. Assert the
-  // work scales ~linearly (not super-linearly) with input size.
-  it("OSC/CSI stripping stays ~linear on adversarial never-terminating input", () => {
-    const time = (n) => {
-      const input = `${ESC}]` + ";".repeat(n) + `${ESC}[` + ";#".repeat(n);
-      const t0 = process.hrtime.bigint();
-      applyLayer1(input);
-      return Number(process.hrtime.bigint() - t0);
-    };
-    // Warm up, then compare 10x size: linear ⇒ ratio well under quadratic (100x).
-    time(2000);
-    const small = Math.max(time(20000), 1);
-    const big = time(200000);
+  // linear; an adversarial never-completing string must not blow up.
+  //
+  // We assert a GENEROUS ABSOLUTE wall-clock bound on one pass over a large
+  // adversarial input, not a ratio of two timings. The old ratio test
+  // (big / small < 40) divided by a tiny ~20k-char `small` denominator: under
+  // CI load spikes that denominator is so small and noisy that genuinely-linear
+  // code spikes the ratio past the threshold, producing false reds (it flaked
+  // #37 while passing locally). An absolute bound has no noisy denominator yet
+  // still catches the ReDoS class with a huge margin: linear stripping of this
+  // 400k-char input is single-digit milliseconds, whereas catastrophic /
+  // quadratic backtracking on a never-terminating n=200000 input would run for
+  // tens of seconds — orders of magnitude past 2000ms. So 2000ms cleanly
+  // separates linear-with-headroom from any super-linear blowup.
+  it("OSC/CSI stripping stays linear on adversarial never-terminating input", () => {
+    const n = 200000;
+    const input = `${ESC}]` + ";".repeat(n) + `${ESC}[` + ";#".repeat(n);
+    const t0 = process.hrtime.bigint();
+    applyLayer1(input);
+    const ms = Number(process.hrtime.bigint() - t0) / 1e6;
     assert.ok(
-      big / small < 40,
-      `super-linear scaling: ${small}ns -> ${big}ns (ratio ${(big / small).toFixed(1)})`,
+      ms < 2000,
+      `applyLayer1 on a ${input.length}-char adversarial input took ${ms.toFixed(1)}ms (>= 2000ms suggests super-linear backtracking)`,
     );
   });
 });

--- a/test/secret-hint-corpus.test.mjs
+++ b/test/secret-hint-corpus.test.mjs
@@ -157,12 +157,44 @@ const POSITIVE_CASES = [
   ["pass => value", 'pass => "' + "a".repeat(20)],
 ];
 
-// Ordinary prose / filenames that must NOT match any arm.
+// Ordinary prose / filenames / identifiers that must NOT match any arm. The
+// second group is the precision guard: legitimate-but-credential-adjacent
+// strings (hashes, UUIDs, version/date strings, slugs, digit runs, descriptive
+// prose) that a name-only or shape-careless gate would over-match. Per the
+// repo's precision doctrine, a false positive here splices real content, so
+// these pin zero findings on benign input. (Descriptive prose deliberately
+// avoids the literal keyword arms — `secret`/`token`/`password`/`pwd` etc. are
+// intentional recall arms and DO match by design; the guard is that a
+// credential SHAPE, not an English topic word, is what drives a match.)
 const NEGATIVE_CASES = [
   ["plain greeting", "hello world"],
   ["ordinary filename", "ordinary-file-name.txt"],
   ["short alnum", "abc123"],
   ["lorem ipsum", "lorem ipsum dolor sit amet"],
+  // ── precision guard: legitimate but credential-adjacent ───────────────────
+  ["lowercase hex git sha", "commit 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b"],
+  ["uuid v4", "id 550e8400-e29b-41d4-a716-446655440000"],
+  ["semver with date", "release 12.4.1 built on 2026-06-29"],
+  [
+    "benign base64 asset hash in word context",
+    "the bundle main.9fbe7a2c4d.css loaded fine",
+  ],
+  [
+    "long kebab slug",
+    "this-is-a-very-long-descriptive-article-slug-about-cats",
+  ],
+  ["long snake slug", "user_profile_settings_page_layout_container_wrapper"],
+  ["isbn", "ISBN 978-3-16-148410-0"],
+  ["phone number", "call 415-555-0132 for support"],
+  ["credit-card-shaped digit run", "4111 1111 1111 1111"],
+  [
+    "descriptive prose, no credential shape (a)",
+    "the API access requires a login first",
+  ],
+  [
+    "descriptive prose, no credential shape (b)",
+    "each visitor receives a numbered raffle entry at the door",
+  ],
 ];
 
 describe("SECRET_HINT / SECRET_HINT_EXT arm corpus", () => {


### PR DESCRIPTION
Four small follow-ups: the root-cause fix for the flaky node-test that intermittently red-flagged PRs, plus the three remaining LOW residuals from the audit.

## ReDoS timing test — the flake behind #37's `test` red
`invisible.test.mjs › OSC/CSI stripping …` divided two `applyLayer1` timings and asserted `ratio < 40`; the tiny ~20k-char denominator has high relative variance under CI load, so genuinely-linear code intermittently spiked past the threshold (it flaked #37, passed locally). It now times **one** pass over the 600k-char adversarial input and asserts an **absolute `< 2000ms`** — no noisy denominator, same ReDoS-class coverage with a huge margin (linear ≈ 2 ms; a measured O(n²) blowup on n=200000 ≈ 30 s). Stable 5/5 runs.

## isSgrOnly blind to C1 OSC (U+009D) — S1 residual
`CONTROL_INTRODUCER_RE` matched only ESC and C1 CSI (U+009B), so a residual whose sole introducer was C1 **OSC** (U+009D) was misread as SGR-only (affecting `output.mjs`'s `sgrNote`). Widened to `/[\x1b\x9b\x9d]/` (rewritten to ASCII hex form — no raw control bytes in source) with tests for the OSC-false and SGR-true cases; reverting the `\x9d` turns the OSC test red. `prompt.mjs`'s `isSgrColorOnly` workaround (#33) is left as belt-and-suspenders. `invisible.mjs` stays at 100% coverage.

## Secret-hint negative corpus — T10
Broadened the precision-guard negatives with 11 legitimate-but-credential-adjacent strings (lowercase hex SHA, UUIDv4, semver+date, benign asset hash, kebab/snake slugs, ISBN, phone/CC digit runs, descriptive prose) asserting zero matches — gate-on-shape, per the repo's precision doctrine. (Descriptive-prose cases deliberately avoid the literal keyword arms `secret`/`token`/… which match by design.)

## Types on git-dependency installs — P12
`prepare` only wired git hooks, so installing this package as a **git** dependency (npm runs `prepare`, not `prepack`) shipped no `.d.mts`. `prepare` now also runs `pnpm build:types`; the hook wiring stays git-guarded (no-ops outside a repo). Registry/tarball consumers are unaffected — they run `prepack`, not `prepare` (the pack-smoke job, a tarball install outside a git repo, never invokes `build:types`).

**Verification:** touched suites 337/337 pass; eslint + prettier clean; `pnpm build:types` emits all 11 `.d.mts`. No test guards `prepare`'s content (searched). Note: `lint-staged` has no `*.mjs` glob, so `.mjs`-only commits report "no matching files" — pre-existing, not changed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5rS4SkyGfErQQYMAWd9Ky)_