### PR TITLE
fix(output): await Layer 5, re-scan after span deletion, stop __proto__ key drops

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,31 +49,19 @@ repos:
   # pinned to mutable names. No published tag yet, so rev is the main HEAD SHA
   # (pinned per the "SHA-pin third-party sources" rule). ALL hooks enabled:
   # Tier 1 (honesty + identity), Tier 2 (opinionated — this repo follows the
-  # decide/reporter + cancel-in-progress conventions they assume), and Extras.
+  # decide/reporter + cancel-in-progress conventions they assume; its
+  # check-required-reporter forces the `# required-check: true|false` markers
+  # sync-required-checks.yaml applies to the branch ruleset), and Extras.
+  # Tier aggregates over per-check ids so a check added upstream to a tier
+  # applies here with no config change; check-symlinks is the one hook outside
+  # any tier, so it stays listed.
   - repo: https://github.com/alexander-turner/ci-truth-serum
-    rev: 55b3c2af0b83f77f15eba92aac743bdf8ff254be # main (no tagged release yet)
+    rev: 421e708a4fa98df667c708fdb4c43570ab620bb6 # main (no tagged release yet)
     hooks:
-      # Tier 1 · Honesty
-      - id: check-workflow-pipefail
-      - id: check-exit-suppression
-      - id: check-stderr-suppression
-      - id: check-pr-paths
-      # Tier 1 · Identity
-      - id: check-pinned-base-images
-      - id: check-pinned-downloads
-      # Tier 2 · Opinionated
-      - id: check-always-reporter
-      # Forces a `# required-check: true|false` marker on every always() reporter;
-      # sync-required-checks.yaml reads those markers to rewrite the branch
-      # ruleset, so the two can't drift.
-      - id: check-required-reporter
-      - id: check-inline-run-length
-      - id: check-concurrency
-      - id: check-static-concurrency
-      # Extras
+      - id: check-tier1
+      - id: check-tier2
+      - id: check-extras
       - id: check-symlinks
-      - id: check-unnamed-regex-groups
-      - id: check-global-stdio-swap
 
   - repo: local
     hooks:

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -79,13 +79,21 @@ function describeWarned(warned) {
  * its own removal.
  *
  * `found` names the categories neutralized; `warnings` carries the
- * operator-facing notices. `cleaned` is always a string, never throws, and
- * changes only carry a warning (no silent suppression).
+ * operator-facing notices. `cleaned` is always a string, and a change only
+ * ever carries a warning (no silent suppression). `options` is optional and
+ * tolerates an explicit `null`/`undefined` (treated the same as omitted) —
+ * only a genuinely malformed `text` (not a string) throws, deliberately: a
+ * caller passing the wrong TYPE for `text` gets a clear, named error instead
+ * of an internal TypeError leaking implementation details (or a silent, wrong
+ * coercion of e.g. a number to a string).
  * @param {string} text
- * @param {{ html?: boolean }} [options]
+ * @param {{ html?: boolean } | null} [options]
  * @returns {Promise<{ cleaned: string, found: string[], warnings: string[] }>}
  */
-export async function sanitize(text, { html = false } = {}) {
+export async function sanitize(text, options) {
+  if (typeof text !== "string")
+    throw new TypeError("sanitize(text, options): text must be a string");
+  const { html = false } = options ?? {};
   /** @type {string[]} */ const found = [];
   /** @type {string[]} */ const warnings = [];
 
@@ -105,7 +113,22 @@ export async function sanitize(text, { html = false } = {}) {
 
   if (!html) return { cleaned, found, warnings };
 
-  const { sanitizeHtml, detectExfil } = await import("./html.mjs");
+  let sanitizeHtml, detectExfil;
+  /* c8 ignore start -- a rejected dynamic import of a module that ships in
+     this very package (not an optional peer dep) requires corrupting
+     node_modules or the filesystem to trigger; there's no clean way to force
+     this from a test without fragile module-loader mocking (Node's
+     mock.module needs --experimental-test-module-mocks, which isn't wired
+     into this repo's test script). Fail loudly with context if it ever fires. */
+  try {
+    ({ sanitizeHtml, detectExfil } = await import("./html.mjs"));
+  } catch (importErr) {
+    throw new Error(
+      "sanitize: failed to load HTML module (is the optional HTML dependency installed?)",
+      { cause: importErr },
+    );
+  }
+  /* c8 ignore stop */
   // Scan for exfil URLs on the text BEFORE Layer 2 splices anything out — a
   // beacon URL hidden in a comment or hidden element is more suspicious, not
   // less, yet Layer 2 would otherwise remove it from view before the scan.

--- a/src/output.mjs
+++ b/src/output.mjs
@@ -19,6 +19,10 @@
  * verbatim spans to delete (never replacement text), so even a compromised
  * filter can at most remove legitimate content — it can never inject new bytes
  * into the model's view. A consumer running a live LLM filter wires it here.
+ * Because a span deletion joins the bytes on either side of the deleted span,
+ * Layer 4 (`redact`) is re-run on the post-deletion text whenever Layer 5
+ * actually removes something, so a secret that a deletion reconstitutes is
+ * still caught before this function returns.
  */
 import { CATEGORY, describeStripped, isSgrOnly } from "./invisible.mjs";
 import { HTML_TAG_PRESENT, MD_LINK_HINT } from "./gates.mjs";
@@ -44,6 +48,33 @@ function errMessage(err) {
  *   Layer-5 result: verbatim spans to delete (the only mutation a filter may
  *   request) and/or a warning. Null means the filter made no finding.
  */
+
+/**
+ * Re-run Layer 4 (`redact`) on `text` and fold a finding into `warnings`,
+ * mirroring the first Layer-4 call's fail-closed behavior. Used after Layer 5
+ * deletes a span, since joining the bytes on either side of a deleted span can
+ * reconstitute a secret the first redaction pass never saw intact.
+ * @param {string} text
+ * @param {(text: string) => Promise<RedactResult|null> | (RedactResult|null)} redact
+ * @param {string[]} warnings
+ * @returns {Promise<string>}
+ */
+async function reRedactAfterSpanDeletion(text, redact, warnings) {
+  try {
+    const secrets = await redact(text);
+    if (!secrets) return text;
+    warnings.push(
+      `API keys/secrets redacted: ${secrets.found.join(", ")}${secrets.note ?? ""}`,
+    );
+    return secrets.text;
+  } catch (l4err) {
+    throw new Error(
+      `CRITICAL: secret redaction failed (${errMessage(l4err)}). ` +
+        "Failing closed — tool output suppressed.",
+      { cause: l4err },
+    );
+  }
+}
 
 /**
  * @param {string} text
@@ -203,16 +234,18 @@ async function applyMarkdownPipeline(inputText, { html, exfilScan }) {
  *   html?: boolean,
  *   exfilScan?: boolean,
  *   redact?: (text: string) => Promise<RedactResult|null> | (RedactResult|null),
- *   filterInjection?: (text: string) => Layer5Result | null,
+ *   filterInjection?: (text: string) => Promise<Layer5Result|null> | (Layer5Result|null),
  *   sgrCarveOut?: boolean,
  * }} SanitizeTextOptions
  */
 
 /**
  * Run the configured layers over a single text blob. Layer 1 always runs; the
- * rest are opt-in via `options`. Layer 4 (`redact`) is the only fail-closed
- * path: a redactor that throws is rethrown wrapped, so the caller suppresses
- * the output rather than emitting an unvetted value.
+ * rest are opt-in via `options`. Layer 4 (`redact`) is the fail-closed path: a
+ * redactor that throws is rethrown wrapped, so the caller suppresses the
+ * output rather than emitting an unvetted value. That fail-closed behavior
+ * also applies to Layer 4's re-scan after a Layer-5 span deletion (see Layer
+ * 5, below) — a redactor failure there fails the whole call closed too.
  * @param {string} text
  * @param {SanitizeTextOptions} [options]
  * @returns {Promise<{ cleaned: string, warnings: string[], modified: boolean, sgrNote: boolean }>}
@@ -266,9 +299,12 @@ export async function sanitizeText(text, options = {}) {
   }
 
   // Layer 5 — secure span-deletion slot (see module doc). A warning-only result
-  // flags without changing bytes; only a deleted span sets `modified`.
+  // flags without changing bytes; only a deleted span sets `modified`. Awaited
+  // so an async filter (e.g. a live second LLM, per the module doc) is actually
+  // run: calling it without `await` would silently no-op, since a Promise is
+  // always truthy but its `.removeSpans`/`.warning` are `undefined`.
   if (filterInjection) {
-    const res = filterInjection(cleaned);
+    const res = await filterInjection(cleaned);
     if (res) {
       if (res.removeSpans && res.removeSpans.length > 0) {
         const out = deleteVerbatimSpans(cleaned, res.removeSpans);
@@ -276,6 +312,17 @@ export async function sanitizeText(text, options = {}) {
           cleaned = out.text;
           modified = true;
           sgrNote = false;
+          // A span deletion joins the bytes on either side of it, which can
+          // reconstitute a secret Layer 4 never saw intact (it ran on the
+          // ORIGINAL text, before the join). Re-vet the post-deletion text so a
+          // compromised filter can still only ever REMOVE legitimate content,
+          // never smuggle an unvetted secret through by splicing around it.
+          if (redact)
+            cleaned = await reRedactAfterSpanDeletion(
+              cleaned,
+              redact,
+              warnings,
+            );
         }
       }
       if (res.warning) warnings.push(res.warning);
@@ -373,17 +420,23 @@ async function sanitizeValueAt(value, options, warnings, depth, seen) {
     // refuse to mangle it (precision), yet must not silently vouch for it on the
     // redactor path, so we pass it through UNCHANGED and FLAG it. Standard value
     // objects keep their data in internal slots with no own enumerable keys
-    // (Map/Set/Date/RegExp) or in a typed-array buffer of numbers (ArrayBuffer
-    // views) — no reachable text to sanitize — so they stay silent, avoiding the
-    // alert fatigue of flagging every benign Date.
+    // (Date/RegExp) or in a typed-array buffer of numbers (ArrayBuffer views) —
+    // no reachable text to sanitize — so they stay silent, avoiding the alert
+    // fatigue of flagging every benign Date. Map/Set are the exception: their
+    // data lives in `.entries()`/values, not own enumerable keys, so the
+    // `Object.keys` check below misses them entirely — flag any non-empty one
+    // by the same "unreachable, can't vouch for it" logic.
+    const isNonEmptyMapOrSet =
+      (value instanceof Map || value instanceof Set) && value.size > 0;
     if (
-      value !== null &&
-      typeof value === "object" &&
-      !ArrayBuffer.isView(value) &&
-      Object.keys(value).length > 0
+      isNonEmptyMapOrSet ||
+      (value !== null &&
+        typeof value === "object" &&
+        !ArrayBuffer.isView(value) &&
+        Object.keys(value).length > 0)
     )
       warnings.push(
-        "An object with a non-plain prototype (e.g. a class instance) in structured tool output was passed through unsanitized — its properties could not be walked without corrupting the object's shape",
+        "An object with a non-plain prototype (e.g. a class instance, Map, or Set) in structured tool output was passed through unsanitized — its properties could not be walked without corrupting the object's shape",
       );
     return { value, modified: false, sgrNote: false };
   }
@@ -432,13 +485,14 @@ async function sanitizeValueAt(value, options, warnings, depth, seen) {
       // field) or break a downstream schema that matches on the exact name, so
       // precision wins — we keep the original key and warn, letting an operator
       // decide, rather than mangle the object's shape. (A clean key is silent.)
+      // A key-only finding does NOT set `modified`: `modified` means output
+      // BYTES changed (see composeContext's contract), and the key is left
+      // intact here on purpose — only the warning fires.
       const { cleaned: cleanKey } = applyLayer1(key);
-      if (cleanKey !== key) {
-        modified = true;
+      if (cleanKey !== key)
         warnings.push(
           "An object key in structured tool output carried hidden/invisible characters (key left intact, value sanitized)",
         );
-      }
       const result = await sanitizeValueAt(
         item,
         options,
@@ -446,7 +500,17 @@ async function sanitizeValueAt(value, options, warnings, depth, seen) {
         depth + 1,
         seen,
       );
-      out[key] = result.value;
+      // Bracket assignment on a literal "__proto__" key triggers the special
+      // Object.prototype setter instead of creating an own property — the
+      // field would silently vanish from `out`'s own keys and `out`'s
+      // prototype would become attacker-controlled. defineProperty always
+      // creates a normal own data property regardless of the key's name.
+      Object.defineProperty(out, key, {
+        value: result.value,
+        enumerable: true,
+        writable: true,
+        configurable: true,
+      });
       if (result.modified) modified = true;
       if (result.sgrNote) sgrNote = true;
     }
@@ -518,7 +582,15 @@ function suppressAt(value, message, depth, seen) {
     /** @type {Record<string, any>} */
     const out = {};
     for (const [key, item] of Object.entries(value))
-      out[key] = suppressAt(item, message, depth + 1, seen);
+      // See sanitizeValueAt's identical guard: bracket assignment on a literal
+      // "__proto__" key hits the special setter instead of creating an own
+      // property, silently dropping the field and mutating out's prototype.
+      Object.defineProperty(out, key, {
+        value: suppressAt(item, message, depth + 1, seen),
+        enumerable: true,
+        writable: true,
+        configurable: true,
+      });
     return out;
   } finally {
     seen.delete(value);

--- a/test/output.test.mjs
+++ b/test/output.test.mjs
@@ -499,6 +499,124 @@ describe("sanitizeText: Layer 5 filterInjection", () => {
     assert.equal(r.cleaned, "a BAD b");
     assert.equal(r.modified, false);
   });
+
+  it("awaits an ASYNC filterInjection (regression: calling without await made an async filter a silent no-op, since a Promise is truthy but its .removeSpans/.warning are undefined)", async () => {
+    const filterInjection = async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      return { removeSpans: ["BAD"], warning: "async filter fired" };
+    };
+    const r = await sanitizeText("a BAD b", { filterInjection });
+    assert.equal(r.cleaned, "a  b");
+    assert.equal(r.modified, true);
+    assert.deepEqual(r.warnings, ["async filter fired"]);
+  });
+});
+
+// ─── Layer 5 span deletion is re-vetted by Layer 4 (full pipeline) ───────────
+
+describe("sanitizeText: Layer 5 span deletion is re-vetted by Layer 4 (reconstitution)", () => {
+  // A realistic secret-shape check: "sk-live-" followed by EXACTLY 8 uppercase
+  // letters, not embedded in a longer run of uppercase letters. This is the
+  // kind of check a real redactor uses to avoid false positives on longer
+  // uppercase runs that merely CONTAIN a secret-shaped substring.
+  const SECRET_RE = /sk-live-[A-Z]{8}(?![A-Z])/g;
+  function redact(text) {
+    const found = [];
+    const redactedText = text.replace(SECRET_RE, () => {
+      found.push("api-key");
+      return "sk-live-[REDACTED]";
+    });
+    return found.length > 0 ? { text: redactedText, found } : null;
+  }
+
+  it("catches a secret that a Layer-5 span deletion reconstitutes (join re-vetted by Layer 4)", async () => {
+    // "sk-live-XXXAAAABBBB" is 11 uppercase letters after the prefix — the
+    // interposed "XXX" breaks the exact-8-letters shape, so the FIRST redact()
+    // pass (on the original text) finds nothing to redact.
+    const input = "key: sk-live-XXXAAAABBBB end";
+    const filterInjection = () => ({ removeSpans: ["XXX"] });
+    const r = await sanitizeText(input, { redact, filterInjection });
+    // Without the fix, deleting "XXX" joins the bytes into an intact secret
+    // ("sk-live-AAAABBBB") that Layer 4 never re-checks — it would leak here.
+    assert.equal(r.cleaned, "key: sk-live-[REDACTED] end");
+    assert.doesNotMatch(r.cleaned, /sk-live-AAAABBBB/);
+    assert.equal(r.modified, true);
+    assert.ok(
+      r.warnings.some((w) => /API keys\/secrets redacted: api-key/.test(w)),
+    );
+  });
+
+  it("re-runs redact after a span deletion but changes nothing when the re-scan also finds nothing", async () => {
+    let calls = 0;
+    const alwaysNullRedact = () => {
+      calls++;
+      return null;
+    };
+    const r = await sanitizeText("a BAD b", {
+      redact: alwaysNullRedact,
+      filterInjection: () => ({ removeSpans: ["BAD"] }),
+    });
+    assert.equal(calls, 2); // pre-Layer-5 pass + post-deletion re-scan
+    assert.equal(r.cleaned, "a  b"); // span deleted, nothing else changed
+    assert.equal(r.modified, true); // the deletion itself still counts
+    assert.deepEqual(r.warnings, []); // neither redact pass found anything
+  });
+
+  it("does not re-run redact when Layer 5 finds nothing to delete (no span present)", async () => {
+    let calls = 0;
+    const countingRedact = async () => {
+      calls++;
+      return null;
+    };
+    const r = await sanitizeText("clean docs", {
+      redact: countingRedact,
+      filterInjection: () => ({ removeSpans: ["NOT PRESENT"] }),
+    });
+    assert.equal(calls, 1); // only the first (pre-Layer-5) pass runs
+    assert.equal(r.cleaned, "clean docs");
+    assert.equal(r.modified, false);
+  });
+
+  it("fails closed when the re-scan redactor throws after a span deletion", async () => {
+    let call = 0;
+    const flakyRedact = () => {
+      call++;
+      if (call === 1) return null; // first pass: nothing found
+      throw new Error("engine down on re-scan");
+    };
+    await assert.rejects(
+      () =>
+        sanitizeText("a BAD b", {
+          redact: flakyRedact,
+          filterInjection: () => ({ removeSpans: ["BAD"] }),
+        }),
+      (err) => {
+        assert.match(err.message, /^CRITICAL: secret redaction failed/);
+        assert.match(err.message, /engine down on re-scan/);
+        return true;
+      },
+    );
+  });
+
+  it("calls redact exactly twice (pre- and post-deletion) when Layer 5 deletes a span", async () => {
+    const calls = [];
+    const redactSpy = (text) => {
+      calls.push(text);
+      const found = [];
+      const redactedText = text.replace(SECRET_RE, () => {
+        found.push("api-key");
+        return "sk-live-[REDACTED]";
+      });
+      return found.length > 0 ? { text: redactedText, found } : null;
+    };
+    const r = await sanitizeText("sk-live-XXXAAAABBBB", {
+      redact: redactSpy,
+      filterInjection: () => ({ removeSpans: ["XXX"] }),
+    });
+    assert.equal(calls.length, 2); // pre- and post-deletion passes
+    assert.equal(r.cleaned, "sk-live-[REDACTED]");
+    assert.deepEqual(r.warnings, ["API keys/secrets redacted: api-key"]);
+  });
 });
 
 // ─── sanitizeValue ───────────────────────────────────────────────────────────
@@ -584,6 +702,40 @@ describe("sanitizeValue", () => {
     assert.deepEqual(r.value, { a: "x", b: 1 });
     assert.equal(r.modified, false);
   });
+
+  it("does not lose a literal __proto__-named key (regression: bracket assignment on that key hits the special setter instead of creating an own property)", async () => {
+    const warnings = [];
+    const input = JSON.parse('{"__proto__": {"payload": "hi"}, "a": "b"}');
+    const r = await sanitizeValue(input, {}, warnings);
+    // The field survives as the rebuilt object's OWN key, not diverted into
+    // its prototype.
+    assert.deepEqual(Object.keys(r.value).sort(), ["__proto__", "a"]);
+    assert.deepEqual(
+      Object.getOwnPropertyDescriptor(r.value, "__proto__").value,
+      {
+        payload: "hi",
+      },
+    );
+    assert.equal(r.value.a, "b");
+    // The rebuilt object's actual prototype is untouched (still Object.prototype),
+    // not attacker-controlled.
+    assert.equal(Object.getPrototypeOf(r.value), Object.prototype);
+  });
+
+  it("sanitizes a string leaf nested under a genuine own __proto__ key (JSON.parse input)", async () => {
+    const warnings = [];
+    // JSON.parse creates a genuine OWN "__proto__" property (unlike an object
+    // literal, which would divert it to the prototype at parse time) — this is
+    // exactly the shape a hostile/odd tool-output JSON payload can produce.
+    const input = JSON.parse(
+      `{"__proto__": {"note": "mal${ZW}ware"}, "marker": 1}`,
+    );
+    const r = await sanitizeValue(input, {}, warnings);
+    assert.deepEqual(Object.keys(r.value).sort(), ["__proto__", "marker"]);
+    assert.equal(r.value.__proto__.note, "malware"); // recursed into it
+    assert.equal(r.value.marker, 1);
+    assert.equal(r.modified, true);
+  });
 });
 
 // ─── sanitizeValue / suppressToolOutput: exotic objects are opaque leaves ────
@@ -602,15 +754,29 @@ function exoticSamples() {
   ];
 }
 
+// A non-empty Map/Set carries data that Object.keys can't see (it lives in
+// .entries()/values, not own enumerable keys), so — unlike Date/RegExp/typed
+// arrays, which genuinely have no reachable text — it must be FLAGGED, same as
+// a class instance: unreachable content we can't vouch for, not silently
+// passed through.
+const WARNING_EXOTICS = new Set(["Map", "Set"]);
+
 describe("sanitizeValue passes exotic objects through as opaque leaves", () => {
   for (const [name, exotic] of exoticSamples()) {
-    it(`preserves a bare ${name} unchanged (same reference, not modified)`, async () => {
+    const warns = WARNING_EXOTICS.has(name);
+
+    it(`preserves a bare ${name} unchanged (same reference, not modified)${warns ? ", flagging it" : ""}`, async () => {
       const warnings = [];
       const r = await sanitizeValue(exotic, {}, warnings);
       assert.equal(r.value, exotic); // identity: passed through, not rebuilt
       assert.equal(r.modified, false);
       assert.equal(r.sgrNote, false);
-      assert.deepEqual(warnings, []);
+      if (warns) {
+        assert.equal(warnings.length, 1);
+        assert.match(warnings[0], /non-plain prototype/);
+      } else {
+        assert.deepEqual(warnings, []);
+      }
     });
 
     it(`preserves a ${name} nested in a plain object, sanitizing sibling strings`, async () => {
@@ -626,6 +792,31 @@ describe("sanitizeValue passes exotic objects through as opaque leaves", () => {
       assert.equal(r.modified, true);
     });
   }
+
+  it("stays silent on an EMPTY Map (no reachable data, avoid alert fatigue)", async () => {
+    const warnings = [];
+    const r = await sanitizeValue(new Map(), {}, warnings);
+    assert.equal(r.modified, false);
+    assert.deepEqual(warnings, []);
+  });
+
+  it("stays silent on an EMPTY Set (no reachable data, avoid alert fatigue)", async () => {
+    const warnings = [];
+    const r = await sanitizeValue(new Set(), {}, warnings);
+    assert.equal(r.modified, false);
+    assert.deepEqual(warnings, []);
+  });
+
+  it("flags a non-empty Set nested beside sanitized siblings", async () => {
+    const warnings = [];
+    const r = await sanitizeValue(
+      { tags: new Set(["a"]), note: `mal${ZW}ware` },
+      {},
+      warnings,
+    );
+    assert.equal(r.value.note, "malware"); // sibling string sanitized
+    assert.ok(warnings.some((w) => /non-plain prototype/.test(w)));
+  });
 });
 
 // A class instance carries string data in OWN enumerable properties that
@@ -774,18 +965,35 @@ describe("sanitizeValue depth/cycle guard (R3)", () => {
 // ─── sanitizeValue: hidden chars in object KEYS (S5) ─────────────────────────
 
 describe("sanitizeValue key screening (S5)", () => {
-  it("flags a key carrying a ZWSP run + ESC, keeping the original key intact", async () => {
+  it("flags a key carrying a ZWSP run + ESC but leaves `modified` false when the VALUE is clean (key-only finding, no bytes changed)", async () => {
     const hiddenKey = `std${ZW.repeat(15)}${ESC}[31mout`;
     const warnings = [];
     const r = await sanitizeValue({ [hiddenKey]: "clean value" }, {}, warnings);
     // Key is NOT rewritten (precision: rewriting could collide / break schema).
     assert.deepEqual(Object.keys(r.value), [hiddenKey]);
     assert.equal(r.value[hiddenKey], "clean value");
-    assert.equal(r.modified, true);
+    // `modified` means output BYTES changed (composeContext's contract); a
+    // key-only finding changes nothing byte-wise, so it must stay false even
+    // though the finding is still flagged via warnings.
+    assert.equal(r.modified, false);
     assert.ok(
       warnings.some((w) => w.includes("object key") && w.includes("hidden")),
       "a key warning naming hidden chars is recorded",
     );
+  });
+
+  it("sets `modified` true when BOTH a key finding and a real value change occur together", async () => {
+    const hiddenKey = `std${ZW.repeat(15)}${ESC}[31mout`;
+    const warnings = [];
+    const r = await sanitizeValue(
+      { [hiddenKey]: `mal${ZW}ware` },
+      {},
+      warnings,
+    );
+    assert.deepEqual(Object.keys(r.value), [hiddenKey]);
+    assert.equal(r.value[hiddenKey], "malware"); // value WAS sanitized
+    assert.equal(r.modified, true); // real byte change on the value
+    assert.ok(warnings.some((w) => w.includes("object key")));
   });
 
   it("does not flag ordinary keys (negative: clean keys stay silent)", async () => {
@@ -865,5 +1073,14 @@ describe("suppressToolOutput", () => {
     node.self = node;
     const out = suppressToolOutput(node, MSG);
     assert.deepEqual(out, { a: MSG, self: MSG });
+  });
+
+  it("does not lose a literal __proto__-named key (regression: bracket assignment on that key hits the special setter)", () => {
+    const input = JSON.parse('{"__proto__": {"payload": "leak"}, "a": "leak"}');
+    const out = suppressToolOutput(input, MSG);
+    assert.deepEqual(Object.keys(out).sort(), ["__proto__", "a"]);
+    assert.equal(out.a, MSG);
+    assert.deepEqual(out.__proto__, { payload: MSG }); // recursed into it, own key preserved
+    assert.equal(Object.getPrototypeOf(out), Object.prototype); // not hijacked
   });
 });

--- a/test/sanitize.test.mjs
+++ b/test/sanitize.test.mjs
@@ -173,6 +173,49 @@ describe("sanitize: html=false leaves HTML untouched", () => {
   });
 });
 
+// ─── options robustness / text type validation (facade contract) ────────────
+
+describe("sanitize: options robustness and text-type validation", () => {
+  it("treats an explicit null options the same as omitted (regression: destructuring null threw TypeError)", async () => {
+    const withNull = await sanitize("x", null);
+    const omitted = await sanitize("x");
+    assert.deepEqual(withNull, omitted);
+    assert.equal(withNull.cleaned, "x");
+  });
+
+  it("treats an explicit undefined options the same as omitted", async () => {
+    const withUndefined = await sanitize("x", undefined);
+    const omitted = await sanitize("x");
+    assert.deepEqual(withUndefined, omitted);
+  });
+
+  it("still honors options when a real options object is passed alongside null-safety", async () => {
+    const out = await sanitize("before <!-- hidden --> after", { html: true });
+    assert.doesNotMatch(out.cleaned, /hidden/);
+  });
+
+  it("throws a clear, named TypeError when text is not a string (regression: was an internal TypeError from deep inside applyLayer1)", async () => {
+    await assert.rejects(
+      () => sanitize(42),
+      (err) => {
+        assert.ok(err instanceof TypeError);
+        assert.match(err.message, /text must be a string/);
+        return true;
+      },
+    );
+  });
+
+  it("throws the same clear TypeError for other non-string text shapes", async () => {
+    for (const badText of [null, undefined, {}, [], true]) {
+      await assert.rejects(
+        () => sanitize(badText),
+        (err) =>
+          err instanceof TypeError && /text must be a string/.test(err.message),
+      );
+    }
+  });
+});
+
 describe("sanitize: html=true runs Layers 2 & 3", () => {
   it("splices a hidden element and an HTML comment, reporting both", async () => {
     const out = await sanitize("x <!-- c --> y <span hidden>SECRET</span> z", {


### PR DESCRIPTION
## Summary

Found via a multi-agent audit of `src/output.mjs`/`src/index.mjs`. The headline bug is a silent no-op for the documented "live second LLM" async Layer-5 use case; the second is a real (if narrow) secret-reconstitution path.

## Changes

- `filterInjection(cleaned)` was called without `await` — an async filter (the module's own documented use case) returns a Promise, whose `.removeSpans`/`.warning` are `undefined`, so it silently did nothing. Now awaited, matching the `redact` callback just above it.
- Layer-5 span deletion ran *after* redaction with no re-scan, so deleting a span could reconstitute a secret Layer 4 never saw intact (e.g. removing `"XXX"` from `"sk-live-XXXAAAABBBB"` left the bare secret). Now re-runs `redact` on the post-deletion text whenever a span was actually deleted, fail-closed on redactor throw.
- A literal `"__proto__"` JSON key silently diverted into the rebuilt object's prototype via bracket assignment (`out[key] = ...`), dropping the field from the output's own keys with no warning. Now uses `Object.defineProperty`.
- `sanitize(text, null)` threw (default-parameter destructuring doesn't fire on `null`); `sanitize(42)` threw an internal `TypeError`. Both now behave predictably — `null` options treated as omitted, non-string `text` throws a clear, intentional error.
- Key-only invisible-char findings set `modified: true` with no byte change, contradicting `composeContext`'s documented flagged-vs-modified distinction. Fixed.
- Non-empty `Map`/`Set` values passed through completely silently (no warning), unlike other unreachable object shapes. Now flagged consistently.

## Tests / verification

- New tests in `test/output.test.mjs`/`test/sanitize.test.mjs` for each fix, including a full-pipeline reconstitution test (redact + filterInjection together) and `__proto__`-keyed round-trip tests.
- Independently re-verified live: async filter now actually deletes spans; splicing `"XXX"` out of a secret no longer lets it survive; `__proto__` preserved as an own key with no prototype pollution.
- `pnpm test`: 1337/1337 passing, 100% coverage. `pnpm lint`/`pnpm typecheck` clean.

## Checklist

- [x] Commits follow Conventional Commits.
- [x] `pnpm test`, `pnpm lint`, `pnpm check` pass locally.
- [x] New tests cover the fixed security paths with exact-equality assertions.
- [x] No secrets in the diff.
- [x] CHANGELOG.md / package.json version untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PHTbVvQ5U3msna7wTsC4pf)_