### PR TITLE
ci: consume ci-truth-serum via tier aggregates and bump pin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,31 +49,19 @@ repos:
   # pinned to mutable names. No published tag yet, so rev is the main HEAD SHA
   # (pinned per the "SHA-pin third-party sources" rule). ALL hooks enabled:
   # Tier 1 (honesty + identity), Tier 2 (opinionated — this repo follows the
-  # decide/reporter + cancel-in-progress conventions they assume), and Extras.
+  # decide/reporter + cancel-in-progress conventions they assume; its
+  # check-required-reporter forces the `# required-check: true|false` markers
+  # sync-required-checks.yaml applies to the branch ruleset), and Extras.
+  # Tier aggregates over per-check ids so a check added upstream to a tier
+  # applies here with no config change; check-symlinks is the one hook outside
+  # any tier, so it stays listed.
   - repo: https://github.com/alexander-turner/ci-truth-serum
-    rev: 55b3c2af0b83f77f15eba92aac743bdf8ff254be # main (no tagged release yet)
+    rev: 421e708a4fa98df667c708fdb4c43570ab620bb6 # main (no tagged release yet)
     hooks:
-      # Tier 1 · Honesty
-      - id: check-workflow-pipefail
-      - id: check-exit-suppression
-      - id: check-stderr-suppression
-      - id: check-pr-paths
-      # Tier 1 · Identity
-      - id: check-pinned-base-images
-      - id: check-pinned-downloads
-      # Tier 2 · Opinionated
-      - id: check-always-reporter
-      # Forces a `# required-check: true|false` marker on every always() reporter;
-      # sync-required-checks.yaml reads those markers to rewrite the branch
-      # ruleset, so the two can't drift.
-      - id: check-required-reporter
-      - id: check-inline-run-length
-      - id: check-concurrency
-      - id: check-static-concurrency
-      # Extras
+      - id: check-tier1
+      - id: check-tier2
+      - id: check-extras
       - id: check-symlinks
-      - id: check-unnamed-regex-groups
-      - id: check-global-stdio-swap
 
   - repo: local
     hooks:


### PR DESCRIPTION
## Summary

The `.pre-commit-config.yaml` block enumerated every ci-truth-serum check by id, which had already drifted: `check-claude-model` (an Extras member) was never enabled despite the comment claiming "ALL hooks enabled". Switching to the `check-tier1`/`check-tier2`/`check-extras` aggregates makes that drift structurally impossible — a check added to a tier upstream applies here with no config change. `check-symlinks` stays listed as the one hook outside any tier.

Also bumps the pinned rev to current upstream main (`421e708`), picking up the multiline exit-suppression fix, Dockerfile `ADD <url>` pinning, and the `${{ always() }}` reporter-shape fix. `sync-required-checks.sh` reads the rev from `.pre-commit-config.yaml`, so the ruleset apply tool follows automatically.

## Changes

- Replace the 14 hand-enumerated ci-truth-serum hook ids with the three tier aggregates plus `check-symlinks`.
- Bump `rev:` `55b3c2a` → `421e708`.

## Tests / verification

- Ran tier1, tier2, and extras at the new rev against this tree — all pass (extras now includes `check-claude-model`, previously unenabled, which also passes).
- No source or detector changes; `CHANGELOG.md` and `package.json` untouched.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/); each subject reads as a user-facing release note.
- [x] Lint/config checks verified (tier lints run clean at the new rev).
- [x] No new or changed detectors in this PR.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version are left untouched (the release workflow owns them).

---
_Generated by [Claude Code](https://claude.ai/code/session_0155o9xwLdCM8K8RWx54btuq)_