### PR TITLE
test: git-derive REPO_ROOT and harden hook/daemon test isolation

### DIFF
--- a/tests/secrets/test_secrets_daemon_lifecycle.py
+++ b/tests/secrets/test_secrets_daemon_lifecycle.py
@@ -126,8 +126,34 @@ def test_bind_or_exit_returns_false_when_live_daemon_owns_path(sock_dir):
             assert S._bind_or_exit(second, socket_path) is False
         finally:
             second.close()
-        # And a full second serve() likewise returns without taking over.
-        S.serve(socket_path, threading.Event())  # returns because path is live
+        # And a full second serve() likewise returns without taking over. Run it
+        # in a helper thread with a bounded join so a regression that blocks
+        # (e.g. taking over the live socket instead of bailing) surfaces as a
+        # failed assertion, not a silent hang that wedges the whole suite.
+        second_serve = threading.Thread(
+            target=S.serve, args=(socket_path, threading.Event()), daemon=True
+        )
+        second_serve.start()
+        # Bound generously: a cold serve() re-runs configure_plugins + a warm-up
+        # scan before it can bail on the live path (the sibling daemon-start
+        # tests allow 10s just for the socket to appear), so a short join could
+        # flake on slow CI while still not being an unbounded hang.
+        second_serve.join(timeout=30)
+        assert not second_serve.is_alive(), (
+            "second serve() must return because the path is live, not block"
+        )
+        # Non-vacuous positive marker: the ORIGINAL daemon still owns the socket
+        # and answers — proving the second serve() bailed without disturbing it,
+        # rather than the assertion passing because nothing was ever serving.
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            client.connect(socket_path)
+            body = json.dumps({"text": "key: AKIAIOSFODNN7EXAMPLE"}).encode("utf-8")
+            client.sendall(struct.pack(">I", len(body)) + body)
+            client.settimeout(5)
+            assert "AWS Access Key" in _drain(client)["found"]
+        finally:
+            client.close()
     finally:
         stop.set()
         thread.join(timeout=5)

--- a/tests/secrets/test_secrets_isolation.py
+++ b/tests/secrets/test_secrets_isolation.py
@@ -10,9 +10,10 @@ base install require detect-secrets.
 
 import subprocess
 import sys
-from pathlib import Path
 
-_PKG = Path(__file__).resolve().parents[2] / "python"
+from tests._helpers import REPO_ROOT
+
+_PKG = REPO_ROOT / "python"
 
 
 def test_base_import_does_not_pull_detect_secrets():

--- a/tests/test_check_token_scope.py
+++ b/tests/test_check_token_scope.py
@@ -9,7 +9,8 @@ import os
 import subprocess
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+from tests._helpers import REPO_ROOT
+
 SCRIPT = REPO_ROOT / ".github" / "scripts" / "check-token-scope.sh"
 
 

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 import pytest
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+from tests._helpers import REPO_ROOT
+
 SESSION_SETUP = REPO_ROOT / ".claude" / "hooks" / "session-setup.sh"
 
 
@@ -27,6 +28,39 @@ def sandbox(tmp_path: Path) -> Path:
 
 def set_remote(sandbox: Path, url: str) -> None:
     subprocess.run(["git", "remote", "add", "origin", url], cwd=sandbox, check=True)
+
+
+# The install section of session-setup.sh curls webi installers and shells out
+# to apt-get/uv/pnpm to fetch tools. Left unstubbed, the smoke test would reach
+# the network (non-hermetic, flaky, slow). Prepending a directory of these stubs
+# to PATH neutralizes the whole section: the tool stubs (shfmt/gh/jq/shellcheck)
+# make `command -v` succeed so their install branch is skipped, and the
+# installer stubs (curl/apt-get/uv/pnpm/npm) are local no-ops if anything still
+# invokes them. The script then runs its git/GH_REPO logic — what these tests
+# actually exercise — without a single outbound call. (This stands alone and
+# does not depend on any script-side skip flag.)
+_INERT_COMMANDS = (
+    "curl",
+    "apt-get",
+    "uv",
+    "pnpm",
+    "npm",
+    "shfmt",
+    "gh",
+    "jq",
+    "shellcheck",
+)
+
+
+def _write_installer_stubs(stub_dir: Path) -> Path:
+    """Write exit-0 stubs for every network/installer command onto a dir that
+    callers prepend to PATH; return the dir."""
+    stub_dir.mkdir(parents=True, exist_ok=True)
+    for name in _INERT_COMMANDS:
+        stub = stub_dir / name
+        stub.write_text("#!/usr/bin/env bash\nexit 0\n")
+        stub.chmod(0o755)
+    return stub_dir
 
 
 def run_session_setup(
@@ -57,6 +91,9 @@ def run_session_setup(
     )
     if extra_env:
         env.update(extra_env)
+    # Neutralize the install section: no outbound curl / apt-get / uv / pnpm.
+    stub_dir = _write_installer_stubs(sandbox / "_installer_stubs")
+    env["PATH"] = f"{stub_dir}{os.pathsep}{env.get('PATH', os.environ['PATH'])}"
     result = subprocess.run(
         ["bash", str(sandbox / ".claude" / "hooks" / "session-setup.sh")],
         env=env,

--- a/tests/test_python_client.py
+++ b/tests/test_python_client.py
@@ -21,7 +21,8 @@ from pathlib import Path
 
 import pytest
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+from tests._helpers import REPO_ROOT
+
 sys.path.insert(0, str(REPO_ROOT / "python"))
 
 import agent_input_sanitizer as ais  # noqa: E402

--- a/tests/test_required_env.py
+++ b/tests/test_required_env.py
@@ -8,7 +8,8 @@ from pathlib import Path
 
 import pytest
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+from tests._helpers import REPO_ROOT
+
 SCRIPTS = REPO_ROOT / ".github" / "scripts"
 
 # (script, required env vars, vars to scrub from inherited environment)

--- a/tests/test_template_sync.py
+++ b/tests/test_template_sync.py
@@ -11,9 +11,8 @@ from pathlib import Path
 
 import pytest
 
-from tests._helpers import GIT_IDENTITY_ENV, commit_all, init_test_repo
+from tests._helpers import GIT_IDENTITY_ENV, REPO_ROOT, commit_all, init_test_repo
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / ".github" / "scripts" / "template-sync.sh"
 
 


### PR DESCRIPTION
Test-only quality pass. All 821 tests pass locally; the touched tests reach neither the network nor an unbounded hang.

## K7 — git-derived `REPO_ROOT` instead of parent-walking
Depth-based `Path(__file__).resolve().parents[N]` silently breaks when a test file moves. Replaced with the already-present, git-derived `tests._helpers.REPO_ROOT` in:

- `tests/test_python_client.py` (`parents[1]`) — import placed before the `sys.path.insert` so it needs no `# noqa: E402`.
- `tests/test_claude_hooks.py` (`parents[1]`)
- `tests/test_required_env.py` (`parents[1]`)
- `tests/test_check_token_scope.py` (`parents[1]`)
- `tests/test_template_sync.py` (`parents[1]`) — folded `REPO_ROOT` into the existing `tests._helpers` import.
- `tests/secrets/test_secrets_isolation.py` (`parents[2] / "python"` → `REPO_ROOT / "python"`; dropped the now-unused `pathlib` import).

The import path was already proven — `tests/secrets/conftest.py` and `tests/secrets/redactor_helpers.py` import `REPO_ROOT` from `tests._helpers` today. Each moved test keeps its identical assertions.

## K8 — session-setup smoke test can no longer reach the network
`tests/test_claude_hooks.py` runs the real `session-setup.sh`, whose install section curls webi installers and shells out to `apt-get`/`uv`. `run_session_setup` now writes exit-0 stubs for `curl`, `apt-get`, `uv`, `pnpm`, `npm`, `shfmt`, `gh`, `jq`, `shellcheck` into a per-sandbox dir prepended to `PATH`. The tool stubs make `command -v` succeed so each install branch is skipped; the installer stubs are local no-ops if anything still invokes them. The script reaches its git/`GH_REPO` logic — what these tests exercise — with zero outbound calls.

## K11 — live-daemon liveness test can no longer hang CI
`tests/secrets/test_secrets_daemon_lifecycle.py::test_bind_or_exit_returns_false_when_live_daemon_owns_path` called `S.serve(...)` on the main thread; a regression that took over the live socket instead of bailing would hang the whole suite silently. It now runs the second `serve()` on a helper thread with `join(timeout=30)` and asserts the thread finished. Non-vacuous positive marker added: a real client request is sent to the original daemon and its `found` list is asserted to contain `AWS Access Key`, proving the second `serve()` bailed without disturbing the live daemon (rather than passing because nothing was serving).

## Decisions made
- **K8 PATH-stub only, and it overlaps PR-H.** The finding notes a sibling PR (PR-H) may add a script-side `SESSION_SETUP_SKIP_INSTALLS` flag. The current `session-setup.sh` honors no such flag, so this PR relies solely on the PATH stub, which stands alone and does not depend on any script change. If PR-H later lands a skip flag, this stub still works; it can optionally be set in addition, but is not required.
- **K8 stubs the tools themselves, not just the installers.** Chosen so `command -v` skips each install branch entirely (fewer warnings, strictly no install attempt) rather than letting the branch run into an inert stubbed `curl`. Under the alternative (stub only `curl`/`apt-get`/`uv`) the script would emit "installer is not a shell script" warnings but still exit 0 and stay hermetic; the assertions (returncode 0, `GH_REPO` exports) are unaffected either way.
- **K11 `join(timeout=30)`.** A cold `serve()` re-runs `configure_plugins` + a warm-up scan before it can bail on the live path; sibling daemon-start tests already allow 10s just for the socket to appear, so a short join risks flaking on slow CI. 30s comfortably exceeds the cold path while still bounding a true hang.

## Commit-hook note
The `pre-commit` hook runs `pnpm exec lint-staged`, which in this isolated worktree (where `node_modules` is a symlink to the shared checkout) triggers pnpm's interactive modules-purge prompt. Committed with `CI=true` per pnpm's own guidance to run non-interactively — the hook (ruff check/format via lint-staged) still ran in full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZSXDUnuc5tDxi2Q7o7CLS)_