### PR TITLE
docs(claude): front-load questions, run multi-item tasks to completion

### DIFF
--- a/.claude/skills/audit-and-parallelize/SKILL.md
+++ b/.claude/skills/audit-and-parallelize/SKILL.md
@@ -64,7 +64,18 @@ branch, Conventional Commits, and a **proving test added before the fix**.
 
 Before handing it over, attack your own plan: Is any "fix" actually changing intentional design?
 Does any finding contradict a documented tradeoff? Are the PRs genuinely independent? Is the volume
-honest? Surface these as a self-critique section rather than letting the reviewer find them.
+honest? Surface these as a self-critique section rather than letting the reviewer find them. This
+presentation is the ONE moment to batch every open question (design calls, scope judgments) —
+concentrate them here, before implementation starts.
+
+### 6. Execute without checkpointing
+
+When the request includes fixing (or the user says to proceed), the whole confirmed-PR list is in
+scope — land **every** PR without stopping to ask "should I continue / move on to the next one?"
+The answer is always yes. A design choice that surfaces only mid-implementation gets a sensible
+default and a `## Decisions made` entry in that PR's description (what came up, the default chosen,
+what would change under the alternative) — logged for async review, not asked. Maintain a checklist
+of the PR queue and tick each off as it opens, so progress is supervisable at a glance.
 
 ## Examples
 
@@ -90,6 +101,9 @@ positives and why.
 - **Trusting a subagent's "CRITICAL" label.** It is a hypothesis, not a result. Read the code.
 - **Padding to a number.** If only five issues are real, plan five. The over-report is the finding.
 - **One giant PR.** Disjoint PRs parallelize and review cleanly; a mega-PR serializes everything.
+- **Checkpointing between PRs.** Pausing after each PR to ask "move on to the next?" stalls the run
+  for hours of wall-clock waiting on a yes. Questions belong batched at plan delivery; after that,
+  run the queue to completion.
 - **Recall over precision in detectors.** A noisy new check that flags legitimate input trains
   operators to ignore the signal. When a heuristic can't cleanly separate payload from benign input,
   prefer the false negative.

--- a/.claude/skills/parallel-audit/SKILL.md
+++ b/.claude/skills/parallel-audit/SKILL.md
@@ -100,9 +100,20 @@ on). For each PR: scope, the findings it closes, the **test that would have caug
 
 Before handing over the plan, attack it: Are any "parallel" PRs actually file-conflicting? Is a
 "high" severity really reachable, or gated behind an opt-in flag (lower it)? Does any fix need a
-design decision the user must make first (surface it as a question, don't pre-decide)? Are there
-findings with no good test? Is the PR count realistic or should some merge? Deliver the plan **with**
-this critique attached — the user asked to see it.
+design decision (flag it **in the delivered plan** with a recommended default — never stop mid-audit
+to ask)? Are there findings with no good test? Is the PR count realistic or should some merge?
+Deliver the plan **with** this critique attached — the user asked to see it. The plan delivery is
+the ONE moment to batch every open question; concentrate them there.
+
+### 7. Executing the plan (when asked)
+
+When the user says to proceed from plan to fixes, the whole PR list is in scope — work through
+**every** PR without checkpointing. Never ask "should I move on to the next PR?"; the answer is
+always yes. Any question you have belongs in the batch delivered with the plan (step 6), before the
+first PR starts. A design choice that surfaces only mid-implementation gets a sensible default and a
+`## Decisions made` entry in that PR's description (what came up, the default chosen, what would
+change under the alternative) — logged for async review, not asked. Maintain a checklist of the PR
+queue and tick each off as it opens, so progress is supervisable at a glance.
 
 ## Lessons baked in
 
@@ -122,7 +133,7 @@ this critique attached — the user asked to see it.
   that only happens when someone turns on a dangerous off-by-default option is really a minor one.
   Check the problem is reachable in normal use before calling it severe.
 
-## Example
+## Examples
 
 **User says:** "Find dozens of security, robustness, testing, and UX issues. Use subagents and confirm
 their findings. Then plan parallel PRs to fix them, and critique the plan."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,14 @@
 - Save all explanation for the END: a short overview of what changed and how it fits, plus anything I need to run/use it. Proportional to the change.
 - Be direct. Flag real risks once; skip caveats I didn’t ask for. Don’t claim it works unless you ran it or read the code.
 
+## Autonomy: front-load questions, then run to completion
+
+- **Concentrate questions at the start.** Before beginning a multi-item task (multiple PRs, findings, files), resolve every clarifying question in one batch up front—scope, priorities, decision authority. Once work begins, no further questions.
+- **Never checkpoint mid-run.** Complete every item in the agreed queue without asking "should I continue?" or "move on to the next one?"—the answer is always yes. Stop mid-task only for a destructive/irreversible action or a genuine scope change the user must decide.
+- **Mid-run decisions are logged, not asked.** When a reversible design choice surfaces after work has begun, pick a sensible default, keep going, and record it under a `## Decisions made` heading in the PR description: what came up, the default chosen, and what would change under the alternative. The user reviews decisions asynchronously in the PR, not live in chat.
+- **Maintain a status checklist.** For multi-item tasks, post the item list at the start (in chat or the PR description) and tick items off as they complete—that is the supervision surface for a user running parallel sessions.
+- **Silent turns on non-actionable events.** A webhook/notification wake-up that needs no action (duplicate event, superseded-SHA cancellation, CI still running) gets no reply—end the turn with no text. Never post "all clear" / "nothing to do."
+
 ## Commands
 
 ```bash


### PR DESCRIPTION
## Summary

Parallel web sessions were stalling every ~15 minutes: the audit skills' execute phase had no continuation rule (runs paused with "should I move on to the next PR?"), and non-actionable webhook wake-ups got "all clear" replies. This restructures where questions surface: **batched at the start of a task** (plan delivery for the audit skills), with mid-run design choices logged asynchronously in the PR instead of asked in chat.

## Changes

- `CLAUDE.md`: new `## Autonomy: front-load questions, then run to completion` section — batch clarifying questions up front; no mid-queue checkpoints; mid-run reversible decisions get a sensible default plus a `## Decisions made` PR entry for async review; maintain a status checklist; end non-actionable webhook turns with no text.
- `.claude/skills/parallel-audit/SKILL.md`: step 6 flags design decisions in the delivered plan with a recommended default (the one batching point for questions); new step 7 runs the whole PR queue without checkpointing. Kept byte-identical to the `claude-guard` copy (same change landing there). `## Example` → `## Examples` clears the pre-existing skills-lint warning.
- `.claude/skills/audit-and-parallelize/SKILL.md`: step 5 concentrates open questions at plan presentation; new step 6 executes without checkpointing; new anti-pattern entry for per-PR checkpointing.

## Tests / verification

Docs-only (contributor instructions + agent skills); no runtime code paths. Commit hooks (Conventional Commits, pre-commit) passed at commit time.

## Checklist

- [x] Commits follow Conventional Commits; subject reads as a release note (`docs` type — excluded from release notes)
- [x] `pnpm test` / `lint` / `check` — n/a, no source touched; hooks passed on commit
- [x] No detectors changed
- [x] No secrets in diff or description
- [x] `CHANGELOG.md` and `package.json` untouched

## Lessons Learned

- **What**: Add an "Autonomy: front-load questions, then run to completion" section to the template `CLAUDE.md` (batch questions before multi-item work; no mid-queue checkpoints; async `## Decisions made` log; status checklist; silent no-op webhook turns). **Where**: `CLAUDE.md` in `claude-automation-template`. **Why**: agent sessions otherwise stall on "should I continue?" questions and waste turns replying to non-actionable events — already landed directly as claude-automation-template#312, so no further propagation needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pym4XEXt1XH7SGW3gSHGo1)_