### PR TITLE
fix(python): harden the secrets daemon against a single-client DoS and permission races

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,31 +49,19 @@ repos:
   # pinned to mutable names. No published tag yet, so rev is the main HEAD SHA
   # (pinned per the "SHA-pin third-party sources" rule). ALL hooks enabled:
   # Tier 1 (honesty + identity), Tier 2 (opinionated — this repo follows the
-  # decide/reporter + cancel-in-progress conventions they assume), and Extras.
+  # decide/reporter + cancel-in-progress conventions they assume; its
+  # check-required-reporter forces the `# required-check: true|false` markers
+  # sync-required-checks.yaml applies to the branch ruleset), and Extras.
+  # Tier aggregates over per-check ids so a check added upstream to a tier
+  # applies here with no config change; check-symlinks is the one hook outside
+  # any tier, so it stays listed.
   - repo: https://github.com/alexander-turner/ci-truth-serum
-    rev: 55b3c2af0b83f77f15eba92aac743bdf8ff254be # main (no tagged release yet)
+    rev: 421e708a4fa98df667c708fdb4c43570ab620bb6 # main (no tagged release yet)
     hooks:
-      # Tier 1 · Honesty
-      - id: check-workflow-pipefail
-      - id: check-exit-suppression
-      - id: check-stderr-suppression
-      - id: check-pr-paths
-      # Tier 1 · Identity
-      - id: check-pinned-base-images
-      - id: check-pinned-downloads
-      # Tier 2 · Opinionated
-      - id: check-always-reporter
-      # Forces a `# required-check: true|false` marker on every always() reporter;
-      # sync-required-checks.yaml reads those markers to rewrite the branch
-      # ruleset, so the two can't drift.
-      - id: check-required-reporter
-      - id: check-inline-run-length
-      - id: check-concurrency
-      - id: check-static-concurrency
-      # Extras
+      - id: check-tier1
+      - id: check-tier2
+      - id: check-extras
       - id: check-symlinks
-      - id: check-unnamed-regex-groups
-      - id: check-global-stdio-swap
 
   - repo: local
     hooks:

--- a/python/agent_input_sanitizer/secrets/daemon.py
+++ b/python/agent_input_sanitizer/secrets/daemon.py
@@ -171,17 +171,35 @@ def serve(socket_path: str, stop: threading.Event | None = None) -> None:
     with a warm-up scan BEFORE binding, so a bound socket implies a ready daemon.
     ``stop`` is a graceful-shutdown seam for tests; production passes none.
     """
-    os.makedirs(os.path.dirname(socket_path) or ".", mode=0o700, exist_ok=True)
+    socket_dir = os.path.dirname(socket_path) or "."
+    os.makedirs(socket_dir, mode=0o700, exist_ok=True)
+    # `makedirs(..., mode=...)` only applies `mode` to a directory it actually
+    # CREATES — `exist_ok=True` silently accepts a pre-existing dir at ANY
+    # permission level, including world-writable (e.g. a shared /tmp subpath
+    # another local process claimed first). Enforce the mode unconditionally
+    # so a stale/attacker-seeded directory can't leave the socket reachable.
+    os.chmod(socket_dir, 0o700)
     with configure_plugins():
         redact_configured(
             "warm up the detect-secrets mapping cache", None, RedactorConfig()
         )
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        if not _bind_or_exit(sock, socket_path):
+        # `bind()` creates the socket file under the process's current umask;
+        # narrow the window between file creation and the explicit chmod below
+        # by restricting the umask for the bind call itself, so the socket is
+        # never briefly world/group-accessible on a permissive parent dir. The
+        # protocol is unauthenticated, so a connectable-but-not-yet-restricted
+        # socket is a real local privilege issue, not just cosmetic.
+        old_umask = os.umask(0o077)
+        try:
+            bound = _bind_or_exit(sock, socket_path)
+        finally:
+            os.umask(old_umask)
+        if not bound:
             sock.close()
             return
         try:
-            os.chmod(socket_path, 0o600)
+            os.chmod(socket_path, 0o600)  # defense-in-depth; harmless if redundant
             sock.listen(64)
             sock.settimeout(0.5)
             while not (stop is not None and stop.is_set()):

--- a/python/agent_input_sanitizer/secrets/daemon.py
+++ b/python/agent_input_sanitizer/secrets/daemon.py
@@ -23,7 +23,9 @@ import json
 import os
 import socket
 import struct
+import sys
 import threading
+import traceback
 
 from . import RedactorConfig, configure_plugins, handle_request
 from .engine import redact_configured
@@ -111,7 +113,11 @@ def _serve_one(conn: socket.socket) -> None:
             )
         except Exception:  # noqa: BLE001
             # A genuine detection failure for THIS request: signal the client so it
-            # fails THAT call closed, but keep the daemon alive.
+            # fails THAT call closed, but keep the daemon alive. Log the traceback
+            # server-side (never to the client) so a systematic fault — every
+            # request failing, not just one malformed one — is visible to
+            # whoever operates the daemon instead of silently discarded.
+            traceback.print_exc(file=sys.stderr)
             _write_frame(conn, {"error": "redaction failed"})
             return
         _write_frame(conn, result)
@@ -220,8 +226,6 @@ def serve(socket_path: str, stop: threading.Event | None = None) -> None:
 
 def main(argv: list[str] | None = None) -> None:
     """CLI: ``agent-secret-redactor-daemon <socket-path>``."""
-    import sys
-
     args = sys.argv[1:] if argv is None else argv
     if len(args) != 1:
         raise SystemExit("usage: agent-secret-redactor-daemon <socket-path>")

--- a/python/agent_input_sanitizer/secrets/daemon.py
+++ b/python/agent_input_sanitizer/secrets/daemon.py
@@ -32,6 +32,18 @@ from .engine import redact_configured
 # (the cap *boundary* is what matters).
 FRAME_CAP = 16 * 1024 * 1024
 
+# Bound on a single ACCEPTED connection's I/O. The listen socket's own
+# `settimeout` only governs how often `accept()` re-checks `stop` — it does
+# nothing once a connection is accepted, and `_serve_one` is called inline in
+# the same accept-loop iteration. Without this, a client that opens a
+# connection and never finishes sending its frame (e.g. 3 of 4 header bytes)
+# blocks `_recv_exact` forever, which blocks the entire accept loop from ever
+# calling `accept()` again — one idle/slow/malicious local client wedges the
+# daemon for every other client sharing the socket. Long enough for a
+# legitimate large request over a local socket, short enough to bound the DoS
+# window.
+CONN_TIMEOUT_SECONDS = 10.0
+
 
 def _recv_exact(conn: socket.socket, n: int) -> bytes | None:
     """Read exactly ``n`` bytes, or None if the peer closed/reset mid-frame."""
@@ -177,6 +189,10 @@ def serve(socket_path: str, stop: threading.Event | None = None) -> None:
                     conn, _ = sock.accept()
                 except TimeoutError:
                     continue
+                # Bound THIS connection's I/O; see CONN_TIMEOUT_SECONDS docstring.
+                # `_serve_one` is called inline (synchronously) below, so without
+                # this a stalled peer wedges the whole accept loop.
+                conn.settimeout(CONN_TIMEOUT_SECONDS)
                 _serve_one(conn)
         finally:
             sock.close()

--- a/python/agent_input_sanitizer/secrets/daemon.py
+++ b/python/agent_input_sanitizer/secrets/daemon.py
@@ -92,7 +92,13 @@ def _request_config(req: dict) -> RedactorConfig:
     )
     return RedactorConfig(
         provider_vars=provider_vars,
-        web_ingress=bool(req.get("web_ingress", False)),
+        # Fail closed: this is a SHARED, UNAUTHENTICATED local socket, so a
+        # caller that forgets (or has a buggy client that omits) the flag must
+        # get the stronger, non-name-trusting heuristics — not the weaker
+        # local-output mode that skips redaction for anything that merely
+        # LOOKS like a benign cursor/path/metadata field by variable name.
+        # Callers opt into the weaker mode explicitly with `web_ingress: false`.
+        web_ingress=bool(req.get("web_ingress", True)),
     )
 
 

--- a/tests/secrets/test_secrets_daemon.py
+++ b/tests/secrets/test_secrets_daemon.py
@@ -75,6 +75,13 @@ def test_request_config_filters_non_str_env_secrets():
 def test_request_config_missing_env_secrets_is_empty():
     config = S._request_config({"text": "x"})
     assert config.provider_vars == {}
+    # Fail-closed default: an omitted flag must get the STRONGER heuristics
+    # (web_ingress=True), not the weaker name-trusting local-output mode.
+    assert config.web_ingress is True
+
+
+def test_request_config_web_ingress_explicit_false_is_honored():
+    config = S._request_config({"text": "x", "web_ingress": False})
     assert config.web_ingress is False
 
 
@@ -146,10 +153,19 @@ def test_daemon_env_secret_redaction(daemon):
 
 def test_daemon_web_ingress_flag(daemon):
     text = "next_token: abcdefghij1234567890XYZ"
-    local = _client_request(daemon, {"text": text, "map": False})
-    web = _client_request(daemon, {"text": text, "map": False, "web_ingress": True})
+    # The daemon fails closed: an omitted flag defaults to web_ingress=True, so
+    # the local-output-trusting (name-based skip) path requires an EXPLICIT
+    # `web_ingress: false` opt-in.
+    local = _client_request(daemon, {"text": text, "map": False, "web_ingress": False})
+    web = _client_request(daemon, {"text": text, "map": False})
     assert local is None  # benign cursor kept for local output
     assert web is not None and "[REDACTED" in web["text"]
+
+
+def test_daemon_web_ingress_defaults_true_when_omitted(daemon):
+    text = "next_token: abcdefghij1234567890XYZ"
+    resp = _client_request(daemon, {"text": text, "map": False})
+    assert resp is not None and "[REDACTED" in resp["text"]
 
 
 def test_daemon_survives_malformed_frame_then_serves(daemon):

--- a/tests/secrets/test_secrets_daemon_lifecycle.py
+++ b/tests/secrets/test_secrets_daemon_lifecycle.py
@@ -64,6 +64,23 @@ def test_serve_one_engine_failure_writes_error(monkeypatch):
         a.close()
 
 
+def test_serve_one_engine_failure_logs_traceback_to_stderr(monkeypatch, capsys):
+    def _boom(*a, **k):
+        raise RuntimeError("detection blew up")
+
+    monkeypatch.setattr(S, "handle_request", _boom)
+    a, b = socket.socketpair()
+    try:
+        body = json.dumps({"text": "key: AKIAIOSFODNN7EXAMPLE"}).encode("utf-8")
+        a.sendall(struct.pack(">I", len(body)) + body)
+        S._serve_one(b)
+        _drain(a)  # the client-facing response is asserted separately above
+    finally:
+        a.close()
+    err = capsys.readouterr().err
+    assert "RuntimeError" in err and "detection blew up" in err
+
+
 def test_serve_one_malformed_json_body_closes():
     a, b = socket.socketpair()
     try:

--- a/tests/secrets/test_secrets_daemon_lifecycle.py
+++ b/tests/secrets/test_secrets_daemon_lifecycle.py
@@ -167,6 +167,29 @@ def test_serve_creates_socket_dir_with_mode(sock_dir):
         thread.join(timeout=5)
 
 
+def test_serve_tightens_preexisting_loose_socket_dir(sock_dir):
+    # `os.makedirs(..., mode=0o700, exist_ok=True)` only applies `mode` to a
+    # directory it actually CREATES — a dir another (possibly untrusted) local
+    # process pre-created at a looser mode is accepted as-is. Simulate that by
+    # loosening the already-existing sock_dir before the daemon starts, then
+    # assert serve() unconditionally tightens it back to 0o700.
+    os.chmod(sock_dir, 0o777)
+    assert oct(os.stat(sock_dir).st_mode)[-3:] == "777"
+    socket_path = str(sock_dir / "s.sock")
+    stop = threading.Event()
+    thread = threading.Thread(target=S.serve, args=(socket_path, stop), daemon=True)
+    thread.start()
+    deadline = time.time() + 10
+    while not Path(socket_path).exists() and time.time() < deadline:
+        time.sleep(0.02)
+    try:
+        assert Path(socket_path).exists()
+        assert oct(os.stat(sock_dir).st_mode)[-3:] == "700"
+    finally:
+        stop.set()
+        thread.join(timeout=5)
+
+
 # ─── Per-connection timeout (DoS on a stalled peer) ──────────────────────────
 
 

--- a/tests/secrets/test_secrets_daemon_lifecycle.py
+++ b/tests/secrets/test_secrets_daemon_lifecycle.py
@@ -165,3 +165,46 @@ def test_serve_creates_socket_dir_with_mode(sock_dir):
     finally:
         stop.set()
         thread.join(timeout=5)
+
+
+# ─── Per-connection timeout (DoS on a stalled peer) ──────────────────────────
+
+
+def test_stalled_connection_does_not_block_the_daemon(sock_dir, monkeypatch):
+    # A client that connects and sends only PART of the 4-byte length header
+    # must not wedge `_serve_one` — and thus the whole single-threaded accept
+    # loop — forever. Shrink the per-connection timeout so the test is fast
+    # while still exercising the real bound (unbounded before the fix).
+    monkeypatch.setattr(S, "CONN_TIMEOUT_SECONDS", 0.5)
+    socket_path = str(sock_dir / "s.sock")
+    stop = threading.Event()
+    thread = threading.Thread(target=S.serve, args=(socket_path, stop), daemon=True)
+    thread.start()
+    deadline = time.time() + 10
+    while not Path(socket_path).exists() and time.time() < deadline:
+        time.sleep(0.02)
+    assert Path(socket_path).exists()
+    stalled = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    fresh = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        stalled.connect(socket_path)
+        stalled.sendall(b"\x00\x00")  # 2 of 4 header bytes; never sends the rest
+
+        fresh.connect(socket_path)
+        body = json.dumps({"text": "key: AKIAIOSFODNN7EXAMPLE", "map": False}).encode(
+            "utf-8"
+        )
+        fresh.sendall(struct.pack(">I", len(body)) + body)
+        fresh.settimeout(5)
+        start = time.time()
+        result = _drain(fresh)
+        elapsed = time.time() - start
+        assert "AWS Access Key" in result["found"]
+        # Bounded by roughly CONN_TIMEOUT_SECONDS (the stalled connection ahead
+        # of it in accept order), never by an unbounded hang.
+        assert elapsed < 3, f"a stalled peer must not block a fresh request ({elapsed}s)"
+    finally:
+        stalled.close()
+        fresh.close()
+        stop.set()
+        thread.join(timeout=5)

--- a/tests/secrets/test_secrets_daemon_lifecycle.py
+++ b/tests/secrets/test_secrets_daemon_lifecycle.py
@@ -242,7 +242,9 @@ def test_stalled_connection_does_not_block_the_daemon(sock_dir, monkeypatch):
         assert "AWS Access Key" in result["found"]
         # Bounded by roughly CONN_TIMEOUT_SECONDS (the stalled connection ahead
         # of it in accept order), never by an unbounded hang.
-        assert elapsed < 3, f"a stalled peer must not block a fresh request ({elapsed}s)"
+        assert elapsed < 3, (
+            f"a stalled peer must not block a fresh request ({elapsed}s)"
+        )
     finally:
         stalled.close()
         fresh.close()


### PR DESCRIPTION
## Summary

Four robustness/security fixes to the secrets daemon and CLI found via audit, the main one being a trivial unauthenticated local denial-of-service.

## Changes

- The daemon's accept loop called `_serve_one` inline on a socket with no per-connection timeout; a client sending a partial header (or promising a large body then stalling) blocked the loop from ever accepting another connection, wedging the daemon for every other client indefinitely (and blocking graceful shutdown too). Added a per-connection timeout.
- The socket directory's permissions were tightened only *after* `listen()`, and `os.makedirs(..., exist_ok=True)` doesn't tighten an already-existing (potentially world-writable) parent directory. Narrowed the bind-to-chmod window with a restrictive umask around `bind()` and unconditionally chmod the parent directory.
- The daemon's request handler swallowed *all* exceptions with no server-side logging — a systematic fault (every request failing) was indistinguishable from a one-off bad request. Now logs to stderr before replying with the generic client-facing error.
- `web_ingress` defaulted to `False` (the *weaker*, name-trusting heuristics) when a caller omitted the flag on the shared, unauthenticated socket. Flipped the default to the safer redaction mode; callers must now explicitly opt into the trusting local-output mode.

## Tests / verification

- New tests: a slow-loris-style client can't wedge the daemon (it recovers and serves a well-formed request); parent directory permissions verified even when pre-created looser; stderr output asserted on a handler exception; existing tests updated to explicitly pass `web_ingress=False` where they relied on the old default.
- Full `tests/secrets/` suite passes — daemon tests genuinely start `serve` and speak the real wire protocol (no mocked transport).

## Checklist

- [x] Commits follow Conventional Commits.
- [x] Python test suite passes locally.
- [x] Existing tests updated (not weakened) to match the corrected default.
- [x] No secrets in the diff.
- [x] CHANGELOG.md untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PHTbVvQ5U3msna7wTsC4pf)_