### PR TITLE
docs(skills): add audit-and-parallelize skill

### DIFF
--- a/.claude/skills/audit-and-parallelize/SKILL.md
+++ b/.claude/skills/audit-and-parallelize/SKILL.md
@@ -1,0 +1,95 @@
+---
+# prettier-ignore
+name: audit-and-parallelize
+description: >
+  Runs a broad "find as many issues as you can" audit by fanning out read-only subagents over
+  disjoint surfaces, VERIFIES every finding against the real code before trusting it, then turns
+  the survivors into a set of small, file-disjoint parallel PRs. Activate when the user asks to
+  "audit this", "find security/robustness/UX issues", "find dozens of problems", "do a deep review
+  and fix everything", or any broad hunt-and-fix request that should fan out across the codebase
+  and land as multiple PRs. Distinct from peer-review (which reviews a pending diff): this audits
+  an entire codebase from scratch and plans the fixes.
+---
+
+# Audit & Parallelize Skill
+
+Codifies the discipline for an open-ended "find lots of issues and fix them" request. The failure
+mode it exists to prevent: **subagents over-report.** A fan-out of explorer agents will confidently
+return "critical" security findings that evaporate the moment you read the cited code. Planning
+fixes off unverified findings wastes effort, manufactures noise, and — in a detection/security
+codebase — risks "fixing" correct, hardened code into something worse.
+
+The non-negotiable rule: **every finding is false until the code proves it true.**
+
+## Workflow
+
+### 1. Fan out over disjoint surfaces
+
+Launch 2–4 **read-only** subagents (`Explore`, or `general-purpose` for deeper traces) in a single
+message so they run concurrently. Partition by surface so they don't overlap — e.g.:
+
+- core logic / algorithms
+- integration, I/O, CLI, language bridges
+- tests, CI, packaging, docs
+
+Give each agent the same explicit shape for findings: `file:line`, one-line defect, a **concrete
+failure input/scenario**, severity, and true-bug-vs-improvement. Ask for a specific count
+("aim for 15+") to push breadth, knowing you will discard most of it.
+
+### 2. Verify before trusting — the core step
+
+Re-read the cited code for **every** high/critical finding. Default each to _false_ and look for the
+guard, the anchored regex, the catch-all branch, the existing test that already covers it. Cheap
+verifications first (does the regex actually match the claimed bypass? is the field already
+type-checked upstream? is there already an e2e test for this path?).
+
+Record each as **CONFIRMED** (with the proof) or **REJECTED** (with why). Expect to reject the
+majority, including most of the scariest ones. If verification deflates the audit, **that deflation
+is the headline result** — report it honestly instead of padding the plan to hit a number.
+
+### 3. Tier and prune
+
+Rank survivors by confidence × severity. Drop precision-risky "recall" additions: a detector tweak
+that adds a rare catch at the cost of false positives on legitimate input is usually net-negative —
+prefer the false negative and say so.
+
+### 4. Plan file-disjoint parallel PRs
+
+Group confirmed fixes into small, single-concern PRs that touch **non-overlapping files**, so they
+can be developed and merged in parallel without conflicts. Watch for shared, workflow-managed files
+(changelogs, lockfiles) that must not be hand-edited. Each PR: its own branch off the latest default
+branch, Conventional Commits, and a **proving test added before the fix**.
+
+### 5. Critique the plan, then present
+
+Before handing it over, attack your own plan: Is any "fix" actually changing intentional design?
+Does any finding contradict a documented tradeoff? Are the PRs genuinely independent? Is the volume
+honest? Surface these as a self-critique section rather than letting the reviewer find them.
+
+## Examples
+
+**Input:** "Find dozens of security and robustness issues in this library, confirm them with
+subagents, then make parallel PRs to fix them."
+
+**Output:** Three `Explore` agents fan out over core / integration / tests-CI-docs and return ~60
+findings. Verification rejects nearly every "critical" one (e.g. a claimed "U+009D escape survives"
+is disproven by the catch-all branch in the splitter; a "secret-exposure" path is already guarded by
+an upstream candidate check). ~5 real, mostly-minor issues survive (a doc file missing from the
+package tarball, a single-Node CI matrix, an O(n²) buffer assembly). These become five file-disjoint
+PRs, each with a proving test, plus a self-critique noting which "fixes" touch intentional design.
+
+**Input:** "Audit the parser and fix what you find."
+
+**Output:** One `Explore` pass (narrow surface → one agent) returns 12 findings; verification
+confirms 2 (an unbounded recursion on nested input; an off-by-one on EOF) and rejects 10. Two PRs
+land the two fixes with regression tests; the report states plainly that the other 10 were false
+positives and why.
+
+## Anti-patterns
+
+- **Trusting a subagent's "CRITICAL" label.** It is a hypothesis, not a result. Read the code.
+- **Padding to a number.** If only five issues are real, plan five. The over-report is the finding.
+- **One giant PR.** Disjoint PRs parallelize and review cleanly; a mega-PR serializes everything.
+- **Recall over precision in detectors.** A noisy new check that flags legitimate input trains
+  operators to ignore the signal. When a heuristic can't cleanly separate payload from benign input,
+  prefer the false negative.


### PR DESCRIPTION
## Summary

Adds a reusable skill that codifies how to handle an open-ended "find lots of
issues and fix them" request. It came directly out of running such an audit on
this repo: three fan-out subagents returned ~60 findings, and **verification
rejected nearly every "critical" one** — the detection/rehydrate core is heavily
hardened, so the scary findings were false positives (a claimed `U+009D` escape
disproven by the splitter's catch-all branch; a "secret-exposure" path already
guarded upstream; "no CLI file-I/O e2e" when `cli.test.mjs` already spawns real
subprocesses). Only ~5 real, minor issues survived.

The skill exists to make that verification step mandatory, so future audits don't
plan fixes off unverified subagent output.

## Changes

- New `.claude/skills/audit-and-parallelize/SKILL.md`: fan out read-only
  subagents over disjoint surfaces → **verify every finding against the real code
  before trusting it** → tier/prune → plan file-disjoint parallel PRs → self-critique.
- Includes `## Examples` and an anti-patterns section.

## Tests / verification

- `bash .hooks/lint-skills.sh .claude/skills/audit-and-parallelize/SKILL.md` passes.
- `pytest tests/test_lint_skills.py` — 8 passed.
- `prettier --write` clean (frontmatter `# prettier-ignore` preserved).

## Checklist

- [x] Commits follow Conventional Commits.
- [x] Skill lint + skill-lint tests pass locally.
- [x] No runtime/detector code changed.
- [x] No secrets in the diff.
- [x] `CHANGELOG.md` and `package.json` version untouched.

## Lessons Learned

- **What:** Add an `audit-and-parallelize` skill that makes finding-verification a
  required step of any broad audit, with the rule "every subagent finding is false
  until the code proves it true."
- **Where:** `.claude/skills/audit-and-parallelize/SKILL.md` (new template skill).
- **Why:** Fan-out audit subagents systematically over-report — they return
  confident "critical" security findings that disappear on reading the cited code.
  Any downstream repo running a "find dozens of issues and fix them" prompt will
  hit this; without an enforced verify-before-trust step, agents waste effort on
  phantom bugs and risk "fixing" already-hardened code. The skill turns the
  verification pass and honest deflation ("the over-report is the finding") into
  standard procedure, and pairs it with the file-disjoint-parallel-PR pattern so
  the confirmed fixes land cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbPyofntiAXHyLF9kisZRe)_