### PR TITLE
fix(secrets,html): precision + leak fixes from the audit

### DIFF
--- a/python/agent_input_sanitizer/secrets/detectors.py
+++ b/python/agent_input_sanitizer/secrets/detectors.py
@@ -200,20 +200,22 @@ class JwtFullTokenDetector(_jwt.JwtTokenDetector):
     Subclasses ``JwtTokenDetector`` to keep its base64/JSON validation; only the
     signature quantifier changes from lazy to greedy. gitleaks rule: ``jwt``."""
 
-    # Per-segment quantifiers are BOUNDED ({1,8192}) rather than ``+``: an
+    # Per-segment quantifiers are BOUNDED ({1,65536}) rather than ``+``: an
     # unbounded run retried at every ``eyJ`` start makes an unanchored search
-    # polynomial, and a finite bound is provably linear. 8192 base64 chars/segment
-    # dwarfs any real header/payload/signature (incl. RS512), so the bound never
-    # truncates a genuine token. The third segment is optional so unsigned
-    # (``header.payload.``) and two-part JWTs still match, exactly as the bundled
-    # detector did.
+    # polynomial, and a finite bound is provably linear. The bound must clear a
+    # full RFC 7515 header carrying an ``x5c`` certificate CHAIN — several base64
+    # DER certs run well past 8192 chars, and a header that overflowed the bound
+    # matched NOTHING and leaked the whole JWT in cleartext. 65536 base64
+    # chars/segment dwarfs even a multi-cert chain while staying linear. The
+    # third segment is optional so unsigned (``header.payload.``) and two-part
+    # JWTs still match, exactly as the bundled detector did.
     # noqa rationale: detect-secrets' RegexBasedDetector declares `denylist` as an
     # instance attribute, so a ClassVar annotation errors pyright; the subclass sets it
     # as a class attribute by framework contract, which is the shared-state RUF012 flags.
     denylist = [  # noqa: RUF012
         re.compile(
-            r"eyJ[A-Za-z0-9_=-]{1,8192}\.[A-Za-z0-9_=-]{1,8192}"
-            r"(?:\.[A-Za-z0-9_=-]{0,8192})?"
+            r"eyJ[A-Za-z0-9_=-]{1,65536}\.[A-Za-z0-9_=-]{1,65536}"
+            r"(?:\.[A-Za-z0-9_=-]{0,65536})?"
         ),
     ]
 

--- a/python/agent_input_sanitizer/secrets/engine.py
+++ b/python/agent_input_sanitizer/secrets/engine.py
@@ -434,6 +434,48 @@ def _is_filesystem_path(m: re.Match[str]) -> bool:
     return _FS_PATH_RE.fullmatch(m.group("secret_value")) is not None
 
 
+# A bare origin/endpoint URL (`https://oauth2.googleapis.com/token`, an OAuth
+# discovery/authorize endpoint) is public content the model needs — but the
+# field-value regex captures the whole URL because the field NAME trips the
+# keyword (`token_url`, `secret_endpoint`, `access_token_url`). Redacting it
+# strips a public endpoint for no security gain. Skip a URL that carries no
+# credential material; keep redacting one that DOES embed a secret.
+_ENDPOINT_URL_RE = re.compile(r"https?://[^\s]+\Z", re.IGNORECASE)
+# Userinfo credentials in the authority (`https://user:pass@host/…`): a password
+# before the `@` is a real secret, so such a URL is never skipped.
+_URL_USERINFO_RE = re.compile(r"https?://[^/@\s]*:[^/@\s]*@", re.IGNORECASE)
+# An opaque credential-shaped run: >=20 CONTIGUOUS base64/hex-alphabet chars
+# mixing letters AND digits (a Slack webhook token path, a bearer blob) — the
+# high-entropy shape a benign path segment (`token`, `authorize`, `v2`,
+# `completions`) never takes. `-`/`_`/`.`/`/` are NOT in the run, so a
+# hyphen-joined dictionary path (`report-2024-01-15-final`) splits into short
+# words and is not mistaken for a secret.
+_URL_OPAQUE_RUN_RE = re.compile(r"[A-Za-z0-9]{20,}")
+
+
+def _has_opaque_run(value: str) -> bool:
+    """True when ``value`` contains a >=20-char contiguous alphanumeric run that
+    mixes letters and digits — an opaque credential-shaped token."""
+    return any(
+        any(c.isdigit() for c in run) and any(c.isalpha() for c in run)
+        for run in _URL_OPAQUE_RUN_RE.findall(value)
+    )
+
+
+def _is_public_endpoint_url(value: str) -> bool:
+    """True when the value is a bare origin/endpoint URL carrying no credential
+    material (no userinfo password, no opaque high-entropy token in the
+    path/query), so redacting it would strip a public endpoint. A URL that DOES
+    embed a secret (a Slack ``webhook_url`` token path, ``user:pass@``) is not
+    skipped. Attacker-safe on web ingress: a clean URL hides no secret, and a
+    smuggled token in the path trips the opaque-run gate."""
+    if _ENDPOINT_URL_RE.fullmatch(value) is None:
+        return False
+    if _URL_USERINFO_RE.match(value):
+        return False
+    return not _has_opaque_run(value)
+
+
 # A content-addressed digest is public data, not a credential: git/OCI object IDs
 # and bare blockchain hashes. Two separate patterns (not one alternation): each is
 # provably ReDoS-safe, but their union blows past recheck's node budget.
@@ -732,8 +774,8 @@ def _redact_core(
     def _replace_field(m: re.Match[str]) -> str:
         # Name-based skips (cursor / path / metadata field) are attacker-relabelable
         # on web ingress, so they only apply to local tool output; the value-shape
-        # skips (placeholder, content-digest, UUID) are trustworthy regardless of
-        # source and apply on web ingress too.
+        # skips (placeholder, content-digest, UUID, public endpoint URL) are
+        # trustworthy regardless of source and apply on web ingress too.
         name_skip = not web_ingress and (
             _is_benign_cursor(m)
             or _is_filesystem_path(m)
@@ -750,6 +792,7 @@ def _redact_core(
             or _is_placeholder_value(value)
             or _is_content_digest(value)
             or _is_uuid(value)
+            or _is_public_endpoint_url(value)
         ):
             return m.group(0)
         found.append("named secret field")

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -81,6 +81,11 @@ const ABSOLUTE_UNIT_RE =
   /^[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?\s*(?:px|em|rem|ex|ch|pt|pc|in|cm|mm)$/;
 const VIEWPORT_UNIT_RE =
   /^[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?\s*(?:vw|vh|vmin|vmax|%)$/;
+// Like VIEWPORT_UNIT_RE but WITHOUT `%`: inside a `translate()` a percentage is
+// resolved against the element's OWN size, not the viewport, so it can't be
+// judged offscreen without layout (see isOffscreenTranslate).
+const VIEWPORT_LENGTH_RE =
+  /^[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?\s*(?:vw|vh|vmin|vmax)$/;
 
 /** @param {string} value @returns {boolean} */
 function isOffscreenOffset(value) {
@@ -94,6 +99,25 @@ function isOffscreenOffset(value) {
   // position), and a unit-blind "contains a negative number" guess flags those
   // benign expressions — which would splice visible text. Ambiguity must fail
   // OPEN (visible), so unresolved calc is left alone.
+  return false;
+}
+
+/**
+ * Like isOffscreenOffset but for a `translate()` argument, where a percentage
+ * resolves against the element's OWN size (not the viewport). A right-aligned
+ * popover `left:100%; transform:translateX(-100%)` sits fully on screen, so a
+ * `%` translate is unresolvable without layout and fails OPEN. Absolute units
+ * (px/em/…) and true viewport units (vw/vh/…) ARE viewport-relative and keep
+ * their offscreen thresholds.
+ * @param {string} value
+ * @returns {boolean}
+ */
+function isOffscreenTranslate(value) {
+  if (!value) return false;
+  if (ABSOLUTE_UNIT_RE.test(value))
+    return parseFloat(value) < OFFSCREEN_ABSOLUTE_THRESHOLD;
+  if (VIEWPORT_LENGTH_RE.test(value))
+    return parseFloat(value) <= OFFSCREEN_VIEWPORT_THRESHOLD;
   return false;
 }
 
@@ -126,7 +150,7 @@ function isHidingTransform(transform) {
   // test each — checking only the first arg missed a `translate(0, -9999px)`.
   for (const match of transform.matchAll(/\btranslate(?:[xy])?\(\s*([^)]*)/gi))
     for (const arg of match[1].split(","))
-      if (isOffscreenOffset(arg.trim())) return true;
+      if (isOffscreenTranslate(arg.trim())) return true;
   return false;
 }
 
@@ -148,13 +172,47 @@ function isHidingFilter(filter) {
   return fraction < NEAR_ZERO_EPSILON;
 }
 
+// A single `clip: rect(top, right, bottom, left)` edge, parsed to its number and
+// unit; `auto` and any non-length token yield null (unresolvable → fail open).
+const CLIP_EDGE_RE = /^([-+]?\d*\.?\d+)\s*([a-z%]*)$/;
+
+/**
+ * True when a legacy `clip: rect(...)` clips the element to ~ZERO AREA — the
+ * clipping window's width (`right - left`) or height (`bottom - top`) collapses
+ * to near nothing. Checking only that the FIRST edge is `0` (the old
+ * `rect(0…)`) spliced a VISIBLE `rect(0px,100px,100px,0px)` (a 100x100 window);
+ * mirrors `isClipPathHidden`'s all-edges rule. Edges may be comma- OR
+ * space-separated; an `auto`/unresolvable edge, or a pair in mismatched units,
+ * fails OPEN (not proven collapsed).
+ * @param {string} clip lowercased, trimmed
+ * @returns {boolean}
+ */
+function isClipRectHidden(clip) {
+  const rect = clip.match(/\brect\(([^)]*)\)/);
+  if (!rect) return false;
+  const parts = rect[1].split(/[\s,]+/).filter(Boolean);
+  if (parts.length !== 4) return false;
+  const edges = parts.map((part) => part.match(CLIP_EDGE_RE));
+  if (edges.some((edge) => edge === null)) return false;
+  const [top, right, bottom, left] = /** @type {RegExpMatchArray[]} */ (
+    edges
+  ).map((edge) => ({ num: parseFloat(edge[1]), unit: edge[2] }));
+  /**
+   * @param {{ num: number, unit: string }} a
+   * @param {{ num: number, unit: string }} b
+   */
+  const collapsed = (a, b) =>
+    a.unit === b.unit && Math.abs(a.num - b.num) < NEAR_ZERO_EPSILON;
+  return collapsed(left, right) || collapsed(top, bottom);
+}
+
 /** @param {(key: string) => string} val */
 function isPositionedOffscreen(val) {
   if (!/\babsolute\b|\bfixed\b/.test(val("position"))) return false;
   for (const side of ["left", "top", "right", "bottom"])
     if (isOffscreenOffset(val(side))) return true;
   const clip = val("clip");
-  return Boolean(clip && /rect\s*\(\s*0/.test(clip));
+  return Boolean(clip && isClipRectHidden(clip));
 }
 
 // CSS named colors that participate in a white-on-white / black-on-black style
@@ -389,11 +447,30 @@ function isClipPathHidden(clipPath) {
   return expandInsetEdges(parts).every(isCollapsingInsetEdge);
 }
 
-// Gradient-clipped / text-filled headings are VISIBLE despite `color:transparent`:
-// `background-clip:text` (or its `-webkit-` alias) paints the background through
-// the glyph shapes, and `-webkit-text-fill-color` overrides `color` for the fill.
-// Either signal means the transparent `color` is not the rendered text color, so
-// the same-`transparent` hide must fail open.
+// The color painted by `-webkit-text-stroke` (the `<color>` token of the
+// shorthand, or the `-webkit-text-stroke-color` longhand), canonicalized — or
+// "" when it does not resolve to a concrete color. The longhand is a whole
+// color value so canonicalizeColor handles it directly; the shorthand is
+// `<line-width> || <color>`, so the width token (a length) is skipped and the
+// remaining color token canonicalized.
+/** @param {(key: string) => string} val @returns {string} */
+function textStrokeColor(val) {
+  const longhand = canonicalizeColor(val("-webkit-text-stroke-color"));
+  if (isConcreteColor(longhand)) return longhand;
+  for (const token of val("-webkit-text-stroke").split(/\s+/).filter(Boolean)) {
+    const color = canonicalizeColor(token);
+    if (isConcreteColor(color)) return color;
+  }
+  return "";
+}
+
+// Gradient-clipped / text-filled / outlined headings are VISIBLE despite
+// `color:transparent`: `background-clip:text` (or its `-webkit-` alias) paints
+// the background through the glyph shapes, `-webkit-text-fill-color` overrides
+// `color` for the fill, and `-webkit-text-stroke` paints a visible outline
+// around the (transparent-filled) glyphs. Any of these means the transparent
+// `color` is not the rendered text color, so the same-`transparent` hide must
+// fail open.
 /** @param {(key: string) => string} val @returns {boolean} */
 function isTextPaintedVisible(val) {
   if (
@@ -402,7 +479,9 @@ function isTextPaintedVisible(val) {
   )
     return true;
   const fill = canonicalizeColor(val("-webkit-text-fill-color"));
-  return isConcreteColor(fill) && fill !== "transparent";
+  if (isConcreteColor(fill) && fill !== "transparent") return true;
+  const stroke = textStrokeColor(val);
+  return isConcreteColor(stroke) && stroke !== "transparent";
 }
 
 /** @param {(key: string) => string} val */
@@ -466,6 +545,13 @@ function parseStyleSalvage(styleStr) {
 // leaving it undecoded here is a detection bypass.
 const CSS_ESCAPE_RE = /\\([0-9a-fA-F]{1,6})[ \t\n]?|\\(.)/g;
 
+// The trailing `!important` priority flag, stripped AFTER escape-decoding so an
+// escaped spelling (`none!\69mportant`) is caught. Bounded whitespace runs:
+// `\s*` on both sides of an unanchored match backtracks super-linearly
+// (redos/no-vulnerable); a CSS value never carries more than a couple of spaces
+// around `!important`.
+const IMPORTANT_FLAG_RE = /\s{0,8}!\s{0,8}important\s{0,8}$/i;
+
 /** @param {string} value @returns {string} */
 function decodeCssEscapes(value) {
   return value.replace(CSS_ESCAPE_RE, (_match, hex, char) => {
@@ -494,25 +580,25 @@ export function isHiddenStyle(styleStr) {
   const rawProps = parseStyleSalvage(styleStr);
   if (!rawProps) return false;
 
-  // CSS property names are case-insensitive and `!important` is a legal
-  // trailing flag; style-to-object preserves both verbatim.
+  // CSS property names are case-insensitive; style-to-object preserves the raw
+  // value (including any `!important` and CSS escapes) verbatim.
   /** @type {Record<string, string>} */
   const props = {};
-  for (const [key, value] of Object.entries(rawProps)) {
-    props[key.toLowerCase()] = String(value).replace(
-      // Bounded whitespace runs: `\s*` on both sides of an unanchored match
-      // backtracks super-linearly (redos/no-vulnerable). A CSS value never
-      // carries more than a couple of spaces around `!important`.
-      /\s{0,8}!\s{0,8}important\s{0,8}$/i,
-      "",
-    );
-  }
+  for (const [key, value] of Object.entries(rawProps))
+    props[key.toLowerCase()] = String(value);
 
-  // Values are CSS-escape-decoded before every keyword/length comparison
-  // below, so an escaped keyword (`no\6e e`) reads at its true decoded value.
+  // Values are CSS-escape-decoded BEFORE the `!important` flag is stripped and
+  // before every keyword/length comparison below: a browser decodes escapes
+  // first, so `none!\69mportant` renders `display:none !important` (hidden).
+  // Stripping `!important` off the RAW value missed the escaped spelling, so the
+  // value read as `none!important` (≠ `none`) and hidden content leaked. Decode,
+  // then strip the (now-literal) flag, then trim/lowercase for the compares.
   /** @param {string} key */
   const val = (key) =>
-    decodeCssEscapes((props[key] || "").toString().trim()).toLowerCase();
+    decodeCssEscapes((props[key] || "").toString())
+      .replace(IMPORTANT_FLAG_RE, "")
+      .trim()
+      .toLowerCase();
 
   if (val("display") === "none") return true;
   if (val("visibility") === "hidden" || val("visibility") === "collapse")

--- a/test/html.test.mjs
+++ b/test/html.test.mjs
@@ -85,6 +85,16 @@ const HIDDEN_STYLE_CASES = [
   ["position:absolute;left:-100vw", true], // a full viewport-width fully clears the screen
   ["position:absolute;left:-100%", true],
   ["clip:rect(0,0,0,0);position:absolute", true],
+  // clip: rect(top,right,bottom,left) hides only when the window collapses to
+  // ~zero AREA (width right-left or height bottom-top near zero) — parsing all
+  // four edges, not just the first (bug: `rect(0,…)` spliced a visible window).
+  ["clip:rect(0px,100px,100px,0px);position:absolute", false], // 100x100 visible window
+  ["position:absolute;clip:rect(1,1,1,1)", true], // degenerate 0x0 window (the sr-only clip hack)
+  ["position:absolute;clip:rect(10px,10px,20px,10px)", true], // right==left → zero width
+  ["position:absolute;clip:rect(0px,50px,0px,0px)", true], // bottom==top → zero height
+  ["position:absolute;clip:rect(auto,auto,auto,auto)", false], // auto edges unresolvable — fail open
+  ["position:absolute;clip:rect(0px,5em,1em,0px)", false], // mismatched-unit pairs — fail open
+  ["position:absolute;clip:rect(0,0,0)", false], // only 3 edges — malformed, fail open
   ["position:absolute;left:10px", false],
   ["position:absolute;left:-900px", false],
   ["position:absolute;left:-10px", false],
@@ -98,7 +108,6 @@ const HIDDEN_STYLE_CASES = [
   ["position:absolute;left:calc(100% - 5px)", false], // ordinary in-flow calc must not splice
   ["position:static;left:-9999px", false],
   ["position:absolute;left:auto", false], // non-length offset is not offscreen
-  ["position:absolute;clip:rect(1,1,1,1)", false],
   ["position:absolute;left:-1000", false], // unitless nonzero length is INVALID CSS; browser drops it, fails open
   ["position:absolute;left:-9999", false], // same, larger magnitude
   // ── text-indent offscreen ──
@@ -152,6 +161,14 @@ const HIDDEN_STYLE_CASES = [
   ["transform:translate(0,0)", false], // neither axis shifts
   ["transform:translate(5px,-10px)", false], // small two-axis shift stays on screen
   ["transform:translatex(-50vw)", false], // half-shift stays partly visible (precision)
+  // A `%` translate is relative to the element's OWN size, not the viewport, so
+  // it can't be judged offscreen without layout — fail OPEN (bug: `%` was read
+  // as a viewport unit and spliced a right-aligned popover).
+  ["transform:translateX(-100%)", false], // element-relative %, not offscreen
+  ["transform:translateY(-100%)", false],
+  ["transform:translate(-100%,0)", false],
+  ["transform:translate(0,-999%)", false], // large % is still element-relative
+  ["position:absolute;left:100%;transform:translateX(-100%)", false], // right-aligned popover, on screen
   ["transform:scale(0.5)", false],
   ["transform:scale(0.8)", false], // mild shrink stays readable
   ["transform:translatex(5px)", false],
@@ -206,6 +223,12 @@ const HIDDEN_STYLE_CASES = [
   ["color:transparent;background-clip:text", false],
   ["color:transparent;-webkit-text-fill-color:#111", false], // fill color overrides transparent
   ["color:transparent;-webkit-text-fill-color:transparent", true], // fill also transparent — still hidden
+  // ── -webkit-text-stroke paints a visible outline despite transparent fill ──
+  ["color:transparent;-webkit-text-stroke:1px black", false], // outlined glyphs are visible
+  ["color:transparent;-webkit-text-stroke:2px #111", false], // hex stroke color, visible
+  ["color:transparent;-webkit-text-stroke-color:black", false], // longhand stroke color
+  ["color:transparent;-webkit-text-stroke:1px transparent", true], // stroke also transparent — still hidden
+  ["color:transparent;-webkit-text-stroke:1px", true], // width only (currentColor=transparent) — still hidden
   // ── unresolved color tokens: can't prove same-color, so fail open ──
   ["color:var(--fg);background-color:var(--fg)", false], // same var, but resolves via cascade — not provably equal
   ["color:inherit;background:inherit", false], // inherit color != inherit background-color
@@ -240,6 +263,13 @@ const HIDDEN_STYLE_CASES = [
   ["display:\\64 isplay-never-a-real-value", false], // decodes to a nonsense keyword, stays visible
   ["display:\\62 lock", false], // `\62` decodes to 'b' -> "block", correctly visible after decode
   ["visibility:hi\\64 den", true], // `\64` decodes to 'd' -> "hidden"
+  // `!important` is stripped AFTER escape-decoding, so an escaped spelling of the
+  // flag is caught (bug: raw-stripping missed `!\69mportant`, leaving the value
+  // `none!important` != `none`, so hidden content leaked).
+  ["display:none!\\69mportant", true], // `\69` -> 'i' -> "none!important" -> stripped -> "none"
+  ["display:none !\\69mportant", true], // with a space before the escaped flag
+  ["display:block!\\69mportant", false], // decodes to "block!important" -> stripped -> "block", visible
+  ["visibility:hi\\64 den!important", true], // escaped value AND a plain important flag
   // ── invalid escaped codepoints (spec: decode to U+FFFD, never throw) ──
   ["display:\\0", false], // codepoint 0 is invalid
   ["display:\\d800", false], // a surrogate half is invalid

--- a/test/html.test.mjs
+++ b/test/html.test.mjs
@@ -95,6 +95,7 @@ const HIDDEN_STYLE_CASES = [
   ["position:absolute;clip:rect(auto,auto,auto,auto)", false], // auto edges unresolvable — fail open
   ["position:absolute;clip:rect(0px,5em,1em,0px)", false], // mismatched-unit pairs — fail open
   ["position:absolute;clip:rect(0,0,0)", false], // only 3 edges — malformed, fail open
+  ["position:absolute;clip:auto", false], // truthy clip with no rect() — fail open (isClipRectHidden !rect)
   ["position:absolute;left:10px", false],
   ["position:absolute;left:-900px", false],
   ["position:absolute;left:-10px", false],
@@ -168,6 +169,7 @@ const HIDDEN_STYLE_CASES = [
   ["transform:translateY(-100%)", false],
   ["transform:translate(-100%,0)", false],
   ["transform:translate(0,-999%)", false], // large % is still element-relative
+  ["transform:translateX()", false], // empty translate arg — isOffscreenTranslate !value early return
   ["position:absolute;left:100%;transform:translateX(-100%)", false], // right-aligned popover, on screen
   ["transform:scale(0.5)", false],
   ["transform:scale(0.8)", false], // mild shrink stays readable

--- a/tests/secrets/test_secrets_detectors.py
+++ b/tests/secrets/test_secrets_detectors.py
@@ -53,6 +53,24 @@ def test_jwt_rejects_non_json_header_or_payload(token):
     assert not list(detector.analyze_string(token))
 
 
+def test_jwt_with_x5c_cert_chain_header_is_redacted():
+    """A JWT whose header carries an x5c certificate CHAIN (RFC 7515) runs the
+    header segment well past the old 8192-char per-segment bound; the bounded
+    quantifier must clear a multi-cert header or the whole token leaks."""
+    import base64
+
+    # A valid base64url-JSON header whose encoded length exceeds 8192 chars — a
+    # realistic x5c chain is several base64 DER certs.
+    header = {"alg": "RS256", "typ": "JWT", "x5c": ["M" * 7000]}
+    encoded_header = (
+        base64.urlsafe_b64encode(json.dumps(header).encode()).rstrip(b"=").decode()
+    )
+    assert len(encoded_header) > 8192
+    token = f"{encoded_header}.{_JWT_PAYLOAD}.{'A' * 43}"
+    detector = D.JwtFullTokenDetector()
+    assert list(detector.analyze_string(token)), "x5c-header JWT leaked in cleartext"
+
+
 def test_custom_detectors_defined():
     anthropic = D.AnthropicApiKeyDetector
     google = D.GoogleApiKeyDetector

--- a/tests/secrets/test_secrets_engine.py
+++ b/tests/secrets/test_secrets_engine.py
@@ -912,6 +912,93 @@ def test_credential_after_keyword_still_redacts():
     assert found == ["named secret field"]
 
 
+# ─── Public endpoint URLs (a credential-named field holding a bare URL) ───────
+
+# A Slack webhook URL embeds its secret in the path; its final segment is a
+# 24-char opaque token mixing letters and digits. Assembled at runtime (like
+# STRIPE_LIVE/AWS_KEY above) so the whole webhook literal never appears in the
+# source and trips GitHub push protection.
+_SLACK_WEBHOOK = (
+    "https://hooks.slack.com/services/"
+    + "T00000000/B00000000/"
+    + "aB3xK9mN2pQ7rT4wY1cV5bZ8"
+)
+
+
+@pytest.mark.parametrize(
+    "label, value, expected",
+    [
+        ("google oauth token endpoint", "https://oauth2.googleapis.com/token", True),
+        (
+            "azure authorize endpoint",
+            "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+            True,
+        ),
+        ("openai completions endpoint", "https://api.openai.com/v1/completions", True),
+        (
+            "hyphen-joined dated path (no opaque run)",
+            "https://example.com/hooks/report-2024-01-15-final-summary",
+            True,
+        ),
+        ("slack webhook with token path", _SLACK_WEBHOOK, False),
+        (
+            "userinfo password in authority",
+            "https://user:s3cr3tpassw0rd@example.com/api",
+            False,
+        ),
+        (
+            "opaque token in query",
+            "https://example.com/cb?access=aB3xK9mN2pQ7rT4wY1cV5bZ8",
+            False,
+        ),
+        ("not a url", "aB3xK9mN2pQ7rT4wY1cV5bZ8dF0gH6jL", False),
+        ("url with trailing junk is not fullmatch", "not-a-url-just-text-here", False),
+    ],
+)
+def test_is_public_endpoint_url(label, value, expected):
+    assert E._is_public_endpoint_url(value) is expected, label
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["token_url", "access_token_url", "secret_endpoint", "auth_url"],
+)
+def test_public_endpoint_url_skipped_after_keyword(field):
+    # A public endpoint under a credential-named field is NOT a secret; skip it
+    # on BOTH local and web ingress (a clean URL smuggles no credential).
+    text = f"{field} = https://oauth2.googleapis.com/token"
+    for web in (False, True):
+        out, found = redact(text, cfg(web_ingress=web))
+        assert out == text, (field, web)
+        assert found == [], (field, web)
+
+
+# A URL embedding a token/password IS a secret and must still redact — whether
+# the field-value regex catches it or a structural detector (Slack/BasicAuth)
+# does first. The carve-out must not let the embedded secret survive.
+@pytest.mark.parametrize(
+    "label, text, needle",
+    [
+        (
+            "slack webhook token path",
+            f"webhook_url = {_SLACK_WEBHOOK}",
+            "aB3xK9mN2pQ7rT4wY1cV5bZ8",
+        ),
+        (
+            "userinfo password",
+            "auth_url = https://user:s3cr3tpassw0rd@example.com/api",
+            "s3cr3tpassw0rd",
+        ),
+    ],
+)
+def test_secret_bearing_url_still_redacted(label, text, needle):
+    assert E._is_public_endpoint_url(text.split(" = ", 1)[1]) is False, label
+    for web in (False, True):
+        out, found = redact(text, cfg(web_ingress=web))
+        assert needle not in out, (label, web)
+        assert found, (label, web)
+
+
 # ─── Web-ingress disables relabelable skips ──────────────────────────────────
 
 


### PR DESCRIPTION
Six audit-confirmed defects, each paired with negative/positive corpus tests (exact-equality), per the precision-over-recall doctrine.

**Under-redaction (leaks):**
- **JWT `x5c` leak** (`detectors.py`): the per-segment denylist bound `{1,8192}` let a JWT whose header carries an RFC 7515 `x5c` cert chain (>8192 base64 chars) escape redaction entirely. Raised to `{1,65536}` (bounded quantifier stays linear). Proven non-vacuous: old detector leaks a 9463-char token, new one redacts it.
- **Public-URL over-redaction** (`engine.py`): `token`/`secret`/`key` prefixing a longer `*_url`/`*_endpoint` field caused a bare public endpoint URL to be redacted. Added a value-shape skip for an origin/endpoint URL whose path/query carries no opaque credential-shaped run; a URL embedding a secret (Slack `webhook_url`, `user:pass@`) is still redacted.

**Over-splicing / hidden-content bypass (`html.mjs`):**
- **`clip:rect(0…)`** parsed only the first edge → a visible `rect(0,100,100,0)` window was spliced. Now parses all four edges; hidden only when the region collapses to ~zero area.
- **`translate(%)`** treated an element-relative `%` as viewport-relative → a right-aligned `translateX(-100%)` popover was spliced. Now fails open on `%`.
- **Escaped `!important`**: the flag was stripped before CSS escapes were decoded, so `display:none!\69mportant` (browser-valid, renders hidden) leaked. Decode-then-strip; it's now treated hidden.
- **`-webkit-text-stroke`**: `color:transparent` outlined text is visible but was spliced. `isTextPaintedVisible` now honors a concrete non-transparent stroke color.

## Decisions made
- `clip:rect(1,1,1,1)` verdict flipped false→true: it collapses to a 0×0 window (the `.sr-only` hack), genuinely invisible, so "collapses to ~zero area" correctly marks it hidden.
- Opaque-run detection requires a letter+digit mix, so a hyphen-joined path (`report-2024-01-15-final`) isn't mistaken for a token — precision over a small recall cost; structural detectors still catch known formats.

Tests: `node --test` 1615 passed; `pytest tests/secrets` 721 passed; tsc + ruff/eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JxiLFJQY4JAQDJ9bAHNN3D)_