### PR TITLE
fix(invisible): preserve standalone presentation-selector emoji

### DIFF
--- a/src/invisible.mjs
+++ b/src/invisible.mjs
@@ -185,18 +185,21 @@ const ZWJ = 0x200d;
 // NOT part of a joined cluster — so an ordinary single joiner per word is kept.
 export const CONSECUTIVE_JOINER_CAP = 8;
 
-// Floor on the document-wide preserve budget. The Joining_Type gate strips
-// joiners that do no rendering work regardless of count, so the bulk covert
-// channel (ZWNJ scattered through Latin/ASCII/mixed text) is closed by shape,
-// not by counting. What remains is the residual channel of MEANINGFUL joiners
-// stuffed into genuine cursive/Indic cover text — each individually legitimate,
+// Floor on the document-wide preserve budget, shared by both preserve kinds
+// (see `kind` in analyzeCarve: joiners AND presentation selectors draw from
+// the same counter). The Joining_Type gate strips joiners that do no
+// rendering work regardless of count, so the bulk covert channel (ZWNJ
+// scattered through Latin/ASCII/mixed text) is closed by shape, not by
+// counting. What remains is the residual channel of MEANINGFUL joiners/
+// selectors stuffed into genuine cover text — each individually legitimate,
 // so indistinguishable one at a time. THIS budget (with CONSECUTIVE_JOINER_CAP
 // and SCATTERED_THRESHOLD) is the explicit, tunable bound on that residual
 // channel; it is not derived, and tightening it trades covert-channel width for
-// clipping genuinely dense prose. The allowance is proportional to visible
-// length (PRESERVED_JOINER_PER_VISIBLE), never below this floor; the floor keeps
-// short but joiner-dense strings (a lone emoji ZWJ sequence, a two-word Persian
-// phrase) un-flagged. Past the allowance the surplus is stripped AND reported.
+// clipping genuinely dense prose or emoji-dense text. The allowance is
+// proportional to visible length (PRESERVED_JOINER_PER_VISIBLE), never below
+// this floor; the floor keeps short but joiner/selector-dense strings (a lone
+// emoji ZWJ sequence, a two-word Persian phrase) un-flagged. Past the
+// allowance the surplus is stripped AND reported.
 export const TOTAL_PRESERVED_JOINER_BUDGET = 16;
 
 // Visible code points required per additional preserved joiner above the floor.

--- a/src/invisible.mjs
+++ b/src/invisible.mjs
@@ -233,9 +233,10 @@ const EMOJI_BASE = /\p{Extended_Pictographic}/u;
 // following ZWJ (🏳️‍🌈 = flag base, VS16, ZWJ, rainbow; 👁️‍🗨️), so the joiner's real
 // left neighbor for the emoji test is the pictograph, not the selector.
 const VARIATION_SELECTOR = new RegExp(`[${VS}]`, "u");
-// U+FE0F forces emoji (vs text) presentation; a single one directly after a
-// pictograph is part of a visible emoji, not a hidden variation-selector run.
-const EMOJI_PRESENTATION_SELECTOR = 0xfe0f;
+// U+FE0F (VS16) forces emoji presentation, U+FE0E (VS15) forces text
+// presentation (☺︎ vs ☺); either one directly after a pictograph is part of a
+// visible glyph, not a hidden variation-selector run.
+const PRESENTATION_SELECTORS = new Set([0xfe0e, 0xfe0f]);
 
 // Non-global single-char classifiers (CHECKS carry `g`, whose lastIndex is
 // stateful across `.test`). carveStrip uses these to attribute each removed
@@ -327,16 +328,17 @@ function isPreservedJoiner(cps, i) {
 }
 
 /**
- * True when `cps[i]` is an emoji presentation selector (U+FE0F) directly after a
- * pictograph/skin-tone modifier — part of a visible emoji, not a hidden VS run,
- * so it is preserved (a longer selector run still surfaces: the next selector's
- * left neighbour is itself a selector, not a pictograph).
+ * True when `cps[i]` is a presentation selector (VS15 U+FE0E or VS16 U+FE0F)
+ * directly after a pictograph/skin-tone modifier — part of a visible glyph,
+ * not a hidden VS run, so it is preserved (a longer selector run still
+ * surfaces: the next selector's left neighbour is itself a selector, not a
+ * pictograph).
  * @param {string[]} cps @param {number} i
  * @returns {boolean}
  */
 function isEmojiPresentationSelector(cps, i) {
   return (
-    cps[i].codePointAt(0) === EMOJI_PRESENTATION_SELECTOR &&
+    PRESENTATION_SELECTORS.has(/** @type {number} */ (cps[i].codePointAt(0))) &&
     EMOJI_LEFT.test(cps[i - 1] ?? "")
   );
 }
@@ -381,9 +383,10 @@ export function countPayloadInvisible(text) {
 }
 
 /**
- * Bulk strip (the common path: no ZWNJ/ZWJ present, so no carve-out can apply).
- * A single regex pass removes every payload-capable char; `found` names the
- * category codes present via `.search` (which ignores the `g` lastIndex).
+ * Bulk strip (the common path: {@link needsCarveOut} found nothing the
+ * carve-out could apply to). A single regex pass removes every payload-
+ * capable char; `found` names the category codes present via `.search`
+ * (which ignores the `g` lastIndex).
  * @param {string} body
  * @returns {{ cleaned: string, found: string[] }}
  */
@@ -482,11 +485,12 @@ function carveStrip(body) {
 }
 
 /**
- * True when `body` holds at least one ZWNJ/ZWJ or emoji presentation selector
- * (U+FE0F) — anything the carve-out in {@link carveStrip} might preserve. A
- * lone pictograph + U+FE0F with no joiner ANYWHERE else in the document (e.g.
- * "I ❤️ pizza") still needs the carve-out's per-neighbor analysis, or bulkStrip
- * strips the selector unconditionally and corrupts a legitimate emoji.
+ * True when `body` holds at least one ZWNJ/ZWJ or presentation selector
+ * (VS15 U+FE0E / VS16 U+FE0F) — anything the carve-out in {@link carveStrip}
+ * might preserve. A lone pictograph + selector with no joiner ANYWHERE else in
+ * the document (e.g. "I ❤️ pizza" or "I ❤︎ pizza") still needs the carve-out's
+ * per-neighbor analysis, or bulkStrip strips the selector unconditionally and
+ * corrupts a legitimate glyph.
  * @param {string} body
  * @returns {boolean}
  */
@@ -494,7 +498,9 @@ function needsCarveOut(body) {
   return (
     body.includes(String.fromCodePoint(ZWNJ)) ||
     body.includes(String.fromCodePoint(ZWJ)) ||
-    body.includes(String.fromCodePoint(EMOJI_PRESENTATION_SELECTOR))
+    [...PRESENTATION_SELECTORS].some((cp) =>
+      body.includes(String.fromCodePoint(cp)),
+    )
   );
 }
 

--- a/src/invisible.mjs
+++ b/src/invisible.mjs
@@ -482,14 +482,19 @@ function carveStrip(body) {
 }
 
 /**
- * True when `body` holds at least one ZWNJ/ZWJ (so the carve-out may apply).
+ * True when `body` holds at least one ZWNJ/ZWJ or emoji presentation selector
+ * (U+FE0F) — anything the carve-out in {@link carveStrip} might preserve. A
+ * lone pictograph + U+FE0F with no joiner ANYWHERE else in the document (e.g.
+ * "I ❤️ pizza") still needs the carve-out's per-neighbor analysis, or bulkStrip
+ * strips the selector unconditionally and corrupts a legitimate emoji.
  * @param {string} body
  * @returns {boolean}
  */
-function hasJoinControl(body) {
+function needsCarveOut(body) {
   return (
     body.includes(String.fromCodePoint(ZWNJ)) ||
-    body.includes(String.fromCodePoint(ZWJ))
+    body.includes(String.fromCodePoint(ZWJ)) ||
+    body.includes(String.fromCodePoint(EMOJI_PRESENTATION_SELECTOR))
   );
 }
 
@@ -506,7 +511,7 @@ function hasJoinControl(body) {
 export function stripInvisibleWithReport(text) {
   const hasLeadingBom = text.charCodeAt(0) === 0xfeff;
   const body = hasLeadingBom ? text.slice(1) : text;
-  const { cleaned, found } = hasJoinControl(body)
+  const { cleaned, found } = needsCarveOut(body)
     ? carveStrip(body)
     : bulkStrip(body);
   return { cleaned: hasLeadingBom ? BOM + cleaned : cleaned, found };

--- a/test/invisible-semantic-fuzz.test.mjs
+++ b/test/invisible-semantic-fuzz.test.mjs
@@ -43,8 +43,10 @@ const KEEP_TOKENS = [
   cp(0x2764) + cp(0xfe0f) + ZWJ + cp(0x1f525),
   // 👨🏻‍🦰 skin-tone modifier + ZWJ + component
   cp(0x1f468) + cp(0x1f3fb) + ZWJ + cp(0x1f9b0),
-  // ❤️ a single pictograph + presentation selector, no joiner at all
+  // ❤️ a single pictograph + emoji presentation selector, no joiner at all
   cp(0x2764) + cp(0xfe0f),
+  // ❤︎ the same pictograph with the TEXT presentation selector (VS15)
+  cp(0x2764) + cp(0xfe0e),
   // "می‌خ" — ZWNJ between Persian (Arabic-script) letters
   cp(0x645) + cp(0x6cc) + ZWNJ + cp(0x62e),
   // "क्‍ष" — ZWJ after a Devanagari virama

--- a/test/invisible-semantic-fuzz.test.mjs
+++ b/test/invisible-semantic-fuzz.test.mjs
@@ -1,0 +1,112 @@
+/**
+ * Semantic-correctness fuzzing for the ZWNJ/ZWJ carve-out.
+ *
+ * invisible-property.test.mjs already fuzzes STRUCTURAL invariants
+ * (subsequence, idempotence, budget) over arbitrary interleavings of the
+ * carve-out's alphabet. Those hold even if the carve-out preserves the WRONG
+ * joiner while dropping the right one — e.g. it could stay under budget by
+ * keeping an unrelated stray ZWJ elsewhere in the document while corrupting a
+ * real emoji it should have left untouched. That's exactly the shape of bug
+ * PR-visible history shows slipping past structural fuzzing (an emoji-dense
+ * false positive in the sibling instructions.mjs scatter floor).
+ *
+ * This suite instead fuzzes PRECISION directly: build random documents that
+ * interleave known-good, complete constructs (real emoji ZWJ sequences, real
+ * linguistic joiners) with known-bad markers (payload joiners, tag chars,
+ * zero-width bits), then assert each *specific* good construct survives byte-
+ * for-byte and each *specific* bad marker is gone — not just "some invariant
+ * held in aggregate."
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fc from "fast-check";
+
+import { stripInvisible } from "../src/invisible.mjs";
+import { fcRunOptions, cp } from "./test-helpers.mjs";
+
+const ZWNJ = cp(0x200c);
+const ZWJ = cp(0x200d);
+const ZWSP = cp(0x200b);
+
+// Known-good, COMPLETE constructs: each must reappear in the output verbatim,
+// unsplit. Mirrors the canonical examples pinned as example tests in
+// invisible.test.mjs, reused here as fuzz-generator inputs rather than fixed
+// cases.
+const KEEP_TOKENS = [
+  // 👨‍👩‍👧‍👦 family (3 ZWJ, no selectors)
+  cp(0x1f468) + ZWJ + cp(0x1f469) + ZWJ + cp(0x1f467) + ZWJ + cp(0x1f466),
+  // 🏳️‍🌈 rainbow flag (VS16 between base and joiner)
+  cp(0x1f3f3) + cp(0xfe0f) + ZWJ + cp(0x1f308),
+  // 👁️‍🗨️ eye in speech bubble (VS16 on both components)
+  cp(0x1f441) + cp(0xfe0f) + ZWJ + cp(0x1f5e8) + cp(0xfe0f),
+  // ❤️‍🔥 heart on fire
+  cp(0x2764) + cp(0xfe0f) + ZWJ + cp(0x1f525),
+  // 👨🏻‍🦰 skin-tone modifier + ZWJ + component
+  cp(0x1f468) + cp(0x1f3fb) + ZWJ + cp(0x1f9b0),
+  // ❤️ a single pictograph + presentation selector, no joiner at all
+  cp(0x2764) + cp(0xfe0f),
+  // "می‌خ" — ZWNJ between Persian (Arabic-script) letters
+  cp(0x645) + cp(0x6cc) + ZWNJ + cp(0x62e),
+  // "क्‍ष" — ZWJ after a Devanagari virama
+  cp(0x915) + cp(0x94d) + ZWJ + cp(0x937),
+];
+
+// Known-bad markers: each must be GONE from the output. Wrapped in ASCII
+// letters reserved to these tokens (never used in filler) so a substring
+// check on the whole token proves the invisible char inside it was actually
+// removed, not just that the surrounding letters happen to still be there.
+const STRIP_TOKENS = [
+  "Q" + ZWJ + "K", // bare ZWJ between plain ASCII — no emoji/script either side
+  "Q" + ZWNJ + "K", // bare ZWNJ between plain ASCII
+  "Q" + ZWSP + "K", // zero-width space, never preserved
+  "Q" + cp(0xe0041) + cp(0xe0070) + "K", // Unicode tag characters (deniable ASCII channel)
+];
+
+const pieceGen = fc.oneof(
+  fc.constantFrom(...KEEP_TOKENS).map((t) => ({ kind: "keep", t })),
+  fc.constantFrom(...STRIP_TOKENS).map((t) => ({ kind: "strip", t })),
+  // Benign filler, disjoint from the "Q"/"K" markers above so it can never
+  // accidentally complete (or mask the removal of) a strip token.
+  fc
+    .array(fc.constantFrom(..."0123456789 .,-_".split("")), {
+      minLength: 1,
+      maxLength: 10,
+    })
+    .map((cs) => ({ kind: "filler", t: cs.join("") })),
+);
+
+const docGen = fc.array(pieceGen, { minLength: 1, maxLength: 8 });
+
+describe("semantic-correctness fuzz: carve-out precision on mixed documents", () => {
+  it("every generated real emoji/linguistic construct survives byte-for-byte", () => {
+    fc.assert(
+      fc.property(docGen, (pieces) => {
+        // A space between every piece isolates each token's boundary so no
+        // two generated constructs can incidentally fuse into a joined
+        // cluster that neither one is on its own — the property is about
+        // each construct's OWN correctness, not emergent cross-token joining.
+        const text = pieces.map((p) => p.t).join(" ");
+        const cleaned = stripInvisible(text);
+
+        for (const p of pieces) {
+          if (p.kind === "keep") {
+            assert.ok(
+              cleaned.includes(p.t),
+              `legitimate construct was corrupted or dropped: ${[...p.t]
+                .map((c) => `U+${c.codePointAt(0).toString(16)}`)
+                .join(" ")}`,
+            );
+          } else if (p.kind === "strip") {
+            assert.ok(
+              !cleaned.includes(p.t),
+              `payload marker survived stripping: ${[...p.t]
+                .map((c) => `U+${c.codePointAt(0).toString(16)}`)
+                .join(" ")}`,
+            );
+          }
+        }
+      }),
+      fcRunOptions(),
+    );
+  });
+});

--- a/test/invisible.test.mjs
+++ b/test/invisible.test.mjs
@@ -267,6 +267,17 @@ describe("stripInvisible: ZWNJ/ZWJ linguistic carve-out", () => {
     });
   }
 
+  it("preserves a standalone pictograph + VS16 with no ZWJ/ZWNJ anywhere in the document", () => {
+    // Regression: stripInvisibleWithReport used to route on "does the WHOLE
+    // document contain a ZWNJ/ZWJ" and fall back to a bulk strip (no emoji
+    // carve-out at all) when it didn't — so "I ❤️ pizza", which has a
+    // presentation selector but no joiner anywhere, had its selector stripped.
+    const sample = `I ${cp(0x2764)}${cp(0xfe0f)} pizza`;
+    const { cleaned, found } = stripInvisibleWithReport(sample);
+    assert.equal(cleaned, sample);
+    assert.deepEqual(found, []);
+  });
+
   it("keeps one emoji selector but strips a stuffed VS16 run", () => {
     // A real emoji keeps ONE selector after the pictograph; a run of them is a
     // hidden channel. Every selector past the first has a selector on its left,

--- a/test/invisible.test.mjs
+++ b/test/invisible.test.mjs
@@ -267,16 +267,24 @@ describe("stripInvisible: ZWNJ/ZWJ linguistic carve-out", () => {
     });
   }
 
-  it("preserves a standalone pictograph + VS16 with no ZWJ/ZWNJ anywhere in the document", () => {
-    // Regression: stripInvisibleWithReport used to route on "does the WHOLE
-    // document contain a ZWNJ/ZWJ" and fall back to a bulk strip (no emoji
-    // carve-out at all) when it didn't — so "I ❤️ pizza", which has a
-    // presentation selector but no joiner anywhere, had its selector stripped.
-    const sample = `I ${cp(0x2764)}${cp(0xfe0f)} pizza`;
-    const { cleaned, found } = stripInvisibleWithReport(sample);
-    assert.equal(cleaned, sample);
-    assert.deepEqual(found, []);
-  });
+  for (const [name, selector] of [
+    ["VS16 (emoji presentation)", cp(0xfe0f)],
+    ["VS15 (text presentation)", cp(0xfe0e)],
+  ]) {
+    it(`preserves a standalone pictograph + ${name} with no ZWJ/ZWNJ anywhere in the document`, () => {
+      // Regression: stripInvisibleWithReport used to route on "does the WHOLE
+      // document contain a ZWNJ/ZWJ" and fall back to a bulk strip (no
+      // presentation-selector carve-out at all) when it didn't — so "I ❤️
+      // pizza" / "I ❤︎ pizza", which have a selector but no joiner anywhere,
+      // had that selector stripped. Also regression for a narrower follow-up
+      // bug: the carve-out itself recognized only VS16, so VS15 was still
+      // stripped even once routed through it.
+      const sample = `I ${cp(0x2764)}${selector} pizza`;
+      const { cleaned, found } = stripInvisibleWithReport(sample);
+      assert.equal(cleaned, sample);
+      assert.deepEqual(found, []);
+    });
+  }
 
   it("keeps one emoji selector but strips a stuffed VS16 run", () => {
     // A real emoji keeps ONE selector after the pictograph; a run of them is a

--- a/test/invisible.test.mjs
+++ b/test/invisible.test.mjs
@@ -677,6 +677,23 @@ describe("document-wide preserved-joiner budget", () => {
     assert.deepEqual(found, [CATEGORY.CF]);
   });
 
+  it("standalone presentation selectors (no joiner in the document) share the same budget", () => {
+    // The budget counts every preserved item — joiners AND presentation
+    // selectors — across the whole document, not per-kind. N gap-separated
+    // pictograph+VS16 pairs with NO ZWNJ/ZWJ anywhere still hit the same cap:
+    // over-strip beats under-strip even for a purely selector-dense document.
+    const pictographPlusSelector = cp(0x2764) + cp(0xfe0f) + " ";
+    const input = pictographPlusSelector.repeat(N);
+    const { cleaned, found } = stripInvisibleWithReport(input);
+    assert.equal(countOf(input, cp(0xfe0f)), N);
+    assert.equal(
+      countOf(cleaned, cp(0xfe0f)),
+      TOTAL_PRESERVED_JOINER_BUDGET,
+      "preserved selector count must not exceed the shared budget",
+    );
+    assert.deepEqual(found, [CATEGORY.VARIATION_SELECTORS]);
+  });
+
   it("preserves exactly the budget at the boundary (none stripped, not flagged)", () => {
     // Exactly TOTAL_PRESERVED_JOINER_BUDGET joiners, one per gap-separated
     // cluster: all preserved, nothing reported. Pins the `<` boundary so a


### PR DESCRIPTION
## Summary

`stripInvisibleWithReport` routed on "does the document contain a ZWNJ/ZWJ" to
decide whether the emoji/linguistic carve-out could apply; anything without
one fell through to an unconditional bulk strip. A document with a standalone
pictograph + presentation selector but no joiner anywhere else (e.g. `I ❤️
pizza`) hit that fast path and lost its selector — a false positive on
legitimate content. A follow-up review pass found the carve-out itself only
recognized VS16 (U+FE0F); VS15 (U+FE0E, "force text presentation") sits in the
identical position after a pictograph and was still stripped even once
correctly routed.

Found via a new semantic-correctness fuzz harness: existing property tests
only assert structural invariants (subsequence, idempotence, preserve budget),
which hold even when the carve-out preserves the wrong thing while corrupting
an unrelated real emoji elsewhere in the same document. The new harness
instead builds random documents mixing known-good complete constructs with
known-bad payload markers and asserts each survives or is removed correctly.

A second review pass flagged that generalizing the routing to selectors makes
the existing document-wide preserve budget (previously only reachable via
joiners) reachable by selector-only documents too — this is the project's
existing, intentional "over-strip beats under-strip" tradeoff, not a new bug,
so it's pinned with a test and a doc-comment update rather than changed.

## Changes

- `src/invisible.mjs`: rename the routing predicate to `needsCarveOut` and
  extend it to fire on either presentation selector, not just ZWNJ/ZWJ.
- `src/invisible.mjs`: generalize `isEmojiPresentationSelector` (and the
  underlying `PRESENTATION_SELECTORS` set) to recognize VS15 alongside VS16.
- `src/invisible.mjs`: clarify the `TOTAL_PRESERVED_JOINER_BUDGET` and
  `bulkStrip` doc comments now that selectors share the budget/routing.
- `test/invisible.test.mjs`: regression tests for the standalone-emoji case
  (both selectors) and for the shared budget applying to selector-only text.
- `test/invisible-semantic-fuzz.test.mjs`: new fast-check suite fuzzing
  carve-out *precision* — random documents mixing real emoji/linguistic
  constructs with payload markers, asserting each specific token's fate.

## Tests / verification

- `pnpm test` (1269 tests, 100% coverage), `pnpm lint`, `pnpm check` all pass.
- The new fuzz test fails against the pre-fix code (confirmed locally) and
  passes after the fix.
- One CI "test" run failed on an unrelated coverage-threshold flake (fast-check
  runs unseeded outside the mutation job, so branch coverage on an untouched
  file can vary run-to-run); a re-run of that job passed.

## Checklist

- [x] Commits follow Conventional Commits; each subject reads as a user-facing
      release note.
- [x] `pnpm test`, `pnpm lint`, and `pnpm check` pass locally.
- [x] New/changed detectors have negative tests (zero findings on legitimate
      input) and pin their invariants with property/fuzz tests.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version are left untouched.
