### PR TITLE
fix(confusables,instructions): stop crashing on prototype-named tools and aborting on escaping symlinks

### DIFF
--- a/src/confusables.mjs
+++ b/src/confusables.mjs
@@ -166,7 +166,7 @@ export function normalizeConfusables(
   toolInput,
   { scan, fields = DEFAULT_FIELDS },
 ) {
-  const keys = fields[tool];
+  const keys = Object.hasOwn(fields, tool) ? fields[tool] : undefined;
   if (!keys || toolInput === null || toolInput === undefined) return null;
 
   // ASCII fast-path: only a field carrying a non-ASCII code unit can hold a

--- a/src/instructions.mjs
+++ b/src/instructions.mjs
@@ -172,26 +172,35 @@ function isContained(realRoot, realChild) {
 
 /**
  * Classify a glob match for containment: resolve it to a real (symlink-
- * followed) path and decide whether to keep, drop, or reject it. Two failure
- * modes are kept distinct:
+ * followed) path and decide whether to keep, drop, or reject it. Three
+ * outcomes are kept distinct:
  *
- *   - The realpath ESCAPES `realRoot` → THROW. A scanner pointed outside its
- *     own tree is a caller misconfiguration that must surface loudly, not a
- *     file silently skipped while the caller believes it was scanned.
+ *   - The realpath is contained in `realRoot` → KEEP.
+ *   - The match is contained LEXICALLY (the glob pattern itself, followed
+ *     literally with no symlink resolution, never leaves `literalRoot`) but its
+ *     REALPATH escapes `realRoot` — an in-tree symlink (e.g. a planted
+ *     `CLAUDE.md -> /etc/passwd`) whose target lives outside the tree → SKIP.
+ *     One planted symlink must not abort scanning every other instruction
+ *     file; treat it like the existing dangling-symlink case.
+ *   - The match ESCAPES LEXICALLY — the glob pattern itself reaches outside
+ *     `literalRoot` via `..` or an absolute path outside the tree, with no
+ *     symlink involved → THROW. That is a caller misconfiguration (a scanner
+ *     pointed outside its own tree) that must surface loudly, not be silently
+ *     skipped.
  *   - The path cannot be resolved at all (ENOENT/EACCES — a dangling symlink or
  *     unreadable entry that still lives inside the tree) → return false to SKIP
  *     it, matching scanInstructionFiles' existing skip-on-unreadable behavior.
- *     A stale symlink in a project must not abort scanning every other file.
  *
  * A genuine resolution failure is never allowed to masquerade as a
  * containment pass: an unresolvable path is skipped, only a successfully
- * resolved in-tree path returns true.
+ * resolved path is classified as kept/skipped/thrown above.
  * @param {string} absPath  absolute path to a glob match
  * @param {string} realRoot  realpath of the scan root
+ * @param {string} literalRoot  `cwd`, resolved but NOT symlink-followed
  * @param {string} pattern  the glob that produced this match
- * @returns {boolean} true to keep the match, false to skip an unresolvable one
+ * @returns {boolean} true to keep the match, false to skip it
  */
-function keepContained(absPath, realRoot, pattern) {
+function keepContained(absPath, realRoot, literalRoot, pattern) {
   let real;
   try {
     real = realpathSync(absPath);
@@ -199,6 +208,10 @@ function keepContained(absPath, realRoot, pattern) {
     return false; // dangling/unreadable in-cwd match: skip, do not abort
   }
   if (isContained(realRoot, real)) return true;
+  // The glob pattern itself never left the scan root lexically, so the escape
+  // is caused by an in-tree symlink resolving outside the tree, not by the
+  // caller's glob configuration. Skip this one match, do not abort the scan.
+  if (isContained(literalRoot, absPath)) return false;
   throw new Error(
     `instruction-file path escapes scan root: pattern ${JSON.stringify(
       pattern,
@@ -213,17 +226,20 @@ function keepContained(absPath, realRoot, pattern) {
  * `node_modules`. The glob set is the caller's instruction-file convention.
  *
  * Containment is enforced per match (see {@link keepContained}): a match whose
- * realpath escapes `cwd` — via `..`, an absolute-path glob, or a symlink
- * pointing outside — THROWS, since reaching outside the tree is a caller
- * misconfiguration. A match that simply cannot be resolved (a dangling symlink
- * or unreadable entry inside the tree) is SKIPPED, so one stale symlink never
- * aborts scanning the rest of the project.
+ * glob pattern itself escapes `cwd` — via `..` or an absolute-path glob
+ * outside the tree — THROWS, since reaching outside the tree is a caller
+ * misconfiguration. A match that lexically stays inside `cwd` but resolves
+ * (via an in-tree symlink) to a target outside the tree, or that simply
+ * cannot be resolved (a dangling symlink or unreadable entry inside the
+ * tree), is SKIPPED, so one bad symlink never aborts scanning the rest of the
+ * project.
  * @param {string[]} globs
  * @param {{ cwd?: string }} [options]
  * @returns {string[]}
  */
 export function findInstructionFiles(globs, { cwd = process.cwd() } = {}) {
-  const realRoot = realpathSync(resolve(cwd));
+  const literalRoot = resolve(cwd);
+  const realRoot = realpathSync(literalRoot);
   const seen = new Set();
   for (const pattern of globs)
     for (const name of globSync(pattern, {
@@ -234,7 +250,8 @@ export function findInstructionFiles(globs, { cwd = process.cwd() } = {}) {
       // cwd-relative names otherwise; joining an already-absolute name would
       // double the prefix into a nonexistent path (the absolute-glob miss bug).
       const absPath = isAbsolute(name) ? name : join(cwd, name);
-      if (keepContained(absPath, realRoot, pattern)) seen.add(absPath);
+      if (keepContained(absPath, realRoot, literalRoot, pattern))
+        seen.add(absPath);
     }
   return [...seen];
 }

--- a/test/confusables.test.mjs
+++ b/test/confusables.test.mjs
@@ -403,6 +403,20 @@ describe("normalizeConfusables: null cases", () => {
     );
   });
 
+  // An MCP tool name is attacker/third-party influenced. `fields` (typically
+  // DEFAULT_FIELDS) is a plain object literal, so a tool literally named
+  // "constructor" etc. resolves through Object.prototype to a truthy builtin
+  // function — without an own-property guard, `keys.filter(...)` a few lines
+  // later throws `keys.filter is not a function` instead of returning null
+  // like any other unrecognized tool name.
+  for (const tool of ["constructor", "toString", "hasOwnProperty", "__proto__"])
+    it(`returns null (does not throw) for the Object.prototype-named tool "${tool}"`, () => {
+      assert.equal(
+        normalizeConfusables(tool, { command: `c${CYR_A}t` }, { scan }),
+        null,
+      );
+    });
+
   for (const [name, toolInput] of [
     ["null toolInput", null],
     ["undefined toolInput", undefined],

--- a/test/instructions.test.mjs
+++ b/test/instructions.test.mjs
@@ -536,16 +536,43 @@ describe("symlink containment", () => {
     rmSync(outsideDir, { recursive: true, force: true });
   });
 
-  it("THROWS when a symlinked dir inside cwd resolves to a file outside cwd", () => {
+  it("SKIPS a symlinked dir inside cwd that resolves outside cwd, without aborting the scan", () => {
     // outsideDir/.claude/skills/evil/SKILL.md, reached via tmpDir/.claude -> outsideDir/.claude
     const outClaudeSkill = join(outsideDir, ".claude", "skills", "evil");
     mkdirSync(outClaudeSkill, { recursive: true });
     writeFileSync(join(outClaudeSkill, "SKILL.md"), "payload\n");
     symlinkSync(join(outsideDir, ".claude"), join(tmpDir, ".claude"), "dir");
+    // A legitimate instruction file sits alongside the escaping symlink; it
+    // must still be found and scanned even though the symlink is excluded.
+    writeFileSync(
+      join(tmpDir, "CLAUDE.md"),
+      `# h\n${tagChars("payload xyz123")}\n`,
+    );
+    const found = findInstructionFiles(GLOBS, { cwd: tmpDir });
+    assert.deepEqual(
+      found,
+      [join(tmpDir, "CLAUDE.md")],
+      "the escaping symlink is excluded, the real in-tree file is still found",
+    );
+    const out = scanInstructionFiles(GLOBS, { cwd: tmpDir });
+    assert.deepEqual(
+      out.map((e) => e.file),
+      ["CLAUDE.md"],
+      "one planted symlink must not abort scanning the rest of the project",
+    );
+    assert.equal(out[0].findings[0].decoded, "payload xyz123");
+  });
+
+  it("still THROWS for a literal `..`/absolute glob escape even alongside symlinks (unchanged)", () => {
+    // Sanity check that the lexical-escape THROW path (bug #1 above) is
+    // untouched by the symlink-target-escape SKIP path added for bug #2: a
+    // glob pattern that itself reaches outside cwd is still a caller
+    // misconfiguration, regardless of any symlink elsewhere in the tree.
+    writeFileSync(join(outsideDir, "secret.md"), "top secret\n");
+    const rel = join("..", `${outsideDir.split("/").pop()}`, "secret.md");
     assert.throws(
-      () => findInstructionFiles(GLOBS, { cwd: tmpDir }),
+      () => findInstructionFiles([rel], { cwd: tmpDir }),
       /escapes scan root/,
-      "a symlinked dir escaping cwd must be caught by the realpath check",
     );
   });
 


### PR DESCRIPTION
## Summary

Two small availability bugs found via audit: an MCP tool literally named `constructor` crashes the confusables sanitizer, and a single planted symlink can abort instruction-file scanning entirely.

## Changes

- `normalizeConfusables(tool, ...)` looked up `fields[tool]`; for `tool` in `{"constructor", "toString", "hasOwnProperty", ...}` this resolves through `Object.prototype` to a function instead of `undefined`, and the code then called `.filter()` on it, throwing. Tool names are third-party/attacker-influenced, so this is a real crash surface. Fixed with an own-property-safe lookup.
- `findInstructionFiles` threw on a matched symlink whose realpath resolves outside the scan root, aborting the scan of *every other* instruction file in the same call — inconsistent with the existing graceful skip for a dangling symlink. Now skips (doesn't scan) an escaping symlink the same way, without aborting the rest of the scan.

## Tests / verification

- New tests covering `'constructor'`/`'toString'`/`'hasOwnProperty'`/`'__proto__'` tool names returning `null` instead of throwing, and a scan with an in-tree symlink escaping the root completing successfully for the other legitimate files.
- Full `confusables*`/`instructions*` test suites (unit + property + fuzz) pass. `pnpm lint` clean.

## Checklist

- [x] Commits follow Conventional Commits.
- [x] `pnpm test`, `pnpm lint` pass locally.
- [x] New tests pin both fixed behaviors.
- [x] No secrets in the diff.
- [x] CHANGELOG.md / package.json version untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PHTbVvQ5U3msna7wTsC4pf)_