### PR TITLE
feat(output): surface Layer-2 reveal from the output sanitization seam

### DIFF
--- a/src/output.mjs
+++ b/src/output.mjs
@@ -247,15 +247,21 @@ function processLayer1(text, sgrCarveOut) {
 
 /**
  * Layers 2+3: HTML sanitisation (`html`) and exfil-URL detection (`exfilScan`).
+ * `reveal` is the pre-splice text, returned only when Layer 2 removed bytes, so a
+ * caller can stash it for later inspection of what the splice hid (the model
+ * cannot otherwise tell a benign `<!-- TODO -->` from an injection payload). The
+ * transform itself stays pure — the caller owns any persistence.
  * @param {string} inputText
  * @param {{ html?: boolean, exfilScan?: boolean }} options
- * @returns {Promise<{ cleaned: string, warnings: string[], modified: boolean }>}
+ * @returns {Promise<{ cleaned: string, warnings: string[], modified: boolean, reveal?: string }>}
  */
 async function applyMarkdownPipeline(inputText, { html, exfilScan }) {
   /** @type {string[]} */
   const warnings = [];
   let modified = false;
   let cleaned = inputText;
+  /** @type {string | undefined} */
+  let reveal;
   if ((!html && !exfilScan) || !needsMarkdownPipeline(cleaned))
     return { cleaned, warnings, modified };
   const { sanitizeHtml, detectExfil } = await import("./html.mjs");
@@ -265,6 +271,7 @@ async function applyMarkdownPipeline(inputText, { html, exfilScan }) {
     const layer2 = sanitizeHtml(cleaned);
     if (layer2) {
       if (layer2.text !== cleaned) {
+        reveal = cleaned;
         cleaned = layer2.text;
         modified = true;
         warnings.push(
@@ -295,7 +302,7 @@ async function applyMarkdownPipeline(inputText, { html, exfilScan }) {
       );
     }
   }
-  return { cleaned, warnings, modified };
+  return { cleaned, warnings, modified, reveal };
 }
 
 /**
@@ -315,9 +322,12 @@ async function applyMarkdownPipeline(inputText, { html, exfilScan }) {
  * output rather than emitting an unvetted value. That fail-closed behavior
  * also applies to Layer 4's re-scan after a Layer-5 span deletion (see Layer
  * 5, below) — a redactor failure there fails the whole call closed too.
+ * `reveal` is the pre-Layer-2 text, present only when the HTML splice removed
+ * bytes, so a caller can persist what was hidden for later inspection (see
+ * {@link applyMarkdownPipeline}); the field is omitted otherwise.
  * @param {string} text
  * @param {SanitizeTextOptions} [options]
- * @returns {Promise<{ cleaned: string, warnings: string[], modified: boolean, sgrNote: boolean }>}
+ * @returns {Promise<{ cleaned: string, warnings: string[], modified: boolean, sgrNote: boolean, reveal?: string }>}
  */
 export async function sanitizeText(text, options = {}) {
   const { redact, filterInjection, sgrCarveOut = false } = options;
@@ -343,6 +353,7 @@ export async function sanitizeText(text, options = {}) {
     sgrNote = false;
   }
   warnings.push(...mdResult.warnings);
+  const reveal = mdResult.reveal;
 
   // Layer 4 — fail closed: a redactor we couldn't run might let a secret
   // through, so rethrow and let the caller replace the output with a
@@ -401,7 +412,15 @@ export async function sanitizeText(text, options = {}) {
     }
   }
 
-  return { cleaned, warnings, modified, sgrNote };
+  // Omit `reveal` unless Layer 2 spliced, so the common-case result shape stays
+  // minimal (callers gate on its presence).
+  return {
+    cleaned,
+    warnings,
+    modified,
+    sgrNote,
+    ...(reveal !== undefined && { reveal }),
+  };
 }
 
 /**
@@ -449,13 +468,27 @@ const CYCLE_PLACEHOLDER = "[withheld: circular reference in structured output]";
  * nesting past {@link MAX_DEPTH}, and a reference cycle. Either replaces the
  * offending subtree with a placeholder string + a warning, never passing the
  * raw subtree through. Keys are also screened for hidden chars (see below).
+ *
+ * `reveals` accumulates each string leaf's pre-Layer-2 text (present only when
+ * the HTML splice removed bytes) so a caller can persist what was hidden — the
+ * structured-output analogue of {@link sanitizeText}'s `reveal`. Same
+ * mutated-accumulator contract as `warnings`.
  * @param {any} value
  * @param {SanitizeTextOptions} options
  * @param {string[]} warnings
+ * @param {string[]} [reveals]
  * @returns {Promise<{ value: any, modified: boolean, sgrNote: boolean }>}
  */
-export async function sanitizeValue(value, options, warnings) {
-  return sanitizeValueAt(value, options, warnings, 0, new WeakSet(), new Map());
+export async function sanitizeValue(value, options, warnings, reveals = []) {
+  return sanitizeValueAt(
+    value,
+    options,
+    warnings,
+    reveals,
+    0,
+    new WeakSet(),
+    new Map(),
+  );
 }
 
 /**
@@ -467,6 +500,7 @@ export async function sanitizeValue(value, options, warnings) {
  * @param {any} value
  * @param {SanitizeTextOptions} options
  * @param {string[]} warnings
+ * @param {string[]} reveals  accumulates each string leaf's pre-Layer-2 text
  * @param {number} depth
  * @param {WeakSet<object>} seen
  * @param {Map<object, { value: any, modified: boolean, sgrNote: boolean }>} memo
@@ -478,13 +512,24 @@ export async function sanitizeValue(value, options, warnings) {
  *   subtrees are cached; the depth/cycle placeholders are path-dependent and
  *   deliberately NOT cached (a node withheld for depth on a long path must still
  *   be walked on a shorter one). Because warnings dedup in composeContext,
- *   skipping a cached node's duplicate warnings is harmless.
+ *   skipping a cached node's duplicate warnings is harmless. A cached node's
+ *   `reveals` are likewise not re-emitted, harmless for the same reason (the
+ *   caller dedups reveals by content).
  * @returns {Promise<{ value: any, modified: boolean, sgrNote: boolean }>}
  */
-async function sanitizeValueAt(value, options, warnings, depth, seen, memo) {
+async function sanitizeValueAt(
+  value,
+  options,
+  warnings,
+  reveals,
+  depth,
+  seen,
+  memo,
+) {
   if (typeof value === "string") {
     const result = await sanitizeText(value, options);
     warnings.push(...result.warnings);
+    if (result.reveal !== undefined) reveals.push(result.reveal);
     return {
       value: result.cleaned,
       modified: result.modified,
@@ -568,6 +613,7 @@ async function sanitizeValueAt(value, options, warnings, depth, seen, memo) {
           item,
           options,
           warnings,
+          reveals,
           depth + 1,
           seen,
           memo,
@@ -602,6 +648,7 @@ async function sanitizeValueAt(value, options, warnings, depth, seen, memo) {
         item,
         options,
         warnings,
+        reveals,
         depth + 1,
         seen,
         memo,

--- a/test/output.test.mjs
+++ b/test/output.test.mjs
@@ -369,6 +369,28 @@ describe("sanitizeText: Layer 2/3 markdown pipeline gating", () => {
     assert.equal(r.modified, false);
     assert.deepEqual(r.warnings, []);
   });
+
+  it("returns the pre-splice text as `reveal` when Layer 2 removes bytes", async () => {
+    const input = "intro <!-- secret --> tail";
+    const r = await sanitizeText(input, { html: true });
+    assert.equal(r.cleaned, "intro [HTML comment removed] tail");
+    // The reveal is the text as it stood BEFORE the splice — the removed
+    // comment intact — so a caller can persist what the model no longer sees.
+    assert.equal(r.reveal, input);
+  });
+
+  it("omits `reveal` when Layer 2 runs but removes nothing (warn-only)", async () => {
+    // A preserved <script> is reported but not spliced, so there is no pre-splice
+    // text to reveal; the field must be absent, not an empty string.
+    const r = await sanitizeText("a <script>x()</script> b", { html: true });
+    assert.equal(r.modified, false);
+    assert.ok(!("reveal" in r));
+  });
+
+  it("omits `reveal` when the HTML pipeline never runs", async () => {
+    const r = await sanitizeText("intro <!-- hidden --> tail");
+    assert.ok(!("reveal" in r));
+  });
 });
 
 // ─── Layer 4 (injected redactor) ─────────────────────────────────────────────
@@ -695,6 +717,33 @@ describe("sanitizeValue", () => {
     const r = await sanitizeValue([`mal${ZW}ware`, "clean"], {}, warnings);
     assert.deepEqual(r.value, ["malware", "clean"]);
     assert.equal(r.modified, true);
+  });
+
+  it("accumulates each spliced string leaf's pre-Layer-2 reveal", async () => {
+    const warnings = [];
+    const reveals = [];
+    const r = await sanitizeValue(
+      { a: "one <!-- x --> two", b: "clean", c: ["nested <!-- y --> end"] },
+      { html: true },
+      warnings,
+      reveals,
+    );
+    assert.equal(r.value.a, "one [HTML comment removed] two");
+    assert.equal(r.value.c[0], "nested [HTML comment removed] end");
+    assert.equal(r.modified, true);
+    // Both spliced leaves surface their pre-splice text; the clean leaf adds none.
+    assert.deepEqual(reveals, ["one <!-- x --> two", "nested <!-- y --> end"]);
+  });
+
+  it("adds no reveal when a leaf is not spliced", async () => {
+    const reveals = [];
+    await sanitizeValue(
+      { a: `mal${ZW}ware`, b: 7 },
+      { html: true },
+      [],
+      reveals,
+    );
+    assert.deepEqual(reveals, []);
   });
 
   it("recurses into a nested object, preserving the shape and non-strings", async () => {


### PR DESCRIPTION
## Summary

`claude-guard` is moving its hand-rolled tool-output sanitizer onto this package's
`agent-input-sanitizer/output` seam. That seam already generalizes Layers 1–4, but
it lacked the one feature `claude-guard` still needs: **surfacing the Layer-2
pre-splice text** so a consumer can persist what the HTML splice hid (a comment or
hidden element) and let the model inspect it behind an untrusted-content envelope.
Without it, the splice removes bytes with no way to recover them, and `claude-guard`
could not delegate its Layer-2 orchestration here.

This adds `reveal` to the seam. Everything else `claude-guard` needs (per-tool
`html`/`exfilScan` gating, the injected `redact`, the SGR carve-out) was already
expressible through existing options.

## Changes

- `sanitizeText` returns `reveal` (the text as it stood **before** the Layer-2
  splice) whenever the HTML splice removed bytes; the field is **omitted** when
  nothing was spliced, so the common-case result shape is unchanged.
- `applyMarkdownPipeline` threads the pre-splice text out for `sanitizeText`.
- `sanitizeValue` gains an optional `reveals` accumulator (4th arg), mirroring its
  `warnings` accumulator, so each spliced string leaf's reveal is collected while
  the structured shape is preserved. Absent-when-unspliced holds here too.

The transforms stay pure — the library only surfaces the pre-splice text; any
persistence is the caller's policy.

## Tests / verification

- `node --test test/output.test.mjs` — 127/127 pass (5 new: `reveal` present on a
  splice / absent on warn-only / absent when the pipeline never runs;
  `sanitizeValue` accumulates reveals across nested leaves / adds none when nothing
  is spliced).
- `test/output-property.test.mjs`, `test/output.fuzz.test.mjs`,
  `test/output-semantic-fuzz.test.mjs` — pass.
- `pnpm check` (tsc) and `eslint`/`prettier` on the changed files — clean.

## Checklist

- [x] Commits follow Conventional Commits; the subject reads as a release note.
- [x] `pnpm test`, `pnpm lint`, and `pnpm check` pass locally (output suites).
- [x] New behavior is pinned with exact-equality tests, including the
      absent-when-unspliced (negative) cases.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version left untouched (release workflow owns them).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMr71cE8bpUyhwCEKvzxB9)_