### PR TITLE
ci: sync branch-protection required checks from workflow annotations

### DIFF
--- a/.github/scripts/sync-required-checks.sh
+++ b/.github/scripts/sync-required-checks.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Apply (or, with CHECK_ONLY=true, only diff) the branch-protection ruleset's
+# required-status-checks to the `# required-check:` annotations in
+# .github/workflows. Invoked solely by sync-required-checks.yaml; reads REPO,
+# CHECK_ONLY, and GH_TOKEN from the environment.
+#
+# The ci-truth-serum rev is read from .pre-commit-config.yaml — its single
+# source — so this apply step and the check-required-reporter lint can never run
+# different parser versions (the drift that would let the gate and the lint read
+# the same YAML two ways).
+set -euo pipefail
+
+ref="$(awk '/repo:.*ci-truth-serum$/{f=1; next} f && /^[[:space:]]*rev:/{print $2; exit}' .pre-commit-config.yaml)"
+if [[ ! "$ref" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "Could not read a 40-char ci-truth-serum rev from .pre-commit-config.yaml (got: '${ref}')" >&2
+  exit 1
+fi
+
+args=(--repo "$REPO")
+if [[ "${CHECK_ONLY:-false}" == "true" ]]; then
+  args+=(--check)
+fi
+
+uv run --no-project \
+  --with "ci-truth-serum @ git+https://github.com/alexander-turner/ci-truth-serum@${ref}" \
+  python -m hooks.sync_required_checks "${args[@]}"

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -52,7 +52,7 @@ jobs:
   # PRs (its result is then `skipped`, not a failure), so if this check is ever
   # marked Required a protected branch never gets stuck on a status that never
   # reports. Mirrors the *-passed gate every other workflow here uses.
-  dependabot-auto-merge-passed:
+  dependabot-auto-merge-passed: # required-check: false  # convenience gate for dependabot auto-merge, not a quality gate
     if: always()
     needs: [auto-merge]
     runs-on: ubuntu-latest

--- a/.github/workflows/format-check.yaml
+++ b/.github/workflows/format-check.yaml
@@ -35,7 +35,7 @@ jobs:
   # protected branch never gets stuck on a check that never reports. Each
   # workflow's gate has a distinct name so it can be marked Required without
   # colliding with the others in branch-protection settings.
-  format-check-passed:
+  format-check-passed: # required-check: true
     if: always()
     needs: [format]
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -63,7 +63,7 @@ jobs:
 
   # Stable Required check: runs even when `lint` is cancelled/skipped, so a
   # protected branch never gets stuck on a check that never reports.
-  lint-passed:
+  lint-passed: # required-check: true
     if: always()
     needs: [lint]
     runs-on: ubuntu-latest

--- a/.github/workflows/mutation.yaml
+++ b/.github/workflows/mutation.yaml
@@ -127,7 +127,7 @@ jobs:
   # Sum every shard's JSON into the project-wide mutation score and apply the
   # break threshold from stryker.conf.json. This is the real gate; the shards
   # themselves run with break disabled.
-  aggregate:
+  aggregate: # required-check: false  # rolled up by mutation-passed (which needs: aggregate)
     needs: [changes, mutation]
     if: always()
     runs-on: ubuntu-latest
@@ -161,7 +161,7 @@ jobs:
 
   # Stable Required check: runs even when upstream jobs are cancelled/skipped, so
   # a protected branch never gets stuck on a check that never reports.
-  mutation-passed:
+  mutation-passed: # required-check: true
     if: always()
     needs: [changes, mutation, aggregate]
     runs-on: ubuntu-latest

--- a/.github/workflows/node-tests.yaml
+++ b/.github/workflows/node-tests.yaml
@@ -56,7 +56,7 @@ jobs:
 
   # Stable Required check: runs even when `test` is cancelled/skipped, so a
   # protected branch never gets stuck on a check that never reports.
-  node-tests-passed:
+  node-tests-passed: # required-check: true
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/.github/workflows/pack-smoke.yaml
+++ b/.github/workflows/pack-smoke.yaml
@@ -43,7 +43,7 @@ jobs:
 
   # Stable Required check: runs even when `pack-smoke` is cancelled/skipped, so a
   # protected branch never gets stuck on a check that never reports.
-  pack-smoke-passed:
+  pack-smoke-passed: # required-check: true
     if: always()
     needs: [pack-smoke]
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -27,7 +27,7 @@ jobs:
 
   # Stable Required check: runs even when `pre-commit` is cancelled/skipped, so
   # a protected branch never gets stuck on a check that never reports.
-  pre-commit-passed:
+  pre-commit-passed: # required-check: true
     if: always()
     needs: [pre-commit]
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-required-checks.yaml
+++ b/.github/workflows/sync-required-checks.yaml
@@ -1,0 +1,55 @@
+name: Sync required status checks
+
+# The apply half of the check-required-reporter pair. The pre-commit hook forces
+# every always() reporter on a PR-triggered workflow to carry a
+# `# required-check: true|false` annotation; this workflow reads those
+# annotations (the SSOT), expands each required job's name across its own matrix,
+# and rewrites the branch-protection ruleset's required_status_checks to exactly
+# that set — so a reporter's classification and the gate that actually blocks
+# merges can never silently drift apart.
+#
+# Runs only post-merge on main (and on demand); it never gates a PR, so it is not
+# itself a required check. Mutating branch protection needs a token with
+# `administration: write` — the stock GITHUB_TOKEN cannot edit rulesets. Provide
+# it as the RULESET_SYNC_TOKEN secret; the job fails loud if it is absent.
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/**
+      - .pre-commit-config.yaml
+  workflow_dispatch:
+    inputs:
+      check-only:
+        description: "Report drift without mutating the ruleset"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize ruleset writes so two back-to-back merges can't race the PATCH. A
+  # static, ref-less group is safe here only because this workflow has no
+  # pull_request trigger — it never backs a required check that a cancelled run
+  # could strand at "Expected — Waiting".
+  group: sync-required-checks
+  cancel-in-progress: false
+  # static-concurrency-ok: not a required check (push/dispatch only)
+
+jobs:
+  sync:
+    name: Sync ruleset to required-check annotations
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - name: Sync required status checks
+        env:
+          GH_TOKEN: ${{ secrets.RULESET_SYNC_TOKEN }}
+          REPO: ${{ github.repository }}
+          CHECK_ONLY: ${{ inputs.check-only }}
+        run: bash .github/scripts/sync-required-checks.sh

--- a/.github/workflows/validate-config.yaml
+++ b/.github/workflows/validate-config.yaml
@@ -83,7 +83,7 @@ jobs:
   # cancelled/skipped, so a protected branch never gets stuck on a check that
   # never reports. A matrix job reports many statuses; gating on this single
   # reporter keeps one stable Required check name regardless of matrix size.
-  validate-config-passed:
+  validate-config-passed: # required-check: true
     if: always()
     needs: [validate, python-client]
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
   # Tier 1 (honesty + identity), Tier 2 (opinionated — this repo follows the
   # decide/reporter + cancel-in-progress conventions they assume), and Extras.
   - repo: https://github.com/alexander-turner/ci-truth-serum
-    rev: 0d932b98e1384685ec289b8f7bb2df760ebfb8af # main (no tagged release yet)
+    rev: 55b3c2af0b83f77f15eba92aac743bdf8ff254be # main (no tagged release yet)
     hooks:
       # Tier 1 · Honesty
       - id: check-workflow-pipefail
@@ -63,6 +63,10 @@ repos:
       - id: check-pinned-downloads
       # Tier 2 · Opinionated
       - id: check-always-reporter
+      # Forces a `# required-check: true|false` marker on every always() reporter;
+      # sync-required-checks.yaml reads those markers to rewrite the branch
+      # ruleset, so the two can't drift.
+      - id: check-required-reporter
       - id: check-inline-run-length
       - id: check-concurrency
       - id: check-static-concurrency


### PR DESCRIPTION
## Summary

The repo already wires ci-truth-serum and enables `check-always-reporter` (every gate has the `if: always()` shape), but nothing tied those reporters to the branch-protection ruleset — so the required-check set was hand-maintained and free to drift from the workflows that produce it (the failure mode behind "the mutation check isn't required"). This adds the **apply half** of ci-truth-serum's `check-required-reporter` pair: the reporters become the single source of truth, and a post-merge workflow rewrites the ruleset to match.

## Changes

- **Enable `check-required-reporter`** (bumping the ci-truth-serum pin from `0d932b98` → `55b3c2af`, the rev that ships it — 27 commits ahead, 0 behind; the other already-enabled hooks were re-run at the new rev with no new findings). The hook forces a `# required-check: true|false` marker on every `always()` reporter.
- **Annotate every reporter:**
  - Required (`true`): `format-check-passed`, `lint-passed`, `mutation-passed`, `node-tests-passed`, `pack-smoke-passed`, `pre-commit-passed`, `validate-config-passed`.
  - Advisory (`false`): `aggregate` (mutation-passed already `needs:` it and rolls up its result) and `dependabot-auto-merge-passed` (a convenience gate, not a quality gate).
- **Add `sync-required-checks.yaml` + `.github/scripts/sync-required-checks.sh`.** Runs post-merge on `main` (and `workflow_dispatch`, with a `check-only` diff mode); reads the annotations, expands each required job's name over its matrix, and PUTs the ruleset's `required_status_checks` to exactly that set. The script reads the ci-truth-serum rev from `.pre-commit-config.yaml` so the lint and the apply step can never run different parser versions.

## ⚠️ One-time setup required

The apply step mutates branch protection, which the stock `GITHUB_TOKEN` cannot do. **Create a `RULESET_SYNC_TOKEN` secret** (a token with `administration: write` on this repo). Until it exists, the workflow **fails loud** on every `main` push that touches `.github/workflows/**` or `.pre-commit-config.yaml` — including this PR's merge — by design (a missing token must not silently no-op). The workflow also assumes a **single branch ruleset**; if there's more than one it asks for `--ruleset-id`.

On the first successful run the ruleset's required checks become exactly the seven `true` contexts above — please confirm that matches your intent before adding the secret (you can dry-run it via the `workflow_dispatch` → `check-only` input once the token exists).

## Tests / verification

ci-truth-serum owns the parser's own tests, so no redundant drift guard is added here (the `check-required-reporter` pre-commit hook *is* the test). Locally, against the committed tree: `check-required-reporter` passes; `desired_contexts` resolves to exactly the 7 intended checks; the new workflow passes `check-static-concurrency`/`check-pr-paths`/`check-concurrency`/`check-inline-run-length`/`check-pinned-*` and `zizmor`; the script is `shellcheck`/`shfmt` clean; `validate-config.sh` passes; and the rev-bumped honesty hooks were re-run across all 19 shell files and every workflow with no new findings.

## Checklist

- [x] Commits follow Conventional Commits; subject reads as a release note (`ci:` keeps repo-internal CI machinery out of the package release notes).
- [x] Targeted lints/hooks pass locally (full suite defers to CI).
- [x] No new detector; no secrets/tokens in the diff.
- [x] `CHANGELOG.md` and `package.json` version left untouched.

## Lessons Learned

- **What:** Add the `check-required-reporter` pre-commit hook + a `sync-required-checks.yaml` workflow (and its `.github/scripts/sync-required-checks.sh`) that rewrites the branch ruleset's `required_status_checks` from `# required-check:` annotations on `always()` reporters.
- **Where:** `.pre-commit-config.yaml` (enable the hook), `.github/workflows/`, `.github/scripts/` in the template.
- **Why:** Downstream repos already inherit `check-always-reporter` but still hand-maintain the required-check set in branch-protection UI, where it silently drifts from the reporters (a stranded "Expected — Waiting" check, or a gate that quietly stops being required). Making the annotations the SSOT and syncing them post-merge closes that gap. Have the apply script read the pinned rev from `.pre-commit-config.yaml` so the lint and the apply step never diverge, and document the required `RULESET_SYNC_TOKEN` (admin:write) secret since the change is inert — and fails loud — without it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAU8airs8GorBaxFzAz2Mg)_