### PR TITLE
build(deps): bump ci-truth-serum pin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
   # applies here with no config change; check-symlinks is the one hook outside
   # any tier, so it stays listed.
   - repo: https://github.com/alexander-turner/ci-truth-serum
-    rev: 421e708a4fa98df667c708fdb4c43570ab620bb6 # main (no tagged release yet)
+    rev: e438c361e232fa2f69ab36ff9a29a1e639e0c5a7 # main
     hooks:
       - id: check-tier1
       - id: check-tier2


### PR DESCRIPTION
Bumps the `ci-truth-serum` pre-commit / ruleset-sync pin in `.pre-commit-config.yaml` from `421e708` to `e438c36` (main).

This picks up the fix where `sync_required_checks` now bootstraps a `required_status_checks` rule when the branch ruleset lacks one, instead of assuming a rule already exists. That means this repo's `# required-check: true` markers actually reach branch protection on sync — previously, with no pre-existing rule, the sync had nothing to attach the checks to and they were silently dropped.

`sync-required-checks.sh` reads the rev from this file, so the single edit covers both the pre-commit hook and the ruleset-sync pin.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5F6hSjCtKT7hk5Fgg5ZAo)_