### PR TITLE
feat(sanitize): point agents to a hex dump for Layer-1 stripped bytes

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -10,7 +10,7 @@
  * subpath entries; import those directly when you want a single layer without
  * the convenience wrapper.
  */
-import { LONG_RUN_RE, CATEGORY, CATEGORY_LABELS } from "./invisible.mjs";
+import { CATEGORY, describeStripped } from "./invisible.mjs";
 import { applyLayer1, LONE_SURROGATE_RE } from "./layer1.mjs";
 
 // Layer 1 lives in the zero-dependency `./layer1.mjs`, shared verbatim with the
@@ -93,11 +93,7 @@ export async function sanitize(text, { html = false } = {}) {
   let cleaned = layer1;
   if (invisFound.length > 0) {
     found.push(...invisFound);
-    let msg = `Stripped: ${invisFound.map((code) => CATEGORY_LABELS[code]).join(", ")}`;
-    LONG_RUN_RE.lastIndex = 0;
-    if (LONG_RUN_RE.test(deAnsi))
-      msg += " [LONG RUN — possible injection payload]";
-    warnings.push(msg);
+    warnings.push(describeStripped(invisFound, deAnsi));
   }
 
   const wellFormed = cleaned.replace(LONE_SURROGATE_RE, "\uFFFD");

--- a/src/invisible.mjs
+++ b/src/invisible.mjs
@@ -127,6 +127,28 @@ export const LONG_RUN_RE = new RegExp(
   REGEX_FLAGS,
 );
 
+/**
+ * The agent-facing "Stripped: …" note for a Layer-1 strip: the removed category
+ * labels, the LONG RUN marker when the de-ANSI'd text still holds a
+ * payload-length invisible run, and a pointer to recover the bytes — a hex dump
+ * is ASCII, so it passes through sanitization untouched. The single source of
+ * this note, shared by the `sanitize` convenience entry and the tool-output
+ * pipeline so the two can't drift.
+ * @param {string[]} invisFound CATEGORY codes applyLayer1 reported removing
+ * @param {string} deAnsi ANSI-stripped text (invisible runs intact), for the LONG_RUN probe
+ * @returns {string}
+ */
+export function describeStripped(invisFound, deAnsi) {
+  let msg = `Stripped: ${invisFound.map((code) => CATEGORY_LABELS[code]).join(", ")}`;
+  LONG_RUN_RE.lastIndex = 0;
+  if (LONG_RUN_RE.test(deAnsi))
+    msg += " [LONG RUN — possible injection payload]";
+  return (
+    msg +
+    " — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+  );
+}
+
 // Leading-BOM marker, preserved by stripInvisibleWithReport (see its doc).
 const BOM = "\uFEFF";
 // ─── ZWNJ/ZWJ linguistic carve-out ───────────────────────────────────────────

--- a/src/output.mjs
+++ b/src/output.mjs
@@ -20,12 +20,7 @@
  * filter can at most remove legitimate content — it can never inject new bytes
  * into the model's view. A consumer running a live LLM filter wires it here.
  */
-import {
-  CATEGORY,
-  CATEGORY_LABELS,
-  LONG_RUN_RE,
-  isSgrOnly,
-} from "./invisible.mjs";
+import { CATEGORY, describeStripped, isSgrOnly } from "./invisible.mjs";
 import { HTML_TAG_PRESENT, MD_LINK_HINT } from "./gates.mjs";
 import { applyLayer1, LONE_SURROGATE_RE } from "./layer1.mjs";
 
@@ -133,13 +128,7 @@ function processLayer1(text, sgrCarveOut) {
       invisFound[0] === CATEGORY.ANSI &&
       isSgrOnly(text) &&
       sgrCarveOut;
-    if (!sgrNote) {
-      LONG_RUN_RE.lastIndex = 0;
-      let msg = `Stripped: ${invisFound.map((code) => CATEGORY_LABELS[code]).join(", ")}`;
-      if (LONG_RUN_RE.test(deAnsi))
-        msg += " [LONG RUN — possible injection payload]";
-      warnings.push(msg);
-    }
+    if (!sgrNote) warnings.push(describeStripped(invisFound, deAnsi));
   }
   // Normalize lone UTF-16 surrogates for ALL output: a secret split by an
   // interposed lone surrogate reads as adjacent to a model rendering its own

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -73,7 +73,9 @@ describe("CLI: invoked through a symlinked bin (published-package shape)", () =>
     assert.deepEqual(JSON.parse(out), {
       cleaned: "ab",
       found: ["cf-format"],
-      warnings: ["Stripped: Format chars (Cf)"],
+      warnings: [
+        "Stripped: Format chars (Cf) — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization",
+      ],
     });
   });
 });

--- a/test/mutation-guards.test.mjs
+++ b/test/mutation-guards.test.mjs
@@ -147,7 +147,7 @@ describe("guard: sanitize warning text is exact, not just present", () => {
     const warn = out.warnings.find((w) => w.startsWith("Stripped:"));
     assert.equal(
       warn,
-      `Stripped: ${CATEGORY_LABELS[CATEGORY.CF]}, ${CATEGORY_LABELS[CATEGORY.VARIATION_SELECTORS]}`,
+      `Stripped: ${CATEGORY_LABELS[CATEGORY.CF]}, ${CATEGORY_LABELS[CATEGORY.VARIATION_SELECTORS]} — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization`,
     );
   });
 });

--- a/test/output.test.mjs
+++ b/test/output.test.mjs
@@ -128,7 +128,9 @@ describe("sanitizeText: Layer 1 invisible/ANSI/surrogate", () => {
     assert.equal(r.cleaned, "malware");
     assert.equal(r.modified, true);
     assert.equal(r.sgrNote, false);
-    assert.deepEqual(r.warnings, ["Stripped: Format chars (Cf)"]);
+    assert.deepEqual(r.warnings, [
+      "Stripped: Format chars (Cf) — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization",
+    ]);
   });
 
   it("appends the LONG RUN marker when a long invisible run is present", async () => {
@@ -137,7 +139,7 @@ describe("sanitizeText: Layer 1 invisible/ANSI/surrogate", () => {
     assert.equal(r.modified, true);
     assert.equal(
       r.warnings[0],
-      "Stripped: Format chars (Cf) [LONG RUN — possible injection payload]",
+      "Stripped: Format chars (Cf) [LONG RUN — possible injection payload] — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization",
     );
   });
 
@@ -155,7 +157,9 @@ describe("sanitizeText: Layer 1 invisible/ANSI/surrogate", () => {
     const r = await sanitizeText(`${ESC}[31mfail${ESC}[0m`);
     assert.equal(r.cleaned, "fail");
     assert.equal(r.sgrNote, false);
-    assert.deepEqual(r.warnings, ["Stripped: ANSI escapes"]);
+    assert.deepEqual(r.warnings, [
+      "Stripped: ANSI escapes — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization",
+    ]);
   });
 
   it("normalizes a lone surrogate, warns, and resets sgrNote to false", async () => {
@@ -450,7 +454,9 @@ describe("sanitizeValue", () => {
     const r = await sanitizeValue(`mal${ZW}ware`, {}, warnings);
     assert.equal(r.value, "malware");
     assert.equal(r.modified, true);
-    assert.deepEqual(warnings, ["Stripped: Format chars (Cf)"]);
+    assert.deepEqual(warnings, [
+      "Stripped: Format chars (Cf) — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization",
+    ]);
   });
 
   it("recurses into an array, sanitizing each string leaf", async () => {

--- a/tests/golden.json
+++ b/tests/golden.json
@@ -24,12 +24,16 @@
       "plain": {
         "cleaned": [97, 98],
         "found": ["cf-format"],
-        "warnings": ["Stripped: Format chars (Cf)"]
+        "warnings": [
+          "Stripped: Format chars (Cf) — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       },
       "html": {
         "cleaned": [97, 98],
         "found": ["cf-format"],
-        "warnings": ["Stripped: Format chars (Cf)"]
+        "warnings": [
+          "Stripped: Format chars (Cf) — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       }
     },
     {
@@ -37,12 +41,16 @@
       "plain": {
         "cleaned": [97, 98],
         "found": ["cf-format"],
-        "warnings": ["Stripped: Format chars (Cf)"]
+        "warnings": [
+          "Stripped: Format chars (Cf) — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       },
       "html": {
         "cleaned": [97, 98],
         "found": ["cf-format"],
-        "warnings": ["Stripped: Format chars (Cf)"]
+        "warnings": [
+          "Stripped: Format chars (Cf) — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       }
     },
     {
@@ -50,12 +58,16 @@
       "plain": {
         "cleaned": [97, 101, 118, 105, 108, 98],
         "found": ["cf-format"],
-        "warnings": ["Stripped: Format chars (Cf)"]
+        "warnings": [
+          "Stripped: Format chars (Cf) — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       },
       "html": {
         "cleaned": [97, 101, 118, 105, 108, 98],
         "found": ["cf-format"],
-        "warnings": ["Stripped: Format chars (Cf)"]
+        "warnings": [
+          "Stripped: Format chars (Cf) — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       }
     },
     {
@@ -63,12 +75,16 @@
       "plain": {
         "cleaned": [99, 111, 111, 112, 101, 114, 97, 116, 101],
         "found": ["cf-format"],
-        "warnings": ["Stripped: Format chars (Cf)"]
+        "warnings": [
+          "Stripped: Format chars (Cf) — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       },
       "html": {
         "cleaned": [99, 111, 111, 112, 101, 114, 97, 116, 101],
         "found": ["cf-format"],
-        "warnings": ["Stripped: Format chars (Cf)"]
+        "warnings": [
+          "Stripped: Format chars (Cf) — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       }
     },
     {
@@ -89,12 +105,16 @@
       "plain": {
         "cleaned": [97, 98],
         "found": ["cf-format"],
-        "warnings": ["Stripped: Format chars (Cf)"]
+        "warnings": [
+          "Stripped: Format chars (Cf) — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       },
       "html": {
         "cleaned": [97, 98],
         "found": ["cf-format"],
-        "warnings": ["Stripped: Format chars (Cf)"]
+        "warnings": [
+          "Stripped: Format chars (Cf) — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       }
     },
     {
@@ -128,12 +148,16 @@
       "plain": {
         "cleaned": [28450, 23383, 32, 116, 101, 115, 116],
         "found": ["cf-format"],
-        "warnings": ["Stripped: Format chars (Cf)"]
+        "warnings": [
+          "Stripped: Format chars (Cf) — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       },
       "html": {
         "cleaned": [28450, 23383, 32, 116, 101, 115, 116],
         "found": ["cf-format"],
-        "warnings": ["Stripped: Format chars (Cf)"]
+        "warnings": [
+          "Stripped: Format chars (Cf) — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       }
     },
     {
@@ -141,12 +165,16 @@
       "plain": {
         "cleaned": [114, 101, 100],
         "found": ["ansi"],
-        "warnings": ["Stripped: ANSI escapes"]
+        "warnings": [
+          "Stripped: ANSI escapes — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       },
       "html": {
         "cleaned": [114, 101, 100],
         "found": ["ansi"],
-        "warnings": ["Stripped: ANSI escapes"]
+        "warnings": [
+          "Stripped: ANSI escapes — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       }
     },
     {
@@ -154,12 +182,16 @@
       "plain": {
         "cleaned": [119, 105, 112, 101],
         "found": ["ansi"],
-        "warnings": ["Stripped: ANSI escapes"]
+        "warnings": [
+          "Stripped: ANSI escapes — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       },
       "html": {
         "cleaned": [119, 105, 112, 101],
         "found": ["ansi"],
-        "warnings": ["Stripped: ANSI escapes"]
+        "warnings": [
+          "Stripped: ANSI escapes — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       }
     },
     {
@@ -167,12 +199,16 @@
       "plain": {
         "cleaned": [109, 111, 118, 101],
         "found": ["ansi"],
-        "warnings": ["Stripped: ANSI escapes"]
+        "warnings": [
+          "Stripped: ANSI escapes — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       },
       "html": {
         "cleaned": [109, 111, 118, 101],
         "found": ["ansi"],
-        "warnings": ["Stripped: ANSI escapes"]
+        "warnings": [
+          "Stripped: ANSI escapes — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       }
     },
     {
@@ -180,12 +216,16 @@
       "plain": {
         "cleaned": [97, 66, 99],
         "found": ["cf-format", "ansi"],
-        "warnings": ["Stripped: Format chars (Cf), ANSI escapes"]
+        "warnings": [
+          "Stripped: Format chars (Cf), ANSI escapes — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       },
       "html": {
         "cleaned": [97, 66, 99],
         "found": ["cf-format", "ansi"],
-        "warnings": ["Stripped: Format chars (Cf), ANSI escapes"]
+        "warnings": [
+          "Stripped: Format chars (Cf), ANSI escapes — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       }
     },
     {
@@ -193,12 +233,16 @@
       "plain": {
         "cleaned": [97, 98],
         "found": ["cf-format"],
-        "warnings": ["Stripped: Format chars (Cf)"]
+        "warnings": [
+          "Stripped: Format chars (Cf) — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       },
       "html": {
         "cleaned": [97, 98],
         "found": ["cf-format"],
-        "warnings": ["Stripped: Format chars (Cf)"]
+        "warnings": [
+          "Stripped: Format chars (Cf) — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       }
     },
     {
@@ -206,12 +250,16 @@
       "plain": {
         "cleaned": [97, 98],
         "found": ["variation-selectors"],
-        "warnings": ["Stripped: Variation selectors"]
+        "warnings": [
+          "Stripped: Variation selectors — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       },
       "html": {
         "cleaned": [97, 98],
         "found": ["variation-selectors"],
-        "warnings": ["Stripped: Variation selectors"]
+        "warnings": [
+          "Stripped: Variation selectors — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       }
     },
     {
@@ -224,12 +272,16 @@
       "plain": {
         "cleaned": [108, 105, 110, 101, 49, 10, 108, 105, 110, 101, 50],
         "found": ["cf-format"],
-        "warnings": ["Stripped: Format chars (Cf)"]
+        "warnings": [
+          "Stripped: Format chars (Cf) — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       },
       "html": {
         "cleaned": [108, 105, 110, 101, 49, 10, 108, 105, 110, 101, 50],
         "found": ["cf-format"],
-        "warnings": ["Stripped: Format chars (Cf)"]
+        "warnings": [
+          "Stripped: Format chars (Cf) — inspect the removed bytes with a hex dump (xxd / od -c), which survives sanitization"
+        ]
       }
     },
     {


### PR DESCRIPTION
## Summary

When Layer 1 strips invisible/ANSI bytes, the model is told *what* category
was removed (`Stripped: Format chars (Cf)`) but not *how* to recover the
bytes if it actually needs them — a real gap for coding/tokenization work
over raw Unicode. This adds that pointer: a hex dump (`xxd` / `od -c`)
survives sanitization because its output is ASCII, so the agent can inspect
the exact bytes on demand. The hint rides on the existing non-SGR warning,
so a cosmetic-only color strip still emits nothing (no new noise on the
benign path).

## Changes

- `src/invisible.mjs` — new `describeStripped(invisFound, deAnsi)` that builds
  the whole note (category labels + LONG RUN marker + recovery hint) in one
  place.
- `src/index.mjs` / `src/output.mjs` — both call sites collapse to
  `describeStripped(...)`, removing the duplicated note-construction logic
  that was a drift risk, and trimming their now-unused imports.
- Tests — updated the five exact-string assertions; the existing mutation
  guard now pins the full note, so a mutant dropping the hint fails there.

## Tests / verification

`node --test` over the four affected suites (`output`, `cli`,
`mutation-guards`, `sanitize`): 165 pass, 0 fail. `pnpm lint` clean on the
changed files. Both branches of the new helper (LONG RUN present/absent) are
exercised.

## Checklist

- [x] Commits follow Conventional Commits; subject reads as a release note.
- [x] Targeted tests + lint pass locally (full `pnpm test`/`check` defer to CI).
- [x] No new detector (display-text-only change); existing exact-equality guards updated.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version left untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAU8airs8GorBaxFzAz2Mg)_