### PR TITLE
ci: rename AUTOFIX_TOKEN secret to AUTOFIX_TOKEN_ORG

### DIFF
--- a/.github/scripts/promote-changelog.mjs
+++ b/.github/scripts/promote-changelog.mjs
@@ -133,5 +133,7 @@ try {
   // Exit 0 deliberately: pnpm publish has already succeeded at this point in
   // the release flow; a CHANGELOG hiccup must not abort the surrounding bash
   // script and skip the tag push.
-  warn(`failed: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
+  warn(
+    `failed: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`,
+  );
 }

--- a/.github/workflows/format-autofix.yaml
+++ b/.github/workflows/format-autofix.yaml
@@ -32,16 +32,16 @@ jobs:
       # preflight step that exposes it as a step output; when it's absent every
       # later step is skipped and the job ends green (a no-op), instead of the
       # checkout failing on an empty token.
-      - name: Check for AUTOFIX_TOKEN
+      - name: Check for AUTOFIX_TOKEN_ORG
         id: guard
         env:
-          AUTOFIX_TOKEN: ${{ secrets.AUTOFIX_TOKEN }}
+          AUTOFIX_TOKEN_ORG: ${{ secrets.AUTOFIX_TOKEN_ORG }}
         run: |
-          if [ -n "$AUTOFIX_TOKEN" ]; then
+          if [ -n "$AUTOFIX_TOKEN_ORG" ]; then
             echo "enabled=true" >>"$GITHUB_OUTPUT"
           else
             echo "enabled=false" >>"$GITHUB_OUTPUT"
-            echo "::notice::AUTOFIX_TOKEN secret is not set; skipping autofix. Add a fine-grained PAT (contents: write) so the fix-commit re-triggers format-check."
+            echo "::notice::AUTOFIX_TOKEN_ORG secret is not set; skipping autofix. Add a fine-grained PAT (contents: write) so the fix-commit re-triggers format-check."
           fi
 
       - if: steps.guard.outputs.enabled == 'true'
@@ -49,7 +49,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           # PAT/App token, NOT GITHUB_TOKEN, so the push re-triggers format-check.
-          token: ${{ secrets.AUTOFIX_TOKEN }}
+          token: ${{ secrets.AUTOFIX_TOKEN_ORG }}
           persist-credentials: true
           fetch-depth: 0
 


### PR DESCRIPTION
## What

Renames the `AUTOFIX_TOKEN` GitHub secret to `AUTOFIX_TOKEN_ORG` — consolidating onto a single org-level PAT instead of a per-repo secret. This is also the fix for the `autofix` job 403 flagged on PR #112: that job's guard step correctly detected `AUTOFIX_TOKEN` was set but the push still 403'd, meaning the old secret was invalid/under-scoped for this repo.

## Where

`.github/workflows/format-autofix.yaml` — the guard step name, its env var, the skip notice text, and the checkout `token:` — all renamed end-to-end, no compatibility alias.

`CHANGELOG.md`'s existing entry mentioning the old name is left untouched — it's a historical record of what shipped, not something to rewrite (this repo's changelog is generated from commit subjects and never hand-edited).

## Tests

Workflow YAML validated. No unit tests cover this workflow directly (it's a thin `secrets.*` wrapper); verified by inspection that the rename is complete and self-consistent (guard step, secret reference, and consuming step all agree).

## Note on the actual secret

This PR only renames the reference — `AUTOFIX_TOKEN_ORG` needs to exist as a valid secret (with `contents: write` on this repo) before the job can push autofix commits.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DoRiQhvXwwux8gMwGz36Y2)_