### PR TITLE
docs(readme): wrap THREAT-MODEL.md filename in code

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ any particular harness.
 | 8   | `/rehydrate`    | Re-anchor a model Edit composed from the _sanitized_ view back onto real bytes; deny anything ambiguous or secret-exposing.                                | `io`                        |
 | —   | `/view-map`     | Pure offset/text machinery mapping a file's on-disk bytes ↔ the sanitized view (Layer-1 deletions, Layer-4 redactions). No I/O — consumed by `/rehydrate`. | —                           |
 
-See [THREAT-MODEL.md](./THREAT-MODEL.md) for per-vector detail.
+See [`THREAT-MODEL.md`](./THREAT-MODEL.md) for per-vector detail.
 
 ### Examples
 


### PR DESCRIPTION
## Summary

The README links to `THREAT-MODEL.md` with the bare filename as link text, while every other filename in the README (`CLAUDE.md`, `AGENTS.md`, `SKILL.md`) is inline code. Wrap it in backticks for consistency — this also reads correctly where the README is transcluded elsewhere.

## Changes

- `README.md`: `[THREAT-MODEL.md](./THREAT-MODEL.md)` → `` [`THREAT-MODEL.md`](./THREAT-MODEL.md) ``.

## Tests / verification

Docs-only change; no code paths affected. Verified the remaining bare-filename scan finds no other prose filenames outside code blocks.

## Checklist

- [x] Commits follow Conventional Commits; each subject reads as a user-facing release note.
- [ ] `pnpm test`, `pnpm lint`, and `pnpm check` pass locally. (Docs-only; no code changed.)
- [x] New or changed detectors have negative tests. (N/A — docs only.)
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version are left untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FegCstUtPtUAMZ2Sa12PqH)_