### PR TITLE
feat(ci): ntfy notification on build/publish failure

### DIFF
--- a/.github/actions/notify-ntfy/action.yaml
+++ b/.github/actions/notify-ntfy/action.yaml
@@ -1,0 +1,48 @@
+name: "Notify ntfy on failure"
+description: >-
+  Push a phone notification through ntfy when a build or publish workflow fails.
+  A no-op when the topic secret is unset, so it never reddens a run on its own.
+
+inputs:
+  topic:
+    description: "ntfy topic, from secrets.GH_NTFY_SUBJECT. When empty the action is a silent no-op."
+    required: true
+  base-url:
+    description: >-
+      ntfy server base URL. Pass secrets.GH_NTFY_URL to target a self-hosted
+      instance; an empty value falls back to https://ntfy.sh.
+    required: false
+    default: ""
+  title:
+    description: "Notification title."
+    required: true
+  message:
+    description: "Notification body."
+    required: true
+  priority:
+    description: "ntfy priority, 1 (min) to 5 (max). Defaults to 5 — a broken build/publish wants attention."
+    required: false
+    default: "5"
+  tags:
+    description: "Comma-separated ntfy tags/emoji shown with the notification."
+    required: false
+    default: "rotating_light"
+  click:
+    description: "URL opened when the notification is tapped — typically the failing run."
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Send ntfy notification
+      shell: bash
+      env:
+        NTFY_TOPIC: ${{ inputs.topic }}
+        NTFY_BASE_URL: ${{ inputs.base-url }}
+        NTFY_TITLE: ${{ inputs.title }}
+        NTFY_MESSAGE: ${{ inputs.message }}
+        NTFY_PRIORITY: ${{ inputs.priority }}
+        NTFY_TAGS: ${{ inputs.tags }}
+        NTFY_CLICK: ${{ inputs.click }}
+      run: bash "${GITHUB_ACTION_PATH}/notify-ntfy.sh"

--- a/.github/actions/notify-ntfy/notify-ntfy.sh
+++ b/.github/actions/notify-ntfy/notify-ntfy.sh
@@ -11,13 +11,13 @@
 set -euo pipefail
 
 topic="${NTFY_TOPIC:-}"
-if [[ -z "${topic}" ]]; then
+if [[ -z "$topic" ]]; then
   echo "notify-ntfy: GH_NTFY_SUBJECT is unset; skipping notification." >&2
   exit 0
 fi
 
 base_url="${NTFY_BASE_URL:-}"
-[[ -z "${base_url}" ]] && base_url="https://ntfy.sh"
+[[ -z "$base_url" ]] && base_url="https://ntfy.sh"
 base_url="${base_url%/}"
 
 message="${NTFY_MESSAGE:-A build or publish workflow failed.}"
@@ -38,8 +38,8 @@ curl_args=(
   -H "Tags: $(sanitize_header "${NTFY_TAGS:-rotating_light}")"
 )
 click="${NTFY_CLICK:-}"
-[[ -n "${click}" ]] && curl_args+=(-H "Click: $(sanitize_header "${click}")")
-curl_args+=(-d "${message}" "${base_url}/${topic}")
+[[ -n "$click" ]] && curl_args+=(-H "Click: $(sanitize_header "$click")")
+curl_args+=(-d "$message" "${base_url}/${topic}")
 
 # The topic is secret; keep it out of the logs even though Actions masks it.
 if curl "${curl_args[@]}"; then

--- a/.github/actions/notify-ntfy/notify-ntfy.sh
+++ b/.github/actions/notify-ntfy/notify-ntfy.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Push a phone notification through ntfy (https://ntfy.sh or a self-hosted
+# instance) when a build or publish workflow fails. Invoked by the notify-ntfy
+# composite action.
+#
+# An unset topic is a silent success: a repo that has not configured the
+# GH_NTFY_SUBJECT secret must not have the notifier redden its runs. Delivery
+# itself is best-effort — a failed POST warns but still exits 0, because the
+# caller invokes this only for an already-failed workflow and a dead ntfy server
+# must not add a second, confusing red.
+set -euo pipefail
+
+topic="${NTFY_TOPIC:-}"
+if [[ -z "${topic}" ]]; then
+  echo "notify-ntfy: GH_NTFY_SUBJECT is unset; skipping notification." >&2
+  exit 0
+fi
+
+base_url="${NTFY_BASE_URL:-}"
+[[ -z "${base_url}" ]] && base_url="https://ntfy.sh"
+base_url="${base_url%/}"
+
+message="${NTFY_MESSAGE:-A build or publish workflow failed.}"
+
+# ntfy carries metadata in HTTP headers, whose values must be single-line;
+# collapse newlines so a multi-line title/tag can neither break the request nor
+# smuggle an extra header.
+sanitize_header() {
+  printf '%s' "$1" | tr '\n\r' '  '
+}
+
+curl_args=(
+  --silent --show-error --fail
+  --max-time 20
+  --retry 3 --retry-delay 2 --retry-connrefused
+  -H "Title: $(sanitize_header "${NTFY_TITLE:-Workflow failed}")"
+  -H "Priority: ${NTFY_PRIORITY:-5}"
+  -H "Tags: $(sanitize_header "${NTFY_TAGS:-rotating_light}")"
+)
+click="${NTFY_CLICK:-}"
+[[ -n "${click}" ]] && curl_args+=(-H "Click: $(sanitize_header "${click}")")
+curl_args+=(-d "${message}" "${base_url}/${topic}")
+
+# The topic is secret; keep it out of the logs even though Actions masks it.
+if curl "${curl_args[@]}"; then
+  echo "notify-ntfy: notification sent to ${base_url}/<topic>."
+else
+  rc=$?
+  echo "notify-ntfy: delivery to ${base_url}/<topic> failed (curl rc=${rc}); continuing." >&2
+fi
+exit 0

--- a/.github/workflows/build-publish-notify.yaml
+++ b/.github/workflows/build-publish-notify.yaml
@@ -1,0 +1,63 @@
+name: Build/publish failure notify
+
+# Push a phone notification (via ntfy) whenever a build or publish workflow
+# fails outside a pull request. Publish/release runs happen on push, tag, or
+# manual dispatch — no PR is in front of you — so a failure there otherwise rots
+# unseen. PR-triggered failures are excluded: they are already visible on the PR.
+#
+# `workflow_run` has no wildcard, so `workflows:` must name each build/publish
+# workflow in THIS repo by its `name:`. Downstream repos adjust that list to
+# their own publishers; the notify-ntfy composite action they call is shared
+# (synced from the template), so only this list is repo-specific.
+#
+# The notification is a no-op unless the GH_NTFY_SUBJECT secret is set, so a repo
+# that has not opted in is unaffected. Set GH_NTFY_URL to target a self-hosted
+# ntfy server (defaults to https://ntfy.sh).
+#
+# The dangerous-triggers finding targets workflows that check out or execute the
+# triggering ref's code with write credentials; this one checks out only its own
+# default-branch action dir, credential-less, and never runs repo code.
+on: # zizmor: ignore[dangerous-triggers]
+  workflow_run:
+    types: [completed]
+    workflows:
+      - Auto version bump and publish
+      - Publish Python to PyPI (break-glass)
+
+concurrency:
+  # Keyed per triggering workflow so notifications never queue behind each other;
+  # never cancel — a dropped alert defeats the point.
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    name: Notify on build/publish failure
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # workflow_run workflows always execute from the default branch, so this
+      # fetches exactly the vetted action; sparse + credential-less keeps it
+      # to the notifier and nothing else.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: .github/actions/notify-ntfy
+          persist-credentials: false
+
+      - name: Notify ntfy
+        uses: ./.github/actions/notify-ntfy
+        with:
+          topic: ${{ secrets.GH_NTFY_SUBJECT }}
+          base-url: ${{ secrets.GH_NTFY_URL }}
+          title: "${{ github.repository }}: ${{ github.event.workflow_run.name }} failed"
+          message: >-
+            ${{ github.event.workflow_run.name }} failed on
+            ${{ github.event.workflow_run.head_branch }}
+            (${{ github.event.workflow_run.event }}, run #${{ github.event.workflow_run.run_number }}).
+          click: ${{ github.event.workflow_run.html_url }}


### PR DESCRIPTION
## Summary
Adds a shared `notify-ntfy` composite action (`.github/actions/notify-ntfy`) and a `workflow_run` listener (`build-publish-notify.yaml`) that sends a phone notification via ntfy to the `GH_NTFY_SUBJECT` topic when a build/publish workflow fails **outside a pull request**. Watched here: `Auto version bump and publish`, `Publish Python to PyPI (break-glass)`.

The helper is byte-identical to the one added in `claude-automation-template` and propagates via `template-sync`; only the per-repo `workflows:` list is local.

## Setup required
- Set repo secret **`GH_NTFY_SUBJECT`** to your private ntfy topic (silent no-op until set).
- Optional: **`GH_NTFY_URL`** for a self-hosted ntfy server (defaults to `https://ntfy.sh`).

## Decisions made
- **Scope: publish/release only, non-PR runs** — `conclusion == 'failure' && event != 'pull_request'`.
- **Included the PyPI break-glass publish** — it is a publish path; it only runs on manual dispatch, so notifications there are rare and desired.
- **Fail-open notifier:** unset topic or dead server warns but exits 0.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjQ1rd6bcW6mYjTa7WopbM)_