### PR TITLE
build: raise the supported Node floor to >=22

### DIFF
--- a/.github/workflows/node-tests.yaml
+++ b/.github/workflows/node-tests.yaml
@@ -30,15 +30,6 @@ permissions:
 
 jobs:
   test:
-    # The package declares `engines.node >= 20`, so exercise the floor (20) and
-    # current (22): a regression on the supported floor (a newer V8/regex/API
-    # used unguarded) would otherwise only surface in a consumer's environment.
-    # `node-tests-passed` below is the stable Required check, so adding matrix
-    # legs (which rename this job to `test (20)` / `test (22)`) is safe.
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: ["20", "22"]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -48,8 +39,6 @@ jobs:
 
       - name: Setup base environment
         uses: ./.github/actions/setup-base-env
-        with:
-          node-version: ${{ matrix.node-version }}
 
       - name: Check if test script is configured
         id: check

--- a/.github/workflows/node-tests.yaml
+++ b/.github/workflows/node-tests.yaml
@@ -30,6 +30,15 @@ permissions:
 
 jobs:
   test:
+    # The package declares `engines.node >= 20`, so exercise the floor (20) and
+    # current (22): a regression on the supported floor (a newer V8/regex/API
+    # used unguarded) would otherwise only surface in a consumer's environment.
+    # `node-tests-passed` below is the stable Required check, so adding matrix
+    # legs (which rename this job to `test (20)` / `test (22)`) is safe.
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["20", "22"]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -39,6 +48,8 @@ jobs:
 
       - name: Setup base environment
         uses: ./.github/actions/setup-base-env
+        with:
+          node-version: ${{ matrix.node-version }}
 
       - name: Check if test script is configured
         id: check

--- a/.github/workflows/validate-config.yaml
+++ b/.github/workflows/validate-config.yaml
@@ -68,8 +68,8 @@ jobs:
       # POSIX setsid/killpg/process groups, which diverge on macOS/BSD. The Node
       # version is pinned (not matrixed) because the repo's packageManager
       # (pnpm@11.8.0) imports node:sqlite and so requires Node >=22.13 — a Node-20
-      # leg can't even bootstrap pnpm. The published library's Node>=20 runtime
-      # support is exercised by the consumer-style pack-smoke job instead.
+      # leg can't even bootstrap pnpm. That toolchain floor is why the package
+      # declares engines.node >=22 (Node 20 can't run the dev/test suite).
       - name: Setup base environment
         uses: ./.github/actions/setup-base-env
         with:

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "keywords": [
     "llm",

--- a/python/README.md
+++ b/python/README.md
@@ -8,7 +8,7 @@ second implementation to keep in sync.
 
 ## Requirements
 
-- Node.js (>= 20) on `PATH`. There is deliberately no pure-Python fallback.
+- Node.js (>= 22) on `PATH`. There is deliberately no pure-Python fallback.
 - The path to a JavaScript checkout's CLI. The wheel does **not** bundle the JS
   (a vendored copy would drift), so set `AGENT_SANITIZER_CLI` to the
   `bin/sanitize-cli.mjs` of a cloned/`npm install`-ed checkout. When imported

--- a/python/agent_input_sanitizer/__init__.py
+++ b/python/agent_input_sanitizer/__init__.py
@@ -3,7 +3,7 @@
 The sanitization logic has a single source of truth: the JavaScript in
 ``src/``. This module is a thin client that shells out to the
 ``bin/sanitize-cli.mjs`` CLI, so a Python pipeline gets byte-identical verdicts
-without a second implementation to keep in sync. It requires Node.js (>=20) on
+without a second implementation to keep in sync. It requires Node.js (>=22) on
 ``PATH``; there is deliberately no pure-Python fallback, because a port is
 exactly the drift this design avoids.
 
@@ -123,7 +123,7 @@ class InstructionFinding:
 
 def _node_missing(node: str) -> RuntimeError:
     return RuntimeError(
-        f"Node.js (>=20) is required but {node!r} was not found on PATH. "
+        f"Node.js (>=22) is required but {node!r} was not found on PATH. "
         "agent-input-sanitizer keeps a single JavaScript source of truth and "
         "has no pure-Python fallback; install Node to use the Python client."
     )

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,7 +3,7 @@
 # This packages ONLY the thin Python bridge (`agent_input_sanitizer`). The
 # sanitization logic is the JavaScript in `src/` and is deliberately NOT bundled
 # into the wheel: a vendored copy is the exact drift this design avoids. An
-# installed package therefore needs Node.js (>=20) on PATH and the path to a
+# installed package therefore needs Node.js (>=22) on PATH and the path to a
 # JavaScript checkout's CLI, supplied via the `AGENT_SANITIZER_CLI` environment
 # variable (see the package docstring). Run `python -m build` from this `python/`
 # directory to produce the sdist/wheel.


### PR DESCRIPTION
## Summary

This PR started as a Node 20/22 CI matrix to exercise the declared `engines.node >= 20`
floor. The matrix immediately **proved the floor was already broken**: the
`test (20)` leg fails before running a single test because the pinned
`packageManager` (`pnpm@11.8.0`) imports `node:sqlite` and requires Node ≥22.13 —
pnpm can't even bootstrap on Node 20, so the dev/test toolchain cannot run there.

Per maintainer direction, the fix is to align the declared support with that
reality rather than chase an unworkable Node-20 test path: **raise the floor to
Node 22.**

## Changes

- `package.json`: `engines.node` `>=20` → `>=22`.
- Revert the infeasible Node-20 test matrix in `node-tests.yaml` (back to the
  single job on the default Node 22).
- Update the Node-version notes to `>=22`: the Python client docstring, its
  `_node_missing` error message, `python/README.md`, and the `python/pyproject.toml`
  install note.
- `validate-config.yaml`: reword the pinned-Node rationale to point at the new
  `engines.node >=22` floor instead of claiming pack-smoke covers a Node-20 runtime
  (it runs on Node 22, so it never did).

## Tests / verification

- `pytest tests/test_python_client.py` — 87 passed (covers the `_node_missing`
  message wording).
- `prettier` / `ruff` clean.
- CI on this PR now runs a single Node 22 leg.

## Checklist

- [x] Commits follow Conventional Commits.
- [x] Python client tests pass locally.
- [x] No detector behavior changed.
- [x] No secrets in the diff.
- [x] `CHANGELOG.md` and `package.json` version untouched (only `engines`).