### PR TITLE
fix(secrets): eliminate FIELD_VALUE_RE ReDoS and close input-leak/precision gaps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,9 @@ requires-python = ">=3.10"
 # dependency (shipped via the wheel's `[secrets]` extra), pulled in here so
 # `uv run --extra dev pytest tests/` exercises the engine and its property tests.
 [project.optional-dependencies]
-dev = ["pytest>=7", "detect-secrets>=1.5.0", "hypothesis>=6"]
+# regexploit statically flags super-linear (ReDoS) regexes; the secrets ReDoS
+# guard (tests/secrets/test_redos_static_guard.py) shells out to it.
+dev = ["pytest>=7", "detect-secrets>=1.5.0", "hypothesis>=6", "regexploit>=1.0.0"]
 
 [tool.ruff]
 target-version = "py310"

--- a/python/agent_input_sanitizer/__init__.py
+++ b/python/agent_input_sanitizer/__init__.py
@@ -52,6 +52,7 @@ options, rather than an opaque ``node: Cannot find module``.
 """
 
 import atexit
+import hashlib
 import json
 import os
 import signal
@@ -188,18 +189,24 @@ def _check(response: dict) -> dict:
 
 def _parse_cli_json(output: str) -> dict:
     """Parse one line of CLI stdout as JSON, wrapping a non-JSON line in a clear
-    error that names the offending output and that it came from the sanitizer CLI.
+    error that fingerprints the offending output and names the sanitizer CLI as
+    its source.
 
     Without this, a Node crash or a stray ``console.log`` in the CLI surfaces as
     a bare ``json.decoder.JSONDecodeError`` with no hint of where the bad bytes
-    came from.
+    came from. The raw output is NOT echoed: a crash mid-sanitize can leave
+    UNsanitized input on stdout, so the error carries only its length and a
+    short SHA-256 fingerprint — enough to correlate/deduplicate reports without
+    surfacing the bytes themselves.
     """
     try:
         return json.loads(output)
     except json.JSONDecodeError as cause:
+        digest = hashlib.sha256(output.encode("utf-8")).hexdigest()[:16]
         raise RuntimeError(
             "sanitize CLI returned non-JSON output (expected one JSON object): "
-            f"{output.strip()!r}"
+            f"{len(output)} bytes, sha256:{digest} (output withheld; it may "
+            "contain unsanitized input)"
         ) from cause
 
 

--- a/python/agent_input_sanitizer/secrets/daemon.py
+++ b/python/agent_input_sanitizer/secrets/daemon.py
@@ -117,13 +117,21 @@ def _serve_one(conn: socket.socket) -> None:
                 _request_config(req),
                 redact_configured,
             )
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             # A genuine detection failure for THIS request: signal the client so it
-            # fails THAT call closed, but keep the daemon alive. Log the traceback
-            # server-side (never to the client) so a systematic fault — every
-            # request failing, not just one malformed one — is visible to
-            # whoever operates the daemon instead of silently discarded.
-            traceback.print_exc(file=sys.stderr)
+            # fails THAT call closed, but keep the daemon alive. Log the exception
+            # TYPE and its stack FRAMES (never to the client) so a systematic
+            # fault — every request failing, not just one malformed one — is
+            # visible to whoever operates the daemon. The exception MESSAGE is
+            # deliberately withheld: it can embed bytes of the secret-bearing
+            # input line (e.g. a re/JSON error echoing the offending text), which
+            # must never reach the logs. Frames are static source locations, not
+            # runtime data, so they are safe.
+            sys.stderr.write(
+                f"secret redaction failed ({type(exc).__name__}); "
+                "input and exception message withheld from log:\n"
+                + "".join(traceback.format_tb(exc.__traceback__))
+            )
             _write_frame(conn, {"error": "redaction failed"})
             return
         _write_frame(conn, result)
@@ -188,9 +196,28 @@ def serve(socket_path: str, stop: threading.Event | None = None) -> None:
     # `makedirs(..., mode=...)` only applies `mode` to a directory it actually
     # CREATES — `exist_ok=True` silently accepts a pre-existing dir at ANY
     # permission level, including world-writable (e.g. a shared /tmp subpath
-    # another local process claimed first). Enforce the mode unconditionally
-    # so a stale/attacker-seeded directory can't leave the socket reachable.
-    os.chmod(socket_dir, 0o700)
+    # another local process claimed first). Enforce the mode so a
+    # stale/attacker-seeded directory can't leave the socket reachable.
+    #
+    # A plain `os.chmod(socket_dir, ...)` re-resolves the PATH: between the
+    # makedirs above and the chmod, another local process could swap the final
+    # component for a symlink and redirect the chmod onto a directory it owns
+    # (TOCTOU). Bind an fd to the real directory instead — O_NOFOLLOW refuses a
+    # symlinked final component — and fchmod/fstat through that fd so the check
+    # and the change target the same inode. Refuse a directory this uid does not
+    # own: tightening someone else's dir to 0o700 neither makes it ours nor
+    # makes the socket safe, so fail loudly rather than serve on it.
+    dir_fd = os.open(socket_dir, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    try:
+        owner = os.fstat(dir_fd).st_uid
+        if owner != os.getuid():
+            raise PermissionError(
+                f"refusing to serve: socket directory {socket_dir!r} is owned by "
+                f"uid {owner}, not {os.getuid()}"
+            )
+        os.fchmod(dir_fd, 0o700)
+    finally:
+        os.close(dir_fd)
     with configure_plugins():
         redact_configured(
             "warm up the detect-secrets mapping cache", None, RedactorConfig()

--- a/python/agent_input_sanitizer/secrets/data/secret-detectors.json
+++ b/python/agent_input_sanitizer/secrets/data/secret-detectors.json
@@ -12,8 +12,8 @@
     {
       "const": "GoogleApiKeyDetector",
       "secret_type": "Google API Key",
-      "patterns": ["AIza[0-9A-Za-z_\\-]{35}"],
-      "note": "gitleaks rule gcp-api-key. detect-secrets ships no Google detector."
+      "patterns": ["AIza[0-9A-Za-z_\\-]{35}(?![A-Za-z0-9])"],
+      "note": "gitleaks rule gcp-api-key. detect-secrets ships no Google detector. Trailing (?![A-Za-z0-9]) pins the 35-char body to a token boundary for consistency with the anchored Anthropic/Terraform entries; the boundary excludes only alphanumerics, NOT -/_, which are in the key-body alphabet but also ordinary delimiters, so a real key written `<key>-`/`<key>_` still redacts."
     },
     {
       "const": "DigitalOceanTokenDetector",

--- a/python/agent_input_sanitizer/secrets/engine.py
+++ b/python/agent_input_sanitizer/secrets/engine.py
@@ -223,7 +223,6 @@ FIELD_VALUE_RE = re.compile(
     # source-code false positives without shortening a real secret. Other specials
     # (!@#) stay allowed so a symbol inside a secret doesn't truncate the capture
     # below the length threshold, and the anchor avoids swallowing trailing prose.
-    # No nested quantifier -> no catastrophic backtracking.
     #
     # The optional open/close bracket groups peel a wrapper that *encloses* the
     # value (`password = (<secret>)`, `key: {<secret>}`, `token: ["<secret>"]`):
@@ -239,14 +238,20 @@ FIELD_VALUE_RE = re.compile(
     # to start at the second operator byte (`= "v"` / `> "v"`), which is <20
     # contiguous chars, so the arm failed and the secret leaked.
     #
-    # `(?:[_-]\w+)*` after the keyword lets it be a PREFIX of a longer
+    # `(?:[_-][A-Za-z0-9]+)*` after the keyword lets it be a PREFIX of a longer
     # underscore/hyphen-segmented identifier (`api_key_prod`, `secret_value`,
     # the env-suffixed `AWS_SECRET_ACCESS_KEY_OLD`) — without it the keyword had
     # to abut the operator and these extremely common names leaked verbatim. The
     # `[_-]` separator is REQUIRED (not a bare `\w*`), so a plain word that merely
     # starts with a keyword (`secretary` = `secret`+`ary`, `tokenizer`) is not
-    # mistaken for a credential field.
-    rf"(?P<field_prefix>(?:{_FIELD_NAMES})(?:[_-]\w+)*[\"']?\s*(?::=|==|=>|[:=])\s*"
+    # mistaken for a credential field. The segment body is `[A-Za-z0-9]+`, NOT
+    # `\w+`: `\w` includes `_`, which is also the separator, so `(?:[_-]\w+)*`
+    # let a run of `_` be repartitioned exponentially many ways — measured
+    # catastrophic backtracking (`token` + `"_"*n` + `!` doubled per 2 chars).
+    # Disjoint separator/body classes make each `[_-]`-delimited segment parse
+    # exactly one way, so the match is linear in the input length (see
+    # tests/secrets/test_secrets_engine.py::test_field_value_re_linear_on_underscore_run).
+    rf"(?P<field_prefix>(?:{_FIELD_NAMES})(?:[_-][A-Za-z0-9]+)*[\"']?\s*(?::=|==|=>|[:=])\s*"
     r"(?:(?:Bearer|Token|Basic)\s+)?)"
     r"(?P<openbracket>[(\[{]?)"
     r"(?P<quote>[\"']?)"
@@ -342,15 +347,20 @@ _METADATA_SUFFIXES = ("type", "name", "label", "keyword", "kind")
 _ASSIGN_OP_CHARS = "=:!>"
 
 
-def _is_metadata_field(line: str, value: str) -> bool:
+def _is_metadata_field(line: str, value: str, value_start: int | None = None) -> bool:
     """True when ``value`` is assigned to a metadata field, not a secret field.
 
     Walks the text before the value with plain string ops (no regex) so a long,
     no-match prefix of attacker-influenced output can't drive backtracking: peel
     a trailing quote/``@``, require a trailing assignment operator (``=`` ``:``
     ``=>`` ``:=`` ``==``), then read back the identifier and test its suffix.
+
+    ``value_start`` is the value's actual offset in ``line`` when the caller has
+    it (from the regex match), so the prefix is exact rather than the FIRST
+    ``line.find(value)`` occurrence — a value that also appears earlier in the
+    line (e.g. inside the field name) would otherwise mislocate the prefix.
     """
-    idx = line.find(value)
+    idx = line.find(value) if value_start is None else value_start
     if idx <= 0:
         return False
     prefix = line[:idx].rstrip()
@@ -727,7 +737,11 @@ def _redact_core(
         name_skip = not web_ingress and (
             _is_benign_cursor(m)
             or _is_filesystem_path(m)
-            or _is_metadata_field(m.group(0), m.group("secret_value"))
+            or _is_metadata_field(
+                m.group(0),
+                m.group("secret_value"),
+                m.start("secret_value") - m.start(),
+            )
         )
         value = m.group("secret_value")
         if (

--- a/tests/secrets/test_redos_static_guard.py
+++ b/tests/secrets/test_redos_static_guard.py
@@ -1,0 +1,97 @@
+"""Static ReDoS guard over every secrets-engine and detector-JSON regex.
+
+This is the *generalizable* check that would have caught the ``FIELD_VALUE_RE``
+ReDoS (audit finding P1) at analysis time. The per-pattern wall-clock test in
+``test_secrets_engine.py`` asserts one pattern stays fast today; this instead
+introspects EVERY compiled regex in the engine module and EVERY detector pattern
+in ``secret-detectors.json`` and rejects super-linear backtracking statically —
+so a *future* pattern with catastrophic backtracking fails here automatically,
+with no timing flakiness.
+
+Analysis is done by ``regexploit`` (a dev dependency). It always exits 0 and
+reports a finding on stdout as ``Worst-case complexity: … (exponential|
+polynomial)``; a pattern it cannot parse is reported as ``Error parsing:``.
+"""
+
+import json
+import re
+import shutil
+import subprocess
+
+import pytest
+
+import agent_input_sanitizer.secrets.engine as E
+from tests._helpers import REPO_ROOT
+
+# Atomic groups / possessive quantifiers cannot backtrack, so a pattern using
+# them is backtracking-safe by construction. regexploit's parser predates
+# Python 3.11 possessive quantifiers and raises on them, so we accept its parse
+# failure ONLY when the pattern actually carries such a guard — an unexplained
+# parse failure is treated as a real problem, not silently passed.
+_ATOMIC_MARKERS = ("*+", "++", "?+", "}+", "(?>")
+
+_DETECTORS_JSON = (
+    REPO_ROOT
+    / "python"
+    / "agent_input_sanitizer"
+    / "secrets"
+    / "data"
+    / "secret-detectors.json"
+)
+
+
+def _engine_patterns() -> dict[str, str]:
+    patterns = {}
+    for name in dir(E):
+        obj = getattr(E, name)
+        if isinstance(obj, re.Pattern):
+            patterns[name] = obj.pattern
+    return patterns
+
+
+def _json_patterns() -> dict[str, str]:
+    data = json.loads(_DETECTORS_JSON.read_text(encoding="utf-8"))
+    patterns = {}
+    for detector in data["detectors"]:
+        for i, pattern in enumerate(detector.get("patterns", [])):
+            patterns[f"{detector['const']}[{i}]"] = pattern
+    return patterns
+
+
+_ALL_PATTERNS = {**_engine_patterns(), **_json_patterns()}
+
+
+def _analyze(pattern: str) -> str:
+    exe = shutil.which("regexploit")
+    assert exe, "regexploit is not installed — it is a dev dependency (pyproject [dev])"
+    return subprocess.run(
+        [exe], input=pattern + "\n", capture_output=True, text=True, check=True
+    ).stdout
+
+
+def test_pattern_inventory_is_non_empty() -> None:
+    # A refactor that stops discovering patterns would make the parametrized
+    # test below pass vacuously; assert both sources are actually populated.
+    assert len(_engine_patterns()) >= 5
+    assert len(_json_patterns()) >= 5
+
+
+@pytest.mark.parametrize("name, pattern", sorted(_ALL_PATTERNS.items()))
+def test_regex_has_no_super_linear_backtracking(name: str, pattern: str) -> None:
+    out = _analyze(pattern)
+    assert "Worst-case complexity" not in out, (
+        f"{name} exhibits super-linear backtracking (ReDoS):\n{pattern}\n{out}"
+    )
+    if "Error parsing" in out:
+        assert any(marker in pattern for marker in _ATOMIC_MARKERS), (
+            f"{name}: regexploit could not analyze this pattern and it carries no "
+            f"atomic/possessive guard proving it is backtracking-safe:\n{pattern}"
+        )
+
+
+def test_guard_detects_a_known_vulnerable_pattern() -> None:
+    # Non-vacuity control: the exact shape the P1 fix removed — a `[_-]`
+    # separator and a `\w` body that both match `_`, so the run repartitions
+    # exponentially — must be flagged by the analyzer.
+    out = _analyze(r"prefix(?:[_-]\w+)*[:=]tail")
+    assert "Worst-case complexity" in out, out

--- a/tests/secrets/test_secrets_daemon_lifecycle.py
+++ b/tests/secrets/test_secrets_daemon_lifecycle.py
@@ -64,21 +64,34 @@ def test_serve_one_engine_failure_writes_error(monkeypatch):
         a.close()
 
 
-def test_serve_one_engine_failure_logs_traceback_to_stderr(monkeypatch, capsys):
+def test_serve_one_engine_failure_logs_type_and_frames_not_input_or_message(
+    monkeypatch, capsys
+):
+    # A detection failure logs the exception TYPE and its stack FRAMES for the
+    # operator, but NEVER the exception message or the request text: either can
+    # embed bytes of the secret-bearing input line, which must not reach the logs.
+    secret_input = "AKIAIOSFODNN7EXAMPLE"
+    secret_message = "leaky-exception-message-9f3a2b"
+
     def _boom(*a, **k):
-        raise RuntimeError("detection blew up")
+        raise RuntimeError(secret_message)
 
     monkeypatch.setattr(S, "handle_request", _boom)
     a, b = socket.socketpair()
     try:
-        body = json.dumps({"text": "key: AKIAIOSFODNN7EXAMPLE"}).encode("utf-8")
+        body = json.dumps({"text": f"key: {secret_input}"}).encode("utf-8")
         a.sendall(struct.pack(">I", len(body)) + body)
         S._serve_one(b)
         _drain(a)  # the client-facing response is asserted separately above
     finally:
         a.close()
     err = capsys.readouterr().err
-    assert "RuntimeError" in err and "detection blew up" in err
+    # Positive markers proving the log path ran and is useful to the operator.
+    assert "RuntimeError" in err  # exception type is logged
+    assert "_serve_one" in err  # a stack frame is logged
+    # The two leak vectors are absent.
+    assert secret_message not in err  # exception message withheld
+    assert secret_input not in err  # request text withheld
 
 
 def test_serve_one_malformed_json_body_closes():

--- a/tests/secrets/test_secrets_engine.py
+++ b/tests/secrets/test_secrets_engine.py
@@ -7,6 +7,7 @@ env-bound values come from a :class:`RedactorConfig` instead of ``os.environ``.
 """
 
 import re
+import time
 
 import pytest
 
@@ -116,6 +117,22 @@ def test_field_value_regex_case_insensitive_and_multiline():
     )
     assert later is not None
     assert later.group("secret_value") == "abc123def456ghi789jkl012"
+
+
+@pytest.mark.parametrize("n", [16, 32, 48, 64])
+def test_field_value_re_linear_on_underscore_run(n):
+    # ReDoS adversarial input: a keyword, a long run of `_`, then a byte that is
+    # not an assignment operator so no match ever completes. The old
+    # `(?:[_-]\w+)*` had separator `[_-]` and body `\w` both matching `_`, so the
+    # run repartitioned exponentially (measured 7.9s at n=38, doubling every 2
+    # chars). The non-overlapping `(?:[_-][A-Za-z0-9]+)*` — disjoint separator
+    # and body classes — parses the run exactly one way, so search stays linear.
+    # Assert a wall-clock ceiling an exponential blowup at these sizes cannot
+    # meet, run against the REAL compiled pattern (not an approximation).
+    adversarial = "token" + "_" * n + "!"
+    start = time.perf_counter()
+    assert E.FIELD_VALUE_RE.search(adversarial) is None
+    assert time.perf_counter() - start < 1.0, n
 
 
 # ─── Bracket-wrapped values ──────────────────────────────────────────────────
@@ -572,6 +589,18 @@ def test_placeholder_values_not_redacted(label, text):
 )
 def test_is_metadata_field(label, line, value, expected):
     assert E._is_metadata_field(line, value) is expected, label
+
+
+def test_is_metadata_field_uses_explicit_offset():
+    # When the value also appears earlier in the line, the first-occurrence
+    # `line.find(value)` fingers the wrong prefix; the caller passes the value's
+    # real match offset so the actual assignment (a metadata field here) is seen.
+    value = "AnthropicAPIKeyValue"
+    line = f"note {value} then token_name = {value}"
+    # No offset -> first occurrence (after "note ") has no operator -> not metadata.
+    assert E._is_metadata_field(line, value) is False
+    # Real offset -> the SECOND occurrence, assigned to token_name -> metadata.
+    assert E._is_metadata_field(line, value, line.rindex(value)) is True
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,7 @@ dev = [
     { name = "detect-secrets" },
     { name = "hypothesis" },
     { name = "pytest" },
+    { name = "regexploit" },
 ]
 
 [package.metadata]
@@ -19,6 +20,7 @@ requires-dist = [
     { name = "detect-secrets", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7" },
+    { name = "regexploit", marker = "extra == 'dev'", specifier = ">=1.0.0" },
 ]
 provides-extras = ["dev"]
 
@@ -308,6 +310,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "regexploit"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/4c/fc58c4892615496d632404633d07ea098e075c68afeb0e0536e21c9babee/regexploit-1.0.0.tar.gz", hash = "sha256:1abd5f6a92fd0959ddf13c5e84246935d21c5cd173e8d38bcf58c24eb24cd36f", size = 72704, upload-time = "2021-03-11T14:32:38.95Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/0a/90dc0759b72d2d1b726dbcdbca2d044cd048f8089936f69c40dca474975f/regexploit-1.0.0-py3-none-any.whl", hash = "sha256:71918acbd0134989cf3928577f3e5a6e0ab1a57891293dc83bfef198fc9949c2", size = 79818, upload-time = "2021-03-11T14:32:37.392Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Six precision/robustness fixes in the Python secrets engine, daemon, and CLI client. The headline is a measured ReDoS in `FIELD_VALUE_RE` that runs on every untrusted-text detection call; the rest are local input-leak and precision gaps. Each is source-disjoint from the other fleet PRs.

Status checklist:
- [x] P1 (high, measured ReDoS) — `FIELD_VALUE_RE` underscore-run catastrophic backtracking
- [x] P2 (med) — daemon `traceback.print_exc` can log secret-bearing input
- [x] P4 (low) — `_parse_cli_json` echoes raw (possibly unsanitized) CLI output
- [x] P5 (low) — `_is_metadata_field` re-searches with `line.find` instead of the real offset
- [x] P6 (low) — Google API-key pattern missing a trailing boundary
- [x] P3 (low) — chmod-after-makedirs TOCTOU on the socket directory

## Changes

**P1 — `perf(secrets)`, `python/.../secrets/engine.py`.** The field-name prefix used `(?:[_-]\w+)*`; separator `[_-]` and body `\w` both match `_`, so a run of underscores repartitions exponentially. Measured 7.9s on `token` + `"_"*38` + `!`, doubling every 2 chars, on the daemon's inline single-threaded path. Fix makes the classes disjoint — `(?:[_-][A-Za-z0-9]+)*` — so each `[_-]`-delimited segment parses exactly one way and matching is linear. Verified directly: old pattern 0.001s→0.007s→0.046s at n=20/24/28 (exponential); new pattern flat at ~1µs. Deleted the false "No nested quantifier" comment. New `test_field_value_re_linear_on_underscore_run` asserts a wall-clock ceiling exponential blowup cannot meet.

**P5 — `python/.../secrets/engine.py`.** `_is_metadata_field` located the value via `line.find(value)` (first occurrence). The `FIELD_VALUE_RE` caller now passes the value's actual offset (`m.start("secret_value") - m.start()`); the keyword caller (no offset available from detect-secrets) keeps the `find` fallback. New `test_is_metadata_field_uses_explicit_offset` pins the difference.

**P2 — `fix(secrets)`, `python/.../secrets/daemon.py`.** A detection failure logged `traceback.print_exc()`, whose final line is the exception repr — which can embed bytes of the secret-bearing input (a re/JSON error echoing the offending text). Now logs the exception TYPE and stack FRAMES only (static source locations, never runtime data); the message is withheld. The client-facing `{"error": "redaction failed"}` is unchanged.

**P3 — `python/.../secrets/daemon.py`.** `os.chmod(socket_dir, ...)` after `makedirs` re-resolves the path, so a swapped-in symlink could redirect the chmod. Now opens an fd with `O_DIRECTORY|O_NOFOLLOW`, verifies the directory is owned by our uid (fails loudly otherwise), and `fchmod`s through that fd so the check and the change target one inode.

**P4 — `python/agent_input_sanitizer/__init__.py`.** `_parse_cli_json` echoed raw CLI stdout into its error; a Node crash mid-sanitize can leave unsanitized input there. Now emits only the output length and a short SHA-256 fingerprint.

**P6 — `python/.../secrets/data/secret-detectors.json`.** Appended `(?[A-Za-z0-9])` to the Google API-key pattern for consistency with the anchored Anthropic/Terraform entries. The boundary excludes only alphanumerics, not `-`/`_`, so a key written `<key>-`/`<key>_` still redacts. Stays JS-`RegExp` portable.

## Tests / verification

- `uv run pytest tests/secrets/` — 676 passed (includes the rewritten daemon-log contract test and the JSON detector coverage).
- `uv run pytest tests/test_python_client.py` — 90 passed (P4).
- `node --test test/secret-detectors-portability.test.mjs` — 29 passed (P6 JSON stays JS-portable).
- `ruff check` / `ruff format --check` clean on all touched Python; `prettier --check` clean on the JSON.
- Direct old-vs-new timing confirms the ReDoS is gone.

## Decisions made

- **P1 double-underscore field names.** The new segment body `[A-Za-z0-9]+` excludes `_`, so a field like `api__key` (consecutive underscores) is no longer treated as a compound keyword-prefix and its value would not be redacted by the field-value arm. This is a deliberate precision-over-recall trade to remove the ambiguity that caused the ReDoS; consecutive-underscore identifiers are rare, and structural/prefix detectors still cover real credentials. Alternative (bounding the run length `{0,64}`) would preserve `\w`-body recall but keep an ambiguous grammar and a length cliff — rejected.
- **P2 log content.** Kept the stack FRAMES (via `traceback.format_tb`) in addition to the exception type, rather than logging the type alone. Frames are static source lines, not runtime input, so they retain operator debuggability without a leak vector. Alternative (type-only) loses the failure location for no additional safety.
- **P3 foreign-owned dir.** Chose to fail loudly (`PermissionError`) when the socket directory is owned by another uid, rather than tightening and serving. Tightening someone else's dir neither makes it ours nor makes the socket safe. Alternative (chmod-and-continue) would silently serve on an attacker-seeded parent.
- **P4 fingerprint.** Emit length + truncated SHA-256 rather than a fixed opaque message, so distinct failures remain correlatable/deduplicable in logs without exposing bytes.

## Checklist

- [x] Commits follow Conventional Commits; each subject reads as a release note.
- [x] Python + JS test suites, ruff, and prettier pass locally.
- [x] Changed detector (Google) keeps its existing negative/coverage tests green; the ReDoS invariant is pinned by a timing test.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZSXDUnuc5tDxi2Q7o7CLS)_