### PR TITLE
fix(ci): stop npm-warning contamination from breaking the version bump

### DIFF
--- a/.github/scripts/version-bump.sh
+++ b/.github/scripts/version-bump.sh
@@ -92,13 +92,21 @@ max_version() {
 # repoint the `latest` dist-tag downward, so anything other than E404 fails loud.
 PACKAGE_NAME=$(node -p "require('./package.json').name")
 NPM_VIEW_RC=0
-NPM_VIEW_OUTPUT=$(npm view "$PACKAGE_NAME" version 2>&1) || NPM_VIEW_RC=$?
+# Capture stdout and stderr SEPARATELY. npm prints the version to stdout but
+# routes warnings (e.g. "Unknown project config" for pnpm-only .npmrc keys like
+# confirm-modules-purge) and the E404 "not published" error to stderr. Folding
+# them together with `2>&1` let a warning land as the first line of the captured
+# output, so the `head -n1` below parsed the warning as the version and the
+# semver guard rejected it. Keep stdout clean for parsing; read E404 off stderr.
+NPM_VIEW_ERR=$(mktemp)
+trap 'rm -f "$NPM_VIEW_ERR"' EXIT
+NPM_VIEW_OUTPUT=$(npm view "$PACKAGE_NAME" version 2>"$NPM_VIEW_ERR") || NPM_VIEW_RC=$?
 if [[ "$NPM_VIEW_RC" -eq 0 ]]; then
   CURRENT_VERSION="$NPM_VIEW_OUTPUT"
-elif grep -q "E404" <<<"$NPM_VIEW_OUTPUT"; then
+elif grep -q "E404" "$NPM_VIEW_ERR"; then
   CURRENT_VERSION="0.0.0"
 else
-  log "Error: npm view failed unexpectedly (not E404). Refusing to guess a version: $NPM_VIEW_OUTPUT"
+  log "Error: npm view failed unexpectedly (not E404). Refusing to guess a version: $(cat "$NPM_VIEW_ERR")"
   exit 1
 fi
 # `npm view` can print nothing on a success exit (never-published package) or

--- a/test/html.test.mjs
+++ b/test/html.test.mjs
@@ -232,6 +232,7 @@ const HIDDEN_STYLE_CASES = [
   // ── per-declaration salvage on parse failure ──
   ["x;display:none", true], // one invalid decl must not blank the whole style (bypass fix)
   ["display:none;x", true], // invalid decl trailing the valid one is salvaged too
+  ["x;;display:none", true], // empty segment from `;;` is skipped, rest salvaged
   ["bad!!!;color:red", false], // salvage must not manufacture a false positive
   ["bad!!!;x also bad", false], // no declaration salvages at all — fails open
   // ── CSS-escaped keyword decoding ──


### PR DESCRIPTION
## Summary

The **Auto version bump and publish** workflow has failed on every merge to `main`, so no release has been published. The `Bump version and publish` step aborts with:

```
Error: npm returned a non-semver current version: 'npm warn Unknown project config "confirm-modules-purge". This will stop working in the next major version of npm...'. Refusing to guess a bump.
```

`version-bump.sh` reads the current published version with `npm view "$PKG" version 2>&1`. `npm view` prints the version to **stdout**, but routes warnings and the E404 "not published" error to **stderr**. The `.npmrc` carries a pnpm-only key (`confirm-modules-purge`) that npm doesn't recognize, so npm emits `Unknown project config` on stderr on every invocation. Folding stderr into stdout with `2>&1` put that warning as the **first** captured line, and the subsequent `head -n1` parsed the warning text as the version — which the strict semver guard then rejected, killing the release.

## Changes

- `.github/scripts/version-bump.sh`: capture `npm view`'s stdout and stderr separately. Parse the version from clean stdout; grep `E404` (and surface unexpected failures) from a dedicated stderr temp file, cleaned up via an `EXIT` trap. The `2>&1` that mixed the two streams is gone, so unknown-config warnings — or any future npm notice — can no longer contaminate the version parse. E404 → `0.0.0` (first release) and non-E404 failures → loud abort are both preserved.
- `test/html.test.mjs`: add a deterministic `isHiddenStyle` case (`"x;;display:none"`) that pins the empty-declaration branch in `parseStyleSalvage` (`html.mjs:444`). See Decisions made.

## Tests / verification

`version-bump.sh` — extracted the capture/parse block into a harness driven by a stub `npm` covering all three paths:

- **Published + npm warns on stderr** → parses `1.4.2` (this is the case that was broken).
- **Unpublished (E404 on stderr, exit 1)** → `0.0.0`.
- **Transient non-E404 failure** → fails loud, exit 1.

`html.test.mjs` — verified via `c8` that `html.mjs:444` is now covered by the unit file alone (previously it dropped out of the deterministic set), so the 100% branch-coverage gate no longer depends on fuzz exploration.

## Decisions made

- **Bundled a one-line coverage-pin test into this PR.** After the first push, the `test` / `node-tests-passed` checks failed on `html.mjs:444` — the `!decl.trim()` skip branch in `parseStyleSalvage`. This PR's `src/` is byte-identical to `main` (only `version-bump.sh` changed) and `main` passed the same check at 100%, so the branch was flaky: it was exercised only incidentally by the fuzz/corpus suites, not by any deterministic case. Rather than re-run the job and leave the flake to bite the next PR, I pinned the branch with a deterministic `isHiddenStyle` case. **Alternative:** split it into its own PR — rejected because the failing gate blocks *this* PR's auto-merge and the fix is a single test line. If you'd prefer it separated, I can lift it out.

## Checklist

- [x] Commits follow Conventional Commits; each subject reads as a user-facing release note.
- [x] Behavior verified via stubbed-`npm` harness (version bump) and `c8` branch coverage (html test).
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version left untouched (this fix is what lets the release workflow own them again).

## Lessons Learned

- **Template file:** `scripts/version-bump.sh` (the `auto-version.yaml` release script that `phone-home.yaml` propagates).
- **What:** Never capture a command's version/output with `2>&1` when only stdout carries the value. `npm view` (and most npm commands) emit warnings and errors on stderr; a single unknown `.npmrc` key — common when the repo uses pnpm, whose config keys npm doesn't recognize — makes npm print `Unknown project config` on stderr, which `2>&1` + `head -n1` then parses as the version and aborts every release.
- **Where:** the `npm view "$PACKAGE_NAME" version` capture in `version-bump.sh`.
- **Why:** downstream repos forked from this template inherit both the pnpm `.npmrc` and this script, so they hit the identical release-blocking failure on their first merge. Capturing stdout for parsing and reading E404 off a separate stderr file makes the bump robust to any npm warning.