### PR TITLE
fix: close two sanitizer-bypass holes (C1 string controls, confusable fold trust)

### DIFF
--- a/src/confusables.mjs
+++ b/src/confusables.mjs
@@ -104,10 +104,30 @@ export function foldConfusables(text, findings) {
     // Fail loud on a finding that does not match the actual bytes at its offset:
     // a buggy/adversarial scanner reporting a wrong char/index would otherwise
     // silently corrupt the path/command, defeating the deny-rule protection.
+    // A negative index is the gap the startsWith guard alone misses: when `char`
+    // is a prefix of the text, `startsWith(char, -1)` is true (the offset is
+    // clamped to 0), and the slice math below then mangles the string instead of
+    // throwing — so range-check the index explicitly first.
+    if (!Number.isInteger(finding.index) || finding.index < 0)
+      throw new Error(
+        `Confusable finding has an out-of-range index ${finding.index}`,
+      );
     if (!folded.startsWith(finding.char, finding.index))
       throw new Error(
         `Confusable finding does not match input at index ${finding.index}: expected ${JSON.stringify(finding.char)}`,
       );
+    // The replacement must be the ASCII canon the contract promises. A non-ASCII
+    // `latinEquivalent` would fold one confusable into ANOTHER look-alike (e.g.
+    // Cyrillic а → Cyrillic е), defeating the whole point — the cross-script
+    // deny-rule bypass would survive — and silently break the fold-to-ASCII
+    // invariant callers rely on, so reject it loudly.
+    for (const ch of finding.latinEquivalent)
+      if (/** @type {number} */ (ch.codePointAt(0)) > 0x7f)
+        throw new Error(
+          `Confusable latinEquivalent ${JSON.stringify(
+            finding.latinEquivalent,
+          )} is not ASCII`,
+        );
     folded =
       folded.slice(0, finding.index) +
       finding.latinEquivalent +

--- a/src/invisible.mjs
+++ b/src/invisible.mjs
@@ -95,14 +95,16 @@ export const STRIP = new RegExp(
 export const SGR_RE = /(?:\x1b\[|)[0-9;]*m/g;
 
 // The raw ANSI control introducers isSgrOnly must treat as NON-SGR after SGR
-// removal: 7-bit ESC (U+001B), 8-bit C1 CSI (U+009B), and 8-bit C1 OSC
-// (U+009D). isSgrOnly is honest only if it tests for ALL THREE — a C1
-// cursor-move or erase (`U+009B 2J`) leaves a U+009B, and a C1-OSC string
-// (`U+009D … BEL`) leaves a U+009D, after SGR removal; both must read as NOT
-// SGR-only, exactly as their 7-bit `ESC[2J` / `ESC]…` twins do. Omitting
-// U+009D would let a residual C1-OSC introducer be misread as SGR-only.
+// removal: 7-bit ESC (U+001B) and the entire 8-bit C1 control block
+// (U+0080–U+009F) — CSI (U+009B), the DCS/SOS/OSC/PM/APC string introducers, and
+// ST. isSgrOnly is honest only if it tests for ALL of them — a C1 cursor-move or
+// erase (`U+009B 2J`) leaves a U+009B, a C1-OSC string (`U+009D … BEL`) leaves a
+// U+009D, and a C1-DCS/APC payload (`U+0090 … ST`) leaves its introducer, after
+// SGR removal; each must read as NOT SGR-only, exactly as their 7-bit `ESC[2J` /
+// `ESC]…` / `ESC P…` twins do. Omitting any would let a residual C1 introducer
+// be misread as SGR-only.
 // eslint-disable-next-line no-control-regex -- the raw introducers are what we test for
-const CONTROL_INTRODUCER_RE = /[\x1b\x9b\x9d]/;
+const CONTROL_INTRODUCER_RE = /[\x1b\u0080-\u009f]/;
 
 /**
  * True when every ANSI control introducer in `text` belongs to a display-only

--- a/src/layer1.mjs
+++ b/src/layer1.mjs
@@ -8,12 +8,17 @@
  */
 import { stripInvisibleWithReport, CATEGORY } from "./invisible.mjs";
 
-// The two raw control introducers an ANSI sequence can start with: 7-bit
-// ESC (U+001B) and the 8-bit C1 CSI (U+009B). Both are category Cc, so the
-// invisible-char pass (which targets Cf / variation / blank fillers) never
-// removes them; the residual sweep below is what guarantees neither survives.
+// Raw control introducers that must not survive: 7-bit ESC (U+001B) and the
+// entire 8-bit C1 control block (U+0080–U+009F) — which includes CSI (U+009B),
+// the string introducers DCS/SOS/OSC/PM/APC (U+0090/0098/009D/009E/009F), and ST
+// (U+009C). All are category Cc, so the invisible-char pass (which targets Cf /
+// variation / blank fillers) never removes them; this residual sweep is the
+// guarantee that none survives. Sweeping the whole C1 block — not just the
+// introducers the ANSI grammar above names — fails closed: a DCS/SOS/PM/APC
+// string the grammar does not consume still loses its introducer and terminator
+// here, so no terminal can hide-render its body as a control payload.
 // eslint-disable-next-line no-control-regex -- matching the raw introducers is the point
-const CONTROL_INTRODUCER_RE = /[\u001b\u009b]/g;
+const CONTROL_INTRODUCER_RE = /[\u001b\u0080-\u009f]/g;
 
 // An OSC (Operating System Command) string is `<introducer> … <terminator>`.
 // Introducer: 7-bit `ESC]` or 8-bit C1 OSC (U+009D). Terminator: ST (`ESC\` or
@@ -89,7 +94,8 @@ export function stripAnsiFully(input) {
 
 /**
  * Layer 1: ANSI + invisible-char strip with a result guaranteed free of every
- * raw ANSI control introducer (7-bit ESC U+001B and 8-bit C1 CSI U+009B).
+ * raw ANSI control introducer (7-bit ESC U+001B and the whole 8-bit C1 control
+ * block U+0080–U+009F: CSI, the DCS/SOS/OSC/PM/APC string introducers, and ST).
  *
  * Removing an invisible character can reconstitute an escape its split hid from
  * the ANSI pass (`ESC`<ZWSP>`[32m` → `ESC[32m`), so strip ANSI again after the

--- a/test/confusables.test.mjs
+++ b/test/confusables.test.mjs
@@ -145,6 +145,40 @@ describe("foldConfusables", () => {
       "/a",
     );
   });
+
+  it("throws on a negative index instead of silently corrupting the text", () => {
+    // startsWith(char, -1) clamps to 0 and returns true when `char` is a prefix,
+    // so without the explicit range check this used to splice to "abxabc".
+    assert.throws(
+      () =>
+        foldConfusables("abc", [
+          { index: -1, char: "a", latinEquivalent: "x" },
+        ]),
+      /out-of-range index -1/,
+    );
+  });
+
+  it("throws when latinEquivalent is non-ASCII (fold would stay a confusable)", () => {
+    // Adversarial scanner: "fold" Cyrillic а to Cyrillic е — still a homoglyph,
+    // so the cross-script deny-rule bypass would survive. Must fail loud.
+    const CYR_E = "е";
+    assert.throws(
+      () =>
+        foldConfusables(`/${CYR_A}b`, [
+          { index: 1, char: CYR_A, latinEquivalent: CYR_E },
+        ]),
+      /is not ASCII/,
+    );
+  });
+
+  it("allows a multi-character ASCII canon (e.g. a ligature fold)", () => {
+    // Precision: a legitimate one-to-many ASCII fold (½ → 1/2, œ → oe) must NOT
+    // be rejected by the ASCII guard — only non-ASCII replacements are refused.
+    assert.equal(
+      foldConfusables("½ x", [{ index: 0, char: "½", latinEquivalent: "1/2" }]),
+      "1/2 x",
+    );
+  });
 });
 
 // ─── normalizeConfusables: folding positive cases ────────────────────────────

--- a/test/confusables.test.mjs
+++ b/test/confusables.test.mjs
@@ -158,6 +158,16 @@ describe("foldConfusables", () => {
     );
   });
 
+  it("throws on a non-integer index", () => {
+    assert.throws(
+      () =>
+        foldConfusables("abc", [
+          { index: 1.5, char: "b", latinEquivalent: "x" },
+        ]),
+      /out-of-range index 1\.5/,
+    );
+  });
+
   it("throws when latinEquivalent is non-ASCII (fold would stay a confusable)", () => {
     // Adversarial scanner: "fold" Cyrillic а to Cyrillic е — still a homoglyph,
     // so the cross-script deny-rule bypass would survive. Must fail loud.

--- a/test/invisible.test.mjs
+++ b/test/invisible.test.mjs
@@ -616,6 +616,37 @@ describe("applyLayer1: OSC strings and C1 sequences", () => {
     });
   }
 
+  // DCS/SOS/PM/APC are the other ECMA-48 string controls. The OSC/CSI grammar
+  // does not consume them, so the residual C1 sweep is what guarantees their
+  // introducer and terminator never survive into the model's view (the body
+  // text remains — it is now equally visible to a human, the point of the fix).
+  const C1_DCS = cp(0x90);
+  const C1_SOS = cp(0x98);
+  const C1_PM = cp(0x9e);
+  const C1_APC = cp(0x9f);
+  for (const [name, input] of [
+    ["7-bit DCS (ESC P … ST)", `before${ESC}P1;2;3|PAYLOAD${ST}after`],
+    ["7-bit APC (ESC _ … ST)", `x${ESC}_hidden-cmd${ST}y`],
+    ["7-bit PM (ESC ^ … ST)", `x${ESC}^secret${ST}y`],
+    ["7-bit SOS (ESC X … ST)", `x${ESC}Xboo${ST}y`],
+    ["8-bit DCS (U+0090 … C1 ST)", `x${C1_DCS}PAYLOAD${C1_ST}y`],
+    ["8-bit APC (U+009F … C1 ST)", `x${C1_APC}hidden-cmd${C1_ST}y`],
+    ["8-bit PM (U+009E … C1 ST)", `x${C1_PM}secret${C1_ST}y`],
+    ["8-bit SOS (U+0098 … C1 ST)", `x${C1_SOS}boo${C1_ST}y`],
+    ["unterminated 8-bit APC", `x${C1_APC}dangling-payload`],
+  ]) {
+    it(`leaves no C1 control for the string control: ${name}`, () => {
+      const { cleaned } = applyLayer1(input);
+      for (const ch of cleaned) {
+        const code = ch.codePointAt(0);
+        assert.ok(
+          (code < 0x80 || code > 0x9f) && code !== 0x1b,
+          `control U+${code.toString(16)} survived in ${name}`,
+        );
+      }
+    });
+  }
+
   it("leaves no raw control introducer for any of the OSC/C1 cases", () => {
     for (const input of [
       `${ESC}]0;t${ST}`,
@@ -794,16 +825,26 @@ describe("property: stripInvisible invariants", () => {
 });
 
 // applyLayer1 over a domain that ALSO includes raw ANSI introducers/terminators
-// (ESC, C1 CSI/OSC/ST, BEL, `[`, `]`, `;`, `m`) so the property exercises the
-// OSC/CSI grammar, not just invisible chars.
+// — ESC, the C1 string introducers DCS/SOS/CSI/OSC/PM/APC (U+0090/0098/009B/
+// 009D/009E/009F), C1 ST (U+009C), BEL, the 7-bit string-intro letters
+// (`P X ] ^ _`), and `[ ; m 0` — so the property exercises the whole control
+// grammar, not just invisible chars or the OSC/CSI subset.
 const ansiChar = fc.constantFrom(
   cp(0x1b),
+  cp(0x90),
+  cp(0x98),
   cp(0x9b),
   cp(0x9c),
   cp(0x9d),
+  cp(0x9e),
+  cp(0x9f),
   cp(0x07),
+  "P",
+  "X",
   "[",
   "]",
+  "^",
+  "_",
   ";",
   "m",
   "0",
@@ -823,12 +864,22 @@ describe("property: applyLayer1 invariants", () => {
     );
   });
 
-  it("no raw ANSI control introducer (ESC / C1 CSI) survives, for any input", () => {
+  // The guarantee is no RAW control introducer survives — 7-bit ESC and the
+  // WHOLE 8-bit C1 block, not just the CSI/OSC the grammar names. Asserting the
+  // entire U+0080–U+009F range is what catches a DCS/SOS/PM/APC introducer (or
+  // its body's terminator) the OSC/CSI branches never matched.
+  it("no raw control introducer (ESC or any C1 U+0080–U+009F) survives, for any input", () => {
     fc.assert(
       fc.property(layer1Text, (text) => {
         const { cleaned } = applyLayer1(text);
         assert.ok(!cleaned.includes(cp(0x1b)), "ESC survived");
-        assert.ok(!cleaned.includes(cp(0x9b)), "C1 CSI survived");
+        for (const ch of cleaned) {
+          const code = ch.codePointAt(0);
+          assert.ok(
+            code < 0x80 || code > 0x9f,
+            `C1 control U+${code.toString(16)} survived`,
+          );
+        }
       }),
       fcRunOptions(),
     );

--- a/test/invisible.test.mjs
+++ b/test/invisible.test.mjs
@@ -352,6 +352,15 @@ describe("isSgrOnly", () => {
     assert.equal(isSgrOnly(`${cp(0x9d)}0;title${cp(0x07)}`), false));
   it("stays true for a genuine 7-bit SGR color string", () =>
     assert.equal(isSgrOnly(`${cp(0x1b)}[31mred${cp(0x1b)}[0m`), true));
+
+  // The other C1 string introducers (DCS/SOS/PM/APC) and C1 ST are NOT SGR, so
+  // a residual one must read as NOT SGR-only — exactly as U+009B/U+009D do. One
+  // case per member so narrowing the introducer range (away from the full C1
+  // block) can't pass: each member would then slip through as "SGR-only".
+  for (const c1 of [0x90, 0x98, 0x9c, 0x9e, 0x9f]) {
+    it(`is false for a residual C1 introducer U+${c1.toString(16).toUpperCase()}`, () =>
+      assert.equal(isSgrOnly(`${cp(c1)}payload`), false));
+  }
 });
 
 // ─── LONG_RUN_RE ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two confirmed, runtime-reproduced bypasses of the Layer-1 / confusable guarantees, each fixed with a test that goes **red on the unfixed code and green after**.

### 1. C1 string-control bypass (`fix(layer1)`)
`applyLayer1`'s residual sweep removed only 7-bit ESC and the C1 CSI (U+009B), and the ANSI grammar only consumed OSC/CSI. The other ECMA-48 string controls — **DCS (U+0090), SOS (U+0098), PM (U+009E), APC (U+009F)** and the C1 ST (U+009C) — and their payload survived into the model's view. A terminal that interprets C1 controls hides such a string from a **human reviewer** while the model still receives the embedded text.

Fix: extend the residual sweep to the entire C1 block `U+0080–U+009F` (in both `applyLayer1` and `isSgrOnly`'s introducer test). No C1 introducer or terminator survives; the body text remains, now equally visible to a human.

### 2. Confusable-fold trust gap (`fix(confusables)`)
`foldConfusables` trusted the injected scanner's `latinEquivalent`/`index` past the single `startsWith` check. A **negative index** slipped through (startsWith clamps to 0) and silently corrupted text (`"abc"` → `"abxabc"`); a **non-ASCII `latinEquivalent`** folded one confusable into another look-alike (Cyrillic а → Cyrillic е), leaving the cross-script deny-rule bypass intact.

Fix: range-check the index and require every replacement code point to be ASCII, both failing loud — symmetric with the existing char-match guard. A legitimate one-to-many ASCII canon (`½` → `1/2`) is still allowed.

## Tests
- `test/invisible.test.mjs`: 7-/8-bit DCS/SOS/PM/APC example cases + a property asserting no `U+0080–U+009F` char survives `applyLayer1`; the property arbitrary now emits every C1 introducer. The 8-bit cases were verified red on the pre-fix sweep.
- `test/confusables.test.mjs`: negative-index and non-ASCII throw cases (red pre-fix), plus a multi-char ASCII fold pinning precision.
- Full `invisible`/`sanitize`/`prompt`/`output`/`confusables` suites green; golden corpus unaffected (no C1 cases); eslint + prettier clean.

## Scope note
These are the first two items from a broader security/robustness audit of this package. Out of scope here (separate work): the rehydrate/view-map offset-mapping gaps, HTML hidden-element parser differentials + the `aria-hidden` false positive, percent-encoded exfil detection, and gating `bin/sanitize-cli.mjs` under tsc/c8/stryker/eslint.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CrYSErTzNaUeWdNaZrYm6m)_