### PR TITLE
refactor(rehydrate): drop inert found field from RedactMapView typedef

### DIFF
--- a/src/rehydrate.mjs
+++ b/src/rehydrate.mjs
@@ -47,7 +47,7 @@ export const DEFAULT_HINT = "[REDACTED";
  * Map-mode response from the redactor: either the mappable view (text + ordered
  * (placeholder, original, start) pairs) or an unmappable verdict carrying its
  * reason — a discriminated pair.
- * @typedef {{text: string, pairs: {placeholder: string, original: string, start: number}[], found?: string[]}
+ * @typedef {{text: string, pairs: {placeholder: string, original: string, start: number}[]}
  *   | {unmappable: string}} RedactMapView
  */
 


### PR DESCRIPTION
## Summary

A sweep of the `src/` modules for inert/unused fields found one: the `RedactMapView` typedef in `src/rehydrate.mjs` declared an optional `found?: string[]` member that **no `redactMap` implementation produces and no consumer reads**. The rehydration path (`rehydrateRedacted` → `rehydrateEdit`/`rehydrateWrite`) uses only `view.text`, `view.pairs`, and `view.unmappable`. The lone `.found` access in the codebase is on the Layer-4 `redact` result (`output.mjs`), a different shape. Dropping the field makes the documented contract match what the code actually exchanges.

The rest of the surface that superficially looks unused (`./confusables`, `SECRET_HINT*`, the `invisible.mjs` constant exports) is deliberate, documented public API re-exported via `package.json` subpaths — verified before discarding, left intact.

## Changes

- Remove the dead `found?: string[]` member from the `RedactMapView` typedef in `src/rehydrate.mjs`.

## Tests / verification

- `tsc --noEmit` passes (the field was JSDoc-only; no runtime change).
- `prettier --check` and `eslint` clean on the changed file.
- Confirmed no test produces or reads `RedactMapView.found`.

## Checklist

- [x] Commit follows Conventional Commits
- [x] Type-check / lint pass locally
- [x] No detector behavior changed (documentation-only contract fix)
- [x] No real secrets in the diff
- [x] `CHANGELOG.md` / `package.json` version untouched

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ut1cfZ8MJGH7mEj2c9WMa4)_