### PR TITLE
fix(secrets): drop plaintext-value cache, propagate __exit__ errors, unblock daemon loop

### DIFF
--- a/python/agent_input_sanitizer/secrets/daemon.py
+++ b/python/agent_input_sanitizer/secrets/daemon.py
@@ -16,6 +16,7 @@ request (the socket may be shared across sessions, so the daemon must redact the
 REQUESTER's keys, not its own environment).
 """
 
+import concurrent.futures
 import contextlib
 import errno
 import fcntl
@@ -45,6 +46,15 @@ FRAME_CAP = 16 * 1024 * 1024
 # legitimate large request over a local socket, short enough to bound the DoS
 # window.
 CONN_TIMEOUT_SECONDS = 10.0
+
+# Accepted connections are handed to a fixed pool of worker threads rather than
+# served inline in the accept loop, so one slow/stalled local client can no longer
+# wedge every other client sharing the socket (a local DoS). The pool is BOUNDED:
+# at most this many requests run concurrently; further accepted connections queue
+# and are picked up as workers free. Each worker is itself time-bounded by
+# CONN_TIMEOUT_SECONDS, so the queue drains. Small — the daemon is a per-request
+# CPU-bound scan, not an I/O fan-out server; a handful of cores' worth is plenty.
+WORKER_POOL_SIZE = 8
 
 
 def _recv_exact(conn: socket.socket, n: int) -> bytes | None:
@@ -237,6 +247,9 @@ def serve(socket_path: str, stop: threading.Event | None = None) -> None:
         if not bound:
             sock.close()
             return
+        pool = concurrent.futures.ThreadPoolExecutor(
+            max_workers=WORKER_POOL_SIZE, thread_name_prefix="secret-redactor"
+        )
         try:
             os.chmod(socket_path, 0o600)  # defense-in-depth; harmless if redundant
             sock.listen(64)
@@ -247,11 +260,17 @@ def serve(socket_path: str, stop: threading.Event | None = None) -> None:
                 except TimeoutError:
                     continue
                 # Bound THIS connection's I/O; see CONN_TIMEOUT_SECONDS docstring.
-                # `_serve_one` is called inline (synchronously) below, so without
-                # this a stalled peer wedges the whole accept loop.
+                # The connection is handed to the worker pool (not served inline),
+                # so a stalled peer occupies only one worker instead of wedging the
+                # accept loop. `_serve_one` always closes its own conn.
                 conn.settimeout(CONN_TIMEOUT_SECONDS)
-                _serve_one(conn)
+                pool.submit(_serve_one, conn)
         finally:
+            # Stop accepting, then drain in-flight handlers so no connection is
+            # dropped mid-response. Each worker is bounded by CONN_TIMEOUT_SECONDS,
+            # so this wait terminates. Close the listen socket and unlink the path
+            # only after the pool has quiesced.
+            pool.shutdown(wait=True)
             sock.close()
             with contextlib.suppress(OSError):
                 os.unlink(socket_path)

--- a/python/agent_input_sanitizer/secrets/engine.py
+++ b/python/agent_input_sanitizer/secrets/engine.py
@@ -147,9 +147,10 @@ def _resolve_marks(text: str, entries: list[tuple[str, str]]) -> tuple[str, list
     return "".join(out), pairs
 
 
-# re.compile self-caches identical patterns, so dropping this decorator is a
-# perf-only (correctness-equivalent) change the fast oracle cannot observe.
-@functools.cache
+# NOT memoized: `re.compile` self-caches identical patterns, so a decorator here
+# is redundant for perf — and an `lru_cache(maxsize=None)` keyed on `value` would
+# retain every requester's PLAINTEXT env-secret forever (unbounded growth plus
+# secret hoarding), since the daemon calls this per request with live secrets.
 def _env_value_re(value: str, charset: frozenset[int]) -> re.Pattern[str]:
     """Match ``value`` tolerating invisible chars (from ``charset``) spliced
     between its characters.
@@ -854,10 +855,18 @@ def configure_plugins(high_confidence: bool = False):
             return self
 
         def __exit__(self, *exc):
+            # A bare `return` inside `finally` swallows any exception propagating
+            # out of the `try` — here a `cache_clear()` fault — replacing it with
+            # the returned value. Clear the cache in the `try`; run the inner
+            # __exit__ (always, so the transient settings are released even if
+            # cache_clear raised) in the `finally`, capturing its verdict; and
+            # `return` that verdict AFTER the finally so a cache_clear exception
+            # propagates instead of being masked.
             try:
                 get_mapping_from_secret_type_to_class.cache_clear()
             finally:
-                return self._settings.__exit__(*exc)
+                settings_result = self._settings.__exit__(*exc)
+            return settings_result
 
     return _Ctx()
 

--- a/python/agent_input_sanitizer/secrets/invisible.py
+++ b/python/agent_input_sanitizer/secrets/invisible.py
@@ -30,11 +30,20 @@ def default_charset() -> frozenset[int]:
 
 
 def strip_invisible(text: str, charset: frozenset[int] | None = None) -> str:
-    """Delete every code point of ``charset`` from ``text`` (deletion only — the
-    result is a subsequence of the input).
+    """DETECTION-NORMALIZATION ONLY: delete every code point of ``charset`` from
+    ``text`` UNCONDITIONALLY (deletion only — the result is a subsequence of the
+    input).
+
+    This is deliberately NOT JS-parity-safe for user-facing stripping. Unlike
+    ``src/invisible.mjs`` (which carves out legitimate joiners/selectors — ZWNJ,
+    ZWJ, variation selectors, tag characters — so it does not corrupt real text),
+    this drops the WHOLE charset with no carve-out, because the secrets engine
+    needs the most aggressive normalization to defeat invisible chars spliced into
+    a leaked key. Do NOT reuse it to sanitize text you will show a user; use the
+    JS deletion set (or a carve-out-aware variant) for that.
 
     ``charset`` defaults to :func:`default_charset` (the shared SSOT). Standalone
-    stripping only — the engine's detection pipeline calls
+    normalization only — the engine's detection pipeline calls
     :func:`strip_invisible_with_map` instead, since redaction must translate a
     match found in the stripped view back to the ORIGINAL text's offsets (this
     function throws that mapping away, which is fine for a caller that only wants

--- a/tests/secrets/test_secrets_daemon.py
+++ b/tests/secrets/test_secrets_daemon.py
@@ -178,3 +178,29 @@ def test_daemon_survives_malformed_frame_then_serves(daemon):
     sock.close()
     resp = _client_request(daemon, {"text": "key: AKIAIOSFODNN7EXAMPLE", "map": False})
     assert "AWS Access Key" in resp["found"]
+
+
+def test_daemon_slow_client_does_not_block_a_second_client(daemon):
+    """A stalled client (partial frame, never completed) must not wedge the accept
+    loop: with the worker pool, a second concurrent client is served promptly
+    instead of waiting out the first client's CONN_TIMEOUT_SECONDS. Served inline,
+    the second request could not return until the stall timed out."""
+    slow = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    slow.connect(daemon)
+    try:
+        # 2 of the 4 header bytes, then silence: the handler blocks in
+        # `_recv_exact` until CONN_TIMEOUT_SECONDS (10s).
+        slow.sendall(b"\x00\x00")
+        start = time.time()
+        resp = _client_request(
+            daemon, {"text": "key: AKIAIOSFODNN7EXAMPLE", "map": False}
+        )
+        elapsed = time.time() - start
+        assert "AWS Access Key" in resp["found"]
+        # Comfortably under CONN_TIMEOUT_SECONDS: a blocked accept loop would make
+        # this second request wait ~10s behind the stalled first client.
+        assert elapsed < 5, f"second client waited {elapsed:.1f}s behind slow client"
+    finally:
+        # Close so the stalled worker's recv returns immediately and the pool can
+        # drain at daemon shutdown instead of waiting out the full timeout.
+        slow.close()

--- a/tests/secrets/test_secrets_engine.py
+++ b/tests/secrets/test_secrets_engine.py
@@ -1403,11 +1403,60 @@ def test_configure_plugins_then_redact_configured():
     assert found == ["AWS Access Key"]
 
 
-def test_env_value_re_is_cached():
+def test_env_value_re_not_memoized_so_no_plaintext_retention():
+    """`_env_value_re` must NOT be wrapped in functools.cache / lru_cache: such a
+    cache is keyed on the PLAINTEXT secret ``value`` and, being unbounded, would
+    retain every requester's secret forever (memory leak + secret hoarding). The
+    presence of ``cache_info``/``cache_clear`` is the tell-tale of that wrapper;
+    their ABSENCE proves distinct plaintext values are not retained across calls.
+    re.compile self-caches the compiled Pattern, so no function-level memo is
+    needed for perf and the pattern is still built correctly."""
     from agent_input_sanitizer.secrets.invisible import default_charset
 
+    assert not hasattr(E._env_value_re, "cache_info")
+    assert not hasattr(E._env_value_re, "cache_clear")
     charset = default_charset()
-    assert E._env_value_re("abcdef", charset) is E._env_value_re("abcdef", charset)
+    assert E._env_value_re("abcdef", charset).fullmatch("abcdef")
+
+
+def test_configure_plugins_exit_propagates_cache_clear_error(eng, monkeypatch):
+    """`configure_plugins().__exit__` must not swallow an exception raised in its
+    `try` body. A `return` inside the `finally` would mask a failing
+    ``cache_clear()``; the fixed version releases the transient settings in the
+    `finally` and lets the exception propagate."""
+    from agent_input_sanitizer.secrets import configure_plugins
+
+    class _Boom(Exception):
+        pass
+
+    ctx = configure_plugins()
+    ctx.__enter__()
+
+    class _RaisingMapping:
+        def cache_clear(self):
+            raise _Boom("cache_clear failed")
+
+    monkeypatch.setattr(eng, "get_mapping_from_secret_type_to_class", _RaisingMapping())
+    with pytest.raises(_Boom):
+        ctx.__exit__(None, None, None)
+
+
+def test_precision_legit_nonsecret_input_yields_zero_findings():
+    """Precision guard: ordinary prose and benign config-shaped lines must produce
+    NO findings — a false positive here mangles real content the model needed."""
+    benign = "\n".join(
+        [
+            "The quick brown fox jumps over the lazy dog.",
+            "user: alice",
+            "port: 8080",
+            "path: /usr/local/bin/agent-input-sanitizer",
+            "retries: 3",
+            "level: info",
+        ]
+    )
+    out, found = redact(benign)
+    assert found == []
+    assert out == benign
 
 
 def test_named_field_keeps_content_digest_value():


### PR DESCRIPTION
Part of a multi-PR audit of the secrets engine. Three robustness fixes + one doc clarification, all confirmed against the code.

## Findings fixed
- **PY2 (med) `engine.py:152-161`** — `_env_value_re` was decorated `@functools.cache` (unbounded) keyed on the **plaintext secret value**; the long-lived daemon called it per-request with requester env-secret values, retaining every secret ever seen in process memory. `re.compile` already self-caches (the function's own comment said so), so the decorator was pure harm. **Dropped the decorator.**
- **PY4 (low) `engine.py:856-860`** — `configure_plugins().__exit__` had `return` inside a `finally`, swallowing any exception from the `try` body. **Moved the return out of `finally`** (settings still released in `finally`, verdict returned after).
- **PY6 (low) `daemon.py:244-253`** — connections were served inline in the accept loop, so one slow local client blocked all others. **Dispatched to a bounded `ThreadPoolExecutor`** (drained on shutdown).
- **PY5 (low) `secrets/invisible.py`** — docstring clarified that `strip_invisible` is detection-normalization-only (no ZW/joiner carve-out) and not JS-parity-safe for user-facing stripping. Behavior unchanged.

## Tests
`uv run --extra dev pytest tests/secrets/ -q` → 734 passed. Added non-vacuous tests: the `__exit__` fix was verified red-on-old/green-on-new; a `cache_info`-absence assertion; a behavioral slow-client-doesn't-block test; and a negative precision test (legit input → zero findings).

## Decisions made
- **PY3 (all-alpha ≥20-char URL token not redacted) left as-is (WAI).** AIS doctrine is favor-precision / fail-open — a long all-letter URL path segment is often a legit slug, so broadening recall here would mangle real content. Not changed. Under the alternative (entropy-gated redaction) we'd trade some precision for recall on digit-free tokens.
- Commit subject shortened to satisfy the repo's 100-char `commit-msg` hook (full three-fix detail in the commit body), rather than bypassing the hook.


---
_Generated by [Claude Code](https://claude.ai/code/session_013ey8pCsjgaK57apoRNCUuX)_