### PR TITLE
feat(html): detect content-visibility:hidden, filter:opacity(0), and two-axis offscreen translate

### DIFF
--- a/src/html.mjs
+++ b/src/html.mjs
@@ -114,10 +114,31 @@ function isHidingTransform(transform) {
     const degrees = ((parseFloat(rotate[1]) % 360) + 360) % 360;
     if (degrees === 90 || degrees === 270) return true;
   }
-  // translateX/translateY/translate far off-screen.
-  for (const match of transform.matchAll(/\btranslate(?:[xy])?\(\s*([^,)]+)/gi))
-    if (isOffscreenOffset(match[1].trim())) return true;
+  // translateX/translateY/translate far off-screen. A two-axis `translate(x, y)`
+  // hides when EITHER axis clears the viewport, so split the argument list and
+  // test each — checking only the first arg missed a `translate(0, -9999px)`.
+  for (const match of transform.matchAll(/\btranslate(?:[xy])?\(\s*([^)]*)/gi))
+    for (const arg of match[1].split(","))
+      if (isOffscreenOffset(arg.trim())) return true;
   return false;
+}
+
+/**
+ * A `filter` that renders content invisible: an `opacity(0)` function drops the
+ * element to fully transparent. The amount is a <number-percentage> (`0`..`1` or
+ * `0%`..`100%`), so a percentage is divided to a fraction before the near-zero
+ * test. Other filter functions (blur, brightness, drop-shadow) keep content
+ * visible and are left alone; an unparseable amount fails OPEN (visible).
+ * @param {string} filter
+ * @returns {boolean}
+ */
+function isHidingFilter(filter) {
+  if (!filter) return false;
+  const match = filter.match(/\bopacity\(\s*([0-9]*\.?[0-9]+)\s*(%?)\s*\)/i);
+  if (!match) return false;
+  const value = parseFloat(match[1]);
+  const fraction = match[2] === "%" ? value / 100 : value;
+  return fraction < NEAR_ZERO_EPSILON;
 }
 
 /** @param {(key: string) => string} val */
@@ -231,6 +252,10 @@ export function isHiddenStyle(styleStr) {
   if (val("display") === "none") return true;
   if (val("visibility") === "hidden" || val("visibility") === "collapse")
     return true;
+  // `content-visibility:hidden` skips rendering the element's contents entirely
+  // (not even laid out), so the text is invisible to a human but present in the
+  // source. `auto`/`visible` keep it rendered and must not match.
+  if (val("content-visibility") === "hidden") return true;
 
   // CSS clamps opacity to [0,1], so any NEGATIVE value renders fully
   // transparent — `parseFloat < EPSILON` (no `Math.abs`) treats `-1`/`-0.5` as
@@ -259,6 +284,7 @@ export function isHiddenStyle(styleStr) {
   )
     return true;
   if (isHidingTransform(val("transform"))) return true;
+  if (isHidingFilter(val("filter"))) return true;
 
   // Same-color text on its background (white-on-white) and fully transparent
   // text are invisible to a human but plain text to the model. Colors are

--- a/test/html.test.mjs
+++ b/test/html.test.mjs
@@ -125,6 +125,10 @@ const HIDDEN_STYLE_CASES = [
   ["transform:rotateX(270deg)", true],
   ["transform:translateX(-9999px)", true], // offscreen via transform (bug: position-only)
   ["transform:translatex(-100vw)", true], // a full viewport-width clears the screen
+  ["transform:translate(0,-9999px)", true], // Y axis offscreen, X=0 (second arg was ignored)
+  ["transform:translate(-9999px,0)", true], // X axis offscreen
+  ["transform:translate(0,0)", false], // neither axis shifts
+  ["transform:translate(5px,-10px)", false], // small two-axis shift stays on screen
   ["transform:translatex(-50vw)", false], // half-shift stays partly visible (precision)
   ["transform:scale(0.5)", false],
   ["transform:scale(0.8)", false], // mild shrink stays readable
@@ -149,6 +153,21 @@ const HIDDEN_STYLE_CASES = [
   ["color:white;background-color:black", false],
   ["background-color:white", false], // color absent — not same-color
   ["color:rgb(0,0,0);background:rgb(255,255,255)", false],
+  // ── content-visibility ──
+  ["content-visibility:hidden", true],
+  ["content-visibility:auto", false], // perf hint; content stays visible
+  ["content-visibility:visible", false],
+  // ── filter: opacity(0) (number or percentage) ──
+  ["filter:opacity(0)", true],
+  ["filter:opacity(0%)", true],
+  ["filter:opacity(0.005)", true], // sub-epsilon fraction
+  ["filter:opacity(0.5%)", true], // 0.5% = 0.005 fraction, effectively invisible
+  ["filter:blur(2px) opacity(0)", true], // opacity(0) anywhere in the list hides
+  ["filter:opacity(0.5)", false], // half-transparent stays readable
+  ["filter:opacity(50%)", false], // 50% = 0.5 fraction, visible
+  ["filter:opacity(1)", false],
+  ["filter:blur(2px)", false], // no opacity function — visible
+  ["filter:none", false],
   // ── degenerate / invalid input ──
   ["", false],
   ["a{b:c}", false],


### PR DESCRIPTION
## Summary

Three classes of content that a browser renders **invisible** but `isHiddenStyle` left visible to the model (so a hidden-injection payload in a fetched page survived Layer 2):

1. **`content-visibility:hidden`** — the element's contents are skipped entirely (not even laid out). `auto`/`visible` keep it rendered and must not match.
2. **`filter:opacity(0)`** — fully transparent. Handles the number (`0`..`1`) and percentage (`0%`..`100%`) forms, and `opacity(0)` anywhere in a multi-function filter list.
3. **`transform:translate(0, -9999px)`** — only the *first* `translate()` argument was parsed, so an element pushed offscreen on the **Y axis** (X=0) slipped through. Now the argument list is split and either axis offscreen counts.

## Precision
All three are unambiguously invisible to *every* human (sighted and screen-reader), so adding them doesn't trade away the layer's precision-first stance. Pinned with negative cases: `content-visibility:auto`, `filter:blur(2px)`, `filter:opacity(0.5)`/`opacity(50%)`, `translate(0,0)`, `translate(5px,-10px)` all stay visible.

## Verification
- `html.mjs` stays at **100%** lines/branches/functions; full suite 1180 green.
- The 7 new positive corpus cases were verified **red against the pre-fix source** and green after; end-to-end `sanitizeHtml` now splices the previously-leaking `content-visibility`/`filter:opacity(0)` elements while leaving `filter:blur` content intact.
- Golden corpus unaffected (no such cases); prettier + eslint clean.

## Scope note
Deliberately **not** changed: `aria-hidden="true"` splicing (a documented, test-locked author decision — aria-hidden removes content from the accessibility tree), and the more ambiguous `<details>`/`font-size:1px`/partial `clip-path:inset()` cases (precision risk). Those are left as-is.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CrYSErTzNaUeWdNaZrYm6m)_