### PR TITLE
ci: correct stale version comments on the checkout SHA pin

### DIFF
--- a/.github/workflows/auto-version.yaml
+++ b/.github/workflows/auto-version.yaml
@@ -39,7 +39,7 @@ jobs:
         # Credentials stay persisted: version-bump.sh pushes the release-docs
         # commit and the vX.Y.Z tag with them. A PAT lets the tag push clear any
         # tag protection; falls back to GITHUB_TOKEN.
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6.0.2 # zizmor: ignore[artipacked]
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 # zizmor: ignore[artipacked]
         with:
           # Need full history so `git describe`/`git log` can find the last tag.
           fetch-depth: 0

--- a/.github/workflows/sync-required-checks.yaml
+++ b/.github/workflows/sync-required-checks.yaml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## Summary

The `# vX.Y` comment on a SHA-pinned GitHub Action is the only human-readable check that an immutable pin matches the intended release. Two workflows carried comments that lied about the pinned commit: `actions/checkout@9c091bb2…` is the **v7.0.0** commit, but it was labelled `# v6` (`sync-required-checks.yaml`) and `# v6.0.2` (`auto-version.yaml`) — versions that resolve to *different* commits (`df4cb1c` and `de0fac2` respectively). A reviewer trusting the comment would believe a different action version is running than actually is.

Verified against the upstream `actions/checkout` tags list: `9c091bb` → v7.0.0, `df4cb1c` → v6.0.3, `de0fac2` → v6.0.2. The SHA is genuinely v7.0.0 (as ~12 other pins in this repo already state); only these two comments had drifted, most likely left stale when the SHA was bumped.

This is comment-only normalization — no pinned SHA changes, so no action behavior changes.

## Changes

- `.github/workflows/auto-version.yaml`: `# v6.0.2` → `# v7.0.0` on the checkout pin (the `# zizmor: ignore[artipacked]` trailer is preserved).
- `.github/workflows/sync-required-checks.yaml`: `# v6` → `# v7.0.0` on the checkout pin.

## Tests / verification

- Confirmed the SHA↔version mapping against the upstream tags list before editing.
- Swept every `uses: owner/repo@<sha> # vX` across `.github/workflows` and `.github/actions`: after this change, each distinct SHA carries a single, truthful version comment. The remaining multi-version actions (`actions/checkout` v7.0.0 **and** v6.0.3, `actions/cache`, `actions/setup-node`, `pnpm/action-setup`) are legitimate version divergence with accurate comments, out of scope here.
- No SHA changed, so no workflow behavior changed; YAML remains valid.

## Decisions made

- **Comment fix only — no SSOT manifest or drift-guard test.** I first considered a generalizable check (a committed pin manifest as the single source of truth, or a SHA↔version consistency guard). Rejected both after discussion: GitHub Actions requires the literal `owner/repo@<sha> # vX.Y` inline in every workflow and cannot reference a manifest at runtime, so the version label is inherently duplicated N times. That leaves only (a) manifest + conformance test (two sources coupled by a guard — not a true SSOT), or (b) manifest + a YAML-rewriting generator with a regeneration round-trip check (a real single-edit SSOT, but heavy and fiddly for a comment fix). Neither is a zero-test SSOT, so for a comment normalization the proportionate choice is to simply make the comments truthful. *Under the alternative*, if this drift recurs often, the generator route (mirroring `gen-standardized-variants.mjs`) would make the manifest the sole edit point and regenerate the inline comments.


---
_Generated by [Claude Code](https://claude.ai/code/session_018ZSXDUnuc5tDxi2Q7o7CLS)_