### PR TITLE
fix(hooks): fail closed on missing tools and harden self-edit surface

### DIFF
--- a/.claude/hooks/lib-checks.sh
+++ b/.claude/hooks/lib-checks.sh
@@ -6,6 +6,14 @@ cd "$PROJECT_DIR" || exit 1
 
 exists() { command -v "$1" &>/dev/null; }
 
+# has_script parses package.json with jq. Without jq it would return "no such
+# script" for everything, silently skipping every configured check (fail open).
+# Require jq up front so a missing dependency fails the gate closed instead.
+if [[ -f package.json ]] && ! command -v jq &>/dev/null; then
+  echo "lib-checks: jq is required to read package.json scripts but is not installed" >&2
+  exit 1
+fi
+
 has_script() {
   [[ -f package.json ]] || return 1
   local val

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -1,10 +1,55 @@
 #!/bin/bash
-# Pre-push/PR hook: Runs configured checks before pushing or creating PRs
-# Only runs scripts that exist and are properly configured in package.json
+# Pre-push/PR hook: Runs configured checks before pushing or creating PRs.
+# Only runs scripts that exist and are properly configured in package.json.
+#
+# Registered in .claude/settings.json as a PreToolUse hook on the "Bash" tool.
+# Claude Code hook matchers filter on the tool NAME only — they do not match
+# command patterns — so we cannot narrow to `git push` / `gh pr create` in the
+# matcher. (The newer `if` field could, but is deliberately avoided here to stay
+# compatible across Claude Code versions that would reject an unknown key.)
+# Instead we read the PreToolUse payload from stdin and gate on the command
+# ourselves. Fail closed: if the command cannot be positively identified as
+# something other than a push/PR-create, the checks run anyway.
 
 set -uo pipefail
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+#######################################
+# Command gate
+#######################################
+
+# stdin carries the PreToolUse payload, already fully buffered by Claude Code
+# (so this read cannot stall). Extract .tool_input.command.
+payload=$(cat)
+command_str=""
+if [[ -n "$payload" ]]; then
+  if command -v jq >/dev/null 2>&1; then
+    command_str=$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null)
+  elif command -v python3 >/dev/null 2>&1; then
+    command_str=$(printf '%s' "$payload" |
+      python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("tool_input", {}).get("command", ""))
+except Exception:
+    pass' 2>/dev/null)
+  fi
+fi
+
+# A non-empty command that is neither a push nor a PR-create needs no checks.
+# An empty command_str means we could not parse it — fall through and run the
+# checks (fail closed).
+if [[ -n "$command_str" ]]; then
+  case "$command_str" in
+  *"git push"* | *"gh pr create"*) : ;;
+  *) exit 0 ;;
+  esac
+fi
+
+#######################################
+# Checks
+#######################################
+
 # shellcheck source=lib-checks.sh
 source "$HOOK_DIR/lib-checks.sh"
 
@@ -26,12 +71,17 @@ has_script lint && run_check "lint" "pnpm lint"
 has_script check && run_check "typecheck" "pnpm check"
 has_script test && run_check "tests" "pnpm test"
 
-# Python checks
+# Python checks. Fail closed: if the project is Python but no runner is
+# available, that is a broken environment, not a reason to silently skip lint.
 if [[ -f pyproject.toml ]] || [[ -f uv.lock ]]; then
   PREFIX=""
   [[ -f uv.lock ]] && exists uv && PREFIX="uv run "
-
-  { exists ruff || [[ -n "$PREFIX" ]]; } && run_check "ruff" "${PREFIX}ruff check ."
+  if [[ -n "$PREFIX" ]] || exists ruff; then
+    run_check "ruff" "${PREFIX}ruff check ."
+  else
+    echo "=== ruff SKIPPED — neither uv nor ruff on PATH; failing closed ===" >&2
+    FAILED=1
+  fi
 fi
 
 exit $FAILED

--- a/.claude/hooks/safe-launch.sh
+++ b/.claude/hooks/safe-launch.sh
@@ -66,6 +66,10 @@ is_under() {
   local candidate="$1" parent="$2" parent_dir resolved
   [[ -n "$candidate" ]] && [[ -n "$parent" ]] || return 1
   case "$candidate" in *..*) return 1 ;; esac
+  # The parent dir is resolved with `pwd -P`, but the leaf is not: a symlinked
+  # leaf (e.g. .claude/hooks/evil -> /etc/cron.d/x) would pass containment while
+  # writes land outside. Reject a symlinked leaf outright.
+  [[ -L "$candidate" ]] && return 1
   parent_dir=$(cd "$(dirname "$candidate")" 2>/dev/null && pwd -P) || return 1
   [[ -n "$parent_dir" ]] || return 1
   resolved="$parent_dir/$(basename "$candidate")"

--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -166,12 +166,18 @@ remote_url="${remote_url:-$(git -C "$PROJECT_DIR" remote get-url origin 2>/dev/n
 if [[ "$remote_url" =~ 127\.0\.0\.1.*/git/ ]]; then
   local_settings="$PROJECT_DIR/.claude/settings.local.json"
   if [ ! -f "$local_settings" ]; then
+    # Grant self-edit only over non-executable Claude assets (skills), and
+    # explicitly DENY the paths that become code the next session executes:
+    # the hooks and the settings files themselves. A blanket Edit/Write(.claude/**)
+    # would let a prompt-injected session rewrite its own PreToolUse/SessionStart
+    # hooks — silent escalation to arbitrary code execution on the next launch.
+    # deny wins over allow, so the deny entries below are the hard boundary.
     cat >"$local_settings" <<'SETTINGS'
 {
   "permissions": {
     "allow": [
-      "Edit(.claude/**)",
-      "Write(.claude/**)",
+      "Edit(.claude/skills/**)",
+      "Write(.claude/skills/**)",
       "Read(.claude/**)",
       "Bash(pnpm build)",
       "Bash(pnpm check:*)",
@@ -181,6 +187,12 @@ if [[ "$remote_url" =~ 127\.0\.0\.1.*/git/ ]]; then
       "Bash(pnpm test:*)",
       "Bash(pre-commit run:*)",
       "Bash(uv run pytest:*)"
+    ],
+    "deny": [
+      "Edit(.claude/hooks/**)",
+      "Write(.claude/hooks/**)",
+      "Edit(.claude/settings*.json)",
+      "Write(.claude/settings*.json)"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,7 +27,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "Bash(git push*|gh pr create*)",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",

--- a/.hooks/commit-msg
+++ b/.hooks/commit-msg
@@ -28,6 +28,11 @@ elif command -v pnpm >/dev/null 2>&1; then
 elif command -v npx >/dev/null 2>&1; then
   npx --yes --package=@commitlint/cli --package=@commitlint/config-conventional \
     commitlint --edit "$1" --config "$config"
+elif [[ "${ALLOW_UNLINTED_COMMITS:-}" == "1" ]]; then
+  echo "commit-msg: commitlint unavailable (no Node.js); ALLOW_UNLINTED_COMMITS=1 — skipping validation." >&2
 else
-  echo "Warning: commitlint not available (no Node.js). Skipping commit message validation." >&2
+  echo "commit-msg: commitlint unavailable (no Node.js) and ALLOW_UNLINTED_COMMITS is not 1." >&2
+  echo "commit-msg: refusing the commit — an unvalidated subject corrupts the next release's version/notes." >&2
+  echo "commit-msg: install Node or set ALLOW_UNLINTED_COMMITS=1 to override." >&2
+  exit 1
 fi

--- a/.hooks/lint-skills.sh
+++ b/.hooks/lint-skills.sh
@@ -50,8 +50,18 @@ for file in "$@"; do
     continue
   fi
 
-  # Extract frontmatter (between first and second ---), filtering YAML comments
-  frontmatter=$(awk '/^---$/{n++; next} n==1' "$file" | grep -v '^#')
+  # Extract frontmatter (between first and second ---), filtering YAML comments.
+  # A frontmatter that is entirely comments makes `grep -v '^#'` exit 1, which
+  # under `set -e` would abort the whole linter — branch on the exit code
+  # instead (grep exit 1 = "no non-comment lines", any other code = real error).
+  fm_raw=$(awk '/^---$/{n++; next} n==1' "$file")
+  if frontmatter=$(printf '%s\n' "$fm_raw" | grep -v '^#'); then
+    : # non-comment lines found
+  else
+    grep_rc=$? # exit status of the `if` condition = grep's (pipefail on)
+    [[ "$grep_rc" -eq 1 ]] || exit "$grep_rc"
+    frontmatter=""
+  fi
 
   # Check frontmatter has name field
   if ! echo "$frontmatter" | grep -q '^name:'; then
@@ -66,10 +76,20 @@ for file in "$@"; do
   fi
 
   # Check description is multi-sentence (at least 2 periods).
-  # Extract description from frontmatter only (not body content).
+  # Extract the description value (its line plus any indented continuation
+  # lines) from the frontmatter only. A sed range like /^description:/,/^[a-z]/p
+  # includes the *next* top-level key's line, so its periods leak into the
+  # count; instead, stop at — and exclude — the next top-level key.
   # `tr -dc` strips everything except '.', so a description with zero periods
   # still produces an empty (not failing) result — required under `pipefail`.
-  desc_block=$(awk '/^---$/{n++; next} n==1' "$file" | sed -n '/^description:/,/^[a-z]/p')
+  desc_block=$(awk '
+    /^---$/ { n++; next }
+    n == 1 {
+      if ($0 ~ /^description:/) { indesc = 1; print; next }
+      if (indesc && $0 ~ /^[A-Za-z][A-Za-z0-9_-]*:/) { indesc = 0 }
+      if (indesc) print
+    }
+  ' "$file")
   periods=$(printf '%s' "$desc_block" | tr -dc '.')
   if [[ "${#periods}" -lt 2 ]]; then
     echo "ERROR: $file description too short — use 2-3 sentences with specific activation triggers" >&2

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -26,4 +26,9 @@ if command -v pnpm >/dev/null 2>&1; then
   pnpm exec lint-staged --allow-empty
 elif command -v npm >/dev/null 2>&1; then
   npx lint-staged --allow-empty
+else
+  # Neither package manager is on PATH, but the lint-staged binary exists (the
+  # guard above already returned when it did not). Run it directly rather than
+  # skipping staged-file formatting silently.
+  "$git_root/node_modules/.bin/lint-staged" --allow-empty
 fi

--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -22,6 +22,12 @@ if ! command -v pre-commit >/dev/null 2>&1; then
   exit 0
 fi
 
+# Snapshot the worktree BEFORE running fixers. If it was already dirty, we
+# cannot tell fixer output apart from the user's in-progress edits, so we must
+# not fold anything into an auto `style:` commit (that would sweep unrelated WIP
+# — and possibly secrets — into history under a misleading message).
+pre_state=$(git status --porcelain)
+
 if pre-commit run --all-files; then
   exit 0
 fi
@@ -31,6 +37,13 @@ if git diff --quiet; then
   exit 1
 fi
 
+if [[ -n "$pre_state" ]]; then
+  echo "pre-push: pre-commit auto-fixed files, but the worktree was already dirty before this run." >&2
+  echo "pre-push: refusing to fold pre-existing changes into a 'style:' commit — review, stage, and commit them yourself, then re-run 'git push'." >&2
+  exit 1
+fi
+
+# Worktree was clean pre-run, so every change now present is fixer output.
 git diff --name-only -z | xargs -0 git add --
 git commit --no-verify -m "style: auto-fix pre-commit issues"
 echo "pre-push: auto-fixed and committed pre-commit issues — re-run 'git push'." >&2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # v6.0.0
     hooks:
       - id: trailing-whitespace
         exclude: ^pnpm-lock\.yaml$
@@ -26,19 +26,19 @@ repos:
         args: [--fix=lf]
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.11.0.1
+    rev: 745eface02aef23e168a8afb6b5737818efbea95 # v0.11.0.1
     hooks:
       - id: shellcheck
         args: [-x, -P, .claude/hooks]
 
   - repo: https://github.com/scop/pre-commit-shfmt
-    rev: v3.12.0-2
+    rev: 2a30809d16bc7a60d9b97353c797f42b510d3368 # v3.12.0-2
     hooks:
       - id: shfmt
         args: [-i, "2", -w]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.5
+    rev: 488940d9de1b658fac229e34c521d75a6ea476f2 # v0.14.5
     hooks:
       - id: ruff-check
         args: [--fix]

--- a/tests/test_hook_fail_closed.py
+++ b/tests/test_hook_fail_closed.py
@@ -1,0 +1,177 @@
+"""Invariant: git/Claude hooks fail CLOSED when a required tool is off PATH.
+
+A hook that silently skips its check (exits 0) when jq/Node/a package manager is
+missing turns a broken environment into a green light — the exact fail-open flaw
+these tests guard against. Each test curates PATH down to a whitelist so a
+specific dependency is genuinely absent, then asserts the hook refuses rather
+than skips. Positive controls (the escape hatch works; the command gate skips
+non-push commands) keep the suite from passing vacuously.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(
+    subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+)
+
+# Coreutils the hooks legitimately need; everything else is "absent" unless a
+# test opts it back in. printf/pwd/cd/command/[[ are bash builtins (always
+# available), so they are intentionally not listed here.
+BASE_TOOLS = [
+    "bash", "sh", "git", "cat", "grep", "sed", "awk", "tr", "head", "cut",
+    "dirname", "basename", "env", "mktemp", "rm", "xargs", "find", "id",
+]  # fmt: skip
+
+
+def curated_path(tmp_path: Path, allow: list[str]) -> str:
+    """A PATH containing symlinks to only the allowed real tools."""
+    bindir = tmp_path / "curated-bin"
+    bindir.mkdir(exist_ok=True)
+    for name in allow:
+        real = shutil.which(name)
+        if real and not (bindir / name).exists():
+            (bindir / name).symlink_to(real)
+    return str(bindir)
+
+
+def base_env(path: str) -> dict[str, str]:
+    return {
+        "PATH": path,
+        "HOME": "/nonexistent",
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+    }
+
+
+def init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    return repo
+
+
+# --------------------------------------------------------------------------- #
+# commit-msg: no Node → refuse (K5), unless the explicit escape hatch is set.
+# --------------------------------------------------------------------------- #
+
+
+def test_commit_msg_fails_closed_without_node(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+    msg = repo / "msg.txt"
+    msg.write_text("feat(scope): a perfectly valid conventional subject\n")
+    path = curated_path(tmp_path, BASE_TOOLS)  # no node/pnpm/npm/npx
+    result = subprocess.run(
+        ["bash", str(REPO_ROOT / ".hooks" / "commit-msg"), str(msg)],
+        cwd=repo,
+        env=base_env(path),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0, "commit-msg must refuse when it cannot validate"
+    assert "refusing" in result.stderr.lower()
+
+
+def test_commit_msg_escape_hatch_allows_skip(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+    msg = repo / "msg.txt"
+    msg.write_text("anything at all\n")
+    path = curated_path(tmp_path, BASE_TOOLS)
+    result = subprocess.run(
+        ["bash", str(REPO_ROOT / ".hooks" / "commit-msg"), str(msg)],
+        cwd=repo,
+        env={**base_env(path), "ALLOW_UNLINTED_COMMITS": "1"},
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+# --------------------------------------------------------------------------- #
+# pre-push-check: Node project without jq → refuse (K3); non-push command is
+# skipped by the stdin gate (K4).
+# --------------------------------------------------------------------------- #
+
+
+def _sandbox_pre_push_check(tmp_path: Path) -> Path:
+    repo = init_repo(tmp_path)
+    (repo / "package.json").write_text('{"scripts":{"build":"echo build"}}\n')
+    hooks = repo / ".claude" / "hooks"
+    hooks.mkdir(parents=True)
+    for name in ("pre-push-check.sh", "lib-checks.sh"):
+        dst = hooks / name
+        dst.write_bytes((REPO_ROOT / ".claude" / "hooks" / name).read_bytes())
+        dst.chmod(0o755)
+    return repo
+
+
+def _run_pre_push_check(
+    repo: Path, path: str, stdin: str
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(repo / ".claude" / "hooks" / "pre-push-check.sh")],
+        cwd=repo,
+        env={**base_env(path), "CLAUDE_PROJECT_DIR": str(repo)},
+        input=stdin,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_pre_push_check_fails_closed_without_jq(tmp_path: Path) -> None:
+    repo = _sandbox_pre_push_check(tmp_path)
+    # python3 present so the gate recognizes "git push"; jq absent so the
+    # package.json script lookup has no parser and must fail closed.
+    path = curated_path(tmp_path, BASE_TOOLS + ["python3"])
+    result = _run_pre_push_check(
+        repo, path, '{"tool_input":{"command":"git push origin HEAD"}}'
+    )
+    assert result.returncode != 0, "must refuse when jq is missing on a Node project"
+    assert "jq is required" in result.stderr
+
+
+def test_pre_push_check_gate_skips_non_push(tmp_path: Path) -> None:
+    repo = _sandbox_pre_push_check(tmp_path)
+    path = curated_path(tmp_path, BASE_TOOLS + ["python3"])  # jq still absent
+    result = _run_pre_push_check(repo, path, '{"tool_input":{"command":"ls -la"}}')
+    # A non-push command exits 0 without ever reaching the (jq-guarded) checks —
+    # proves the gate fires and that fail-closed only applies to gated commands.
+    assert result.returncode == 0, result.stderr
+
+
+# --------------------------------------------------------------------------- #
+# pre-commit: neither pnpm nor npm on PATH → run the lint-staged binary directly
+# rather than skipping (K6).
+# --------------------------------------------------------------------------- #
+
+
+def test_pre_commit_runs_lint_staged_directly_without_package_manager(
+    tmp_path: Path,
+) -> None:
+    repo = init_repo(tmp_path)
+    binp = repo / "node_modules" / ".bin"
+    binp.mkdir(parents=True)
+    marker = tmp_path / "lint-staged-ran"
+    fake = binp / "lint-staged"
+    fake.write_text(f'#!/bin/bash\necho ran > "{marker}"\nexit 0\n')
+    fake.chmod(0o755)
+    (repo / "a.txt").write_text("hello\n")
+    subprocess.run(["git", "add", "a.txt"], cwd=repo, check=True)
+    path = curated_path(tmp_path, BASE_TOOLS)  # no pnpm/npm
+    result = subprocess.run(
+        ["bash", str(REPO_ROOT / ".hooks" / "pre-commit")],
+        cwd=repo,
+        env=base_env(path),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert marker.exists() and marker.read_text().strip() == "ran", (
+        "pre-commit must invoke the lint-staged binary directly, not skip"
+    )


### PR DESCRIPTION
## Summary

Closes a set of fail-open and self-escalation gaps in the git and Claude Code hooks (audit findings K1–K6, K9, K10, K12). Every hook now refuses rather than silently skips when a required tool is absent, and the web-session self-edit grant can no longer reach the code the next session executes.

Each finding was confirmed against the current code before fixing.

## Findings fixed

- **K1** (`.claude/hooks/session-setup.sh`) — the generated `settings.local.json` granted `Edit/Write(.claude/**)`, letting a prompt-injected web session rewrite its own hooks/settings (silent escalation to next-session code exec). Narrowed the allow-list to `.claude/skills/**` and added a `deny` block for `.claude/hooks/**` and `.claude/settings*.json` (deny wins over allow).
- **K4** (`.claude/settings.json`, `.claude/hooks/pre-push-check.sh`) — the PreToolUse matcher `"Bash(git push*|gh pr create*)"` used permission-rule syntax, but hook matchers filter on **tool name only** (confirmed against the current hooks docs), so the push gate never fired. Changed the matcher to `"Bash"` and moved the command filter into the hook: it reads the PreToolUse payload from stdin, extracts `.tool_input.command`, and runs the checks only for `git push` / `gh pr create` — failing closed (running the checks) when the command can't be parsed.
- **K3** (`.claude/hooks/lib-checks.sh`, `pre-push-check.sh`) — `has_script` returned "no such script" for everything when `jq` was missing, skipping every configured check. Now requires `jq` up front; the Python leg fails closed when a Python project has neither `uv` nor `ruff`.
- **K2** (`.hooks/pre-push`) — the auto-fix path ran `git add -A` + `git commit --no-verify`, sweeping pre-existing dirty WIP into a `style:` commit. Now snapshots `git status --porcelain` first and refuses to auto-commit when the worktree was already dirty.
- **K5** (`.hooks/commit-msg`) — skipped Conventional-Commit validation when Node was absent (corrupting the next release's version/notes). Now fails closed, gated by an explicit `ALLOW_UNLINTED_COMMITS=1` escape hatch.
- **K6** (`.hooks/pre-commit`) — exited 0 without running lint-staged when neither pnpm nor npm was on PATH. Now runs `node_modules/.bin/lint-staged` directly (the binary's presence is already guaranteed by the guard above).
- **K9** (`.claude/hooks/safe-launch.sh`) — the degraded-path containment check resolved the parent dir but not the leaf, so a symlinked leaf could pass while writes landed outside. Now rejects a symlinked leaf outright (falls through to the "ask" default).
- **K10** (`.hooks/lint-skills.sh`) — a comment-only frontmatter made `grep -v '^#'` exit 1 and abort the whole linter under `set -e`; and the description period-count `sed` range read into the next frontmatter field. Now branches on grep's exit code and extracts the description value (stopping before the next top-level key) with awk.
- **K12** (`.pre-commit-config.yaml`) — pinned the four framework hooks (`pre-commit-hooks`, `shellcheck-py`, `pre-commit-shfmt`, `ruff-pre-commit`) to commit SHAs with `# vX.Y` comments.

## Invariant test

`tests/test_hook_fail_closed.py` (new file) curates `PATH` down to a whitelist so a specific dependency is genuinely absent, then asserts each hook fails closed:
- `commit-msg` refuses without Node — and the `ALLOW_UNLINTED_COMMITS=1` escape hatch positively allows the skip.
- `pre-push-check` refuses on a Node project without `jq` — and the stdin command gate positively skips a non-push command (`ls -la`) without ever reaching the jq-guarded checks.
- `pre-commit` invokes the lint-staged binary directly (verified via a marker file) when no package manager is on PATH.

## Decisions made

- **K4 — stdin command-gating instead of the newer `if` field.** The docs' recommended narrowing is the per-handler `if` field, but that key may be rejected by older pinned Claude Code versions (which could break the whole hooks config), and setting only `"matcher": "Bash"` would fire the heavy checks on every Bash call. Reading the command from the PreToolUse stdin payload is version-agnostic and fails closed. Alternative (add `if: "Bash(git push*)"`): cleaner config but risks schema rejection on the pinned version.
- **K2 — refuse rather than selectively add.** When the pre-run worktree is dirty I refuse to auto-commit at all (rather than trying to diff fixer output from user WIP). `git status --porcelain` counts untracked files as dirty too, so this is deliberately conservative; the alternative (add only files the fixers touched) is fragile because a fixer can also touch a file the user was mid-editing.
- **K1 — allow `skills/**` only.** Skills are instructions, not executed hook code. `Read(.claude/**)` stays broad; only executable/config paths are denied.
- **Invariant test placement.** Added as a new file `tests/test_hook_fail_closed.py` (rather than editing `tests/test_claude_hooks.py`) to keep this PR file-disjoint from the parallel Python-test-quality PR.

## Validation

- `tests/test_hook_fail_closed.py` and `tests/test_claude_hooks.py` — pass.
- `shellcheck -x` and `shfmt -i 2` — clean on all edited scripts.
- `prettier --check` — clean on `.claude/settings.json` and `.pre-commit-config.yaml`.
- `ruff check` / `ruff format --check` — clean on the new test.


---
_Generated by [Claude Code](https://claude.ai/code/session_018ZSXDUnuc5tDxi2Q7o7CLS)_