### PR TITLE
test(mutation): fail when a split file shrinks below a shard boundary

### DIFF
--- a/test/mutation-shards.test.mjs
+++ b/test/mutation-shards.test.mjs
@@ -85,6 +85,23 @@ describe("mutation shard matrix", () => {
         ranges.at(-1).end >= EOF_SENTINEL,
         `${file}: last range must end open (>= ${EOF_SENTINEL}) so the tail is always mutated`,
       );
+
+      // Tiling [1, EOF) is not enough: the ranges are static line numbers, so if
+      // the file SHRINKS below a boundary, every shard whose `start` now sits
+      // past EOF mutates zero lines and Stryker silently covers nothing while
+      // this test stays green. Pin each shard's `start` to the file's real line
+      // count so every range is guaranteed to cover at least one real line.
+      const lineCount = readFileSync(join(repoRoot, file), "utf8").split(
+        "\n",
+      ).length;
+      for (const range of ranges) {
+        assert.ok(
+          range.start <= lineCount,
+          `${file}: range start ${range.start} is past the file's real line count (${lineCount}); ` +
+            `the file shrank below a shard boundary, so this shard mutates zero lines and covers nothing — ` +
+            `re-tile .github/mutation-shards.json to the current file length`,
+        );
+      }
     }
   });
 });

--- a/test/view-map.test.mjs
+++ b/test/view-map.test.mjs
@@ -35,10 +35,11 @@ describe("occurrences", () => {
     assert.deepEqual(occurrences("abc", "z"), []);
   });
 
-  it("a length-1 needle steps by exactly its length (the max(len, 1) boundary)", () => {
-    // The Math.max(needle.length, 1) step is what guarantees forward progress;
-    // for a length-1 needle the max picks the length (1), so overlapping single
-    // chars are reported once each without revisiting an index.
+  it("a length-1 needle steps by exactly its length", () => {
+    // Forward progress comes from the `if (needle === "") return []` guard (which
+    // rules out the only zero-length step) plus the `i + needle.length` advance;
+    // for a length-1 needle each step is 1, so overlapping single chars are
+    // reported once each without revisiting an index.
     assert.deepEqual(occurrences("aaa", "a"), [0, 1, 2]);
     assert.deepEqual(occurrences("aXa", "a"), [0, 2]);
   });


### PR DESCRIPTION
## Summary

Audit finding on test realness. The mutation-shard config lists per-file line
ranges, but nothing asserted those ranges still fit the real files — a shard
whose start line exceeds the file's length would silently mutate nothing,
passing vacuously. Add a guard so shrinking a file below a shard boundary fails
CI instead of quietly reducing coverage.

## Changes

- `test/mutation-shards.test.mjs`: assert each shard's start line ≤ the real
  file's line count.
- `test/view-map.test.mjs`: fix a stale `Math.max` comment.

## Tests / verification

- 27 tests pass locally; `pnpm lint`, `pnpm check` pass.

## Checklist

- [x] Commits follow Conventional Commits.
- [x] `pnpm test`, `pnpm lint`, and `pnpm check` pass locally.
- [x] Guard test is non-vacuous (asserts against real file line counts).
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version left untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxxKGkv5x5666q1z3JTCok)_