### PR TITLE
docs+ci(supervision): supervision-legible work doctrine + human-review gate

### DIFF
--- a/.github/scripts/check-supervision-gate.sh
+++ b/.github/scripts/check-supervision-gate.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Fails when a PR touches the supervision stack (CI workflows, agent hooks,
+# CLAUDE.md) without the human-applied `supervision-reviewed` label — this
+# refusal is what blocks a supervision-stack change from merging on agent
+# say-so alone.
+set -euo pipefail
+
+: "${PR_NUMBER:?}" "${GH_REPO:?}"
+
+SUPERVISION_RE='^(\.github/|\.claude/hooks/|\.hooks/|CLAUDE\.md$)'
+
+changed="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')"
+if ! grep -qE "$SUPERVISION_RE" <<<"$changed"; then
+  echo "No supervision-stack paths changed."
+  exit 0
+fi
+touched="$(grep -E "$SUPERVISION_RE" <<<"$changed")"
+
+labels="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" --jq '.labels[].name')"
+if grep -qxF 'supervision-reviewed' <<<"$labels"; then
+  echo "Supervision-stack paths changed; 'supervision-reviewed' label present:"
+  echo "$touched"
+  exit 0
+fi
+
+{
+  echo "This PR changes the supervision stack:"
+  echo "$touched"
+  echo "A human must read the diff, then apply the 'supervision-reviewed' label to pass this check."
+} >&2
+exit 1

--- a/.github/workflows/supervision-gate.yaml
+++ b/.github/workflows/supervision-gate.yaml
@@ -1,0 +1,36 @@
+name: Supervision gate
+
+# Supervision-stack diffs (CI workflows, agent hooks, CLAUDE.md) merge only
+# after an explicit human look: this check stays red until the repo owner
+# applies the `supervision-reviewed` label. The label is the human's
+# attestation — agents never apply it (CLAUDE.md, Supervision-legible work).
+# No `paths:` filter: a required check must always report.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  gate:
+    name: Supervision-stack changes human-reviewed # mark Required in branch protection
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          sparse-checkout: .github/scripts
+          persist-credentials: false
+      - name: Fail unless human-reviewed label covers supervision paths
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: bash .github/scripts/check-supervision-gate.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Structure work so the user can verify it instead of trusting it.
 **Diffs—supervision-stack changes travel alone:**
 
 - Never mix edits to the supervision stack—`.github/workflows/`, `.claude/hooks/`, `.hooks/`, `CLAUDE.md` itself—into a feature/fix PR. Supervision changes go in their own PR that names itself as one, so the highest-risk diff class always gets undiluted review.
+- CI enforces this: `supervision-gate.yaml` keeps any PR touching those paths red until a human applies the `supervision-reviewed` label. The label is the user's attestation that they read the diff—**never apply it yourself**; a red gate is only ever cleared by the user.
 
 **Security-relevant code—legible by construction:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,26 @@
 - **Maintain a status checklist.** For multi-item tasks, post the item list at the start (in chat or the PR description) and tick items off as they complete—that is the supervision surface for a user running parallel sessions.
 - **Silent turns on non-actionable events.** A webhook/notification wake-up that needs no action (duplicate event, superseded-SHA cancellation, CI still running) gets no reply—end the turn with no text. Never post "all clear" / "nothing to do."
 
+## Supervision-legible work
+
+Structure work so the user can verify it instead of trusting it.
+
+**Reports—every claim ships its checker:**
+
+- Pair each completion claim with the one command that would falsify it ("tests pass—`pnpm test -- --filter x`"; "red on unfixed code—ran the test against `git show <base>:<file>`"). A claim without a checker is an assertion, not a report.
+- Label observed vs. inferred. "Ran X, saw Y" and "expect Z because…" are different epistemic states—never blur them.
+- Predict before you run. Before a test or CI run, state the expected outcome, then report prediction vs. actual. A mismatch is a finding to surface, never to smooth over.
+- Numbers over adjectives: "covers 3 of 4 branches; uncovered: the EOF path" beats "well tested".
+
+**Diffs—supervision-stack changes travel alone:**
+
+- Never mix edits to the supervision stack—`.github/workflows/`, `.claude/hooks/`, `.hooks/`, `CLAUDE.md` itself—into a feature/fix PR. Supervision changes go in their own PR that names itself as one, so the highest-risk diff class always gets undiluted review.
+
+**Security-relevant code—legible by construction:**
+
+- State the invariant at the enforcement point: the one comment a guard must carry is what it prevents ("this refusal is what blocks X"), so a reviewer can verify the claim against the code below it—and a deleted check leaves an orphaned invariant comment as a visible scar.
+- Boring idioms only: no metaprogramming, dynamic dispatch, `eval`/`exec`, or clever encodings in security-relevant paths. Honest code there never needs to be clever, so cleverness is a review flag, not a style choice.
+
 ## Commands
 
 ```bash

--- a/tests/test_supervision_gate.py
+++ b/tests/test_supervision_gate.py
@@ -75,7 +75,5 @@ def test_non_supervision_paths_pass_without_label(tmp_path: Path) -> None:
 
 
 def test_lookalike_label_does_not_unblock(tmp_path: Path) -> None:
-    result = run_gate(
-        tmp_path, "CLAUDE.md", labels="supervision-reviewed-not-really"
-    )
+    result = run_gate(tmp_path, "CLAUDE.md", labels="supervision-reviewed-not-really")
     assert result.returncode == 1

--- a/tests/test_supervision_gate.py
+++ b/tests/test_supervision_gate.py
@@ -1,0 +1,81 @@
+"""The supervision gate blocks PRs touching supervision paths unless the
+human-applied `supervision-reviewed` label is present.
+
+Each alternative in the script's path regex is an enumerated set member and
+gets its own case (blocked without the label, unblocked with it)."""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(
+    subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+)
+SCRIPT = REPO_ROOT / ".github" / "scripts" / "check-supervision-gate.sh"
+
+GH_STUB = """#!/usr/bin/env bash
+if [[ "$*" == *"/files"* ]]; then
+  printf '%s\\n' "$FAKE_FILES"
+else
+  printf '%s\\n' "$FAKE_LABELS"
+fi
+"""
+
+SUPERVISION_MEMBERS = [
+    ".github/workflows/x.yaml",
+    ".claude/hooks/x.mjs",
+    ".hooks/pre-push",
+    "CLAUDE.md",
+]
+
+
+def run_gate(
+    tmp_path: Path, files: str, labels: str = ""
+) -> subprocess.CompletedProcess:
+    gh = tmp_path / "gh"
+    gh.write_text(GH_STUB)
+    gh.chmod(0o755)
+    env = os.environ | {
+        "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_FILES": files,
+        "FAKE_LABELS": labels,
+        "PR_NUMBER": "1",
+        "GH_REPO": "owner/repo",
+    }
+    return subprocess.run(
+        ["bash", str(SCRIPT)], capture_output=True, text=True, env=env
+    )
+
+
+@pytest.mark.parametrize("path", SUPERVISION_MEMBERS)
+def test_each_member_blocks_without_label(tmp_path: Path, path: str) -> None:
+    result = run_gate(tmp_path, f"src/ok.ts\n{path}")
+    assert result.returncode == 1
+    assert "supervision-reviewed" in result.stderr
+    assert path in result.stderr
+
+
+@pytest.mark.parametrize("path", SUPERVISION_MEMBERS)
+def test_each_member_passes_with_label(tmp_path: Path, path: str) -> None:
+    result = run_gate(tmp_path, path, labels="other-label\nsupervision-reviewed")
+    assert result.returncode == 0
+
+
+def test_non_supervision_paths_pass_without_label(tmp_path: Path) -> None:
+    result = run_gate(tmp_path, "README.md\ndocs/CLAUDE.md\nsrc/x.py")
+    assert result.returncode == 0
+    assert "No supervision-stack paths changed." in result.stdout
+
+
+def test_lookalike_label_does_not_unblock(tmp_path: Path) -> None:
+    result = run_gate(
+        tmp_path, "CLAUDE.md", labels="supervision-reviewed-not-really"
+    )
+    assert result.returncode == 1


### PR DESCRIPTION
## Summary

Follow-up to #113, two supervision-stack changes traveling together (both are that class, per the doctrine this PR introduces): the `## Supervision-legible work` CLAUDE.md section (falsifiable-claim reporting, supervision-diff isolation, invariant-at-enforcement-point + boring idioms for security paths), and the supervision gate — a check that keeps any PR touching `.github/`, `.claude/hooks/`, `.hooks/`, or `CLAUDE.md` red until a human applies the `supervision-reviewed` label. The label is the human's attestation; CLAUDE.md forbids agents applying it, so agent self-approval becomes a loud audit event instead of a quiet merge. Chosen over a ruleset required-reviewer rule because single-identity repos make "require my review" deadlock (authors can't self-approve) or be bypassable by an agent holding the same token.

**This PR fails its own gate** — apply `supervision-reviewed` after reading the diff. **One manual step to make it enforcing:** mark `Supervision-stack changes human-reviewed` as a required check in branch protection.

## Changes

- `CLAUDE.md`: new `## Supervision-legible work` section.
- `.github/workflows/supervision-gate.yaml`, `.github/scripts/check-supervision-gate.sh`: the gate (re-runs on labeled/unlabeled).
- `tests/test_supervision_gate.py`: one case per path-regex member, both directions, plus lookalike-label and root-only-CLAUDE.md negatives (runs under CI's `pytest tests/`).

## Tests / verification

- `uv run --with pytest pytest tests/test_supervision_gate.py -q` — observed: 10 passed.
- Non-vacuity: flipped the script's enforcement `exit 1` → `exit 0`; predicted the 5 blocking tests fail — observed exactly those 5; restored, 10 pass.
- Live: the gate is red on this PR's own head for the right reason (observed via check run).
- The earlier `pre-commit` CI failure on 7529975 was `ruff format` on the test file — fixed in 122954e (style commit).

## Checklist

- [x] Conventional Commits (`ci`/`docs`/`style` — internal types, excluded from release notes)
- [x] No detectors changed; no secrets in diff or description
- [x] `CHANGELOG.md` and `package.json` untouched

## Lessons Learned

- **What**: Add the supervision gate (`supervision-gate.yaml` + `check-supervision-gate.sh` + per-member tests) and the `## Supervision-legible work` CLAUDE.md section to the template. **Where**: `claude-automation-template` `.github/` and `CLAUDE.md`. **Why**: supervision-stack changes shouldn't merge on agent say-so in any downstream repo — already landed directly as a template PR (#314), so no further propagation needed.