### PR TITLE
build(deps): bump ci-truth-serum to pick up branch-ruleset disambiguation fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
   # applies here with no config change; check-symlinks is the one hook outside
   # any tier, so it stays listed.
   - repo: https://github.com/alexander-turner/ci-truth-serum
-    rev: e438c361e232fa2f69ab36ff9a29a1e639e0c5a7 # main
+    rev: 1314a61e16854aa43da3612989c86533a5667b30 # main
     hooks:
       - id: check-tier1
       - id: check-tier2


### PR DESCRIPTION
The `sync-required-checks` workflow here was failing with `Expected exactly one branch ruleset on AlexanderMattTurner/agent-input-sanitizer, found 2; pass --ruleset-id to disambiguate` — this repo is covered by both its own repo-level branch ruleset and an inherited org-level one, and the old `find_branch_ruleset` bailed on the ambiguity.

That's now fixed in ci-truth-serum ([#35](https://github.com/AlexanderMattTurner/ci-truth-serum/pull/35)): when several branch rulesets exist it narrows to the sole `source_type == "Repository"` one (the only target the `/repos/{repo}/rulesets/{id}` PATCH can write). This PR bumps the pinned ci-truth-serum rev (read from `.pre-commit-config.yaml`, which is also the SSOT the sync step uses) from `e438c361` to the merged `1314a61` so the fix goes live here.

The bump also pulls other accumulated ci-truth-serum changes (e.g. stricter workflow-lint hooks); CI will surface anything that needs attention.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGE731B9SzBXvHC59CnGEk)_