### PR TITLE
feat(cli): add --help/-h and reject unknown flags instead of hanging on stdin

### DIFF
--- a/bin/sanitize-cli.mjs
+++ b/bin/sanitize-cli.mjs
@@ -364,7 +364,45 @@ function invokedAsScript() {
     return false;
   }
 }
-if (invokedAsScript())
-  await (process.argv.includes("--worker") ? runWorker() : runOneShot());
+export const USAGE = `sanitize-cli — sanitize untrusted text before an LLM sees it.
+
+Reads JSON on stdin, writes one JSON response line on stdout.
+
+Usage:
+  sanitize-cli            one-shot: read ONE request object from stdin, write one response
+  sanitize-cli --worker   worker: read newline-delimited requests until EOF, one response per line
+  sanitize-cli --help     show this help
+
+Request: { "op"?: string, ...fields }. Ops: sanitize (default), sanitizeText,
+classifyPrompt, scanInstructionFiles, cleanFile. A failure response is { "error": string }.
+`;
+
+/**
+ * Resolve argv to a run mode. `-h`/`--help` prints usage; an unrecognized `-…`
+ * flag is a usage error rather than a silent fall-through to one-shot mode,
+ * which would block reading stdin from a TTY with no output. The only real flag
+ * is `--worker`; a bare invocation (or any non-flag arg) is one-shot.
+ * @param {string[]} argv  process.argv (argv[0]=node, argv[1]=script)
+ * @returns {{ mode: "help" | "worker" | "oneshot" | "error", unknown?: string[] }}
+ */
+export function parseArgs(argv) {
+  const flags = argv.slice(2).filter((arg) => arg.startsWith("-"));
+  if (flags.includes("-h") || flags.includes("--help")) return { mode: "help" };
+  const unknown = flags.filter((flag) => flag !== "--worker");
+  if (unknown.length > 0) return { mode: "error", unknown };
+  return { mode: flags.includes("--worker") ? "worker" : "oneshot" };
+}
+
+if (invokedAsScript()) {
+  const parsed = parseArgs(process.argv);
+  if (parsed.mode === "help") process.stdout.write(USAGE);
+  else if (parsed.mode === "error") {
+    process.stderr.write(
+      `sanitize CLI: unrecognized option(s): ${/** @type {string[]} */ (parsed.unknown).join(", ")}\n\n${USAGE}`,
+    );
+    process.exitCode = 2;
+  } else if (parsed.mode === "worker") await runWorker();
+  else await runOneShot();
+}
 
 export { createLineSplitter };

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -22,7 +22,7 @@ import { sanitize } from "../src/index.mjs";
 import { classifyPrompt } from "../src/prompt.mjs";
 import { sanitizeText } from "../src/output.mjs";
 import { scanInstructionFiles } from "../src/instructions.mjs";
-import { createLineSplitter } from "../bin/sanitize-cli.mjs";
+import { createLineSplitter, parseArgs, USAGE } from "../bin/sanitize-cli.mjs";
 import { fcRunOptions } from "./test-helpers.mjs";
 
 const ESC = "\u001b";
@@ -693,5 +693,57 @@ describe("createLineSplitter", () => {
       ),
       fcRunOptions({ numRuns: 200 }),
     );
+  });
+});
+
+// ─── Argument parsing: --help and unknown-flag handling ──────────────────────
+// `parseArgs` is the pure resolver; the bottom-of-file dispatch only acts on its
+// verdict. A bare/`--worker` invocation keeps its existing mode; the new cases
+// are `--help`/`-h` (print usage, don't read stdin) and an unrecognized flag
+// (usage error, exit 2) rather than the old silent fall-through that blocked on
+// a TTY's stdin with no output.
+describe("parseArgs", () => {
+  for (const [argv, expected] of [
+    [["node", "cli"], { mode: "oneshot" }],
+    [["node", "cli", "--worker"], { mode: "worker" }],
+    [["node", "cli", "--help"], { mode: "help" }],
+    [["node", "cli", "-h"], { mode: "help" }],
+    [["node", "cli", "--hepl"], { mode: "error", unknown: ["--hepl"] }],
+    // an unknown flag alongside --worker is still an error (don't silently run)
+    [
+      ["node", "cli", "--worker", "--bogus"],
+      { mode: "error", unknown: ["--bogus"] },
+    ],
+    // a non-flag positional arg is ignored (still one-shot)
+    [["node", "cli", "somefile"], { mode: "oneshot" }],
+    // --help wins even with other flags present
+    [["node", "cli", "--worker", "--help"], { mode: "help" }],
+  ]) {
+    it(`${argv.slice(2).join(" ") || "(no args)"} → ${expected.mode}`, () =>
+      assert.deepEqual(parseArgs(argv), expected));
+  }
+});
+
+describe("CLI flag behavior (spawned)", () => {
+  it("--help prints usage to stdout and exits 0 without reading stdin", () => {
+    // No `input` is supplied: a help invocation must NOT block on stdin.
+    const out = execFileSync("node", [CLI, "--help"], { encoding: "utf8" });
+    assert.equal(out, USAGE);
+  });
+
+  it("an unknown flag exits 2 with an error on stderr, not a silent stdin hang", () => {
+    let status = 0;
+    let stderr = "";
+    try {
+      execFileSync("node", [CLI, "--nope"], {
+        encoding: "utf8",
+        stdio: "pipe",
+      });
+    } catch (err) {
+      status = err.status;
+      stderr = String(err.stderr);
+    }
+    assert.equal(status, 2);
+    assert.match(stderr, /unrecognized option\(s\): --nope/);
   });
 });


### PR DESCRIPTION
## Summary

`bin/sanitize-cli.mjs` only checked for `--worker`; every other argument fell through to one-shot mode and then **blocked reading stdin from a TTY** with no output — so `sanitize-cli --help` in a terminal just hung, and a typo'd flag silently waited for input forever.

Add a pure `parseArgs` resolver and act on its verdict:
- `-h` / `--help` → print usage to stdout, exit 0, **without touching stdin**;
- an unrecognized `-…` flag → print the offending option(s) to stderr, exit 2;
- `--worker` and bare invocations keep their existing modes.

`parseArgs` and `USAGE` are exported so the resolver is unit-tested **in-process** (one case per mode, including `--help` winning over `--worker`, and an unknown flag alongside `--worker` still erroring), with spawned tests pinning the exit codes and confirming `--help` no longer reads stdin.

## Verification
Full suite 1173 green; prettier clean; `node bin/sanitize-cli.mjs --help </dev/null` prints usage immediately (previously hung on a TTY).

## Scope note
This is the DX half of the CLI audit finding. Bringing `bin/sanitize-cli.mjs` under the c8/stryker/tsc/eslint gates (the other half) needs a refactor to make its internals import-testable plus `c8-ignore` on the top-level invocation — a structural change to the security-critical stdin parser that I've left for a supervised pass rather than bundle here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CrYSErTzNaUeWdNaZrYm6m)_