### PR TITLE
fix(html): stop splicing visible content and close a display:none bypass

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,31 +49,19 @@ repos:
   # pinned to mutable names. No published tag yet, so rev is the main HEAD SHA
   # (pinned per the "SHA-pin third-party sources" rule). ALL hooks enabled:
   # Tier 1 (honesty + identity), Tier 2 (opinionated — this repo follows the
-  # decide/reporter + cancel-in-progress conventions they assume), and Extras.
+  # decide/reporter + cancel-in-progress conventions they assume; its
+  # check-required-reporter forces the `# required-check: true|false` markers
+  # sync-required-checks.yaml applies to the branch ruleset), and Extras.
+  # Tier aggregates over per-check ids so a check added upstream to a tier
+  # applies here with no config change; check-symlinks is the one hook outside
+  # any tier, so it stays listed.
   - repo: https://github.com/alexander-turner/ci-truth-serum
-    rev: 55b3c2af0b83f77f15eba92aac743bdf8ff254be # main (no tagged release yet)
+    rev: 421e708a4fa98df667c708fdb4c43570ab620bb6 # main (no tagged release yet)
     hooks:
-      # Tier 1 · Honesty
-      - id: check-workflow-pipefail
-      - id: check-exit-suppression
-      - id: check-stderr-suppression
-      - id: check-pr-paths
-      # Tier 1 · Identity
-      - id: check-pinned-base-images
-      - id: check-pinned-downloads
-      # Tier 2 · Opinionated
-      - id: check-always-reporter
-      # Forces a `# required-check: true|false` marker on every always() reporter;
-      # sync-required-checks.yaml reads those markers to rewrite the branch
-      # ruleset, so the two can't drift.
-      - id: check-required-reporter
-      - id: check-inline-run-length
-      - id: check-concurrency
-      - id: check-static-concurrency
-      # Extras
+      - id: check-tier1
+      - id: check-tier2
+      - id: check-extras
       - id: check-symlinks
-      - id: check-unnamed-regex-groups
-      - id: check-global-stdio-swap
 
   - repo: local
     hooks:

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -70,8 +70,15 @@ const OFFSCREEN_VIEWPORT_THRESHOLD = -100;
 // The numeric arm accepts a sign and scientific notation (`-1e4px`) so a
 // browser-honored exponent form is read at its true magnitude, not truncated
 // at the `e` (which would make `translateX(-1e4px)` read as `-1px`, on-screen).
+// The unit is MANDATORY: per the CSS spec a nonzero unitless length is an
+// INVALID declaration and a browser drops it entirely (the element keeps its
+// normal on-screen position), so an optional unit here would read
+// `left:-1000` as offscreen and splice content a browser still renders. A
+// bare unitless `0` also fails this regex now, but that's inert — 0 never
+// clears the negative offscreen threshold below, so it was never flagged
+// either way.
 const ABSOLUTE_UNIT_RE =
-  /^[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?\s*(?:px|em|rem|ex|ch|pt|pc|in|cm|mm)?$/;
+  /^[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?\s*(?:px|em|rem|ex|ch|pt|pc|in|cm|mm)$/;
 const VIEWPORT_UNIT_RE =
   /^[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?\s*(?:vw|vh|vmin|vmax|%)$/;
 
@@ -228,20 +235,82 @@ function isOverflowHidden(val) {
 }
 
 /**
+ * Parse a style string into a property map, salvaging what we can when the
+ * whole string is syntactically invalid. `style-to-object` throws on the
+ * FIRST bad declaration and abandons the rest of the string, but a browser
+ * recovers per-declaration — it drops only the invalid one and keeps parsing
+ * and applying the others. Gating detection on "the whole string parsed
+ * cleanly" would let `x;display:none` hide content from a human (the browser
+ * drops the bogus `x` and applies `display:none`) while going undetected
+ * here — a splice bypass. So on a whole-string parse failure, this re-parses
+ * each `;`-delimited declaration independently and keeps whichever ones
+ * parse; a declaration that still fails on its own is dropped, matching the
+ * browser's per-declaration recovery.
+ * @param {string} styleStr
+ * @returns {Record<string, unknown> | null}
+ */
+function parseStyleSalvage(styleStr) {
+  try {
+    // @ts-ignore -- style-to-object default export not resolved under NodeNext
+    return styleToObject(styleStr);
+  } catch {
+    // Fall through to per-declaration salvage below.
+  }
+  /** @type {Record<string, unknown>} */
+  const salvaged = {};
+  let sawAny = false;
+  for (const decl of styleStr.split(";")) {
+    if (!decl.trim()) continue;
+    try {
+      // @ts-ignore -- see above
+      const parsed = styleToObject(decl);
+      if (parsed) {
+        Object.assign(salvaged, parsed);
+        sawAny = true;
+      }
+    } catch {
+      // This one declaration is invalid; a browser drops only it and keeps
+      // the rest, so skip it rather than failing the whole style.
+    }
+  }
+  return sawAny ? salvaged : null;
+}
+
+// CSS escape sequences (used in property VALUES, not just identifiers): a
+// backslash followed by 1-6 hex digits (with an optional single trailing
+// whitespace terminator that is consumed, not emitted) encodes a codepoint;
+// a backslash followed by any other character is that literal character. A
+// keyword can be spelled through this mechanism (`no\6e e` decodes to
+// `none`) and a real browser decodes it before matching the keyword, so
+// leaving it undecoded here is a detection bypass.
+const CSS_ESCAPE_RE = /\\([0-9a-fA-F]{1,6})[ \t\n]?|\\(.)/g;
+
+/** @param {string} value @returns {string} */
+function decodeCssEscapes(value) {
+  return value.replace(CSS_ESCAPE_RE, (_match, hex, char) => {
+    if (!hex) return char;
+    const codepoint = parseInt(hex, 16);
+    // Per the CSS syntax spec, an escaped codepoint of zero, a surrogate
+    // half, or anything past the Unicode maximum is invalid and decodes to
+    // U+FFFD REPLACEMENT CHARACTER — not the raw codepoint, which would
+    // throw in `String.fromCodePoint` (e.g. `\ffffff` > 0x10FFFF) and break
+    // this module's never-throws contract.
+    if (
+      codepoint === 0 ||
+      (codepoint >= 0xd800 && codepoint <= 0xdfff) ||
+      codepoint > 0x10ffff
+    )
+      return "\uFFFD";
+    return String.fromCodePoint(codepoint);
+  });
+}
+
+/**
  * @param {string} styleStr
  * @returns {boolean}
  */
 export function isHiddenStyle(styleStr) {
-  // style-to-object throws on syntactically invalid CSS; a browser would
-  // ignore the broken declaration, so we do too rather than letting the
-  // exception escape and suppress the entire tool output.
-  let rawProps;
-  try {
-    // @ts-ignore -- style-to-object default export not resolved under NodeNext
-    rawProps = styleToObject(styleStr);
-  } catch {
-    return false;
-  }
+  const rawProps = parseStyleSalvage(styleStr);
   if (!rawProps) return false;
 
   // CSS property names are case-insensitive and `!important` is a legal
@@ -258,8 +327,11 @@ export function isHiddenStyle(styleStr) {
     );
   }
 
+  // Values are CSS-escape-decoded before every keyword/length comparison
+  // below, so an escaped keyword (`no\6e e`) reads at its true decoded value.
   /** @param {string} key */
-  const val = (key) => (props[key] || "").toString().trim().toLowerCase();
+  const val = (key) =>
+    decodeCssEscapes((props[key] || "").toString().trim()).toLowerCase();
 
   if (val("display") === "none") return true;
   if (val("visibility") === "hidden" || val("visibility") === "collapse")
@@ -285,8 +357,13 @@ export function isHiddenStyle(styleStr) {
     if (n < NEAR_ZERO_EPSILON) return true;
   }
 
-  for (const dim of ["height", "width", "font-size"])
-    if (isNearZeroLength(val(dim))) return true;
+  // `height`/`width` are deliberately NOT tested standalone here: with the
+  // default `overflow:visible`, a zero-sized box still paints its overflowing
+  // children, so a bare `width:0`/`height:0` leaves content on screen.
+  // `isOverflowHidden` below already covers the case where a zero dimension
+  // DOES hide content — gated on `overflow:hidden` also being present.
+  // `font-size:0`, in contrast, reliably collapses text to nothing on its own.
+  if (isNearZeroLength(val("font-size"))) return true;
 
   if (isPositionedOffscreen(val)) return true;
 
@@ -372,10 +449,13 @@ export function isHiddenElement(node) {
   const { properties = {} } = node;
   if (properties.hidden !== undefined && properties.hidden !== null)
     return true;
-  // `aria-hidden="true"` removes the element from the accessibility tree, so a
-  // human using the rendered page never perceives it; a model reading raw
-  // source still does. (rehype maps the attribute to the `ariaHidden` prop.)
-  if (String(properties.ariaHidden).toLowerCase() === "true") return true;
+  // `aria-hidden="true"` is deliberately NOT treated as a hiding signal: it
+  // removes the element only from the ACCESSIBILITY TREE, not the rendered
+  // page — a sighted human viewing the page still sees it (it's routinely
+  // used on decorative icons and icon-font glyphs, and on visible text
+  // duplicated for screen-reader dedup). Splicing on it would delete content
+  // a human plainly sees, which is real harm under the precision-over-recall
+  // doctrine for this layer.
   if (properties.style && isHiddenStyle(properties.style)) return true;
   return false;
 }
@@ -952,6 +1032,39 @@ function isBase64UrlBlob(value) {
   return BLOB_VALUE_B64URL_RE.test(value) && B64URL_RUN_RE.test(value);
 }
 
+/** @param {string} value @returns {boolean} */
+function isBlobValue(value) {
+  return (
+    BLOB_VALUE_B64_RE.test(value) ||
+    BLOB_VALUE_HEX_RE.test(value) ||
+    isBase64UrlBlob(value)
+  );
+}
+
+/**
+ * True when the percent-DECODED form of `value` is blob-shaped, even though
+ * the raw value isn't (e.g. `A%41A%41…` decodes to a run of `A`s). This is a
+ * REPORT-ONLY check — `paramExfilReason` never rewrites the URL, it only
+ * names a reason for the caller's warning — so the false-positive cost of
+ * decoding is much lower than it would be in the splicing layer. Applied IN
+ * ADDITION to the raw-value test (never instead of it): the raw scan stays
+ * the primary signal since `URLSearchParams`-style decoding elsewhere in this
+ * file is deliberately avoided (it mangles `+` in base64). A malformed
+ * percent-sequence throws in `decodeURIComponent`; that failure is not a
+ * blob shape either way, so it fails open (skip the decoded check).
+ * @param {string} value
+ * @returns {boolean}
+ */
+function decodedBlobMatch(value) {
+  let decoded;
+  try {
+    decoded = decodeURIComponent(value);
+  } catch {
+    return false;
+  }
+  return isBlobValue(decoded);
+}
+
 /**
  * RAW (un-decoded) `name=value` pairs of a query/fragment string, split on `&`
  * and `;`. URLSearchParams is avoided on purpose: it percent-/`+`-decodes
@@ -990,11 +1103,7 @@ function paramExfilReason(name, value) {
     matchesSecretHint(value)
   )
     return "credential-shaped token in URL parameter";
-  if (
-    BLOB_VALUE_B64_RE.test(value) ||
-    BLOB_VALUE_HEX_RE.test(value) ||
-    isBase64UrlBlob(value)
-  )
+  if (isBlobValue(value) || decodedBlobMatch(value))
     return "suspicious query parameter";
   return null;
 }

--- a/test/html-corpus.test.mjs
+++ b/test/html-corpus.test.mjs
@@ -102,12 +102,20 @@ const CORPUS = {
       name: "black-on-black-shorthand",
       input: hidden("color:#000;background:rgb(0,0,0) url(x)"),
     },
-    {
-      name: "aria-hidden-span",
-      input: `<span aria-hidden="true">${CANARY}</span>`,
-    },
     { name: "html-comment", input: `text<!-- ${CANARY} -->OK` },
     { name: "bare-hidden-attr", input: `<div hidden>${CANARY}</div>` },
+    {
+      // A malformed sibling declaration (`x`, no colon) must not blank
+      // detection of the valid `display:none` next to it — a browser
+      // recovers per-declaration and still hides the element.
+      name: "malformed-decl-does-not-block-detection",
+      input: hidden("x;display:none"),
+    },
+    {
+      // A CSS hex-escaped keyword decodes to `none` in a real browser.
+      name: "css-escaped-display-none",
+      input: hidden("display:no\\6e e"),
+    },
     {
       name: "hidden-span-in-heading",
       input: `# Title <span style="display:none">${CANARY}</span> end`,
@@ -334,6 +342,13 @@ const CORPUS = {
       input: `https://evil.example/${"Zm9vQmFyMTIz".repeat(11)}-_`,
       reason: "encoded data blob in path segment",
     },
+    {
+      // Percent-encoded blob: the raw value is percent-escapes, not a blob
+      // shape, but it decodes to a 40+ run of "A"s.
+      name: "percent-encoded-blob",
+      input: "https://evil.example/log?q=" + "%41".repeat(40),
+      reason: "suspicious query parameter",
+    },
   ],
   urlBenign: [
     { name: "fragment-anchor", input: "https://ok.example/page#section-2" },
@@ -372,6 +387,16 @@ const CORPUS = {
     {
       name: "long-hyphenated-slug",
       input: "https://ok.example/the-" + "quick-".repeat(40) + "end",
+    },
+    {
+      // Percent-encoded but decodes to something short — must not flag.
+      name: "percent-encoded-short",
+      input: "https://ok.example/p?q=%41%42%43",
+    },
+    {
+      // Malformed percent-sequence: decodeURIComponent throws — fail open.
+      name: "malformed-percent-sequence",
+      input: "https://ok.example/p?q=%zzinvalid",
     },
     // S4 precision: legit url-safe shapes must NOT be mistaken for a blob.
     {
@@ -441,6 +466,39 @@ const CORPUS = {
       input: hidden("color:white;background:#fefefe"),
     },
     { name: "distinct-grays", input: hidden("color:#777;background:#888") },
+    {
+      // aria-hidden removes an element only from the ACCESSIBILITY TREE, not
+      // the rendered page — a sighted human still sees it.
+      name: "aria-hidden-span",
+      input: `<span aria-hidden="true">${CANARY}</span>`,
+    },
+    {
+      // A zero width/height with the default overflow:visible still paints
+      // overflowing children — content stays on screen.
+      name: "zero-height-no-overflow",
+      input: hidden("height:0"),
+    },
+    {
+      name: "zero-width-no-overflow",
+      input: hidden("width:0"),
+    },
+    {
+      // A nonzero unitless length is INVALID CSS; a browser drops the whole
+      // declaration and the element keeps its normal on-screen position.
+      name: "unitless-offscreen-invalid",
+      input: hidden("position:absolute;left:-9999"),
+    },
+    {
+      name: "unitless-text-indent-invalid",
+      input: hidden("text-indent:-9999"),
+    },
+    {
+      // A malformed declaration (`x`) in a style string must not blank
+      // detection of the REST of the style — but salvage also must not
+      // manufacture a false positive out of the broken half.
+      name: "malformed-decl-does-not-poison-valid-sibling",
+      input: hidden("bad!!!;color:red"),
+    },
   ],
 };
 

--- a/test/html-exfil-semantic-fuzz.test.mjs
+++ b/test/html-exfil-semantic-fuzz.test.mjs
@@ -46,6 +46,8 @@ const BENIGN_URLS = [
   // Signed-CDN URL: long by design, every param allowlisted.
   "https://cdn.example.com/a.js?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240101T000000Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=" +
     "b".repeat(64),
+  // Percent-encoded but decodes to something short — must not flag.
+  "https://benignpct.example.com/p?q=%41%42%43",
 ];
 
 // Each exfil token is a genuine data-exfiltration shape with a UNIQUE host so
@@ -106,6 +108,13 @@ const EXFIL_URLS = [
     url: `https://kw.evil/p?token=${"Ab1".repeat(14)}`,
     reason: "suspicious query parameter",
     target: "kw.evil",
+  },
+  {
+    // Percent-encoded blob: the raw value is percent-escapes, not a blob
+    // shape, but decodes to a 40+ run of "A"s.
+    url: `https://pctblob.evil/log?q=${"%41".repeat(40)}`,
+    reason: "suspicious query parameter",
+    target: "pctblob.evil",
   },
 ];
 

--- a/test/html-property.test.mjs
+++ b/test/html-property.test.mjs
@@ -137,12 +137,15 @@ const hidingDeclarations = {
     .tuple(casedPropertyName("text-indent"), offscreenLength)
     .map(([name, length]) => `${name}: ${length}`),
 };
-for (const dimension of ["height", "width", "font-size"]) {
-  hidingDeclarations[dimension] = fc
-    .tuple(casedPropertyName(dimension), zeroLength)
-    .map(([name, length]) => `${name}: ${length}`);
-}
-for (const dimension of ["height", "max-width"]) {
+// `font-size:0` reliably collapses text to nothing on its own, so it stays a
+// standalone hiding signal. `height`/`width` are deliberately NOT standalone
+// here — with the default `overflow:visible` a zero-sized box still paints
+// its overflowing children — so they only flag paired with `overflow:hidden`
+// in the loop below (precision fix).
+hidingDeclarations["font-size"] = fc
+  .tuple(casedPropertyName("font-size"), zeroLength)
+  .map(([name, length]) => `${name}: ${length}`);
+for (const dimension of ["height", "width", "max-height", "max-width"]) {
   hidingDeclarations[`overflow+${dimension}`] = fc
     .tuple(
       casedPropertyName("overflow"),
@@ -188,6 +191,10 @@ const visibleDeclaration = fc.constantFrom(
   "position: absolute; left: -50%",
   "position: absolute; left: -10%",
   "position: absolute; left: calc(100% - 5px)",
+  "position: absolute; left: -9999", // unitless nonzero length is invalid CSS, fails open
+  "text-indent: -9999", // same, unitless
+  "height: 0", // zero box alone (no overflow:hidden) still shows overflowing children
+  "width: 0",
   "margin-left: -2em",
   "text-indent: -0.5em",
   "clip-path: inset(10%)",

--- a/test/html-semantic-fuzz.test.mjs
+++ b/test/html-semantic-fuzz.test.mjs
@@ -42,6 +42,16 @@ const KEEP_TOKENS = [
   '<div style="font-size: 12px; height: 40px">KEEPSIZED</div>',
   '<div style="text-indent: 2em">KEEPINDENT</div>',
   '<div style="overflow: hidden; height: 100px">KEEPOVERFLOW</div>',
+  // aria-hidden removes an element only from the ACCESSIBILITY TREE, not the
+  // rendered page — a sighted human still sees it, so it must survive.
+  '<p aria-hidden="true">KEEPARIA</p>',
+  // A zero width/height alone (no overflow:hidden) still shows overflowing
+  // content under the default overflow:visible.
+  '<div style="width: 0">KEEPZEROWIDTH</div>',
+  '<div style="height: 0">KEEPZEROHEIGHT</div>',
+  // A nonzero unitless offset is invalid CSS; a browser drops the whole
+  // declaration and the element keeps its normal on-screen position.
+  '<div style="position: absolute; left: -9999">KEEPUNITLESS</div>',
 ];
 
 // Each STRIP token is a genuinely hidden construct; its MARKER (the payload a
@@ -68,8 +78,20 @@ const STRIP_TOKENS = [
     marker: "STRIPFONTZERO",
   },
   {
-    t: '<p aria-hidden="true">STRIPARIA</p>',
-    marker: "STRIPARIA",
+    // A malformed sibling declaration must not blank detection of the valid
+    // `display:none` next to it (per-declaration salvage bypass fix).
+    t: '<div style="x;display:none">STRIPMALFORMED</div>',
+    marker: "STRIPMALFORMED",
+  },
+  {
+    // A CSS hex-escaped keyword decodes to `none` in a real browser.
+    t: '<div style="display:no\\6e e">STRIPESCAPED</div>',
+    marker: "STRIPESCAPED",
+  },
+  {
+    // A zero box paired with overflow:hidden hides its content.
+    t: '<div style="overflow:hidden;width:0">STRIPOVERFLOWZERO</div>',
+    marker: "STRIPOVERFLOWZERO",
   },
 ];
 

--- a/test/html.test.mjs
+++ b/test/html.test.mjs
@@ -61,8 +61,14 @@ const HIDDEN_STYLE_CASES = [
   ["opacity:0px", false], // invalid unit — a browser ignores it, element stays visible
   ["opacity:0em", false], // invalid unit — fail open (was parseFloat'd to 0 → over-flagged)
   // ── zero / near-zero size (epsilon) ──
-  ["height:0", true],
-  ["width:0", true],
+  // `height`/`width` alone (no `overflow:hidden`) are deliberately NOT
+  // standalone-hidden: the default `overflow:visible` still paints
+  // overflowing children, so the element stays visible (precision fix).
+  ["height:0", false],
+  ["width:0", false],
+  ["overflow:hidden;height:0", true], // zero box + overflow:hidden together hide
+  ["overflow:hidden;width:0", true],
+  ["overflow:visible;height:0", false], // explicit visible overflow: not hidden
   ["font-size:0", true],
   ["font-size:0.0001px", true], // sub-epsilon (bug: required exact 0)
   ["font-size:0.005em", true],
@@ -93,12 +99,15 @@ const HIDDEN_STYLE_CASES = [
   ["position:static;left:-9999px", false],
   ["position:absolute;left:auto", false], // non-length offset is not offscreen
   ["position:absolute;clip:rect(1,1,1,1)", false],
+  ["position:absolute;left:-1000", false], // unitless nonzero length is INVALID CSS; browser drops it, fails open
+  ["position:absolute;left:-9999", false], // same, larger magnitude
   // ── text-indent offscreen ──
   ["text-indent:-9999px", true],
   ["text-indent:-100vw", true],
   ["text-indent:-900px", false],
   ["text-indent:-0.5em", false], // ordinary hanging indent is not offscreen
   ["text-indent:calc(2em - 1px)", false], // calc indent fails open
+  ["text-indent:-9999", false], // unitless nonzero — invalid CSS, fails open (was over-flagged)
   // ── overflow + zero box ──
   ["overflow:hidden;max-width:0", true],
   ["overflow:hidden;max-height:0", true],
@@ -181,6 +190,20 @@ const HIDDEN_STYLE_CASES = [
   // ── degenerate / invalid input ──
   ["", false],
   ["a{b:c}", false],
+  // ── per-declaration salvage on parse failure ──
+  ["x;display:none", true], // one invalid decl must not blank the whole style (bypass fix)
+  ["display:none;x", true], // invalid decl trailing the valid one is salvaged too
+  ["bad!!!;color:red", false], // salvage must not manufacture a false positive
+  ["bad!!!;x also bad", false], // no declaration salvages at all — fails open
+  // ── CSS-escaped keyword decoding ──
+  ["display:no\\6e e", true], // `\6e` decodes to 'n' + space terminator consumed
+  ["display:\\64 isplay-never-a-real-value", false], // decodes to a nonsense keyword, stays visible
+  ["display:\\62 lock", false], // `\62` decodes to 'b' -> "block", correctly visible after decode
+  ["visibility:hi\\64 den", true], // `\64` decodes to 'd' -> "hidden"
+  // ── invalid escaped codepoints (spec: decode to U+FFFD, never throw) ──
+  ["display:\\0", false], // codepoint 0 is invalid
+  ["display:\\d800", false], // a surrogate half is invalid
+  ["display:\\ffffff", false], // past the Unicode maximum (0x10FFFF)
 ];
 
 describe("unit: isHiddenStyle exact verdicts", () => {
@@ -215,12 +238,24 @@ describe("unit: isHiddenElement exact verdicts", () => {
     assert.equal(isHiddenElement(elem("div", { hidden: "" })), true));
   it("does not flag hidden=null (the !== null half of the guard)", () =>
     assert.equal(isHiddenElement(elem("div", { hidden: null })), false));
-  it("flags aria-hidden=true (removed from the accessibility tree)", () =>
-    assert.equal(isHiddenElement(elem("span", { ariaHidden: "true" })), true));
+  // aria-hidden removes an element only from the ACCESSIBILITY TREE — a
+  // sighted human viewing the page still sees it (decorative icons,
+  // icon-font glyphs, visible text duplicated for screen-reader dedup).
+  // Splicing on it would delete content a human plainly sees, so it is
+  // deliberately NOT a hiding signal here (precision fix).
+  it("does not flag aria-hidden=true (visible on the rendered page)", () =>
+    assert.equal(isHiddenElement(elem("span", { ariaHidden: "true" })), false));
   it("does not flag aria-hidden=false", () =>
     assert.equal(
       isHiddenElement(elem("span", { ariaHidden: "false" })),
       false,
+    ));
+  it("still flags aria-hidden=true when it ALSO carries a real hiding style", () =>
+    assert.equal(
+      isHiddenElement(
+        elem("span", { ariaHidden: "true", style: "display:none" }),
+      ),
+      true,
     ));
   it("flags a hiding inline style", () =>
     assert.equal(
@@ -1013,7 +1048,6 @@ describe("property: hidden/bogus content is stripped on either branch (#2)", () 
     `<![CDATA[${CANARY}]]>`,
     `<span style="display:none">${CANARY}</span>`,
     `<div hidden>${CANARY}</div>`,
-    `<span aria-hidden="true">${CANARY}</span>`,
   );
 
   it("the canary never survives, the visible marker always does", () => {
@@ -1057,5 +1091,29 @@ describe("property: hidden/bogus content is stripped on either branch (#2)", () 
       sawSourceBranch > 0 && sawProseBranch > 0,
       "a branch was never exercised",
     );
+  });
+
+  // Precision counterpart: aria-hidden is visible on the rendered page (it
+  // only removes an element from the accessibility tree), so it must NOT be
+  // spliced on either branch — the opposite of the hiddenConstruct property
+  // above.
+  it("an aria-hidden-only construct survives byte-for-byte on either branch", () => {
+    const ariaConstruct = `<span aria-hidden="true">${CANARY}</span>`;
+    const sourceDoc = [
+      "<section>",
+      "<p>intro</p>",
+      `<p>${MARKER}</p>`,
+      ariaConstruct,
+      "<p>outro</p>",
+      "</section>",
+    ].join("\n");
+    const proseDoc = `Here is ${MARKER} then ${ariaConstruct} and more prose.`;
+    assert.equal(looksLikeHtmlSource(sourceDoc), true);
+    assert.equal(looksLikeHtmlSource(proseDoc), false);
+    for (const doc of [sourceDoc, proseDoc]) {
+      const out = applyHtml(doc);
+      assert.ok(out.includes(CANARY), `aria-hidden content spliced: ${doc}`);
+      assert.ok(out.includes(MARKER), `visible marker lost: ${doc}`);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Found via a multi-agent audit of `src/html.mjs`. Six bugs cutting both directions: bypasses that let hidden content through undetected, and false positives that splice content real users can see (the doctrine explicitly treats the latter as harm).

## Changes

- `isHiddenStyle` threw and failed the *whole* style attribute open on one malformed declaration (`style="x;display:none"` went undetected, though a browser renders `display:none`). Added per-declaration salvage parsing.
- `aria-hidden="true"` was treated as a hiding signal — it only removes elements from the accessibility tree, not from what sighted users see. Removed the check entirely.
- Unitless offsets (`left:-1000`, no unit) were treated as offscreen; that's invalid CSS a browser ignores (stays visible). Unit is now required.
- Bare `width:0`/`height:0` (no `overflow:hidden`) were treated as hidden even though overflow-visible content still paints. Removed from the standalone zero-length check; `isOverflowHidden` already gates this correctly.
- CSS hex escapes (`display:no\6e e` → `none`) bypassed keyword checks. Added a CSS-escape decoder applied before keyword/length comparisons.
- Percent-encoded exfil blob values evaded detection (report-only path). Added a percent-decoded check alongside the raw one, fail-open on malformed encoding.

## Tests / verification

- Each fix has a positive (bug-gone) test and a negative-corpus case proving no new false positive/negative, across `test/html*.test.mjs` (corpus, property, semantic-fuzz).
- Independently re-verified the three headline repros live (`x;display:none` now spliced, `aria-hidden` visible content no longer spliced, unitless offset no longer flagged).
- `pnpm test`: 1348 tests, 100% coverage. `pnpm lint`/`pnpm format` clean.

## Checklist

- [x] Commits follow Conventional Commits.
- [x] `pnpm test`, `pnpm lint` pass locally.
- [x] New/changed detectors have negative tests (zero findings on legitimate input) and property/fuzz coverage.
- [x] No secrets in the diff.
- [x] CHANGELOG.md / package.json version untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PHTbVvQ5U3msna7wTsC4pf)_