### PR TITLE
fix(prompt): block all C1 control introducers, not just CSI/OSC

### DIFF
--- a/src/prompt.mjs
+++ b/src/prompt.mjs
@@ -28,15 +28,18 @@ import {
 } from "./invisible.mjs";
 import { stripAnsiFully } from "./layer1.mjs";
 
-// The three raw ANSI control introducers a prompt can carry: 7-bit ESC
-// (U+001B), 8-bit C1 CSI (U+009B), and 8-bit C1 OSC (U+009D). Gating on ESC
-// alone is blind to a pure-C1 sequence whose only escape content is, e.g.,
-// `U+009B 2J` (erase) or `U+009D 0;...BEL` (OSC): Layer 1 strips it, dropping
-// the invisible count to zero, so the prompt reads clean. Layer 1's CSI/OSC
-// branches recognize all three, so this gate must too. C1 ST (U+009C) is a
-// terminator, never an introducer, so it is deliberately absent.
-// eslint-disable-next-line no-control-regex -- the raw introducers are exactly what we detect
-const ANSI_INTRODUCER = /[]/;
+// Every raw ANSI control a prompt can carry: 7-bit ESC (U+001B) and the entire
+// 8-bit C1 block (U+0080-U+009F). Gating on ESC alone -- or on only CSI/OSC --
+// is blind to a pure-C1 sequence whose escape content is, e.g., `U+009B 2J`
+// (CSI erase), `U+009D 0;...BEL` (OSC), or the string introducers DCS (U+0090),
+// SOS (U+0098), PM (U+009E), APC (U+009F): Layer 1 strips it, dropping the
+// invisible count to zero, so the prompt reads clean and passes. This gate must
+// match Layer 1's residual sweep (CONTROL_INTRODUCER_RE) exactly -- no raw C1
+// control belongs in a legitimate prompt (the SGR color carve-out is applied
+// separately, after SGR removal), so the whole block is gated, not a hand-picked
+// subset that lets DCS/SOS/PM/APC through.
+// eslint-disable-next-line no-control-regex -- the raw control introducers are exactly what we detect
+const ANSI_INTRODUCER = /[\u001b\u0080-\u009f]/;
 
 /**
  * True when every ANSI introducer in `prompt` belongs to a display-only SGR

--- a/test/prompt.test.mjs
+++ b/test/prompt.test.mjs
@@ -19,6 +19,11 @@ const ESC = cp(0x1b);
 const BEL = cp(0x07);
 const C1_CSI = cp(0x9b); // 8-bit C1 CSI (U+009B): one-byte `ESC[` equivalent
 const C1_OSC = cp(0x9d); // 8-bit C1 OSC (U+009D): one-byte `ESC]` equivalent
+const C1_DCS = cp(0x90); // 8-bit C1 DCS (U+0090): device control string introducer
+const C1_SOS = cp(0x98); // 8-bit C1 SOS (U+0098): start of string
+const C1_PM = cp(0x9e); // 8-bit C1 PM (U+009E): privacy message
+const C1_APC = cp(0x9f); // 8-bit C1 APC (U+009F): application program command
+const C1_ST = cp(0x9c); // 8-bit C1 ST (U+009C): string terminator
 const SH = cp(0x00ad); // soft hyphen (U+00AD), category Cf
 
 // ─── pass ────────────────────────────────────────────────────────────────────
@@ -115,6 +120,14 @@ describe("classifyPrompt: non-SGR ANSI blocks", () => {
     ["C1 erase display (U+009B 2J)", `${C1_CSI}2J`],
     ["C1 cursor-position report (U+009B 6n)", `${C1_CSI}6n`],
     ["C1 OSC title-set (U+009D 0;x BEL)", `${C1_OSC}0;x${BEL}`],
+    // 8-bit C1 STRING introducers the CSI/OSC-only gate also missed: DCS/SOS/
+    // PM/APC open a device/application string Layer 1 strips to nothing, so an
+    // ASCII payload between introducer and terminator used to pass clean.
+    ["C1 DCS string (U+0090 … ST)", `${C1_DCS}qpayload${C1_ST}`],
+    ["C1 SOS string (U+0098 … ST)", `${C1_SOS}payload${C1_ST}`],
+    ["C1 PM string (U+009E … ST)", `${C1_PM}payload${C1_ST}`],
+    ["C1 APC string (U+009F … ST)", `${C1_APC}payload${C1_ST}`],
+    ["lone C1 ST (U+009C)", C1_ST],
   ]) {
     it(`blocks ${name}`, () => {
       const verdict = classifyPrompt(`hello ${seq} world`);


### PR DESCRIPTION
## Summary

Audit finding **H3**. The prompt classifier's ANSI-introducer gate only matched
ESC, CSI (U+009B) and OSC (U+009D), so DCS/SOS/PM/APC/ST (U+0090, U+0098,
U+009E, U+009F, U+009C) slipped past classification even though Layer 1 already
strips the whole C1 block. That inconsistency meant the classifier under-counted
control sequences relative to what the sanitizer removes. Widen the gate to the
full C1 range so the two layers agree.

## Changes

- `ANSI_INTRODUCER` now matches `[-]` (was three specific
  characters), matching Layer 1's `CONTROL_INTRODUCER_RE`.

## Tests / verification

- New block-table cases exercising DCS/SOS/PM/APC/ST introducers.
- `pnpm test`, `pnpm lint`, `pnpm check` pass locally.

## Checklist

- [x] Commits follow Conventional Commits.
- [x] `pnpm test`, `pnpm lint`, and `pnpm check` pass locally.
- [x] New/changed detectors have negative tests and pin invariants.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version left untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxxKGkv5x5666q1z3JTCok)_