### PR TITLE
fix(ci): base the auto-publish bump on the highest live version, not the lagging latest tag

### DIFF
--- a/.github/scripts/version-bump.sh
+++ b/.github/scripts/version-bump.sh
@@ -90,41 +90,79 @@ max_version() {
   printf '%s\n%s\n' "$1" "$2" | sort -V | tail -1
 }
 
-# Get the latest published version from npm (source of truth). Distinguish a
-# genuinely-unpublished package (npm error `E404` -> treat as 0.0.0, a first
-# release) from a transient registry/network failure. A blanket
+# The release base is the highest NON-DEPRECATED published version — NOT
+# `npm view <pkg> version`, which returns only the `latest` dist-tag. `latest` can
+# lag far behind the highest published version (a mis-set tag, or a line published
+# faster than the tag advanced); bumping from a lagging `latest` computes a version
+# that is already published, and the publish-conflict guard below then treats that
+# as success and skips — so every release silently no-ops on the same taken version
+# forever. `npm view <pkg> versions --json` is a bare string ARRAY carrying no
+# deprecation flag, so we walk candidates high-to-low and probe each with
+# `npm view <pkg>@<v> deprecated` until one is not deprecated: that first live
+# version is the base, so a retired (deprecated) higher release can never become
+# it. Distinguish a genuinely-unpublished package (npm error `E404` -> treat as
+# 0.0.0, a first release) from a transient registry/network failure: a blanket
 # `|| echo "0.0.0"` would silently rebase the version to 0.0.1 on any outage and
 # repoint the `latest` dist-tag downward, so anything other than E404 fails loud.
 PACKAGE_NAME=$(node -p "require('./package.json').name")
 NPM_VIEW_RC=0
-# Capture stdout and stderr SEPARATELY. npm prints the version to stdout but
+# Capture stdout and stderr SEPARATELY. npm prints the JSON array to stdout but
 # routes warnings (e.g. "Unknown project config" for pnpm-only .npmrc keys like
-# confirm-modules-purge) and the E404 "not published" error to stderr. Folding
-# them together with `2>&1` let a warning land as the first line of the captured
-# output, so the `head -n1` below parsed the warning as the version and the
-# semver guard rejected it. Keep stdout clean for parsing; read E404 off stderr.
+# confirm-modules-purge) and the E404 "not published" error to stderr; folding
+# them with `2>&1` would corrupt the JSON parse. Keep stdout clean for parsing;
+# read E404 off stderr.
 NPM_VIEW_ERR=$(mktemp)
 trap 'rm -f "$NPM_VIEW_ERR"' EXIT
-NPM_VIEW_OUTPUT=$(npm view "$PACKAGE_NAME" version 2>"$NPM_VIEW_ERR") || NPM_VIEW_RC=$?
-if [[ "$NPM_VIEW_RC" -eq 0 ]]; then
-  CURRENT_VERSION="$NPM_VIEW_OUTPUT"
-elif grep -q "E404" "$NPM_VIEW_ERR"; then
-  CURRENT_VERSION="0.0.0"
+VERSIONS_JSON=$(npm view "$PACKAGE_NAME" versions --json 2>"$NPM_VIEW_ERR") || NPM_VIEW_RC=$?
+if [[ "$NPM_VIEW_RC" -ne 0 ]]; then
+  if grep -q "E404" "$NPM_VIEW_ERR"; then
+    CURRENT_VERSION="0.0.0" # unpublished — first release
+  else
+    log "Error: npm view failed unexpectedly (not E404). Refusing to guess a version: $(cat "$NPM_VIEW_ERR")"
+    exit 1
+  fi
 else
-  log "Error: npm view failed unexpectedly (not E404). Refusing to guess a version: $(cat "$NPM_VIEW_ERR")"
-  exit 1
+  # Stable X.Y.Z versions, highest first. `npm view versions --json` is a single
+  # string when only one version exists, so normalize to an array; the strict
+  # X.Y.Z filter drops prereleases so the arithmetic bump below can't misfire.
+  CANDIDATES=$(printf '%s' "$VERSIONS_JSON" | node -e '
+    const raw = JSON.parse(require("fs").readFileSync(0, "utf8"));
+    const all = Array.isArray(raw) ? raw : [raw];
+    const cmp = (a, b) => {
+      const A = a.split(".").map(Number);
+      const B = b.split(".").map(Number);
+      return A[0] - B[0] || A[1] - B[1] || A[2] - B[2];
+    };
+    const stable = all
+      .filter((v) => /^[0-9]+\.[0-9]+\.[0-9]+$/.test(v))
+      .sort(cmp)
+      .reverse();
+    process.stdout.write(stable.join("\n"));
+  ') || {
+    log "Error: could not parse the published version list. Refusing to guess a version."
+    exit 1
+  }
+  CURRENT_VERSION=""
+  while IFS= read -r candidate; do
+    [[ -z "$candidate" ]] && continue
+    # `npm view <pkg>@<v> deprecated` prints the deprecation string for a retired
+    # version and nothing for a live one, so an empty result is "not deprecated".
+    if [[ -z "$(npm view "$PACKAGE_NAME@$candidate" deprecated 2>/dev/null)" ]]; then
+      CURRENT_VERSION="$candidate"
+      break
+    fi
+    log "Skipping deprecated published version $candidate when choosing the release base."
+  done <<<"$CANDIDATES"
+  if [[ -z "$CURRENT_VERSION" ]]; then
+    log "Error: no live (non-deprecated) published version found. Refusing to guess a base."
+    exit 1
+  fi
 fi
-# `npm view` can print nothing on a success exit (never-published package) or
-# emit a prerelease like `1.2.3-beta.0`; take the first line and require strict
-# X.Y.Z so the arithmetic bump below can't silently misfire. Empty -> 0.0.0
-# (first release); any other non-semver value fails loudly.
-CURRENT_VERSION=$(printf '%s\n' "$CURRENT_VERSION" | head -n1)
-[[ -z "$CURRENT_VERSION" ]] && CURRENT_VERSION="0.0.0"
 if ! [[ "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  log "Error: npm returned a non-semver current version: '$CURRENT_VERSION'. Refusing to guess a bump."
+  log "Error: computed a non-semver current version: '$CURRENT_VERSION'. Refusing to guess a bump."
   exit 1
 fi
-log "Current npm version: $CURRENT_VERSION"
+log "Highest live npm version: $CURRENT_VERSION"
 
 # Find the latest version tag to determine which commits to analyze
 LAST_TAG=$(git describe --tags --match "v*" --abbrev=0 HEAD 2>/dev/null || echo "")

--- a/scripts/version-bump.test.mjs
+++ b/scripts/version-bump.test.mjs
@@ -82,6 +82,8 @@ test("the live release script carries the hardened npm-view logic", () => {
   const requiredMarkers = [
     /grep -q "E404"/, // distinguishes unpublished from a network outage
     /Refusing to guess a version/, // fails loud on a non-E404 npm error
+    /npm view "\$PACKAGE_NAME" versions --json/, // reads the full version list, not the lagging `latest` tag
+    /npm view "\$PACKAGE_NAME@\$candidate" deprecated/, // probes each candidate to skip retired versions
     /max_version/, // reconciles npm vs the highest git tag
     /BASE_VERSION=\$\(max_version/,
     /emit_output "released=true"/, // couples the PyPI publish
@@ -150,7 +152,7 @@ test("a network-error npm view aborts rather than rebasing to 0.0.0", () => {
     assert.match(stderr, /failed unexpectedly \(not E404\)/);
     assert.doesNotMatch(
       stderr,
-      /Current npm version: 0\.0\.0/,
+      /Highest live npm version: 0\.0\.0/,
       "must not silently treat a network outage as an unpublished package",
     );
   } finally {
@@ -167,7 +169,41 @@ test("an E404 npm view treats the package as unpublished (0.0.0)", () => {
     // HEAD is already tagged v0.0.0, so the script logs the resolved version and
     // exits 0 at the "no new commits" guard — proving E404 -> 0.0.0, no abort.
     assert.equal(status, 0, "E404 must not abort the release run");
-    assert.match(stderr, /Current npm version: 0\.0\.0/);
+    assert.match(stderr, /Highest live npm version: 0\.0\.0/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("bumps from the highest live version, not the lagging latest dist-tag", () => {
+  // The registry's `latest` tag can lag the highest published version. The base
+  // must be the max LIVE version (1.37.0 -> 1.38.0), never `latest` (1.6.4 ->
+  // 1.7.0, already taken -> skip-forever), and a deprecated higher major (6.0.0)
+  // must be excluded. Every `@version` existence probe answers "exists" so the
+  // run stops at the already-exists guard before any publish/push.
+  // `npm view pkg versions --json` -> the full array (latest lags at 1.6.4).
+  // `npm view pkg@<v> deprecated` -> the retired-major note for 6.0.0, empty
+  // (live) otherwise. `npm view pkg@<v> version` (existence probe) -> exists.
+  const stub = `if [[ "$2" == *@* ]]; then
+  if [[ "$3" == "deprecated" ]]; then
+    [[ "$2" == *@6.0.0 ]] && echo "automated major-bump bug"
+    exit 0
+  fi
+  exit 0
+else
+  echo '["1.6.4","1.7.0","1.37.0","6.0.0"]'
+fi`;
+  const { dir, binDir } = makeSandbox(stub);
+  try {
+    const git = (...args) =>
+      execFileSync("git", args, { cwd: dir, stdio: "ignore" });
+    git("commit", "-q", "--allow-empty", "-m", "feat: add a real feature");
+    const { status, stderr } = runScript(dir, binDir);
+    assert.equal(status, 0, stderr);
+    assert.match(stderr, /Highest live npm version: 1\.37\.0/);
+    assert.match(stderr, /New version: 1\.38\.0/);
+    assert.doesNotMatch(stderr, /New version: 1\.7\.0/); // not the lagging-tag bump
+    assert.doesNotMatch(stderr, /New version: 6\./); // deprecated major excluded
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -180,8 +216,12 @@ test("an E404 npm view treats the package as unpublished (0.0.0)", () => {
 // The npm stub reports the package at 5.0.0 and answers the `pkg@<version>`
 // existence probe with success, so each run stops at the "already exists" guard
 // BEFORE any publish/push — nothing leaves the sandbox.
-const NPM_AT_5_STUB =
-  'if [[ "$2" == *@* ]]; then exit 0; else echo "5.0.0"; fi';
+const NPM_AT_5_STUB = `if [[ "$2" == *@* ]]; then
+  # deprecated probe -> empty (live); version-existence probe -> exists (exit 0)
+  exit 0
+else
+  echo '["5.0.0"]'
+fi`;
 
 for (const { name, subject, body } of [
   {


### PR DESCRIPTION
## Summary

The auto-publish has been silently no-op'ing every release: `version-bump.sh` read the release base from `npm view <pkg> version`, which returns the version the **`latest` dist-tag** points at — not the highest published version. Here `latest` sits at `1.6.4` while the `1.x` line is really published up to `1.37.0` (all live), plus deprecated majors `2.0.0`/`3.0.0`/`6.0.0`. So the script computed `1.6.4` → minor → `1.7.0`, found `1.7.0` already published, and the publish-conflict guard treated that as success and skipped. Every release lands on the same taken `1.7.0` and no-ops — which is why the merged reveal feature (#139) never reached npm.

## Changes

- Base the bump on the highest **non-deprecated** published version:
  - read the full list with `npm view <pkg> versions --json` (a bare string array — it carries no deprecation flag);
  - walk candidates high-to-low, probing each with `npm view <pkg>@<v> deprecated` (empty = live) until one is not deprecated. That first live version is the base.
- A retired (deprecated) higher release can never become the base, so the intended line continues instead of the version jumping onto a bad major.
- Preserved the fail-loud posture: a non-E404 registry error still aborts (no silent rebase to `0.0.0`); E404 still resolves to `0.0.0` for a first release; an all-deprecated list fails loud.
- `scripts/version-bump.test.mjs`: updated the `npm` stubs to the new call shape (`versions --json` + per-version `deprecated` probe), refreshed the hardened-logic markers, and added a test proving the base is the highest **live** version (`1.37.0` → `1.38.0`), never the lagging `latest` (`1.6.4` → `1.7.0`) and never a deprecated major (`6.0.0`).

## Tests / verification

- `node --test scripts/version-bump.test.mjs` → 9/9 (new "bumps from the highest live version" test + the existing E404 / network-abort / major-cap tests, green with the reworked stubs).
- Ran the real candidate walk against the live registry: it skips `6.0.0`, `3.0.0`, `2.0.0` (deprecated) and selects `1.37.0` — so the next release is `1.38.0`.
- `shfmt -i 2`, `shellcheck -x`, and `prettier --check` clean on the changed files.

## Impact

Merging re-triggers the auto-version workflow; with the reveal feature already on `main`, the next publish is **`1.38.0`** (minor — the reveal `feat` is in range), which finally ships `sanitizeText`'s `reveal` so the `claude-guard` consumer PR can pin it.

## Checklist

- [x] Commits follow Conventional Commits.
- [x] `pnpm test` (version-bump suite), `shellcheck`, `shfmt`, `prettier` pass locally.
- [x] The SSOT contract test changed in lockstep with the script.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` / `package.json` version left untouched (release workflow owns them).

## Lessons Learned

- **What:** In `.github/scripts/version-bump.sh`, base the computed release version on the highest **non-deprecated published** version, not on `npm view <pkg> version`.
- **Where:** the version-computation block of the release script (template file propagated by `phone-home.yaml`).
- **Why:** `npm view <pkg> version` returns whatever the mutable **`latest` dist-tag** points at, which is independent of the highest published version. A mis-set or lagging `latest` (a botched release, a manual `dist-tag add`, or a line published faster than the tag advanced) makes the script compute an **already-published** version every run; the publish-conflict guard then swallows the collision as success, so releases silently stop forever with a green workflow. Read the full list (`npm view <pkg> versions --json`) and skip deprecated versions (`npm view <pkg>@<v> deprecated`) so the base is always the highest real release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMr71cE8bpUyhwCEKvzxB9)_