### PR TITLE
test(python): pin client version format and document npm independence

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -13,6 +13,14 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-input-sanitizer"
+# Versions the PYTHON CLIENT surface (this wrapper's API), NOT the npm release
+# line. The two share a name but are published from different ecosystems and bump
+# independently: the npm version is owned by the git-tag release workflow (the
+# committed package.json "version" is intentionally frozen), while this is bumped
+# by hand when the bridge's Python-visible API changes. So `pip install
+# agent-input-sanitizer` and `npm i agent-input-sanitizer` will report different
+# numbers — that is expected, not drift. Keep this a valid PEP 440 release; the
+# guard in tests/test_python_version.py fails the build on a malformed edit.
 version = "1.2.6"
 description = "Python client for agent-input-sanitizer: a thin bridge to the Node.js CLI for byte-identical sanitization verdicts."
 readme = "README.md"

--- a/tests/test_python_version.py
+++ b/tests/test_python_version.py
@@ -40,9 +40,9 @@ def _read_version(pyproject: Path) -> str:
         stripped = line.strip()
         if stripped.startswith("#"):
             continue
-        match = re.match(r'version\s*=\s*"([^"]+)"', stripped)
+        match = re.match(r'version\s*=\s*"(?P<value>[^"]+)"', stripped)
         if match:
-            return match.group(1)
+            return match.group("value")
     raise AssertionError(f"no version field found in {pyproject}")
 
 
@@ -72,7 +72,9 @@ def test_version_independence_policy_is_documented() -> None:
         "python/pyproject.toml — restore it before changing the version policy"
     )
     npm_version = re.search(
-        r'"version":\s*"([^"]+)"',
+        r'"version":\s*"(?P<value>[^"]+)"',
         (REPO_ROOT / "package.json").read_text(encoding="utf-8"),
     )
-    assert npm_version and npm_version.group(1), "npm package.json version missing"
+    assert npm_version and npm_version.group("value"), (
+        "npm package.json version missing"
+    )

--- a/tests/test_python_version.py
+++ b/tests/test_python_version.py
@@ -1,0 +1,78 @@
+"""Guard the Python client's package version.
+
+The Python distribution (`python/pyproject.toml`) versions the wrapper's own
+API and is bumped BY HAND, independently of the npm release line (see the
+comment on its ``version`` field). Hand-maintained version strings rot two ways:
+a typo makes ``python -m build`` emit an unpublishable/mis-sorted wheel, and a
+copy of the *npm* coupling assumption ("they must match") would be wrong here.
+This pins the format and documents the policy so neither slips through.
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+# Resolve the repo root via git rather than parent-walking from __file__, so the
+# test keeps working if it is moved (per the project test conventions).
+REPO_ROOT = Path(
+    subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+)
+
+# A normal PEP 440 *release* version (the only shape this project ships):
+# 2-3 dot-separated integers, optionally a pre/post/dev suffix. Deliberately
+# stricter than full PEP 440 — the client never ships epochs or local versions,
+# so anything exotic is a mistake worth failing on.
+_RELEASE_RE = re.compile(r"^\d+\.\d+(?:\.\d+)?(?:(?:a|b|rc|\.post|\.dev)\d+)?$")
+
+
+def _read_version(pyproject: Path) -> str:
+    """Pull the ``version = "..."`` line out of a pyproject without a TOML lib.
+
+    Avoids ``tomllib`` so the guard runs unchanged on Python 3.10 (the package's
+    floor; ``tomllib`` is 3.11+).
+    """
+    for line in pyproject.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        match = re.match(r'version\s*=\s*"([^"]+)"', stripped)
+        if match:
+            return match.group(1)
+    raise AssertionError(f"no version field found in {pyproject}")
+
+
+def test_python_client_version_is_a_valid_release() -> None:
+    version = _read_version(REPO_ROOT / "python" / "pyproject.toml")
+    assert _RELEASE_RE.match(version), (
+        f"python/pyproject.toml version {version!r} is not a plain PEP 440 "
+        "release (e.g. 1.2.6) — fix the version before publishing the wheel"
+    )
+
+
+def test_version_independence_policy_is_documented() -> None:
+    """The independence-from-npm policy must stay written down next to the
+    version, so a future maintainer who notices the two numbers differ reads
+    *why* before "fixing" it into a wrong coupling.
+
+    Asserts the rationale comment is present (a positive marker that we are on
+    the intended line), not just that some text exists — a deleted comment is
+    the regression. Pairs with a sanity check that the npm version is still
+    parseable, proving the two files are genuinely independent inputs.
+    """
+    pyproject_text = (REPO_ROOT / "python" / "pyproject.toml").read_text(
+        encoding="utf-8"
+    )
+    assert "NOT the npm release" in pyproject_text, (
+        "the version-independence rationale comment was dropped from "
+        "python/pyproject.toml — restore it before changing the version policy"
+    )
+    npm_version = re.search(
+        r'"version":\s*"([^"]+)"',
+        (REPO_ROOT / "package.json").read_text(encoding="utf-8"),
+    )
+    assert npm_version and npm_version.group(1), "npm package.json version missing"


### PR DESCRIPTION
## Summary

The Python distribution version (`python/pyproject.toml`, currently `1.2.6`) is
hand-maintained and diverges from the npm release line (`v1.4.x`). An audit
flagged this as possible drift — but on inspection it's **intentional**: the two
packages share a name but live in different ecosystems and bump independently
(npm is owned by the git-tag release workflow; the committed `package.json`
version is frozen). The real risk is that the policy is undocumented, so a future
maintainer "fixes" the mismatch into a wrong coupling, or a typo in the
hand-edited version ships an unpublishable wheel.

This documents the policy and guards it, rather than imposing a lockstep the
maintainer may not want.

## Changes

- Comment the `version` field in `python/pyproject.toml` explaining it versions
  the Python client surface independently of the npm release line.
- Add `tests/test_python_version.py`:
  - assert the version is a plain PEP 440 release (catches a malformed hand edit
    before `python -m build`);
  - assert the independence rationale stays documented (a positive marker, so a
    deleted comment regresses loudly and nobody re-couples the two by mistake).
- Regex-based parse (no `tomllib`) so it runs on the package's Python 3.10 floor.

## Tests / verification

- `uv run --frozen pytest tests/test_python_version.py -q` — 2 passed.
- `ruff check` clean.

## Checklist

- [x] Commits follow Conventional Commits.
- [x] Tests pass locally.
- [x] No detector behavior changed.
- [x] No secrets in the diff.
- [x] `CHANGELOG.md` and `package.json` version untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbPyofntiAXHyLF9kisZRe)_