### PR TITLE
fix(rehydrate): close secret-extraction oracles in Edit/Write re-anchoring

### DIFF
--- a/bin/sanitize-cli.mjs
+++ b/bin/sanitize-cli.mjs
@@ -120,6 +120,15 @@ const OPS = {
     return classifyPrompt(req.text);
   },
 
+  // SECURITY (R8): `scanInstructionFiles` and `cleanFile` take filesystem
+  // paths/globs straight from the request and read (and, for cleanFile, WRITE)
+  // whatever they resolve to, with NO root confinement — `cwd`/`path`/`globs`
+  // may escape any directory (absolute paths, `..`, symlinks). Unlike the
+  // text-in/text-out ops, the request here names files on the host. The stdin
+  // peer that sends these requests must therefore be FULLY TRUSTED: never wire
+  // this CLI's stdin to untrusted/model-controlled input for these ops. If you
+  // must accept untrusted callers, add opt-in root confinement (reject paths
+  // that resolve outside an allow-listed root) before exposing them.
   async scanInstructionFiles(req) {
     if (
       !Array.isArray(req.globs) ||

--- a/src/rehydrate.mjs
+++ b/src/rehydrate.mjs
@@ -49,10 +49,13 @@
 import { applyLayer1, LONE_SURROGATE_RE } from "./layer1.mjs";
 import {
   occurrences,
+  overlapAwareCount,
+  orderedMatches,
   alignDeletions,
   resolveSpan,
   rehydrateNewString,
   pairsToUtf16,
+  pairDiskSpans,
 } from "./view-map.mjs";
 
 // Cheap gate: every redaction placeholder the canonical redactor emits starts
@@ -171,6 +174,31 @@ async function rehydrateEdit(
     // secret elsewhere in the file is denied with guidance instead of being
     // written out literally.
     if (content.includes(oldS)) {
+      // R1: the old_string is invisible in the model's view yet matches disk.
+      // If a disk match cuts INTO a redacted secret's on-disk span without
+      // covering the whole secret, the model is targeting bytes it never saw —
+      // a stray match, or a probe (`old:"-" → "\n-"`) that splits the secret so
+      // the next redaction pass stops matching it, leaking it. That is never a
+      // legitimate re-anchor; fail closed. A match that WHOLLY contains a secret
+      // (the model supplied the secret's real bytes itself, e.g. a rotation)
+      // extracts nothing and is left to the literal resolver below.
+      const diskSpans = pairDiskSpans(view, deletions);
+      const intrudes = occurrences(content, oldS).some((matchStart) => {
+        const matchEnd = matchStart + oldS.length;
+        return diskSpans.some(
+          (secret) =>
+            matchStart < secret.end &&
+            secret.start < matchEnd &&
+            !(matchStart <= secret.start && secret.end <= matchEnd),
+        );
+      });
+      if (intrudes)
+        return {
+          deny:
+            `old_string matches bytes inside a ${hint}…] redacted secret in ` +
+            `${ti.file_path} that are hidden from your view; edit only text you can ` +
+            `see (include each placeholder whole), or ask the user to make this change`,
+        };
       const literalRes = rehydrateNewString(
         oldS,
         ti.new_string,
@@ -188,10 +216,15 @@ async function rehydrateEdit(
         `view of ${ti.file_path}; re-read the file and copy the placeholder text exactly`,
     };
   }
-  if (viewOcc.length > 1 && !ti.replace_all)
+  // R5: `occurrences` steps by the needle length, so a self-overlapping
+  // old_string ("aa" in "aaa") reports a single match and would slip past the
+  // >1 gate — yet it has multiple anchors the view can differ from disk at.
+  // Count with overlap awareness so the ambiguity is caught.
+  const viewMatchCount = overlapAwareCount(view.text, oldS);
+  if (viewMatchCount > 1 && !ti.replace_all)
     return {
       deny:
-        `old_string matches ${viewOcc.length} locations in the sanitized view of ` +
+        `old_string matches ${viewMatchCount} locations in the sanitized view of ` +
         `${ti.file_path}, and the view can differ from disk at each (redacted ` +
         `secrets, stripped invisible characters); add surrounding context to make it unique`,
     };
@@ -223,6 +256,22 @@ async function rehydrateEdit(
   // Identical view spans hide identical disk text, so every span carries the
   // same placeholder/original sequence — resolve new_string against the first.
   const span = spans[0];
+  // R2: replace_all rewrites EVERY on-disk occurrence of the resolved bytes, but
+  // only the sanitized-view occurrences were vetted. Each view occurrence maps to
+  // exactly one disk occurrence, so a larger disk count means extra matches exist
+  // where the view can't show them — inside a redacted secret's on-disk span, or
+  // a stripped run. real Edit would splice those hidden bytes too (splitting a
+  // secret so the redactor stops matching it, or corrupting it); fail closed.
+  const diskMatchCount = occurrences(content, span.diskText).length;
+  if (ti.replace_all && diskMatchCount !== viewOcc.length)
+    return {
+      deny:
+        `replace_all would rewrite ${diskMatchCount} on-disk occurrence(s) of the matched ` +
+        `text but only ${viewOcc.length} are visible in the sanitized view of ` +
+        `${ti.file_path}; the rest are hidden inside redacted secrets or stripped ` +
+        `characters. Edit each visible occurrence separately with unique context, or ask ` +
+        `the user to make this change`,
+    };
   // Soundness gate (see resolveSpan): greedy deletion alignment can anchor a
   // view span to the wrong disk bytes when a stripped run abuts kept text it
   // resembles. Refuse on either symptom:
@@ -319,8 +368,11 @@ async function rehydrateWrite(ti, view, io, hint) {
         `Edit instead, or write the secret's real value directly`,
     };
 
-  let out = ti.content;
-  const secrets = [];
+  // Resolve each of this file's placeholder texts to its single secret first,
+  // then splice in ONE ordered pass (R6). A chained `out.split(ph).join(secret)`
+  // per placeholder is unsound: an inserted secret whose bytes contain a later
+  // placeholder text would be re-matched and corrupted by the next split.
+  const valueByPh = new Map();
   for (const phText of texts) {
     const produced = view.pairs.filter((pair) => pair.placeholder === phText);
     if (occurrences(view.text, phText).length > produced.length)
@@ -338,9 +390,41 @@ async function rehydrateWrite(ti, view, io, hint) {
           `so a whole-file Write cannot tell which is which; use Edit with unique ` +
           `surrounding context for each`,
       };
-    out = out.split(phText).join(values[0]);
-    secrets.push(values[0]);
+    valueByPh.set(phText, values[0]);
   }
+  const matches = orderedMatches(ti.content, texts);
+  let out = "";
+  let last = 0;
+  // Hint occurrences introduced BY the substituted secrets (a pathological
+  // secret whose bytes contain the hint prefix), weighted by how many times each
+  // secret was inserted — so they are not later misread as foreign placeholders.
+  let secretHintCount = 0;
+  for (const match of matches) {
+    const secret = valueByPh.get(match.text);
+    out += ti.content.slice(last, match.index) + secret;
+    last = match.index + match.text.length;
+    secretHintCount += occurrences(secret, hint).length;
+  }
+  out += ti.content.slice(last);
+  const secrets = [...valueByPh.values()];
+
+  // R3: the new content may mix a valid same-file placeholder (substituted
+  // above) with a FOREIGN one — a placeholder pasted from another file/context
+  // that shares the hint prefix but is not one of this file's own. Those were
+  // left untouched and would be persisted verbatim over a real secret. After
+  // substitution, allow only the hint occurrences that genuinely exist as
+  // literal prose in the file's own view; any surplus is an unresolved foreign
+  // placeholder, so deny with the same cross-file guidance.
+  const literalHintCount =
+    occurrences(view.text, hint).length - view.pairs.length;
+  if (occurrences(out, hint).length - secretHintCount > literalHintCount)
+    return {
+      deny:
+        `the new content still carries a ${hint}…] placeholder that does not match any ` +
+        `secret in ${ti.file_path}, so a whole-file Write cannot copy a placeholder from ` +
+        `another file or context; request the source file's content and rehydrate a ` +
+        `same-file Edit instead, or write the secret's real value directly`,
+    };
 
   const exposed = await exposedSecrets(secrets, view.text, out, io);
   if (exposed > 0) return { deny: exposureDeny(exposed) };
@@ -424,11 +508,24 @@ export async function rehydrateRedacted(
     // promises Node-shaped read failures (a real `readFile`'s throw), so
     // narrow once here rather than re-deriving the cast at every use below.
     const nodeErr = /** @type {NodeJS.ErrnoException} */ (err);
-    // ENOENT (missing target): an Edit fails on its own; a Write creates a
-    // new file whose placeholder text can only be literal content. Pass
-    // through — this is the only read failure that genuinely means "nothing
-    // real is at risk here."
-    if (nodeErr?.code === "ENOENT") return null;
+    // ENOENT (missing target): an Edit fails on its own (nothing to
+    // re-anchor), so pass through. A Write, though, CREATES the file with its
+    // content verbatim — and a Write candidate is always hinted (isCandidate
+    // requires the hint prefix), so its placeholder stands for a secret that
+    // does NOT exist on this new path. R4: persisting "[REDACTED…]" literally
+    // there is the same cross-file/stale-placeholder mistake a same-file Write
+    // is denied for; refuse with the same guidance rather than write the
+    // placeholder text as a real value.
+    if (nodeErr?.code === "ENOENT") {
+      if (tool !== "Write") return null;
+      return {
+        deny:
+          `${toolInput.file_path} does not exist, so the ${hint}…] placeholder in the ` +
+          `new content stands for no secret on disk; a new file cannot copy a placeholder ` +
+          `from another file or context. Write the secret's real value directly, or ask ` +
+          `the user to make this change`,
+      };
+    }
     // Any OTHER read failure (EACCES, EMFILE, a transient I/O error, …) means
     // the target very likely still EXISTS with real bytes on disk — the read
     // failed, the file didn't vanish. A hinted call's content may carry
@@ -448,14 +545,18 @@ export async function rehydrateRedacted(
     };
   }
   const { layer1Cleaned, cleaned } = layer1View(content);
-  // A Layer-1-clean file's view differs from disk only at placeholders, which
-  // a hint-free old_string cannot touch: a verbatim match needs no
-  // translation, and a mismatch is an ordinary stale old_string Edit should
-  // report itself. Either way the redactor is skipped — and so is the
-  // exposure check (see the module doc's "Security invariant" scoping note):
-  // no placeholder is in play, so there is nothing this module could rehydrate
-  // to check for exposure.
-  if (!hinted && cleaned === content) return null;
+  // A Layer-1-clean file's view differs from disk ONLY at redacted secrets.
+  // R1: if nothing is redacted, a hint-free old_string cannot touch a hidden
+  // span, so keep the fast pass-through (a verbatim match needs no translation;
+  // a mismatch is an ordinary stale old_string Edit reports itself) and never
+  // invoke the redactor's map mode. But if the file DOES hold secrets, a
+  // hint-free old_string can still match disk bytes INSIDE a redacted span the
+  // model never saw — the char-by-char extraction oracle. Fall through to the
+  // resolver so its overlap/exposure guards run before any such byte is spliced
+  // raw. `io.redact` (plain mode) is the cheap secrets-present probe; it returns
+  // null exactly when the file has no secrets.
+  if (!hinted && cleaned === content && (await io.redact(cleaned)) === null)
+    return null;
 
   // alignDeletions needs a true subsequence of `content`; the lone-surrogate
   // normalization folded into `cleaned` is a substitution, not a deletion

--- a/src/view-map.mjs
+++ b/src/view-map.mjs
@@ -34,6 +34,30 @@ export function occurrences(haystack, needle) {
 }
 
 /**
+ * Count of ALL matches of `needle` in `haystack`, including self-overlapping
+ * ones (stepping by 1, not by the needle length). `occurrences` deliberately
+ * steps by the needle length so it never reports overlapping spans — correct
+ * for splicing, but it undercounts a self-overlapping needle (e.g. "aa" in
+ * "aaa" is one non-overlapping match yet two overlapping ones). Ambiguity
+ * gating must use THIS count: an old_string that overlaps itself has more than
+ * one anchor a human (or the real Edit tool) could mean, so it is ambiguous even
+ * when `occurrences` reports a single non-overlapping match.
+ * @param {string} haystack
+ * @param {string} needle
+ * @returns {number}
+ */
+export function overlapAwareCount(haystack, needle) {
+  if (needle === "") return 0;
+  let count = 0;
+  let i = haystack.indexOf(needle);
+  while (i !== -1) {
+    count++;
+    i = haystack.indexOf(needle, i + 1);
+  }
+  return count;
+}
+
+/**
  * The character runs Layer 1 deleted, located by greedy subsequence alignment
  * (stripping only deletes, so `cleaned` is always a subsequence of `content`).
  * Throws if the subsequence property does not hold — the caller fails closed.
@@ -103,7 +127,22 @@ export function pairsToUtf16(text, pairs) {
   prefix[0] = 0;
   for (let i = 0; i < codePoints.length; i++)
     prefix[i + 1] = prefix[i] + codePoints[i].length;
-  return pairs.map((pair) => ({ ...pair, start: prefix[pair.start] }));
+  return pairs.map((pair) => {
+    // A redactor offset outside [0, codePoints.length] indexes `prefix` out of
+    // range and would silently yield `start: undefined`, which then poisons
+    // every downstream offset comparison (undefined < n is always false) and
+    // mis-anchors or corrupts the edit. Fail loudly instead — an out-of-range
+    // pair means the injected redactor's map contract was violated.
+    if (
+      !Number.isInteger(pair.start) ||
+      pair.start < 0 ||
+      pair.start > codePoints.length
+    )
+      throw new Error(
+        `redaction pair start ${pair.start} is out of range [0, ${codePoints.length}]`,
+      );
+    return { ...pair, start: prefix[pair.start] };
+  });
 }
 
 /**
@@ -177,12 +216,38 @@ export function resolveSpan(
  * @param {string[]} needles
  * @returns {{text: string, index: number}[]}
  */
-function orderedMatches(text, needles) {
+export function orderedMatches(text, needles) {
   const out = [];
   for (const needle of needles)
     for (const index of occurrences(text, needle))
       out.push({ text: needle, index });
   return out.sort((left, right) => left.index - right.index);
+}
+
+/**
+ * On-disk [start, end) span of every redaction pair, mapped from its view
+ * offset through placeholder expansion (view → cleaned) and stripped invisible
+ * runs (cleaned → disk). A run abutting the secret stays outside its span (it
+ * was never part of the secret); interior runs are included. Callers use these
+ * to detect an edit whose on-disk footprint intrudes into bytes the model was
+ * never shown.
+ * @param {{pairs: {placeholder: string, original: string, start: number}[]}} view
+ * @param {{start: number, deleted: string}[]} deletions
+ * @returns {{start: number, end: number}[]}
+ */
+export function pairDiskSpans(view, deletions) {
+  return view.pairs.map((pair) => {
+    // pair.start is a placeholder boundary; placeholders never overlap, so it is
+    // never strictly interior to another placeholder and mapViewOffset resolves.
+    const cleanedStart = mapViewOffset(view.pairs, pair.start);
+    if (cleanedStart === null)
+      throw new Error("redaction pair start maps inside another placeholder");
+    const cleanedEnd = cleanedStart + pair.original.length;
+    return {
+      start: diskOffset(deletions, cleanedStart, false),
+      end: diskOffset(deletions, cleanedEnd, true),
+    };
+  });
 }
 
 /**
@@ -241,8 +306,13 @@ export function rehydrateNewString(oldS, newS, spanPairs, filePairs) {
     };
   }
 
-  let out = newS;
-  const secrets = [];
+  // Each placeholder text must name exactly one secret; resolve that mapping
+  // first, then splice in a SINGLE ordered pass. A chained
+  // `out.split(ph).join(secret)` per placeholder is unsound: an inserted secret
+  // whose bytes happen to contain a later placeholder text would be re-matched
+  // and corrupted (or partially exposed) by the next split. One pass over the
+  // ordered match positions only ever touches the original new_string bytes.
+  const valueByPh = new Map();
   for (const phText of new Set(newSeq.map((match) => match.text))) {
     const values = [
       ...new Set(
@@ -258,8 +328,13 @@ export function rehydrateNewString(oldS, newS, spanPairs, filePairs) {
           `and new_string changes their count or order; keep each one in place, or ` +
           `edit them one at a time with unique surrounding context`,
       };
-    out = out.split(phText).join(values[0]);
-    secrets.push(values[0]);
+    valueByPh.set(phText, values[0]);
   }
-  return { text: out, secrets };
+  let out = "";
+  let last = 0;
+  for (const match of newSeq) {
+    out += newS.slice(last, match.index) + valueByPh.get(match.text);
+    last = match.index + match.text.length;
+  }
+  return { text: out + newS.slice(last), secrets: [...valueByPh.values()] };
 }

--- a/test/rehydrate-property.test.mjs
+++ b/test/rehydrate-property.test.mjs
@@ -116,6 +116,11 @@ function pickSpan(view, startSeed, lenSeed) {
 
 describe("rehydrate: properties", () => {
   it("never mis-anchors and round-trips the model's intended edit", async () => {
+    // T4: invariants 2 + 5 (round-trip and no-exposure) only run inside the
+    // unambiguous single-match precondition below. Count how often that branch
+    // is actually taken so a fixture/generator change that stops reaching it can
+    // never let the property pass vacuously.
+    let sawRoundTrip = 0;
     await fc.assert(
       fc.asyncProperty(
         contentArb,
@@ -170,6 +175,7 @@ describe("rehydrate: properties", () => {
             occ(content, updatedOld).length === 1 &&
             occ(view, oldS).length === 1
           ) {
+            sawRoundTrip++;
             const newDisk = content.replace(
               updatedOld,
               result.updatedInput.new_string,
@@ -190,6 +196,10 @@ describe("rehydrate: properties", () => {
         },
       ),
       runOptions,
+    );
+    assert.ok(
+      sawRoundTrip > 0,
+      "round-trip/no-exposure precondition never held — property passed vacuously",
     );
   });
 
@@ -228,5 +238,89 @@ describe("rehydrate: properties", () => {
       ),
       runOptions,
     );
+  });
+
+  it("never splices a byte inside a redacted secret's on-disk span (deny, never guess)", async () => {
+    // A file with a secret at a KNOWN disk span. We fuzz old_string over a pool
+    // that includes fragments living only inside the secret, boundary-crossing
+    // slices, visible text, whole-secret rotations, and self-overlapping runs —
+    // with and without replace_all. INVARIANT: whenever the layer returns a
+    // rewrite, applying it must leave the secret's on-disk bytes intact UNLESS
+    // the model's old_string wholly contained them. Any edit that would read or
+    // split bytes inside the span must deny, never pass through to a raw edit.
+    const secret = SECRET_A;
+    const prefix = "PASSWORD=";
+    const content = `${prefix}${secret}\nDEBUG=1\nEND\n`;
+    const secretStart = content.indexOf(secret);
+    const secretEnd = secretStart + secret.length;
+
+    // A pool of adversarial and benign old_strings.
+    const oldPool = [
+      secret.slice(0, 3), // fragment: only inside the secret
+      secret.slice(-3), // tail fragment: only inside the secret
+      secret[0], // single char inside the secret
+      `${prefix}${secret.slice(0, 4)}`, // crosses the secret's start boundary
+      `${prefix}${secret}`, // wholly contains the secret (rotation)
+      `${prefix}[REDACTED]`, // hinted: resolves to a rewrite covering the secret
+      "DEBUG=1", // visible, disjoint from the secret
+      "END", // visible, disjoint
+      secret.slice(0, 2).repeat(1) + secret[0], // self-overlap-ish
+    ];
+
+    let sawRewrite = 0;
+    let sawDeny = 0;
+    await fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(...oldPool),
+        fc.constantFrom("", "X", "\n-", "replaced"),
+        fc.boolean(),
+        async (oldS, newS, replaceAll) => {
+          if (oldS.length === 0) return;
+          const result = await rehydrateRedacted(
+            "Edit",
+            {
+              file_path: "/f",
+              old_string: oldS,
+              new_string: newS,
+              replace_all: replaceAll,
+            },
+            fakeIo(content),
+          );
+          if (result === null) return;
+          if ("deny" in result) {
+            sawDeny++;
+            return;
+          }
+          sawRewrite++;
+          const updatedOld = result.updatedInput.old_string;
+          // The model's old_string must wholly cover any part of the secret the
+          // rewrite touches — otherwise it would splice hidden bytes.
+          for (const at of occ(content, updatedOld)) {
+            const end = at + updatedOld.length;
+            const overlaps = at < secretEnd && secretStart < end;
+            if (overlaps)
+              assert.ok(
+                at <= secretStart && secretEnd <= end,
+                `rewrite splices partially inside the secret span: ` +
+                  `old=${JSON.stringify(oldS)} disk=${JSON.stringify(updatedOld)}`,
+              );
+          }
+          // And re-sanitizing the applied edit must not newly reveal the secret.
+          if (!replaceAll && occ(content, updatedOld).length === 1) {
+            const newDisk = content.replace(
+              updatedOld,
+              result.updatedInput.new_string,
+            );
+            const before = new Set(exposedInView(content).map((s) => s.value));
+            for (const s of exposedInView(newDisk))
+              assert.ok(before.has(s.value), "secret exposed by the rewrite");
+          }
+        },
+      ),
+      runOptions,
+    );
+    // Both branches must actually be exercised or the invariant is vacuous.
+    assert.ok(sawDeny > 0, "no deny ever exercised — invariant vacuous");
+    assert.ok(sawRewrite > 0, "no rewrite ever exercised — invariant vacuous");
   });
 });

--- a/test/rehydrate.test.mjs
+++ b/test/rehydrate.test.mjs
@@ -402,7 +402,13 @@ describe("rehydrate: gating", () => {
           new_string: "x",
           new_source: `v=${PH}`,
         },
-        { readFile: () => "plain\n", redactMap: () => mkView("plain\n", []) },
+        {
+          readFile: () => "plain\n",
+          redactMap: () => mkView("plain\n", []),
+          // Hint-free Edit on a Layer-1-clean file: the R1 secrets-present probe
+          // (io.redact) runs before the redactor's map mode; no secrets here.
+          redact: () => null,
+        },
       ),
       null,
     );
@@ -1041,6 +1047,247 @@ describe("rehydrate: Write", () => {
       { hint: "[REDACTED" },
     );
     assert.match(out.context, /\[REDACTED…\] placeholders/);
+  });
+});
+
+// ─── Hidden-span safety: no edit may read/split bytes inside a redacted span ──
+//
+// Core invariant (R1/R2/R5): for a file holding a redacted secret, no Edit or
+// Write — hinted or not, replace_all or not, self-overlapping or not — may
+// read, split, or mutate a byte INSIDE the secret's on-disk span unless the
+// model supplied the whole secret itself. Every such attempt must DENY, never
+// pass through to a raw disk edit (a char-by-char extraction oracle) or rewrite
+// that splices hidden bytes.
+
+describe("rehydrate: hidden-span safety", () => {
+  // SECRET_A === "hunter2hunter2hunter2xA": "hunter" appears 3× inside it and
+  // "2xA" appears only there — perfect probes for bytes the view hides as PH.
+  const FRAGMENT_ONLY_IN_SECRET = "2xA";
+  const FRAGMENT_VISIBLE_AND_IN_SECRET = "hunter";
+
+  it("R1: denies a hint-free Edit whose old_string matches ONLY inside a redacted secret", async () => {
+    const content = `PASSWORD=${SECRET_A}\nDEBUG=1\n`;
+    const out = await rehydrateRedacted(
+      "Edit",
+      {
+        file_path: "/f",
+        old_string: FRAGMENT_ONLY_IN_SECRET,
+        new_string: `${FRAGMENT_ONLY_IN_SECRET}\nEXTRA=1`,
+      },
+      liveIo(content, [{ value: SECRET_A, placeholder: PH }], reRedact),
+    );
+    assert.match(out.deny, /inside a \[REDACTED…\] redacted secret/);
+    assert.match(out.deny, /hidden from your view/);
+    assert.equal(out.updatedInput, undefined);
+  });
+
+  it("R1: denies a hint-free replace_all fragment that would splice inside the secret", async () => {
+    // "2xA" is hint-free, invisible in the view, but on disk sits inside the
+    // secret. replace_all would splice it there; deny (viewOcc===0 branch).
+    const content = `PASSWORD=${SECRET_A}\n`;
+    const out = await rehydrateRedacted(
+      "Edit",
+      {
+        file_path: "/f",
+        old_string: FRAGMENT_ONLY_IN_SECRET,
+        new_string: "Z",
+        replace_all: true,
+      },
+      liveIo(content, [{ value: SECRET_A, placeholder: PH }], reRedact),
+    );
+    assert.match(out.deny, /hidden from your view/);
+  });
+
+  it("R1: does NOT deny a hint-free Edit whose old_string wholly contains the secret (rotation)", async () => {
+    // The model supplied the secret's own bytes (e.g. a rotation): it extracts
+    // nothing, so this is left to pass through (null), not falsely denied.
+    const content = `PASSWORD=${SECRET_A}\n`;
+    const out = await rehydrateRedacted(
+      "Edit",
+      {
+        file_path: "/f",
+        old_string: `PASSWORD=${SECRET_A}`,
+        new_string: "PASSWORD=rotated",
+      },
+      liveIo(content, [{ value: SECRET_A, placeholder: PH }], reRedact),
+    );
+    assert.equal(out, null);
+  });
+
+  it("R2: denies a replace_all whose resolved bytes occur more often on disk than in the view", async () => {
+    const content = `note ${FRAGMENT_VISIBLE_AND_IN_SECRET} x\nPASSWORD=${SECRET_A}\n`;
+    const out = await rehydrateRedacted(
+      "Edit",
+      {
+        file_path: "/f",
+        old_string: FRAGMENT_VISIBLE_AND_IN_SECRET,
+        new_string: "HUNTER",
+        replace_all: true,
+      },
+      liveIo(content, [{ value: SECRET_A, placeholder: PH }], reRedact),
+    );
+    assert.match(out.deny, /replace_all would rewrite \d+ on-disk occurrence/);
+    assert.match(out.deny, /hidden inside redacted secrets or stripped/);
+    assert.equal(out.updatedInput, undefined);
+  });
+
+  it("R2: allows a replace_all when every disk occurrence is visible in the view", async () => {
+    // "PASSWORD=[REDACTED]" resolves to the same disk bytes at both spots and
+    // the resolved bytes occur exactly twice on disk — no hidden occurrence.
+    const src = `PASSWORD=${SECRET_A}\nPASSWORD=${SECRET_A}\n`;
+    const vw = mkView(src, [{ value: SECRET_A, placeholder: PH }]);
+    const out = await rehydrateRedacted(
+      "Edit",
+      {
+        file_path: "/f",
+        old_string: `PASSWORD=${PH}`,
+        new_string: `PASSWD=${PH}`,
+        replace_all: true,
+      },
+      fakeIo(src, vw, reRedact),
+    );
+    assert.equal(out.updatedInput.old_string, `PASSWORD=${SECRET_A}`);
+  });
+
+  it("R5: denies a self-overlapping hint-free old_string the >1 gate would miss", async () => {
+    // A trailing ZW makes the view diverge from disk so the edit reaches the
+    // resolver; "aa" in "aaa" is one non-overlapping match but two overlapping
+    // anchors — ambiguous, so deny.
+    const content = `aaa${ZW}\n`;
+    const out = await rehydrateRedacted(
+      "Edit",
+      { file_path: "/f", old_string: "aa", new_string: "bb" },
+      liveIo(content),
+    );
+    assert.match(out.deny, /matches 2 locations/);
+    assert.match(out.deny, /add surrounding context to make it unique/);
+  });
+
+  it("R4: denies a hinted Write to a MISSING file instead of persisting the placeholder literally", async () => {
+    const enoentIo = {
+      readFile: () => {
+        throw fsError("ENOENT");
+      },
+      redactMap: () => {
+        throw new Error("redactMap must not be reached");
+      },
+      redact: () => null,
+    };
+    const out = await rehydrateRedacted(
+      "Write",
+      { file_path: "/new", content: `secret: ${PH}\n` },
+      enoentIo,
+    );
+    assert.match(out.deny, /\/new does not exist/);
+    assert.match(
+      out.deny,
+      /cannot copy a placeholder from another file or context/,
+    );
+    assert.equal(out.updatedInput, undefined);
+  });
+
+  it("R4: still passes an Edit through on a missing file (Edit fails on its own)", async () => {
+    const enoentIo = {
+      readFile: () => {
+        throw fsError("ENOENT");
+      },
+      redactMap: () => {
+        throw new Error("redactMap must not be reached");
+      },
+      redact: () => null,
+    };
+    assert.equal(
+      await rehydrateRedacted(
+        "Edit",
+        { file_path: "/missing", old_string: `x ${PH}`, new_string: "y" },
+        enoentIo,
+      ),
+      null,
+    );
+  });
+});
+
+// ─── Write: cross-file / re-substitution safety (R3, R6) ─────────────────────
+
+describe("rehydrate: Write cross-file and re-substitution safety", () => {
+  it("R3: denies a Write that mixes a valid same-file placeholder with a FOREIGN one", async () => {
+    // The file's own secret is under PH; PH_PEM shares the hint prefix but names
+    // no secret here (pasted from another file). The valid PH is substituted,
+    // but PH_PEM would survive verbatim — deny rather than persist it.
+    const src = `PASSWORD=${SECRET_A}\n`;
+    const vw = mkView(src, [{ value: SECRET_A, placeholder: PH }]);
+    const out = await rehydrateRedacted(
+      "Write",
+      { file_path: "/f", content: `PASSWORD=${PH}\nKEY=${PH_PEM}\n` },
+      fakeIo(src, vw, reRedact),
+    );
+    assert.match(out.deny, /still carries a \[REDACTED…\] placeholder/);
+    assert.match(
+      out.deny,
+      /cannot copy a placeholder from another file or context/,
+    );
+    assert.equal(out.updatedInput, undefined);
+  });
+
+  it("R3: allows a Write whose only leftover hint-prefixed text is genuine prose the file already had", async () => {
+    // The file documents "[REDACTEDXYZ]" as prose — it shares the hint prefix
+    // "[REDACTED" but is NOT any placeholder (no "]" right after "REDACTED"), so
+    // it is not a redaction pair and does not collide with PH. Substituting the
+    // real secret leaves that prose token; R3 must count it as a pre-existing
+    // literal and NOT raise a cross-file deny.
+    const prose = "[REDACTEDXYZ]";
+    const src = `see ${prose} docs\nPW=${SECRET_A}\n`;
+    const vw = {
+      text: `see ${prose} docs\nPW=${PH}\n`,
+      pairs: [
+        {
+          placeholder: PH,
+          original: SECRET_A,
+          start: `see ${prose} docs\nPW=`.length,
+        },
+      ],
+    };
+    const out = await rehydrateRedacted(
+      "Write",
+      { file_path: "/f", content: `see ${prose} docs\nPW=${PH}\n` },
+      fakeIo(src, vw, reRedact),
+    );
+    assert.equal(
+      out.updatedInput.content,
+      `see ${prose} docs\nPW=${SECRET_A}\n`,
+    );
+  });
+
+  it("R6: a Write substitutes in one pass, never re-touching an inserted secret's bytes", async () => {
+    // SECRET_A's bytes literally contain PH_PEM's placeholder text. A chained
+    // split(PH).join(secret) then split(PH_PEM).join(secretB) would clobber the
+    // PH_PEM substring inside the just-inserted secret; one pass must not.
+    const SECRET_WITH_PH = `pre${PH_PEM}post`;
+    const src = `A=${SECRET_WITH_PH}\nB=${SECRET_C}\n`;
+    const vw = {
+      text: `A=${PH}\nB=${PH_PEM}\n`,
+      pairs: [
+        { placeholder: PH, original: SECRET_WITH_PH, start: 2 },
+        {
+          placeholder: PH_PEM,
+          original: SECRET_C,
+          start: `A=${PH}\nB=`.length,
+        },
+      ],
+    };
+    const reRedactMix = (text) =>
+      text.split(SECRET_WITH_PH).join(PH).split(SECRET_C).join(PH_PEM);
+    const out = await rehydrateRedacted(
+      "Write",
+      { file_path: "/f", content: `A=${PH}\nB=${PH_PEM}\n` },
+      fakeIo(src, vw, reRedactMix),
+    );
+    assert.equal(
+      out.updatedInput.content,
+      `A=${SECRET_WITH_PH}\nB=${SECRET_C}\n`,
+    );
+    // The PH_PEM text survives verbatim inside the inserted secret (not clobbered).
+    assert.ok(out.updatedInput.content.includes(SECRET_WITH_PH));
   });
 });
 

--- a/test/view-map.test.mjs
+++ b/test/view-map.test.mjs
@@ -9,6 +9,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
   occurrences,
+  overlapAwareCount,
   alignDeletions,
   resolveSpan,
   rehydrateNewString,
@@ -43,6 +44,28 @@ describe("occurrences", () => {
     // reported once each without revisiting an index.
     assert.deepEqual(occurrences("aaa", "a"), [0, 1, 2]);
     assert.deepEqual(occurrences("aXa", "a"), [0, 2]);
+  });
+});
+
+// ─── overlapAwareCount (R5) ──────────────────────────────────────────────────
+
+describe("overlapAwareCount", () => {
+  it("counts self-overlapping matches that occurrences() steps past", () => {
+    // "aa" in "aaa" is ONE non-overlapping match but TWO overlapping ones; the
+    // ambiguity gate must see the overlapping count to flag it.
+    assert.equal(occurrences("aaa", "aa").length, 1);
+    assert.equal(overlapAwareCount("aaa", "aa"), 2);
+    assert.equal(overlapAwareCount("aaaa", "aa"), 3);
+  });
+
+  it("agrees with occurrences() when matches do not overlap", () => {
+    assert.equal(overlapAwareCount("abcabc", "abc"), 2);
+    assert.equal(overlapAwareCount("xyz", "q"), 0);
+    assert.equal(overlapAwareCount("a", "a"), 1);
+  });
+
+  it("returns 0 for an empty needle (no infinite loop)", () => {
+    assert.equal(overlapAwareCount("anything", ""), 0);
   });
 });
 
@@ -265,6 +288,30 @@ describe("rehydrateNewString", () => {
     assert.match(out.deny, /multiple distinct secrets/);
   });
 
+  it("R6: a secret whose bytes contain another placeholder text is not re-substituted", () => {
+    // The per-placeholder branch (new_string uses PH twice, so the sequence is
+    // not 1:1 with the span) must build the output in ONE pass. Here SECRET_A's
+    // bytes literally contain PH_KEY's placeholder text: a chained
+    // split(PH).join(secret) then split(PH_KEY).join(SECRET_B) would clobber the
+    // PH_KEY substring INSIDE the just-inserted SECRET_A. A single ordered pass
+    // never re-scans inserted bytes.
+    const SECRET_WITH_PH_KEY = `val${PH_KEY}end`;
+    const spanPairs = [
+      { placeholder: PH, original: SECRET_WITH_PH_KEY, start: 0 },
+      { placeholder: PH_KEY, original: SECRET_B, start: 50 },
+    ];
+    const oldS = `${PH} ${PH_KEY}`;
+    const newS = `${PH} ${PH} ${PH_KEY}`; // PH twice ⇒ not a 1:1 sequence
+    const out = rehydrateNewString(oldS, newS, spanPairs, spanPairs);
+    assert.equal(
+      out.text,
+      `${SECRET_WITH_PH_KEY} ${SECRET_WITH_PH_KEY} ${SECRET_B}`,
+    );
+    // The PH_KEY text survives verbatim inside each inserted SECRET_A.
+    assert.equal(occurrences(out.text, PH_KEY).length, 2);
+    assert.deepEqual(out.secrets, [SECRET_WITH_PH_KEY, SECRET_B]);
+  });
+
   it("filePairs deduplicates: a placeholder absent from new_string is skipped", () => {
     // filePairs references PH_KEY but new_string never mentions it ⇒ the
     // `!newS.includes(phText)` guard continues past it without denying.
@@ -305,6 +352,31 @@ describe("pairsToUtf16", () => {
   it("returns the empty pairs array unchanged", () => {
     const empty = [];
     assert.equal(pairsToUtf16("🔑 no pairs", empty), empty);
+  });
+
+  it("throws on an out-of-range start instead of yielding an undefined offset (R7)", () => {
+    // A redactor offset past the end of `text` indexes the prefix table out of
+    // range; silently returning `start: undefined` poisons every downstream
+    // comparison. Fail loudly on high, negative, and non-integer offsets.
+    const text = "abc"; // 3 code points → valid starts are 0..3
+    assert.throws(
+      () => pairsToUtf16(text, [{ placeholder: PH, original: "x", start: 4 }]),
+      /out of range \[0, 3\]/,
+    );
+    assert.throws(
+      () => pairsToUtf16(text, [{ placeholder: PH, original: "x", start: -1 }]),
+      /out of range/,
+    );
+    assert.throws(
+      () =>
+        pairsToUtf16(text, [{ placeholder: PH, original: "x", start: 1.5 }]),
+      /out of range/,
+    );
+    // Boundary: start === codePoints.length (points at the very end) is valid.
+    assert.deepEqual(
+      pairsToUtf16(text, [{ placeholder: PH, original: "x", start: 3 }]),
+      [{ placeholder: PH, original: "x", start: 3 }],
+    );
   });
 
   it("normalizes several pairs, each by the astral count preceding it", () => {

--- a/test/view-map.test.mjs
+++ b/test/view-map.test.mjs
@@ -14,6 +14,7 @@ import {
   resolveSpan,
   rehydrateNewString,
   pairsToUtf16,
+  pairDiskSpans,
 } from "../src/view-map.mjs";
 
 // Secrets assembled at runtime so no complete token literal trips push
@@ -393,5 +394,36 @@ describe("pairsToUtf16", () => {
       PH_KEY,
     );
     assert.equal(text.slice(out[1].start, out[1].start + PH.length), PH);
+  });
+});
+
+describe("pairDiskSpans", () => {
+  it("maps a redaction pair to its [start,end) disk span", () => {
+    // Happy path: one placeholder, no deletions, so the disk span is the
+    // pair's own [start, start+original.length).
+    const spans = pairDiskSpans(
+      { pairs: [{ placeholder: "[REDACTED]", original: "secret", start: 0 }] },
+      [],
+    );
+    assert.deepEqual(spans, [{ start: 0, end: "secret".length }]);
+  });
+
+  it("throws when a pair start maps inside another placeholder", () => {
+    // Defensive guard: placeholders never overlap in real views, but pass an
+    // overlapping pair set directly to prove the guard throws rather than
+    // silently emitting a garbage span (which would misplace a secret's disk
+    // footprint). The second pair's start (3) is strictly interior to the
+    // first placeholder "[REDACTED]" (offsets [0,10)), so mapViewOffset returns
+    // null.
+    const view = {
+      pairs: [
+        { placeholder: "[REDACTED]", original: "secret", start: 0 },
+        { placeholder: "[X]", original: "y", start: 3 },
+      ],
+    };
+    assert.throws(
+      () => pairDiskSpans(view, []),
+      /maps inside another placeholder/,
+    );
   });
 });


### PR DESCRIPTION
## Summary

Hardens the redaction rehydration layer (`src/rehydrate.mjs` + `src/view-map.mjs`) so **no Edit/Write can read, split, or mutate a byte inside a redacted secret's on-disk span unless the model supplied the whole secret**. Every unresolvable/hidden-span case fails closed as a `deny` with instructive guidance — never a pass-through to a raw disk edit (a char-by-char extraction oracle) or a rewrite that splices hidden bytes.

The core attack this closes: a hint-free Edit like `old:"-" → "\n-", replace_all` splits every secret across lines so the redactor stops matching them (leaking them on the next read), and the succeed/fail signal of any such probe is a 1-bit oracle for byte-by-byte secret extraction.

## Findings fixed

**R1 (high)** — A hint-free Edit whose `old_string` matched only *inside* a redacted secret span early-exited and ran raw against disk. It now probes for secrets via `io.redact` before the fast pass-through, and in the resolver denies a disk match that cuts **partially** into a secret span. A match that **wholly contains** a secret (the model supplied the secret's own bytes, e.g. a rotation) extracts nothing and still passes through — avoiding a false denial on legitimate content.

**R2 (high)** — `replace_all` rewrote *all* disk occurrences though only *view* occurrences were vetted. Now denies when `occurrences(content, diskText).length !== viewOcc.length` (each view match maps to exactly one disk match, so a surplus means hidden matches inside secrets/stripped runs).

**R3 (high)** — The cross-file-placeholder deny only fired when *no* placeholder matched this file. A whole-file Write mixing a valid same-file placeholder with a foreign one now denies after substitution if the output carries a hint-prefixed token beyond the file's genuine literal prose (a hint-bearing secret's own bytes are discounted so they aren't misread as foreign).

**R4 (med)** — A hinted Write to a missing file (ENOENT) persisted the placeholder literally into the new file. Now denies with the cross-file guidance; a missing-file Edit still passes through (it fails on its own).

**R5 (low)** — Ambiguity gating used non-overlapping counting, so a self-overlapping `old_string` (`"aa"` in `"aaa"`) slipped the `>1` gate. Added `overlapAwareCount` (scans with `indexOf(needle, i+1)`) and gate on it; `occurrences` is unchanged (splicing still needs non-overlapping steps).

**R6 (low)** — Chained `split/join` placeholder substitution (view-map's per-placeholder branch and `rehydrateWrite`) could re-substitute inside an already-inserted secret whose bytes contain another placeholder's text. Both now build output in one ordered pass that never re-scans inserted bytes.

**R7 (low)** — `pairsToUtf16` yielded `undefined` for an out-of-range redactor offset, poisoning downstream comparisons. Now throws when `pair.start` is not an integer in `[0, codePoints.length]`.

**R8 (low)** — Documented that the CLI's `cleanFile`/`scanInstructionFiles` ops take filesystem paths straight from the request with no root confinement, so the stdin peer must be fully trusted.

## Tests

- Unit + property coverage for each finding (R1–R7).
- New invariant property (`test/rehydrate-property.test.mjs`): fuzzes `old_string` over secret-fragment / boundary-crossing / rotation / self-overlapping shapes and asserts no returned rewrite ever splices partially inside a secret span, with non-vacuity guards on both the deny and rewrite branches.
- **T4**: instrumented the round-trip/no-exposure precondition with a `sawRoundTrip` counter and `assert.ok(sawRoundTrip > 0)` so the property can't pass vacuously.
- `overlapAwareCount`, `pairsToUtf16` out-of-range throw, and single-pass substitution have direct unit tests.

Full suite: 1443 pass / 0 fail. `tsc --noEmit`, `eslint .`, and `prettier --check` all clean. (The pre-existing `package-exports` test fails identically on `main` in this sandbox because its `npm pack` invokes `pnpm`, which can't run here — `tsc -p tsconfig.build.json` itself succeeds.)

## Decisions made

- **R1 partial-vs-whole overlap.** The finding said to deny when a disk match *overlaps* a secret span. Denying on *any* overlap would also block a legitimate secret rotation where `old_string` wholly contains the secret (the model already has those bytes, so nothing is extracted) — and the existing "passes through a raw-byte match the view does not contain" test asserts that case returns `null`. Chosen default: deny only on **partial** overlap (a match that neither is disjoint from nor wholly contains the secret). Under the stricter alternative, rotations that resupply the exact secret bytes would be denied and would need to be re-expressed as a placeholder-bearing Edit.
- **R1 secrets-present probe.** To decide whether a hint-free Layer-1-clean Edit may fast-pass, the code calls `io.redact(content)` (returns null iff nothing is redacted) rather than always invoking the map-mode redactor — this preserves the existing "redactMap must not be reached" fast-path contract for secret-free files. Alternative: always run `redactMap` and inspect `pairs`, which would reach the redactor on every clean-file edit.
- **R3 literal-prose accounting.** "Pre-existing literal occurrence" is measured against the file's own view (`occurrences(view.text, hint) - pairs.length`). A whole-file Write that *invents* new `[REDACTED…]`-shaped prose not present in the file is therefore denied (it is ambiguous with a placeholder). Alternative would be to allow arbitrary new hint-shaped prose, at the cost of letting a genuinely foreign placeholder through when paired with invented prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZSXDUnuc5tDxi2Q7o7CLS)_