### PR TITLE
fix(rehydrate): fail closed on preserved payloads, foreign placeholders, and unsorted pairs

### DIFF
--- a/src/instructions.mjs
+++ b/src/instructions.mjs
@@ -126,7 +126,31 @@ export function decodeRun(run) {
     };
   }
 
-  // Mixed/unknown
+  // Neither class holds a strict majority (e.g. a 50/50 tag + zero-width run),
+  // or the run mixes both classes without one dominating. Raw-dumping U+…
+  // codepoints here would bury BOTH payloads; instead decode each recognized
+  // sub-encoding and concatenate, keeping any unrecognized remainder visible as
+  // a `+ N other char(s)` note.
+  if (tagBytes.length > 0 || zwCount > 0) {
+    const parts = [];
+    if (tagBytes.length > 0)
+      parts.push(`${UNTRUSTED_PREFIX}"${neutralizeTagBytes(tagBytes)}"`);
+    if (zwCount > 0) {
+      const bits = cps
+        .filter((cp) => ZW_BIT.has(cp))
+        .map((cp) => ZW_BIT.get(cp))
+        .join("");
+      parts.push(`[${zwCount} zero-width chars: ${bits.slice(0, 80)}]`);
+    }
+    const otherCount = cps.length - tagBytes.length - zwCount;
+    const note = otherCount > 0 ? ` + ${otherCount} other char(s)` : "";
+    return {
+      method: "mixed tag + zero-width encodings",
+      decoded: parts.join(" ") + note,
+    };
+  }
+
+  // Unknown: no recognized sub-encoding present; report the raw code points.
   return {
     method: "invisible Unicode sequence",
     decoded: cps
@@ -140,7 +164,9 @@ export function decodeRun(run) {
  * run (with its decoded payload) plus a single scattered-chars finding when the
  * non-run invisible count crosses the threshold-evasion floor.
  * @param {string} content
- * @returns {Array<{ line: number, charCount: number, method: string, decoded: string }>}
+ * @returns {Array<{ line: number | null, charCount: number, method: string, decoded: string }>}
+ *   `line` is the 1-based line of a long-run finding, or `null` for the
+ *   whole-file scattered-chars finding (not tied to a single line).
  */
 export function scanText(content) {
   const findings = [];
@@ -178,7 +204,7 @@ export function scanText(content) {
   const scattered = countPayloadInvisible(content) - runChars;
   if (scattered >= SCATTERED_THRESHOLD) {
     findings.push({
-      line: 0,
+      line: null, // whole-file finding: scattered chars aren't tied to one line
       charCount: scattered,
       method: "scattered invisible chars (possible threshold evasion)",
       decoded: `[${scattered} invisible chars distributed across file]`,
@@ -393,8 +419,12 @@ export function atomicReplaceFile(
 
 /**
  * Strip payload-capable invisible characters from `absPath` in place. Returns
- * true when the file changed (it held a payload {@link scanText} flags), false
- * when {@link scanText} reports nothing.
+ * `true` when the file's bytes actually changed (a payload {@link scanText}
+ * flags was removed), `false` when {@link scanText} reports nothing, and `null`
+ * when scan flagged a payload but {@link stripInvisible} removes nothing — a
+ * fail-closed signal that the flagged run was PRESERVED (e.g. a well-formed
+ * emoji-tag sequence the stripper keeps), so the caller must not treat it as
+ * cleaned. `true` means and only means "bytes changed".
  *
  * Contract (scan/clean coherence): clean strips exactly what scan flags. A
  * write happens ONLY when `scanText` reports a finding, so the "scan, then
@@ -431,7 +461,7 @@ export function atomicReplaceFile(
  *   {@link atomicReplaceFile}'s `tmpName`): lets a test drive the concurrent
  *   write/symlink-swap that the TOCTOU guard exists to catch, which is otherwise
  *   unreachable from this fully-synchronous path. Defaults to `lstatSync`.
- * @returns {boolean}
+ * @returns {boolean | null}
  */
 export function cleanFile(absPath, lstat = lstatSync) {
   let fd;
@@ -472,12 +502,16 @@ export function cleanFile(absPath, lstat = lstatSync) {
 
     // Scan is the SSOT for what counts as a payload: don't rewrite a file scan
     // would not flag, even if stripInvisible would technically remove a char.
-    // A scan finding (a >=LONG_RUN_THRESHOLD run, or >=SCATTERED_THRESHOLD
-    // scattered chars) is past the carve-out's preserve window, so stripInvisible
-    // always removes at least one char here — stripped !== original is guaranteed.
     if (scanText(original).length === 0) return false;
 
     const stripped = stripInvisible(original);
+    // scanText can flag a run that stripInvisible PRESERVES — a well-formed but
+    // bogus emoji-tag run (a base pictograph + tag chars + CANCEL) trips the
+    // scanner yet is kept intact by the stripper. Rewriting identical bytes and
+    // returning `true` would falsely report the payload removed. Fail closed:
+    // the bytes did not change, so signal "flagged but not strippable" (null),
+    // never "cleaned" (true).
+    if (stripped === original) return null;
     // Re-verify the on-path file against the open-time snapshot before writing:
     // an inode/size/mtime change (or a swap to a symlink) means someone modified
     // it under us, so fail loud rather than clobber their write (lost update).

--- a/src/rehydrate.mjs
+++ b/src/rehydrate.mjs
@@ -343,6 +343,42 @@ async function rehydrateEdit(
 }
 
 /**
+ * Foreign redaction placeholders surviving in post-substitution content `out`:
+ * hint-prefixed, placeholder-shaped tokens that are neither introduced by a
+ * substituted secret (they fall inside `secretSpans`) nor already present
+ * verbatim in the file's own sanitized `viewText` (a genuine same-file
+ * placeholder, or literal prose like `[REDACTEDXYZ]` that merely shares the hint
+ * prefix). A non-empty result means the Write pasted a `[REDACTED…]` placeholder
+ * from another file or context that would be persisted verbatim in place of a
+ * real secret. Comparing the actual token strings — not scalar hint counts —
+ * catches a count-offsetting edit (drop one literal hint, add one foreign
+ * placeholder) that a scalar `>` gate lets through.
+ * @param {string} out post-substitution content
+ * @param {string} hint placeholder prefix
+ * @param {string} viewText the file's own sanitized view
+ * @param {{start: number, end: number}[]} secretSpans byte ranges of substituted secrets in `out`
+ * @returns {string[]}
+ */
+function foreignPlaceholders(out, hint, viewText, secretSpans) {
+  const foreign = [];
+  for (const start of occurrences(out, hint)) {
+    if (secretSpans.some((span) => span.start <= start && start < span.end))
+      continue;
+    // Extend the token to the placeholder's closing "]"; a hint with no closing
+    // bracket is malformed, so treat the rest of the string as its text and let
+    // the same-view check below decide (an unclosed hint absent from the view
+    // is foreign, failing closed).
+    const close = out.indexOf("]", start + hint.length);
+    const token = close === -1 ? out.slice(start) : out.slice(start, close + 1);
+    // Genuine same-file text: the exact token already exists in the file's own
+    // sanitized view (an own placeholder, or hint-prefixed prose it documents).
+    if (viewText.includes(token)) continue;
+    foreign.push(token);
+  }
+  return foreign;
+}
+
+/**
  * @param {{file_path: string, content: string}} ti
  * @param {{text: string, pairs: {placeholder: string, original: string, start: number}[]}} view
  * @param {RehydrateIo} io
@@ -395,15 +431,18 @@ async function rehydrateWrite(ti, view, io, hint) {
   const matches = orderedMatches(ti.content, texts);
   let out = "";
   let last = 0;
-  // Hint occurrences introduced BY the substituted secrets (a pathological
-  // secret whose bytes contain the hint prefix), weighted by how many times each
-  // secret was inserted — so they are not later misread as foreign placeholders.
-  let secretHintCount = 0;
+  // Byte ranges in `out` occupied by the substituted secret values. A hint
+  // occurrence inside one of these is a pathological secret whose bytes contain
+  // the hint prefix, NOT a placeholder the model pasted — so it is excluded from
+  // the foreign-placeholder scan below.
+  const secretSpans = [];
   for (const match of matches) {
     const secret = valueByPh.get(match.text);
-    out += ti.content.slice(last, match.index) + secret;
+    out += ti.content.slice(last, match.index);
+    const secretStart = out.length;
+    out += secret;
+    secretSpans.push({ start: secretStart, end: out.length });
     last = match.index + match.text.length;
-    secretHintCount += occurrences(secret, hint).length;
   }
   out += ti.content.slice(last);
   const secrets = [...valueByPh.values()];
@@ -411,13 +450,12 @@ async function rehydrateWrite(ti, view, io, hint) {
   // R3: the new content may mix a valid same-file placeholder (substituted
   // above) with a FOREIGN one — a placeholder pasted from another file/context
   // that shares the hint prefix but is not one of this file's own. Those were
-  // left untouched and would be persisted verbatim over a real secret. After
-  // substitution, allow only the hint occurrences that genuinely exist as
-  // literal prose in the file's own view; any surplus is an unresolved foreign
-  // placeholder, so deny with the same cross-file guidance.
-  const literalHintCount =
-    occurrences(view.text, hint).length - view.pairs.length;
-  if (occurrences(out, hint).length - secretHintCount > literalHintCount)
+  // left untouched and would be persisted verbatim over a real secret. Compare
+  // the ACTUAL placeholder STRINGS, not scalar hint counts: a scalar comparison
+  // is defeated by an edit that drops one literal hint and adds one foreign
+  // placeholder (the counts net to zero), which would then persist the foreign
+  // placeholder. Deny when any genuinely-foreign placeholder survives.
+  if (foreignPlaceholders(out, hint, view.text, secretSpans).length > 0)
     return {
       deny:
         `the new content still carries a ${hint}…] placeholder that does not match any ` +
@@ -575,11 +613,22 @@ export async function rehydrateRedacted(
   // UTF-16. Normalize once here so an astral char before a placeholder can't
   // mis-anchor the edit (identical to a no-op for BMP-only files).
   view.pairs = pairsToUtf16(view.text, view.pairs);
-  // View identical to disk: any placeholders in the input are literal text.
-  // `cleaned === content` also rules out a lone-surrogate-only divergence
-  // (view.pairs/deletions alone would miss that, since the normalization is
-  // neither a redaction pair nor a Layer-1 deletion).
-  if (view.pairs.length === 0 && deletions.length === 0 && cleaned === content)
+  // View identical to disk: any placeholders in an Edit's old_string are
+  // literal text, so there is nothing to re-anchor. `cleaned === content` also
+  // rules out a lone-surrogate-only divergence (view.pairs/deletions alone
+  // would miss that, since the normalization is neither a redaction pair nor a
+  // Layer-1 deletion). A Write is the exception: its content still carries the
+  // hint prefix (isCandidate guaranteed it), and with no own placeholder to
+  // resolve that hint is a FOREIGN [REDACTED…] placeholder that would be
+  // persisted verbatim over pristine bytes. Fall through to rehydrateWrite so
+  // it denies with the cross-file guidance — the same verdict a Write onto a
+  // secret-bearing or absent target already gets.
+  if (
+    view.pairs.length === 0 &&
+    deletions.length === 0 &&
+    cleaned === content &&
+    !(tool === "Write" && toolInput.content.includes(hint))
+  )
     return null;
 
   return tool === "Edit"

--- a/src/view-map.mjs
+++ b/src/view-map.mjs
@@ -127,6 +127,11 @@ export function pairsToUtf16(text, pairs) {
   prefix[0] = 0;
   for (let i = 0; i < codePoints.length; i++)
     prefix[i + 1] = prefix[i] + codePoints[i].length;
+  // Code-point end of the previous pair's placeholder span. mapViewOffset's
+  // `else break` (and pairDiskSpans) assume pairs are sorted by start and never
+  // overlap; an out-of-order or overlapping pair would make the scan stop early
+  // and mis-map an offset onto the wrong bytes. Enforce the contract here.
+  let prevEnd = 0;
   return pairs.map((pair) => {
     // A redactor offset outside [0, codePoints.length] indexes `prefix` out of
     // range and would silently yield `start: undefined`, which then poisons
@@ -141,6 +146,15 @@ export function pairsToUtf16(text, pairs) {
       throw new Error(
         `redaction pair start ${pair.start} is out of range [0, ${codePoints.length}]`,
       );
+    // Sorted + non-overlapping: `start` must be monotonically non-decreasing and
+    // each pair's placeholder span must end at or before the next pair's start.
+    // `prevEnd` already encodes the previous end, so `start < prevEnd` catches
+    // both an out-of-order start and an overlap in one comparison. Fail closed.
+    if (pair.start < prevEnd)
+      throw new Error(
+        `redaction pairs must be sorted and non-overlapping: pair start ${pair.start} precedes previous pair end ${prevEnd}`,
+      );
+    prevEnd = pair.start + Array.from(pair.placeholder).length;
     return { ...pair, start: prefix[pair.start] };
   });
 }

--- a/test/instructions-property.test.mjs
+++ b/test/instructions-property.test.mjs
@@ -54,7 +54,7 @@ describe("property: scanText invariants", () => {
         const findings = scanText(text);
         assert.ok(Array.isArray(findings));
         for (const f of findings) {
-          assert.equal(typeof f.line, "number");
+          assert.ok(f.line === null || typeof f.line === "number");
           assert.equal(typeof f.charCount, "number");
           assert.equal(typeof f.method, "string");
           assert.equal(typeof f.decoded, "string");

--- a/test/instructions-semantic-fuzz.test.mjs
+++ b/test/instructions-semantic-fuzz.test.mjs
@@ -172,7 +172,7 @@ describe("semantic-correctness fuzz: scanText precision on mixed documents", () 
           planted >= SCATTERED_THRESHOLD
             ? [
                 {
-                  line: 0,
+                  line: null,
                   charCount: planted,
                   method:
                     "scattered invisible chars (possible threshold evasion)",

--- a/test/instructions.test.mjs
+++ b/test/instructions.test.mjs
@@ -28,7 +28,11 @@ import {
   cleanFile,
   atomicReplaceFile,
 } from "../src/instructions.mjs";
-import { LONG_RUN_THRESHOLD, SCATTERED_THRESHOLD } from "../src/invisible.mjs";
+import {
+  LONG_RUN_THRESHOLD,
+  SCATTERED_THRESHOLD,
+  stripInvisible,
+} from "../src/invisible.mjs";
 import { cp } from "./test-helpers.mjs";
 
 // The caller's instruction-file globs (the package bakes in no convention).
@@ -99,12 +103,34 @@ describe("decodeRun", () => {
     assert.equal(result.decoded, `[90 zero-width chars: ${"0".repeat(80)}]`);
   });
 
-  it("decodes mixed/unknown invisibles as hex (case, padding, separator)", () => {
-    // U+00AD is neither tag nor a ZW-bit char, so the run lands in the mixed
-    // branch; pin uppercase, zero-pad-to-4, space-joined rendering.
-    const result = decodeRun(`${cp(0x00ad)}${cp(0x200b)}`);
+  it("decodes unknown invisibles (no recognized sub-encoding) as hex (case, padding, separator)", () => {
+    // Neither U+00AD (soft hyphen) nor U+2060 (word joiner) is a tag char or a
+    // ZW-bit char, so the run carries no recognized sub-encoding and lands in the
+    // unknown branch; pin uppercase, zero-pad-to-4, space-joined rendering.
+    const result = decodeRun(`${cp(0x00ad)}${cp(0x2060)}`);
     assert.match(result.method, /invisible Unicode/);
-    assert.equal(result.decoded, "U+00AD U+200B");
+    assert.equal(result.decoded, "U+00AD U+2060");
+  });
+
+  it("decodes BOTH sub-encodings for a 50/50 tag + zero-width run (no majority)", () => {
+    // A run split evenly between tag chars and zero-width bits gives neither
+    // class a strict majority, so both majority branches fall through. Raw-hex
+    // dumping would bury both payloads; instead each recognized sub-encoding is
+    // decoded and concatenated (P5).
+    const result = decodeRun(`${tagChars("AB")}${cp(0x200b)}${cp(0x200b)}`);
+    assert.equal(result.method, "mixed tag + zero-width encodings");
+    assert.equal(result.decoded, `${untrusted("AB")} [2 zero-width chars: 00]`);
+  });
+
+  it("notes an unrecognized remainder in the mixed-decode branch", () => {
+    // 2 tag + 1 ZW + 1 unrecognized (soft hyphen): no majority, so the mixed
+    // branch decodes tag + ZW and reports the leftover as `+ N other char(s)`.
+    const result = decodeRun(`${tagChars("Z")}${cp(0x200b)}${cp(0x00ad)}`);
+    assert.equal(result.method, "mixed tag + zero-width encodings");
+    assert.equal(
+      result.decoded,
+      `${untrusted("Z")} [1 zero-width chars: 0] + 1 other char(s)`,
+    );
   });
 
   it("reports the zero-width count for a run mixing tag-ASCII and ZW chars", () => {
@@ -202,7 +228,7 @@ describe("scanText", () => {
     assert.deepEqual(scanText("# Clean\n\nJust regular markdown.\n"), []);
   });
 
-  it("flags scattered chars at exactly the threshold (inclusive bound), line 0", () => {
+  it("flags scattered chars at exactly the threshold (inclusive bound), whole-file line null", () => {
     // No single run reaches LONG_RUN_THRESHOLD: interleave visible text.
     const chunks = Array.from({ length: SCATTERED_THRESHOLD }, () =>
       cp(0x200b),
@@ -212,7 +238,7 @@ describe("scanText", () => {
       .join("");
     const findings = scanText(content);
     assert.equal(findings.length, 1);
-    assert.equal(findings[0].line, 0);
+    assert.equal(findings[0].line, null);
     assert.match(findings[0].method, /scattered/);
     assert.equal(findings[0].charCount, SCATTERED_THRESHOLD);
     assert.equal(
@@ -707,6 +733,31 @@ describe("scan/clean contract", () => {
     assert.ok(scanText(original).length > 0, "precondition: scan flags it");
     assert.equal(cleanFile(file), true);
     assert.equal(readFileSync(file, "utf-8"), "xy\n");
+  });
+
+  it("clean returns null (NOT true) for a flagged-but-preserved emoji-tag run", () => {
+    // A well-formed but bogus subregional-flag sequence: WAVING BLACK FLAG base
+    // + >=LONG_RUN_THRESHOLD spec tag chars + CANCEL TAG. The consecutive Cf tag
+    // chars trip scanText's long-run detector, but the sequence is a VALID tag
+    // grammar so stripInvisible PRESERVES it verbatim. cleanFile must not rewrite
+    // identical bytes and claim `true` (payload removed); it fails closed with
+    // `null` meaning "flagged but not strippable", and the file is untouched.
+    const flag = `${cp(0x1f3f4)}${cp(0xe0041).repeat(LONG_RUN_THRESHOLD)}${cp(0xe007f)}`;
+    const original = `region: ${flag}\n`;
+    assert.ok(scanText(original).length > 0, "precondition: scan flags it");
+    assert.equal(
+      stripInvisible(original),
+      original,
+      "precondition: stripInvisible preserves the well-formed tag run",
+    );
+    const file = join(tmpDir, "CLAUDE.md");
+    writeFileSync(file, original);
+    assert.equal(cleanFile(file), null);
+    assert.equal(
+      readFileSync(file, "utf-8"),
+      original,
+      "bytes must be untouched when nothing was stripped",
+    );
   });
 });
 

--- a/test/rehydrate.test.mjs
+++ b/test/rehydrate.test.mjs
@@ -1308,6 +1308,22 @@ describe("rehydrate: Write cross-file and re-substitution safety", () => {
     assert.equal(out.updatedInput, undefined);
   });
 
+  it("P3: denies a Write carrying an UNCLOSED foreign hint (no trailing ']')", async () => {
+    // A valid same-file PH is substituted (so the foreign scan runs), but the
+    // content also pastes a hint-prefixed token with NO closing bracket. The
+    // token extends to end-of-string; absent from the file's own view, it is a
+    // foreign placeholder and must be denied (fail closed on the malformed run).
+    const src = `PASSWORD=${SECRET_A}\n`;
+    const vw = mkView(src, [{ value: SECRET_A, placeholder: PH }]);
+    const out = await rehydrateRedacted(
+      "Write",
+      { file_path: "/f", content: `PASSWORD=${PH}\nnote ${DEFAULT_HINT}-oops\n` },
+      fakeIo(src, vw, reRedact),
+    );
+    assert.match(out.deny, /still carries a \[REDACTED…\] placeholder/);
+    assert.equal(out.updatedInput, undefined);
+  });
+
   it("R6: a Write substitutes in one pass, never re-touching an inserted secret's bytes", async () => {
     // SECRET_A's bytes literally contain PH_PEM's placeholder text. A chained
     // split(PH).join(secret) then split(PH_PEM).join(secretB) would clobber the

--- a/test/rehydrate.test.mjs
+++ b/test/rehydrate.test.mjs
@@ -1317,7 +1317,10 @@ describe("rehydrate: Write cross-file and re-substitution safety", () => {
     const vw = mkView(src, [{ value: SECRET_A, placeholder: PH }]);
     const out = await rehydrateRedacted(
       "Write",
-      { file_path: "/f", content: `PASSWORD=${PH}\nnote ${DEFAULT_HINT}-oops\n` },
+      {
+        file_path: "/f",
+        content: `PASSWORD=${PH}\nnote ${DEFAULT_HINT}-oops\n`,
+      },
       fakeIo(src, vw, reRedact),
     );
     assert.match(out.deny, /still carries a \[REDACTED…\] placeholder/);

--- a/test/rehydrate.test.mjs
+++ b/test/rehydrate.test.mjs
@@ -1258,6 +1258,56 @@ describe("rehydrate: Write cross-file and re-substitution safety", () => {
     );
   });
 
+  it("P2: denies a foreign-placeholder Write onto a PRISTINE (secret-free) target", async () => {
+    // The target holds no secrets, so its view is byte-identical to disk
+    // (view.pairs empty, cleaned === content) and the early "view identical to
+    // disk" return would fire. A Write whose content carries a foreign
+    // [REDACTED…] placeholder must NOT sail through that fast path — it is
+    // denied exactly like a Write onto a secret-bearing or absent target,
+    // rather than persisting the placeholder verbatim over pristine bytes.
+    const src = "plain config, no secrets here\n";
+    const vw = mkView(src, []); // no pairs
+    const out = await rehydrateRedacted(
+      "Write",
+      { file_path: "/f", content: `KEY=${PH_PEM}\n` },
+      fakeIo(src, vw),
+    );
+    assert.match(out.deny, /does not match any secret/);
+    assert.match(
+      out.deny,
+      /cannot copy a placeholder from another file or context/,
+    );
+    assert.equal(out.updatedInput, undefined);
+  });
+
+  it("P3: denies a count-offsetting foreign-placeholder Write (drop one literal hint, add one foreign)", async () => {
+    // The file documents literal "[REDACTEDXYZ]" prose (one hint occurrence that
+    // is NOT a placeholder) and holds a real secret under PH. A Write that DROPS
+    // the prose and ADDS a foreign PH_PEM leaves the raw hint COUNT unchanged, so
+    // the old scalar `>` gate passed it — persisting the foreign placeholder.
+    // Comparing the actual placeholder STRINGS must still deny it.
+    const prose = "[REDACTEDXYZ]";
+    const src = `see ${prose} docs\nPW=${SECRET_A}\n`;
+    const vw = {
+      text: `see ${prose} docs\nPW=${PH}\n`,
+      pairs: [
+        {
+          placeholder: PH,
+          original: SECRET_A,
+          start: `see ${prose} docs\nPW=`.length,
+        },
+      ],
+    };
+    const out = await rehydrateRedacted(
+      "Write",
+      // prose dropped, foreign PH_PEM added, valid PH kept
+      { file_path: "/f", content: `PW=${PH}\nKEY=${PH_PEM}\n` },
+      fakeIo(src, vw, reRedact),
+    );
+    assert.match(out.deny, /still carries a \[REDACTED…\] placeholder/);
+    assert.equal(out.updatedInput, undefined);
+  });
+
   it("R6: a Write substitutes in one pass, never re-touching an inserted secret's bytes", async () => {
     // SECRET_A's bytes literally contain PH_PEM's placeholder text. A chained
     // split(PH).join(secret) then split(PH_PEM).join(secretB) would clobber the

--- a/test/view-map.test.mjs
+++ b/test/view-map.test.mjs
@@ -380,6 +380,42 @@ describe("pairsToUtf16", () => {
     );
   });
 
+  it("throws on out-of-order or overlapping pairs (mapViewOffset's else-break contract)", () => {
+    // mapViewOffset stops scanning at the first pair whose start is past the
+    // offset (`else break`), which is only sound if pairs are sorted and never
+    // overlap. Enforce that at ingestion — fail closed on a violation.
+    const text = `${PH} ${PH}`;
+    const s2 = text.indexOf(PH, 1);
+    // Out of order: the second pair's start precedes the first pair's.
+    assert.throws(
+      () =>
+        pairsToUtf16(text, [
+          { placeholder: PH, original: "a", start: s2 },
+          { placeholder: PH, original: "b", start: 0 },
+        ]),
+      /sorted and non-overlapping/,
+    );
+    // Overlapping: the first placeholder's span (start 0, len 10) still covers
+    // offset 1, where the second pair claims to start.
+    assert.throws(
+      () =>
+        pairsToUtf16(text, [
+          { placeholder: PH, original: "a", start: 0 },
+          { placeholder: PH, original: "b", start: 1 },
+        ]),
+      /sorted and non-overlapping/,
+    );
+    // Adjacent (previous end === next start) is the tight boundary and is valid.
+    const adj = `${PH}${PH}`;
+    assert.deepEqual(
+      pairsToUtf16(adj, [
+        { placeholder: PH, original: "a", start: 0 },
+        { placeholder: PH, original: "b", start: PH.length },
+      ]).map((pair) => pair.start),
+      [0, PH.length],
+    );
+  });
+
   it("normalizes several pairs, each by the astral count preceding it", () => {
     const text = `🔑 ${PH_KEY} 🔑 ${PH}`;
     const cp = Array.from(text);


### PR DESCRIPTION
Audit of the rehydrate security boundary + instruction scanner. All fail-closed / correctness fixes.

## Findings fixed
- **P1 (high) `instructions.mjs`** — `cleanFile` gated the rewrite on `scanText().length === 0` and claimed "stripInvisible always removes a char here." False: a well-formed-but-bogus emoji-tag run is flagged by `scanText` yet **preserved** by `stripInvisible`, so it rewrote identical bytes and returned `true` (falsely reporting the payload removed). Now returns a distinct `null` fail-closed signal when bytes are unchanged despite a scan finding (gated on `stripped !== original`).
- **P2 (med) `rehydrate.mjs`** — a foreign `[REDACTED…]` placeholder in a `Write` onto a **pristine** target hit the early `return null` (allow), while nonexistent/secret-bearing targets denied. Now denies consistently.
- **P3 (med) `rehydrate.mjs`** — the foreign-placeholder gate compared scalar hint **counts**, so a count-offsetting edit passed. Now detects foreign placeholders by actual string.
- **P4 (med) `view-map.mjs`** — caller-injected redactor `pairs` were range-validated but not order-validated, though `mapViewOffset` relies on sorted/non-overlapping pairs. `pairsToUtf16` now fails closed (throws) on unsorted/overlapping pairs.
- **P5/P6 (low) `instructions.mjs`** — `decodeRun` now decodes both sub-encodings on a no-majority mixed run; the scattered finding uses `line: null` instead of the `line: 0` sentinel.

## Tests
`node --test` → 205 in the focused set; full suite 1644 pass. New tests assert every invariant: a preserved fake-flag run is NOT reported cleaned, unsorted pairs throw, and pristine/count-offset foreign placeholders are denied.

## Decisions made
- **`cleanFile` now returns `null`** (in addition to `true`/`false`) as the "flagged but not strippable" signal; callers/tests updated. Alternative (a thrown error) would force every caller into a try/catch for an expected outcome.
- Commit subject shortened to satisfy the 100-char commitlint header cap (detail in the body), not bypassed.


---
_Generated by [Claude Code](https://claude.ai/code/session_013ey8pCsjgaK57apoRNCUuX)_