### PR TITLE
ci: align setup-uv pin and stop pack-smoke swallowing grep errors

### DIFF
--- a/.github/actions/setup-base-env/action.yaml
+++ b/.github/actions/setup-base-env/action.yaml
@@ -54,7 +54,7 @@ runs:
 
     - name: Set up uv
       if: inputs.setup-python == 'true'
-      uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         enable-cache: true
         cache-dependency-glob: "uv.lock"

--- a/.github/scripts/pack-smoke.sh
+++ b/.github/scripts/pack-smoke.sh
@@ -27,7 +27,17 @@ fi
 # Every file shipped under src/ must be an .mjs module — a stray .py/.d.ts/.map
 # under src/ means the `files` allowlist widened by accident. Pull the src/ path
 # tokens out of the listing and assert each ends in .mjs.
-src_nonmjs="$(grep -oE 'src/[^[:space:]]+' <<<"$pack_listing" | grep -vE '\.mjs$' || true)"
+# `grep` exits 1 when there is simply nothing to report (no non-.mjs file — the
+# healthy case), which must not abort the job; but exit >=2 is a real grep
+# failure that `|| true` would silently swallow (masking a broken scan as "all
+# clean"). Branch on the code: tolerate <=1, propagate anything higher.
+src_nonmjs=""
+rc=0
+src_nonmjs="$(grep -oE 'src/[^[:space:]]+' <<<"$pack_listing" | grep -vE '\.mjs$')" || rc=$?
+if [ "$rc" -gt 1 ]; then
+  echo "ERROR: pack-listing scan failed (grep exit $rc)" >&2
+  exit "$rc"
+fi
 if [ -n "$src_nonmjs" ]; then
   echo "ERROR: tarball ships a non-.mjs file under src/:" >&2
   echo "$src_nonmjs" >&2


### PR DESCRIPTION
## Summary

Audit findings **M6 / M7** on CI hygiene:

- The `setup-uv` action was pinned to a SHA whose `# v3` comment no longer
  matched the actual release; realign the pin and comment to `v8.2.0`.
- `pack-smoke.sh` used `|| true` on the src/ file scan, which silently swallows a
  real `grep` failure (exit ≥2) as "all clean" — a CLAUDE.md-forbidden idiom.
  Branch on the exit code instead: tolerate `grep`'s no-match exit 1, propagate
  anything higher.

## Changes

- `.github/actions/setup-base-env/action.yaml`: pin
  `astral-sh/setup-uv@fac544c… # v8.2.0`.
- `.github/scripts/pack-smoke.sh`: replace `|| true` with an explicit exit-code
  branch that errors out on `grep` exit >1.

## Tests / verification

- `shellcheck` and `shfmt` clean on the modified script (no diff).
- Logic reviewed: the healthy "no non-.mjs file" case (grep exit 1) still passes;
  a genuine scan failure now aborts the job.

## Checklist

- [x] Commits follow Conventional Commits.
- [x] Third-party action pinned to a commit SHA with an accurate version comment.
- [x] No real secrets/tokens in the diff or description.
- [x] `CHANGELOG.md` and `package.json` version left untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxxKGkv5x5666q1z3JTCok)_