### PR TITLE
docs: ship SECURITY.md in the tarball and document the input cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,20 @@ await rehydrateRedacted("Edit", toolInput, {
 }); // { updatedInput, context } | { deny } | null — a deny never exposes a secret
 ```
 
+## Limits
+
+The CLI (and the worker that backs the Python client) rejects any single request
+larger than `AGENT_SANITIZER_MAX_INPUT_BYTES` UTF-8 bytes — **default 10 MiB** —
+with a structured error instead of buffering an unbounded payload. Raise or lower
+it by setting that environment variable in the calling process.
+
+## Security
+
+Found a vulnerability? See [`SECURITY.md`](./SECURITY.md) for the private
+disclosure channel — it ships in the npm tarball, so it is also available offline
+from an installed copy. [`THREAT-MODEL.md`](./THREAT-MODEL.md) covers what each
+layer does and does not defend against.
+
 ## Non-JS pipelines (Python, etc.)
 
 The JS is the **single source of truth**—non-JS callers drive the same verdicts

--- a/package.json
+++ b/package.json
@@ -139,7 +139,8 @@
     "types",
     "LICENSE",
     "README.md",
-    "THREAT-MODEL.md"
+    "THREAT-MODEL.md",
+    "SECURITY.md"
   ],
   "dependencies": {
     "rehype-parse": "9.0.1",

--- a/test/package-exports.test.mjs
+++ b/test/package-exports.test.mjs
@@ -82,4 +82,24 @@ describe("packaging contract: exports map vs. published tarball", () => {
       `exports promise runtime files the tarball does not ship: ${missing.join(", ")}`,
     );
   });
+
+  // Top-level docs a consumer reaches for from an installed copy: the license,
+  // the readme, the threat model, and — so a vulnerability is reported privately
+  // rather than filed in the open — the disclosure policy. Each must be listed in
+  // `files` AND actually land in the tarball; a literal entry that doesn't pack
+  // (typo, renamed/deleted file) is the regression this guards.
+  it("ships the user-facing top-level docs", () => {
+    const docs = ["LICENSE", "README.md", "THREAT-MODEL.md", "SECURITY.md"];
+    for (const doc of docs)
+      assert.ok(
+        pkg.files.includes(doc),
+        `package.json "files" is missing ${doc}`,
+      );
+    const missing = docs.filter((f) => !packed.has(f));
+    assert.deepEqual(
+      missing,
+      [],
+      `top-level docs listed in "files" but not packed: ${missing.join(", ")}`,
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Two packaging/docs gaps surfaced by an audit of the published surface:

1. `SECURITY.md` was **not** in `package.json` `files`, so the private
   vulnerability-disclosure policy never shipped in the npm tarball — a consumer
   reading an installed copy had no offline pointer to the disclosure channel and
   might file a vuln in the open instead.
2. The CLI/worker enforces a 10 MiB per-request cap
   (`AGENT_SANITIZER_MAX_INPUT_BYTES`), but that limit was undocumented, so a
   caller hitting it had to read the source to learn the default and the override.

## Changes

- Add `SECURITY.md` to `files` so it packs into the tarball.
- Extend the existing packaging contract test (`test/package-exports.test.mjs`) to
  assert each user-facing top-level doc (LICENSE, README, THREAT-MODEL, SECURITY)
  is both listed in `files` and actually packed — non-vacuous, so a future drop
  regresses loudly.
- README: add a **Limits** note (the 10 MiB cap + override env var) and a
  **Security** section linking the disclosure policy and threat model.

## Tests / verification

- `node --test test/package-exports.test.mjs` — 3/3 pass, including the new
  doc-shipping guard.
- Docs-only otherwise; no runtime code changed.

## Checklist

- [x] Commits follow Conventional Commits.
- [x] Packaging contract test passes locally.
- [x] No detector behavior changed (no negative tests needed).
- [x] No secrets in the diff.
- [x] `CHANGELOG.md` and `package.json` version untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbPyofntiAXHyLF9kisZRe)_