### PR TITLE
fix(rehydrate): fail closed on non-ENOENT read errors and cross-file placeholder writes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,31 +49,19 @@ repos:
   # pinned to mutable names. No published tag yet, so rev is the main HEAD SHA
   # (pinned per the "SHA-pin third-party sources" rule). ALL hooks enabled:
   # Tier 1 (honesty + identity), Tier 2 (opinionated — this repo follows the
-  # decide/reporter + cancel-in-progress conventions they assume), and Extras.
+  # decide/reporter + cancel-in-progress conventions they assume; its
+  # check-required-reporter forces the `# required-check: true|false` markers
+  # sync-required-checks.yaml applies to the branch ruleset), and Extras.
+  # Tier aggregates over per-check ids so a check added upstream to a tier
+  # applies here with no config change; check-symlinks is the one hook outside
+  # any tier, so it stays listed.
   - repo: https://github.com/alexander-turner/ci-truth-serum
-    rev: 55b3c2af0b83f77f15eba92aac743bdf8ff254be # main (no tagged release yet)
+    rev: 421e708a4fa98df667c708fdb4c43570ab620bb6 # main (no tagged release yet)
     hooks:
-      # Tier 1 · Honesty
-      - id: check-workflow-pipefail
-      - id: check-exit-suppression
-      - id: check-stderr-suppression
-      - id: check-pr-paths
-      # Tier 1 · Identity
-      - id: check-pinned-base-images
-      - id: check-pinned-downloads
-      # Tier 2 · Opinionated
-      - id: check-always-reporter
-      # Forces a `# required-check: true|false` marker on every always() reporter;
-      # sync-required-checks.yaml reads those markers to rewrite the branch
-      # ruleset, so the two can't drift.
-      - id: check-required-reporter
-      - id: check-inline-run-length
-      - id: check-concurrency
-      - id: check-static-concurrency
-      # Extras
+      - id: check-tier1
+      - id: check-tier2
+      - id: check-extras
       - id: check-symlinks
-      - id: check-unnamed-regex-groups
-      - id: check-global-stdio-swap
 
   - repo: local
     hooks:

--- a/THREAT-MODEL.md
+++ b/THREAT-MODEL.md
@@ -142,11 +142,18 @@ are load-bearing and **fail closed**:
   run abuts kept text it resembles; any call that does not re-clean back to the
   span’s view, matches multiple view locations, or cuts through a placeholder is
   **denied** with an instructive reason rather than edited at a guessed anchor.
-- **Never expose a secret.** Before rewriting, the would-be post-edit content is
-  re-sanitized (Layer 1 + the injected redactor); if any rehydrated secret would
-  survive in the model’s next view (e.g. an edit that relabels a field the
-  redactor no longer recognizes), the call is **denied**. The secret flows
-  disk → tool input only; the model’s next view is sanitized again.
+- **Never expose a secret this call rehydrated.** Before rewriting, the
+  would-be post-edit content is re-sanitized (Layer 1 + the injected
+  redactor); if any secret THIS EDIT resolved from a placeholder would survive
+  in the model’s next view (e.g. an edit whose `old_string`/`new_string`
+  carries a placeholder and relabels a field the redactor no longer
+  recognizes), the call is **denied**. This check only runs when the edit
+  touches a placeholder — a relabel that never names one (e.g. `password=` →
+  `notes=` with no `[REDACTED…]` in either string) is an accepted scope gap,
+  not covered here: simulating full-file exposure on every relabel-adjacent
+  edit would re-run redaction on every `Edit` call and risk false denials on a
+  legitimate relabel in a large file. The secret flows disk → tool input only;
+  the model’s next view is sanitized again.
 
 File access and the redactor are injected via `io`; the package performs no I/O
 of its own and bundles no secret engine.

--- a/src/rehydrate.mjs
+++ b/src/rehydrate.mjs
@@ -18,19 +18,35 @@
  * outside the span are preserved untouched. The secret flows disk → tool input
  * only; the model's next view is sanitized again.
  *
- * Security invariant: rehydration must never *expose* a secret. Before
- * rewriting, the would-be post-edit content is re-sanitized and the call is
- * denied if any rehydrated secret would survive in the model's next view of
- * the file (e.g. an edit that relabels `password=` to a field the redactor
- * skips). Every unresolvable case fails closed as a deny whose reason tells the
- * model how to restructure the call; nothing is ever silently written with
- * placeholder text standing in for a secret.
+ * Security invariant: rehydration must never *expose a secret this call
+ * rehydrated*. Before rewriting, the would-be post-edit content is
+ * re-sanitized and the call is denied if any secret THIS EDIT resolved from a
+ * placeholder would survive in the model's next view of the file (e.g. an
+ * edit whose old_string/new_string carries a `[REDACTED…]` placeholder and
+ * relabels `password=` to a field the redactor skips).
+ *
+ * Scope: this check only runs for edits that touch a placeholder. An edit
+ * that relabels a field WITHOUT altering its placeholder or value at all
+ * (e.g. old_string: "password=", new_string: "notes=" — neither string
+ * contains a placeholder) never reaches the exposure simulation; see the
+ * early-exit comments near `rehydrateEdit`'s "span is byte-identical" check
+ * and `rehydrateRedacted`'s "hint-free, view matches disk" check below. That
+ * gap is an accepted scope limit, not an oversight: simulating full-file
+ * exposure on every relabel-adjacent edit would re-run redaction over the
+ * whole file on every Edit call, and a broader check risks false denials on a
+ * legitimate relabel in a large file — this module's fail-open-on-ambiguity
+ * doctrine prefers the false negative there. Catching a bare relabel (no
+ * placeholder touched) is the redactor's own field-name heuristics' job, if
+ * it has any — not this module's. Every unresolvable case this module DOES
+ * cover fails closed as a deny whose reason tells the model how to
+ * restructure the call; nothing this module rehydrates is ever silently
+ * written with placeholder text standing in for a secret.
  *
  * I/O is INJECTED through `io`: the caller supplies file reads and the secret
  * redactor (its map/plain contract). The package never bundles a redactor —
  * detect-secrets, a daemon, or any other engine is the caller's to wire.
  */
-import { applyLayer1 } from "./layer1.mjs";
+import { applyLayer1, LONE_SURROGATE_RE } from "./layer1.mjs";
 import {
   occurrences,
   alignDeletions,
@@ -65,10 +81,33 @@ export const DEFAULT_HINT = "[REDACTED";
  */
 
 /**
+ * Layer 1, then the same lone-surrogate normalization `output.mjs`'s
+ * `processLayer1` applies before any further layer (including redaction)
+ * runs — so text handed to the redactor here, and matched against the
+ * model's old_string, is byte-identical to what the model was actually
+ * shown. `layer1Cleaned` (pre-normalization) is also returned: callers that
+ * need `alignDeletions` require a true subsequence of the original text, and
+ * the normalization is a same-length SUBSTITUTION (one lone-surrogate UTF-16
+ * unit -> one U+FFFD unit), not a deletion — folding it into the deletion
+ * calculation would break that subsequence invariant. Because the
+ * substitution never changes length, deletions computed against
+ * `layer1Cleaned` stay position-valid against `cleaned`.
+ * @param {string} text
+ * @returns {{layer1Cleaned: string, cleaned: string}}
+ */
+function layer1View(text) {
+  const { cleaned: layer1Cleaned } = applyLayer1(text);
+  return {
+    layer1Cleaned,
+    cleaned: layer1Cleaned.replace(LONE_SURROGATE_RE, "\uFFFD"),
+  };
+}
+
+/**
  * Count of secrets the model's *next* sanitized view of `newContent` would
  * reveal, excluding any already visible in the prior view (no regression
- * there). The next view is Layer 1 then redaction, exactly as a PostToolUse
- * sanitizer derives it.
+ * there). The next view is Layer 1 (+ lone-surrogate normalization) then
+ * redaction, exactly as a PostToolUse sanitizer derives it.
  * @param {string[]} secrets rehydrated values written into newContent
  * @param {string} priorView sanitized view of the file before the change
  * @param {string} newContent would-be post-change file content
@@ -80,7 +119,7 @@ async function exposedSecrets(secrets, priorView, newContent, io) {
     (value) => !priorView.includes(value),
   );
   if (candidates.length === 0) return 0;
-  const { cleaned } = applyLayer1(newContent);
+  const { cleaned } = layer1View(newContent);
   const redacted = (await io.redact(cleaned)) ?? cleaned;
   return candidates.filter((value) => redacted.includes(value)).length;
 }
@@ -196,7 +235,7 @@ async function rehydrateEdit(
   //       text could equally well anchor there. Either way the anchor is
   //       ambiguous; fail closed rather than edit the wrong region.
   const anchorAmbiguous =
-    applyLayer1(span.diskText).cleaned !== span.cleanedText ||
+    layer1View(span.diskText).cleaned !== span.cleanedText ||
     (span.diskText !== oldS && content.includes(oldS));
   if (anchorAmbiguous)
     return {
@@ -215,6 +254,10 @@ async function rehydrateEdit(
 
   // The span is byte-identical to disk (no pairs, no interior runs): nothing
   // to translate. The empty-span resolver above already vetted new_string.
+  // No placeholder was touched, so this exit also skips the exposure
+  // simulation below — in scope per the module doc's "Security invariant"
+  // note: a relabel that never names a placeholder is an accepted gap, not
+  // covered here.
   if (span.diskText === oldS && newRes.text === ti.new_string) return null;
 
   // Simulate the post-edit content for the exposure check. When the disk
@@ -260,8 +303,21 @@ async function rehydrateWrite(ti, view, io, hint) {
   const texts = [...new Set(view.pairs.map((pair) => pair.placeholder))].filter(
     (phText) => ti.content.includes(phText),
   );
-  // None of the file's redaction placeholders appear: content is literal.
-  if (texts.length === 0) return null;
+  // None of THIS file's redaction placeholders appear in the new content.
+  // isCandidate already guaranteed ti.content contains the hint prefix (e.g.
+  // "[REDACTED"), so an empty `texts` here means the content carries a
+  // placeholder-shaped string that names a secret from a DIFFERENT file or
+  // context (or a stale/mistyped one) — not literal prose. Persisting it
+  // verbatim would silently write "[REDACTED:…]" into the file where the
+  // model likely intended an actual secret value; deny instead.
+  if (texts.length === 0)
+    return {
+      deny:
+        `the ${hint}…] placeholder in the new content does not match any secret in ` +
+        `${ti.file_path}, so a whole-file Write cannot copy a placeholder from another ` +
+        `file or context; request the source file's content and rehydrate a same-file ` +
+        `Edit instead, or write the secret's real value directly`,
+    };
 
   let out = ti.content;
   const secrets = [];
@@ -363,19 +419,50 @@ export async function rehydrateRedacted(
   let content;
   try {
     content = io.readFile(toolInput.file_path);
-  } catch {
-    // Missing/unreadable target: an Edit fails on its own; a Write creates a
-    // new file whose placeholder text can only be literal content.
-    return null;
+  } catch (err) {
+    // The catch binding is `unknown` under strict TS; io's contract only
+    // promises Node-shaped read failures (a real `readFile`'s throw), so
+    // narrow once here rather than re-deriving the cast at every use below.
+    const nodeErr = /** @type {NodeJS.ErrnoException} */ (err);
+    // ENOENT (missing target): an Edit fails on its own; a Write creates a
+    // new file whose placeholder text can only be literal content. Pass
+    // through — this is the only read failure that genuinely means "nothing
+    // real is at risk here."
+    if (nodeErr?.code === "ENOENT") return null;
+    // Any OTHER read failure (EACCES, EMFILE, a transient I/O error, …) means
+    // the target very likely still EXISTS with real bytes on disk — the read
+    // failed, the file didn't vanish. A hinted call's content may carry
+    // placeholder text that must never be persisted literally over whatever
+    // secret is actually there, so fail closed with a deny instead of the
+    // silent pass-through above. A non-hinted call was never going to write a
+    // secret-shaped placeholder either way, and the underlying tool call will
+    // hit this exact same read error itself, so let it propagate rather than
+    // swallow an unexpected failure.
+    if (!hinted) throw err;
+    return {
+      deny:
+        `could not read ${toolInput.file_path} to rehydrate its secrets ` +
+        `(${nodeErr?.code ?? nodeErr?.message}); the file likely still exists, so writing ` +
+        `the placeholder text as-is risks overwriting a real secret. Retry the read, or ` +
+        `ask the user to make this change directly`,
+    };
   }
-  const { cleaned } = applyLayer1(content);
+  const { layer1Cleaned, cleaned } = layer1View(content);
   // A Layer-1-clean file's view differs from disk only at placeholders, which
   // a hint-free old_string cannot touch: a verbatim match needs no
   // translation, and a mismatch is an ordinary stale old_string Edit should
-  // report itself. Either way the redactor is skipped.
+  // report itself. Either way the redactor is skipped — and so is the
+  // exposure check (see the module doc's "Security invariant" scoping note):
+  // no placeholder is in play, so there is nothing this module could rehydrate
+  // to check for exposure.
   if (!hinted && cleaned === content) return null;
 
-  const deletions = alignDeletions(content, cleaned);
+  // alignDeletions needs a true subsequence of `content`; the lone-surrogate
+  // normalization folded into `cleaned` is a substitution, not a deletion
+  // (see layer1View), so deletions are computed against the pre-normalization
+  // text. The substitution is same-length, so the resulting offsets remain
+  // valid against `cleaned` throughout the rest of this module.
+  const deletions = alignDeletions(content, layer1Cleaned);
   const view = await io.redactMap(cleaned);
   if ("unmappable" in view) {
     if (!hinted) return null;
@@ -388,7 +475,11 @@ export async function rehydrateRedacted(
   // mis-anchor the edit (identical to a no-op for BMP-only files).
   view.pairs = pairsToUtf16(view.text, view.pairs);
   // View identical to disk: any placeholders in the input are literal text.
-  if (view.pairs.length === 0 && deletions.length === 0) return null;
+  // `cleaned === content` also rules out a lone-surrogate-only divergence
+  // (view.pairs/deletions alone would miss that, since the normalization is
+  // neither a redaction pair nor a Layer-1 deletion).
+  if (view.pairs.length === 0 && deletions.length === 0 && cleaned === content)
+    return null;
 
   return tool === "Edit"
     ? rehydrateEdit(

--- a/test/rehydrate.test.mjs
+++ b/test/rehydrate.test.mjs
@@ -73,10 +73,21 @@ const reRedact = (text) =>
 
 // ─── Gating: which calls the layer even looks at ─────────────────────────────
 
+/**
+ * An error shaped like Node's real `fs` failures: a `.code` property, not
+ * just a message string that happens to say "ENOENT".
+ * @param {string} code
+ */
+function fsError(code) {
+  const err = new Error(code);
+  err.code = code;
+  return err;
+}
+
 describe("rehydrate: gating", () => {
   const unreadableIo = {
     readFile: () => {
-      throw new Error("ENOENT");
+      throw fsError("ENOENT");
     },
     redactMap: () => {
       throw new Error("redactMap must not be reached");
@@ -141,7 +152,7 @@ describe("rehydrate: gating", () => {
     );
   });
 
-  it("passes through when the target file is unreadable", async () => {
+  it("passes through when the target file is missing (ENOENT)", async () => {
     assert.equal(
       await rehydrateRedacted(
         "Edit",
@@ -149,6 +160,68 @@ describe("rehydrate: gating", () => {
         unreadableIo,
       ),
       null,
+    );
+  });
+
+  it("denies a hinted call on a non-ENOENT read failure instead of passing the placeholder through", async () => {
+    // EACCES (or any other read failure) means the file almost certainly still
+    // EXISTS with real bytes on disk — unlike ENOENT. Silently passing this
+    // through would let a hinted Write persist literal "[REDACTED…]" text over
+    // whatever real secret is actually there.
+    const eaccesIo = {
+      readFile: () => {
+        throw fsError("EACCES");
+      },
+      redactMap: () => {
+        throw new Error("redactMap must not be reached");
+      },
+      redact: () => null,
+    };
+    const out = await rehydrateRedacted(
+      "Write",
+      { file_path: "/locked", content: `secret: ${PH}` },
+      eaccesIo,
+    );
+    assert.match(out.deny, /could not read \/locked/);
+    assert.match(out.deny, /EACCES/);
+    assert.equal(out.updatedInput, undefined);
+  });
+
+  it("falls back to the error message when a non-ENOENT failure carries no .code", async () => {
+    const noCodeIo = {
+      readFile: () => {
+        throw new Error("disk gremlins");
+      },
+      redactMap: () => {
+        throw new Error("redactMap must not be reached");
+      },
+      redact: () => null,
+    };
+    const out = await rehydrateRedacted(
+      "Write",
+      { file_path: "/weird", content: `secret: ${PH}` },
+      noCodeIo,
+    );
+    assert.match(out.deny, /disk gremlins/);
+  });
+
+  it("rethrows a non-ENOENT read failure for a non-hinted call instead of swallowing it", async () => {
+    const eaccesIo = {
+      readFile: () => {
+        throw fsError("EACCES");
+      },
+      redactMap: () => {
+        throw new Error("redactMap must not be reached");
+      },
+      redact: () => null,
+    };
+    await assert.rejects(
+      rehydrateRedacted(
+        "Edit",
+        { file_path: "/locked", old_string: "a", new_string: "b" },
+        eaccesIo,
+      ),
+      /EACCES/,
     );
   });
 
@@ -888,8 +961,22 @@ describe("rehydrate: Write", () => {
     assert.match(out.context, /are preserved in the written file/);
   });
 
-  it("passes through content whose placeholders match none of the file's", async () => {
-    assert.equal(await write(`docs about ${PH_PEM} markers\n`), null);
+  it("denies content whose placeholder does not match any of the file's (cross-file/stale placeholder)", async () => {
+    // PH_PEM starts with the default hint ("[REDACTED") but this file's own
+    // view only produced PH ("[REDACTED]") — PH_PEM names a secret from
+    // elsewhere (or a stale/mistyped placeholder), not literal prose. Writing
+    // it verbatim would silently persist "[REDACTED: Private Key]" into a file
+    // where the model likely intended a real secret value.
+    const out = await write(`docs about ${PH_PEM} markers\n`);
+    assert.match(
+      out.deny,
+      /\[REDACTED…\] placeholder in the new content does not match any secret/,
+    );
+    assert.match(
+      out.deny,
+      /cannot copy a placeholder from another file or context/,
+    );
+    assert.equal(out.updatedInput, undefined);
   });
 
   it("denies when distinct secrets share one placeholder text", async () => {
@@ -1161,5 +1248,90 @@ describe("rehydrate: astral chars before a placeholder", () => {
     );
     assert.equal(out.updatedInput.old_string, `${SECRET_A}\nDEBUG=1`);
     assert.equal(out.updatedInput.new_string, `${SECRET_A}\nDEBUG=0`);
+  });
+});
+
+// ─── Lone-surrogate normalization matches the model's real view ──────────────
+
+// output.mjs normalizes lone UTF-16 surrogates to U+FFFD right after Layer 1,
+// BEFORE redaction runs — so that is what the model actually sees. rehydrate
+// must re-derive that exact same text (Layer 1, then the same normalization)
+// before matching old_string/handing text to the redactor, or the model's
+// faithfully-copied old_string can never match and every edit near a lone
+// surrogate is permanently, unfixably denied (re-reading the file reproduces
+// the same mismatch every time).
+describe("rehydrate: lone-surrogate normalization", () => {
+  const LONE_HIGH = String.fromCharCode(0xd800); // unpaired high surrogate
+  const FFFD = String.fromCharCode(0xfffd);
+
+  it("rehydrates a hinted edit whose old_string copies the model's U+FFFD-normalized view across a lone surrogate", async () => {
+    const content = `PASSWORD=${SECRET_A}${LONE_HIGH}\nDEBUG=1\n`;
+    const io = liveIo(
+      content,
+      [{ value: SECRET_A, placeholder: PH }],
+      reRedact,
+    );
+    const out = await rehydrateRedacted(
+      "Edit",
+      {
+        file_path: "/f",
+        old_string: `PASSWORD=${PH}${FFFD}\nDEBUG=1`,
+        new_string: `PASSWORD=${PH}${FFFD}\nDEBUG=0`,
+      },
+      io,
+    );
+    // old_string is re-anchored to the real disk bytes (the raw surrogate).
+    assert.equal(
+      out.updatedInput.old_string,
+      `PASSWORD=${SECRET_A}${LONE_HIGH}\nDEBUG=1`,
+    );
+    // new_string only has its PLACEHOLDER substituted; the model-authored
+    // U+FFFD elsewhere in it is not a placeholder, so it is carried through
+    // verbatim rather than reverted to the raw surrogate.
+    assert.equal(
+      out.updatedInput.new_string,
+      `PASSWORD=${SECRET_A}${FFFD}\nDEBUG=0`,
+    );
+  });
+
+  it("re-anchors a hint-free edit across a lone surrogate with nothing else divergent", async () => {
+    // No secrets, no Layer-1-stripped bytes anywhere in the file — the ONLY
+    // divergence between disk and the model's view is the surrogate
+    // normalization. Before the fix this hit the "view identical to disk"
+    // early exit and passed through, so the edit (built from the model's
+    // actual U+FFFD view) would never match raw disk bytes.
+    const content = `add(a, b)${LONE_HIGH};\nDEBUG=1\n`;
+    const out = await rehydrateRedacted(
+      "Edit",
+      {
+        file_path: "/f",
+        old_string: `add(a, b)${FFFD};\nDEBUG=1`,
+        new_string: `add(a, b, c)${FFFD};\nDEBUG=1`,
+      },
+      liveIo(content),
+    );
+    // old_string is re-anchored to the real disk bytes (the raw surrogate).
+    assert.equal(
+      out.updatedInput.old_string,
+      `add(a, b)${LONE_HIGH};\nDEBUG=1`,
+    );
+    // new_string carries no placeholder here, so nothing is translated: it is
+    // the model-authored text verbatim (still U+FFFD, not the raw surrogate).
+    assert.equal(out.updatedInput.new_string, `add(a, b, c)${FFFD};\nDEBUG=1`);
+  });
+
+  it("does not spuriously deny as an ambiguous anchor when a lone surrogate sits inside the matched span", async () => {
+    // Regression guard for the anchor-ambiguity re-clean check: comparing a
+    // freshly re-cleaned disk span against a normalized view span must ALSO
+    // normalize the re-clean, or every lone-surrogate-crossing edit would be
+    // misdiagnosed as an unsound anchor and denied instead of rewritten.
+    const content = `A${LONE_HIGH}B\n`;
+    const out = await rehydrateRedacted(
+      "Edit",
+      { file_path: "/f", old_string: `A${FFFD}B`, new_string: "X" },
+      liveIo(content),
+    );
+    assert.equal(out.updatedInput.old_string, `A${LONE_HIGH}B`);
+    assert.equal(out.updatedInput.new_string, "X");
   });
 });


### PR DESCRIPTION
## Summary

Found via a multi-agent audit of `src/rehydrate.mjs`, a fail-closed module that re-anchors model Edits/Writes against the sanitized view back onto real bytes. Two logic fixes close real fail-open holes; one is a documentation scoping fix (deliberately not a logic change — see below).

## Changes

- `readFile` failures other than `ENOENT` (EACCES, EMFILE, transient I/O — cases where the file still exists with real bytes) were swallowed by a blanket `catch`, letting a hinted Write silently persist `[REDACTED:…]` placeholder text over a real secret. Now only `ENOENT` passes through; other errors deny (hinted) or propagate (non-hinted).
- A Write whose content carries a placeholder that doesn't match any secret in the *target* file (e.g. copied from a different file's view) was persisted as literal placeholder text. Now denied with an actionable reason.
- The model's re-derived view skipped the lone-surrogate → U+FFFD normalization `output.mjs` applies before the model ever sees the text, so an edit whose `old_string` faithfully copied what the model was shown near a lone surrogate hit a permanent, unfixable deny. Fixed by applying the same normalization in the re-derived view.
- **Documentation-only, per explicit decision**: the module's core "never expose a secret" invariant only ever inspected placeholder-derived secrets, so a relabel that never touches a placeholder (`password=` → `notes=`) was never covered. Rather than widening the exposure check (perf cost on every Edit, false-denial risk on large files, against the fail-open-on-ambiguity doctrine), the module doc and THREAT-MODEL.md now explicitly scope the invariant to placeholder-touching edits, with the tradeoff spelled out inline.

## Tests / verification

- New/expanded tests in `test/rehydrate.test.mjs` for the EACCES-deny path, cross-file placeholder-write deny, and lone-surrogate-adjacent edits (previously-denied case now succeeds).
- `pnpm test`: full `rehydrate*` suite (unit + property + fuzz) passes, 100% coverage on `rehydrate.mjs`. `pnpm lint` clean.

## Checklist

- [x] Commits follow Conventional Commits.
- [x] `pnpm test`, `pnpm lint` pass locally.
- [x] New tests pin the fixed invariants with unit + existing property/fuzz coverage.
- [x] No secrets in the diff.
- [x] CHANGELOG.md / package.json version untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PHTbVvQ5U3msna7wTsC4pf)_