### PR TITLE
test(invisible): teach the residual-invisible property the selector carve-out

### DIFF
--- a/test/invisible.test.mjs
+++ b/test/invisible.test.mjs
@@ -284,6 +284,18 @@ describe("stripInvisible: ZWNJ/ZWJ linguistic carve-out", () => {
       assert.equal(cleaned, sample);
       assert.deepEqual(found, []);
     });
+
+    it(`preserves an emoji-modifier base + ${name} (fuzz counterexample 🏻︎)`, () => {
+      // Regression pin for an unseeded fast-check counterexample: the carve-out
+      // preserves a presentation selector after ANY pictograph-class base,
+      // including a standalone skin-tone modifier (U+1F3FB, \\p{Emoji_Modifier}
+      // but also a visible swatch glyph) — the residual-allowlist property must
+      // model that, not just ZWNJ/ZWJ.
+      const sample = `${cp(0x1f3fb)}${selector}`;
+      const { cleaned, found } = stripInvisibleWithReport(sample);
+      assert.equal(cleaned, sample);
+      assert.deepEqual(found, []);
+    });
   }
 
   it("keeps one emoji selector but strips a stuffed VS16 run", () => {
@@ -1018,14 +1030,28 @@ describe("property: stripInvisible invariants", () => {
       fc.property(adversarialText, (text) => {
         const cleaned = stripInvisible(text);
         // After stripping, the only STRIP-class chars left must be ZWNJ/ZWJ
-        // (carve-out) or a single leading BOM.
+        // (carve-out), a presentation selector kept on a pictograph/modifier
+        // base (the carve-out preserves VS15/VS16 directly after one — 🏻︎ is
+        // a visible glyph, not a hidden selector run), or a single leading BOM.
+        const selectorBase = /^[\p{Extended_Pictographic}\p{Emoji_Modifier}]$/u;
         for (let i = 0; i < cleaned.length; i++) {
           const ch = cleaned[i];
           STRIP.lastIndex = 0;
           if (!STRIP.test(ch)) continue;
           const code = cleaned.codePointAt(i);
+          // The base before a selector may be an astral pair: step back two
+          // units when the preceding unit is a low surrogate.
+          const baseStart =
+            i >= 2 && /[\uDC00-\uDFFF]/.test(cleaned[i - 1]) ? i - 2 : i - 1;
+          const keptSelector =
+            (code === 0xfe0e || code === 0xfe0f) &&
+            i > 0 &&
+            selectorBase.test(cleaned.slice(baseStart, i));
           const ok =
-            code === 0x200c || code === 0x200d || (code === 0xfeff && i === 0);
+            code === 0x200c ||
+            code === 0x200d ||
+            keptSelector ||
+            (code === 0xfeff && i === 0);
           assert.ok(ok, `unexpected residual invisible U+${code.toString(16)}`);
         }
       }),


### PR DESCRIPTION
## Summary

The `STRIP-matchable chars are gone unless preserved by the carve-out` property in `test/invisible.test.mjs` still modeled the pre-#85 carve-out: its residual allowlist accepted only ZWNJ/ZWJ and a leading BOM. Since #85 intentionally preserves a presentation selector (VS15/VS16) directly after a pictograph-class base, any unseeded fast-check draw that lands a base+selector pair fails the property — which is exactly what broke PR #92's unseeded `hook-lifecycle` job (counterexample `🏻︎` = U+1F3FB Emoji_Modifier + U+FE0E), on code that PR never touched.

## Changes

- `test/invisible.test.mjs`: the residual allowlist now also accepts VS15/VS16 when the preceding code point (astral-aware) matches `\p{Extended_Pictographic}` or `\p{Emoji_Modifier}` — the same rule the implementation applies.
- Two deterministic pinning tests: a standalone emoji-modifier base + VS15 and + VS16 must survive byte-for-byte with zero findings.

## Tests / verification

- Reproduced the CI counterexample against the old model; confirmed `🏻︎`/`🏻️` pass the new model.
- `pnpm test` (100% coverage), `pnpm lint`, `pnpm check`, `npx prettier --check .` all pass.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/); each subject reads as a user-facing release note.
- [x] `pnpm test`, `pnpm lint`, and `pnpm check` pass locally.
- [x] New or changed detectors have negative tests (zero findings on legitimate input) and pin their invariants with property/fuzz tests.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version are left untouched (the release workflow owns them).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VqdkGYAAAQ26RN4ZeZpP5r)_