### PR TITLE
perf(cli): assemble worker input lines in O(n), not O(n²)

### DIFF
--- a/bin/sanitize-cli.mjs
+++ b/bin/sanitize-cli.mjs
@@ -198,13 +198,32 @@ async function readAll(stream) {
  * @param {number} limit  per-line byte cap (`maxInputBytes()`)
  */
 function createLineSplitter(limit) {
-  // `buffer` holds the bytes of the current line while it's still under the cap.
-  // The moment appending the next segment would push its byte length over
-  // `limit`, `buffer` is freed and `discarding` flips: from there we scan only
-  // for the terminating `\n`, never re-accumulating, so peak buffering for one
-  // line is bounded by `limit` regardless of how long the line runs.
-  let buffer = Buffer.alloc(0);
+  // The bytes of the current line are held as a LIST of chunk slices plus their
+  // running total, joined into one Buffer only when the line completes. Pushing
+  // a slice is O(1), so assembling an N-byte line costs O(N) overall. The old
+  // single growing `Buffer.concat([buffer, segment])` per segment re-copied the
+  // whole accumulated prefix each time — O(N^2) for a line streamed as many
+  // small chunks (e.g. a multi-MiB line arriving in 1-byte reads). `discarding`
+  // still caps peak buffering at `limit`: once a line would breach it, the
+  // pending slices are dropped and we scan only for the terminating `\n`.
+  /** @type {Buffer[]} */
+  let pending = [];
+  let pendingLen = 0;
   let discarding = false;
+
+  /** Drop any pending slices (line abandoned or fully consumed). */
+  const reset = () => {
+    pending = [];
+    pendingLen = 0;
+  };
+
+  /** Join the pending slices into one line buffer (single copy) and reset. */
+  const take = () => {
+    const buf =
+      pending.length === 1 ? pending[0] : Buffer.concat(pending, pendingLen);
+    reset();
+    return buf;
+  };
 
   /** Strip one trailing `\r` so CRLF input frames identically to LF. */
   const toLine = (buf) => {
@@ -213,17 +232,20 @@ function createLineSplitter(limit) {
   };
 
   // Fold one segment (the bytes of the current line seen so far in this chunk)
-  // into `buffer`, flipping to `discarding` if it would breach the cap. Applies
-  // identically to a newline-terminated segment and to the unterminated tail, so
-  // an oversize line is caught WITHIN a chunk, not only at its trailing edge.
+  // into the pending list, flipping to `discarding` if it would breach the cap.
+  // Applies identically to a newline-terminated segment and to the unterminated
+  // tail, so an oversize line is caught WITHIN a chunk, not only at its edge.
   const accumulate = (segment) => {
     if (discarding) return;
-    if (buffer.length + segment.length > limit) {
-      buffer = Buffer.alloc(0);
+    if (pendingLen + segment.length > limit) {
+      reset();
       discarding = true;
       return;
     }
-    if (segment.length > 0) buffer = Buffer.concat([buffer, segment]);
+    if (segment.length > 0) {
+      pending.push(segment);
+      pendingLen += segment.length;
+    }
   };
 
   /** Feed one chunk, returning the events it completes (newline-terminated). */
@@ -236,10 +258,10 @@ function createLineSplitter(limit) {
       if (discarding) {
         events.push({ kind: "oversize" });
         discarding = false;
+        reset();
       } else {
-        events.push({ kind: "line", text: toLine(buffer) });
+        events.push({ kind: "line", text: toLine(take()) });
       }
-      buffer = Buffer.alloc(0);
       start = i + 1;
     }
     accumulate(chunk.subarray(start));
@@ -254,12 +276,11 @@ function createLineSplitter(limit) {
   push.end = () => {
     if (discarding) {
       discarding = false;
+      reset();
       return [{ kind: "oversize" }];
     }
-    if (buffer.length === 0) return [];
-    const event = { kind: "line", text: toLine(buffer) };
-    buffer = Buffer.alloc(0);
-    return [event];
+    if (pendingLen === 0) return [];
+    return [{ kind: "line", text: toLine(take()) }];
   };
 
   return push;

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -638,6 +638,25 @@ describe("createLineSplitter", () => {
     for (const cs of [1, 2, 3, 5, 7, 13]) assert.deepEqual(kinds(cs), oneShot);
   });
 
+  it("reassembles a multi-slice line byte-for-byte", () => {
+    // The line spans thousands of 1-byte chunks, so the splitter holds it as a
+    // LIST of slices and joins them once at the newline (the O(n) accumulation
+    // that replaced a per-segment Buffer.concat). Pin that the join reconstructs
+    // the exact bytes — ASCII only, so no chunk boundary lands mid-codepoint.
+    const line = "x".repeat(5000);
+    assert.deepEqual(splitAll(`${line}\n`, 1_000_000, 1), [
+      { kind: "line", text: line },
+    ]);
+  });
+
+  it("strips a trailing CR delivered as its own chunk", () => {
+    // CRLF fed byte-by-byte: the CR is the final slice, so the trailing-CR strip
+    // must inspect the JOINED line's last byte, not a single accumulator's.
+    assert.deepEqual(splitAll("abc\r\n", 100, 1), [
+      { kind: "line", text: "abc" },
+    ]);
+  });
+
   it("property: # line events == # in-cap lines; framing chunk-invariant", () => {
     // Domain: random lines (some > cap), joined by \\n, fed at random chunk
     // sizes. INVARIANTS: (1) total events == number of input lines (one response


### PR DESCRIPTION
## Summary

The worker-mode line splitter (`createLineSplitter` in `bin/sanitize-cli.mjs`)
accumulated each line with `buffer = Buffer.concat([buffer, segment])` per
segment. That re-copies the entire accumulated prefix on every chunk, so a single
long line streamed as many small reads is **O(n²)** — e.g. a multi-MiB line
arriving in 1-byte chunks copies ~n²/2 bytes total. The per-line memory cap
bounds the worst case at 10 MiB, but the wasted copying is real and avoidable.

## Changes

- Hold the in-progress line as a **list of slices** with a running byte length,
  and `Buffer.concat(pending, pendingLen)` **once** when the newline arrives —
  O(n) assembly. Single-slice lines skip the concat entirely.
- Behavior is unchanged: same `discarding` cap (peak buffering still bounded by
  the limit), same CRLF strip, same one-event-per-line framing, same oversize
  handling.
- New unit tests pin the refactor's specific risk: byte-for-byte reassembly of a
  multi-slice line fed 1 byte at a time, and trailing-CR strip when the CR lands
  in its own chunk.

## Tests / verification

- `node --test test/cli.test.mjs` — 36/36 (the existing chunk-invariance property
  test already feeds byte-by-byte; the two new cases cover decoded-text
  reassembly, which that property test deliberately doesn't).
- `eslint` + `tsc --noEmit` clean.

## Checklist

- [x] Commits follow Conventional Commits.
- [x] `node --test`, `eslint`, `tsc` pass locally.
- [x] No detector behavior changed; framing/cap invariants pinned by tests.
- [x] No secrets in the diff.
- [x] `CHANGELOG.md` and `package.json` version untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbPyofntiAXHyLF9kisZRe)_