### PR TITLE
fix(invisible): tighten the tag/joiner/selector carve-out against smuggled invisibles

### DIFF
--- a/src/confusables.mjs
+++ b/src/confusables.mjs
@@ -112,6 +112,15 @@ export function foldConfusables(text, findings) {
       throw new Error(
         `Confusable finding has an out-of-range index ${finding.index}`,
       );
+    // An empty `char` makes startsWith("", i) vacuously true for ANY index, so
+    // the slice below inserts latinEquivalent without consuming a code point —
+    // silent insertion-corruption — and describeFolds then crashes on
+    // "".codePointAt(0). A finding must name a real matched glyph, so reject it
+    // loudly rather than let a buggy/adversarial scanner corrupt the input.
+    if (finding.char === "")
+      throw new Error(
+        `Confusable finding at index ${finding.index} has an empty char`,
+      );
     if (!folded.startsWith(finding.char, finding.index))
       throw new Error(
         `Confusable finding does not match input at index ${finding.index}: expected ${JSON.stringify(finding.char)}`,

--- a/src/invisible.mjs
+++ b/src/invisible.mjs
@@ -222,6 +222,17 @@ const ZWJ = 0x200d;
 // NOT part of a joined cluster — so an ordinary single joiner per word is kept.
 export const CONSECUTIVE_JOINER_CAP = 8;
 
+// Max variation selectors the carve-out preserves in one uninterrupted run of
+// selected glyphs (an `ideograph selector ideograph selector …` chain, or the
+// standardized-variation equivalent). Each selector encodes up to a byte, so an
+// attacker who variant-selects every character of a CJK/base run opens a
+// high-bit-rate channel that the joiner cap does not touch (these are not
+// joiners). A genuine document variant-selects only the odd rare glyph, never a
+// long unbroken run, so past this many consecutive PRESERVED IVS/stdvs with no
+// real gap the surplus is stripped. The counter resets at a genuine gap (two
+// visible characters in a row), exactly like CONSECUTIVE_JOINER_CAP.
+export const CONSECUTIVE_SELECTOR_CAP = 8;
+
 // Floor on the document-wide preserve budget, shared by both preserve kinds
 // (see `kind` in analyzeCarve: joiners AND presentation selectors draw from
 // the same counter). The Joining_Type gate strips joiners that do no
@@ -245,6 +256,15 @@ export const TOTAL_PRESERVED_JOINER_BUDGET = 16;
 // residual channel to a fixed fraction of the cover text.
 export const PRESERVED_JOINER_PER_VISIBLE = 8;
 
+// Absolute ceiling on the document-wide preserve allowance, regardless of how
+// much visible cover text an attacker supplies. Without it, maxPreserved grows
+// linearly with visible length (visibleLen / PRESERVED_JOINER_PER_VISIBLE), so a
+// large benign-looking body lets the residual joiner/selector channel scale with
+// attacker input — preserved chars do not count toward the scatter floor, so
+// nothing else bounds it. This caps the whole channel at a fixed width no cover
+// text can widen.
+export const PRESERVE_HARD_CAP = 64;
+
 // Scripts whose orthography uses ZWNJ/ZWJ between letters as a rendering
 // control. The runtime gate is now script-agnostic (it reads Joining_Type, so it
 // covers every cursive/Brahmic script, not just these), but this list remains
@@ -267,23 +287,19 @@ export const LINGUISTIC_SCRIPTS = [
 // Left side of an emoji joiner: a pictograph or a skin-tone modifier (a base
 // emoji may carry a modifier before the joiner, e.g. a health-worker sequence).
 const EMOJI_LEFT = /[\p{Extended_Pictographic}\p{Emoji_Modifier}]/u;
-// Left side of a presentation selector (VS15/VS16): everything EMOJI_LEFT
-// accepts, PLUS the three keycap bases (digit, `#`, `*`) that Unicode's
-// keycap sequence grammar allows before VS16 + U+20E3 COMBINING ENCLOSING
-// KEYCAP (1️⃣ #️⃣ *️⃣ … 9️⃣). None of those
-// bases is Extended_Pictographic or Emoji_Modifier, so EMOJI_LEFT alone
-// misses them and the VS16 in a keycap gets stripped as a bare junk
-// selector, corrupting the glyph. A keycap base is accepted ONLY for the
-// presentation-selector check (isEmojiPresentationSelector) — never folded
-// into EMOJI_LEFT itself — so it cannot also loosen the ZWJ emoji-sequence
-// carve-out (isPreservedJoiner): digits/`#`/`*` do not legitimately precede
-// a ZWJ. We preserve VS16 after a keycap base even without checking for a
-// trailing U+20E3: failing open here (never stripping a VS16 that MIGHT be
-// part of a keycap) beats failing closed (mangling a real keycap glyph),
-// and a keycap base + VS16 with no combining keycap after it is still just
-// an ordinary, harmless "digit rendered with emoji presentation".
-const PRESENTATION_SELECTOR_LEFT =
-  /[\p{Extended_Pictographic}\p{Emoji_Modifier}0-9#*]/u;
+// The three keycap bases (digit, `#`, `*`) Unicode's keycap grammar allows
+// before VS16 + U+20E3 COMBINING ENCLOSING KEYCAP (1️⃣ #️⃣ *️⃣ … 9️⃣). None is
+// Extended_Pictographic or Emoji_Modifier, so EMOJI_LEFT misses them; the
+// presentation-selector check accepts one ONLY when the required U+20E3 keycap
+// actually follows the selector (see isEmojiPresentationSelector). A bare
+// digit/`#`/`*` + VS with no keycap is NOT a glyph — it is a hidden presentation
+// selector spliced after ordinary text, the top low-effort VS-smuggling shape —
+// so it fails closed and is stripped. The base set is confined to the keycap
+// check (never folded into EMOJI_LEFT) so it cannot loosen the ZWJ carve-out.
+const KEYCAP_BASE = /[0-9#*]/u;
+// U+20E3 COMBINING ENCLOSING KEYCAP — the mandatory terminator of a keycap
+// sequence, the one signal that a digit/`#`/`*` + VS16 is a real glyph.
+const COMBINING_KEYCAP = 0x20e3;
 // Right side of an emoji joiner is always the next component's base pictograph.
 const EMOJI_BASE = /\p{Extended_Pictographic}/u;
 // A variation selector legitimately sits between a base pictograph and a
@@ -307,6 +323,16 @@ const TAG_BASE = 0x1f3f4; // WAVING BLACK FLAG
 const TAG_CANCEL = 0xe007f; // CANCEL TAG (the required terminator)
 const TAG_SPEC_MIN = 0xe0020; // first tag char a flag sequence may carry
 const TAG_SPEC_MAX = 0xe007e; // last tag char a flag sequence may carry
+// A tag char decodes to ASCII (cp − 0xE0000), so a grammatically-valid
+// 🏴 … CANCEL run can spell ARBITRARY ASCII ("ignore rules") and, if preserved
+// only on grammar, smuggle it verbatim to the model. Preservation is therefore
+// gated on the decoded payload naming a REGISTERED subdivision (the only tag
+// sequences that render as a real flag) and on a tag-char cap — every other
+// run, however well-formed, stays stripped (fail closed on the top ASCII vector).
+const REGISTERED_TAG_PAYLOADS = new Set(["gbeng", "gbsct", "gbwls"]);
+// Longest registered subdivision payload is 5 tag chars; cap a touch above it so
+// a malformed-but-registered-prefix run can never carry a long ASCII rider.
+const MAX_TAG_SPEC_CHARS = 6;
 
 // ─── Ideographic variation selectors (VS17–VS256, U+E0100–U+E01EF) ────────────
 // An ideographic variation sequence is a CJK ideograph followed by a selector in
@@ -335,6 +361,38 @@ const CJK_IDEOGRAPH_RANGES = [
  * selector legitimately follows). @param {number} cp @returns {boolean} */
 function isCjkIdeograph(cp) {
   for (const [start, end] of CJK_IDEOGRAPH_RANGES)
+    if (cp >= start && cp <= end) return true;
+  return false;
+}
+
+// Consonant (KA..HA and script-specific additional-consonant) ranges of the
+// Brahmic scripts the joiner carve-out serves. A virama does half-form/conjunct
+// work ONLY on a consonant base; a bare or base-less halant + ZWJ carries no
+// rendering and is a smuggling channel, so the Indic joiner is preserved only
+// when its virama sits on one of these. Broad per-block spans — precision here
+// only needs "a real Brahmic letter of this script", not an exact consonant set.
+const BRAHMIC_CONSONANT_RANGES = [
+  [0x0915, 0x0939], // Devanagari KA–HA
+  [0x0958, 0x095f], // Devanagari additional consonants
+  [0x0995, 0x09b9], // Bengali
+  [0x09dc, 0x09df], // Bengali additional consonants
+  [0x0a15, 0x0a39], // Gurmukhi
+  [0x0a59, 0x0a5e], // Gurmukhi additional consonants
+  [0x0a95, 0x0ab9], // Gujarati
+  [0x0b15, 0x0b39], // Oriya
+  [0x0b5c, 0x0b5f], // Oriya additional consonants
+  [0x0b95, 0x0bb9], // Tamil
+  [0x0c15, 0x0c39], // Telugu
+  [0x0c58, 0x0c5a], // Telugu additional consonants
+  [0x0c95, 0x0cb9], // Kannada
+  [0x0d15, 0x0d3a], // Malayalam
+  [0x0d9a, 0x0dc6], // Sinhala
+];
+
+/** True when `cp` is a Brahmic consonant — the only base a virama attaches to.
+ * @param {number} cp @returns {boolean} */
+function isBrahmicConsonant(cp) {
+  for (const [start, end] of BRAHMIC_CONSONANT_RANGES)
     if (cp >= start && cp <= end) return true;
   return false;
 }
@@ -440,11 +498,34 @@ function effectiveNeighbor(cps, i, dir) {
 }
 
 /**
+ * True when the joiner at `cps[i]` follows a virama that itself sits on a real
+ * Brahmic consonant — a genuine half-form/conjunct request (क् + ZWJ), not a
+ * bare or base-less halant (a smuggling channel a raw `cps[i-1]` virama test
+ * would wave through). Steps left over removable invisibles to LAND on the
+ * virama (which is Joining_Type Transparent, so it is the anchor, never skipped),
+ * then uses effectiveNeighbor to find the consonant base past any transparent
+ * marks / invisibles between it and the virama.
+ * @param {string[]} cps @param {number} i
+ * @returns {boolean}
+ */
+function followsBrahmicConjunct(cps, i) {
+  let j = i - 1;
+  while (j >= 0 && !isJoinControl(cps[j]) && classify(cps[j]) !== null) j--;
+  if (j < 0 || !isVirama(/** @type {number} */ (cps[j].codePointAt(0))))
+    return false;
+  const base = effectiveNeighbor(cps, j, -1);
+  return (
+    base !== "" &&
+    isBrahmicConsonant(/** @type {number} */ (base.codePointAt(0)))
+  );
+}
+
+/**
  * True when the joiner at `cps[i]` does real rendering work and so must be
  * preserved rather than stripped, decided from the neighbours' Joining_Type:
  *   - emoji ZWJ: between two emoji components (its left pictograph may sit behind
  *     a VS16, so step over selectors — see leftNonSelector);
- *   - Indic joiner: immediately after a virama;
+ *   - Indic joiner: after a virama that sits on a real Brahmic consonant;
  *   - Arabic-family joiner: between two cursive letters (ZWNJ needs both, ZWJ at
  *     least one — it forces a connected form). A joiner whose effective neighbour
  *     is ANOTHER joiner is a run (a zero-width payload channel) and is rejected.
@@ -455,7 +536,6 @@ function effectiveNeighbor(cps, i, dir) {
 function isPreservedJoiner(cps, i) {
   const cp = /** @type {number} */ (cps[i].codePointAt(0));
   if (cp !== ZWNJ && cp !== ZWJ) return false;
-  const prev = cps[i - 1] ?? "";
   // Emoji ZWJ sequences use ZWJ only; the real neighbours are the pictographs,
   // which may each sit behind a variation selector (🏳️‍🌈 = base VS16 ZWJ rainbow;
   // a selector can also follow the ZWJ before the next base), so step over
@@ -466,9 +546,8 @@ function isPreservedJoiner(cps, i) {
     EMOJI_BASE.test(rightNonSelector(cps, i))
   )
     return true;
-  // Indic: meaningful only immediately after a virama (halant / half-form).
-  if (prev && isVirama(/** @type {number} */ (prev.codePointAt(0))))
-    return true;
+  // Indic: meaningful only after a virama sitting on a real consonant base.
+  if (followsBrahmicConjunct(cps, i)) return true;
   // Arabic-family cursive joining, on the nearest non-Transparent neighbours.
   const left = effectiveNeighbor(cps, i, -1);
   const right = effectiveNeighbor(cps, i, 1);
@@ -480,17 +559,26 @@ function isPreservedJoiner(cps, i) {
 
 /**
  * True when `cps[i]` is a presentation selector (VS15 U+FE0E or VS16 U+FE0F)
- * directly after a pictograph/skin-tone modifier OR a keycap base
- * (digit/`#`/`*`) — part of a visible glyph, not a hidden VS run, so it is
- * preserved (a longer selector run still surfaces: the next selector's left
- * neighbour is itself a selector, not a pictograph/keycap base).
+ * that is part of a visible glyph, not a hidden VS run:
+ *   - directly after a pictograph/skin-tone modifier, preserved; OR
+ *   - directly after a keycap base (digit/`#`/`*`) AND immediately followed by
+ *     U+20E3 COMBINING ENCLOSING KEYCAP — a complete keycap glyph (1️⃣ #️⃣ …).
+ * A keycap base + selector with NO trailing U+20E3 is a bare hidden presentation
+ * selector, so it fails closed and is stripped. A longer selector run still
+ * surfaces: the next selector's left neighbour is itself a selector.
  * @param {string[]} cps @param {number} i
  * @returns {boolean}
  */
 function isEmojiPresentationSelector(cps, i) {
+  if (
+    !PRESENTATION_SELECTORS.has(/** @type {number} */ (cps[i].codePointAt(0)))
+  )
+    return false;
+  const prev = cps[i - 1] ?? "";
+  if (EMOJI_LEFT.test(prev)) return true;
   return (
-    PRESENTATION_SELECTORS.has(/** @type {number} */ (cps[i].codePointAt(0))) &&
-    PRESENTATION_SELECTOR_LEFT.test(cps[i - 1] ?? "")
+    KEYCAP_BASE.test(prev) &&
+    (cps[i + 1]?.codePointAt(0) ?? -1) === COMBINING_KEYCAP
   );
 }
 
@@ -600,13 +688,16 @@ function rightNonSelector(cps, i) {
 }
 
 /**
- * Mark every index that belongs to a well-formed emoji tag sequence (subregional
- * flag): a U+1F3F4 tag_base, then one or more tag chars in U+E0020–U+E007E, then
- * U+E007F CANCEL TAG. Only the tag chars and the terminating CANCEL are marked
- * (the base is a visible pictograph). A run missing the CANCEL, or with no tag
- * char before it, is malformed and left unmarked so it is stripped (fail closed).
+ * Mark every index that belongs to a PRESERVABLE emoji tag sequence (subregional
+ * flag): a U+1F3F4 tag_base, then tag chars in U+E0020–U+E007E whose decoded
+ * ASCII payload names a REGISTERED subdivision, then U+E007F CANCEL TAG. Only the
+ * tag chars and the terminating CANCEL are marked (the base is a visible
+ * pictograph). A run missing the CANCEL, exceeding the tag-char cap, or whose
+ * payload is not a registered subdivision is left unmarked so it is stripped —
+ * grammatical validity alone is NOT enough, since a valid run spells arbitrary
+ * ASCII (fail closed on the top ASCII-smuggling vector).
  * @param {string[]} cps
- * @returns {boolean[]} keep[i] true iff `cps[i]` is inside a valid tag sequence
+ * @returns {boolean[]} keep[i] true iff `cps[i]` is inside a preservable tag sequence
  */
 function markTagSequences(cps) {
   const keep = new Array(cps.length).fill(false);
@@ -615,10 +706,25 @@ function markTagSequences(cps) {
   for (let i = 0; i < cps.length; i++) {
     if (cpAt(i) !== TAG_BASE) continue;
     let j = i + 1;
-    while (j < cps.length && cpAt(j) >= TAG_SPEC_MIN && cpAt(j) <= TAG_SPEC_MAX)
+    let payload = "";
+    while (
+      j < cps.length &&
+      cpAt(j) >= TAG_SPEC_MIN &&
+      cpAt(j) <= TAG_SPEC_MAX
+    ) {
+      payload += String.fromCharCode(cpAt(j) - 0xe0000);
       j++;
-    // Require ≥1 spec tag char (j advanced past i+1) AND a terminating CANCEL.
-    if (j > i + 1 && j < cps.length && cpAt(j) === TAG_CANCEL) {
+    }
+    const tagLen = j - (i + 1);
+    // Require ≥1 tag char, at most MAX_TAG_SPEC_CHARS, a terminating CANCEL, and
+    // a payload naming a registered subdivision — else the run stays stripped.
+    if (
+      tagLen >= 1 &&
+      tagLen <= MAX_TAG_SPEC_CHARS &&
+      j < cps.length &&
+      cpAt(j) === TAG_CANCEL &&
+      REGISTERED_TAG_PAYLOADS.has(payload)
+    ) {
       for (let k = i + 1; k <= j; k++) keep[k] = true;
       i = j; // resume after the consumed sequence
     }
@@ -703,18 +809,30 @@ function carveStrip(body) {
   // joiner is stripped (threshold-evasion catch — over-strip beats under).
   const allowCarveOut = payloadInvis < SCATTERED_THRESHOLD;
   // Document-wide preserve allowance, proportional to visible text but never
-  // below the floor (see TOTAL_PRESERVED_JOINER_BUDGET / PRESERVED_JOINER_PER_VISIBLE).
-  const maxPreserved = Math.max(
-    TOTAL_PRESERVED_JOINER_BUDGET,
-    Math.ceil(visibleLen / PRESERVED_JOINER_PER_VISIBLE),
+  // below the floor (see TOTAL_PRESERVED_JOINER_BUDGET / PRESERVED_JOINER_PER_VISIBLE)
+  // and never above PRESERVE_HARD_CAP — the absolute ceiling stops the channel
+  // scaling with attacker-supplied cover text.
+  const maxPreserved = Math.min(
+    PRESERVE_HARD_CAP,
+    Math.max(
+      TOTAL_PRESERVED_JOINER_BUDGET,
+      Math.ceil(visibleLen / PRESERVED_JOINER_PER_VISIBLE),
+    ),
   );
 
   const foundCodes = new Set();
   let out = "";
-  // Preserved JOINERS in the current uninterrupted cluster (selectors/tags/blank
-  // fillers don't chain, so they are exempt). A genuine gap (two visible chars in
-  // a row — see prevVisible) resets it; past the cap the surplus is stripped.
+  // Preserved JOINERS in the current uninterrupted cluster (tags/blank fillers
+  // and presentation selectors don't chain, so they are exempt). A genuine gap
+  // (two visible chars in a row — see prevVisible) resets it; past the cap the
+  // surplus is stripped.
   let joinerRun = 0;
+  // Preserved IVS/standardized variation selectors in the current uninterrupted
+  // run (an `ideograph selector ideograph selector …` chain never breaks the
+  // prevVisible gap, so joinerRun's reset does not bound it — this counter does).
+  // Same genuine-gap reset as joinerRun; past CONSECUTIVE_SELECTOR_CAP the
+  // surplus is stripped, closing the high-bit-rate variation-selector channel.
+  let selectorRun = 0;
   // Preserved chars across the WHOLE string — never reset at a gap, so it bounds
   // the document-wide channel joinerRun cannot. Past maxPreserved a preserved
   // char is stripped and its category reported.
@@ -726,7 +844,10 @@ function carveStrip(body) {
     if (code === null) {
       // A visible char following another visible char is a real word/segment
       // boundary, not a join — the joined cluster (if any) ended here.
-      if (prevVisible) joinerRun = 0;
+      if (prevVisible) {
+        joinerRun = 0;
+        selectorRun = 0;
+      }
       prevVisible = true;
       out += cps[i]; // ordinary visible character
       i++;
@@ -747,13 +868,16 @@ function carveStrip(body) {
       continue;
     }
     const joiner = kind[i] === "joiner";
+    const selector = kind[i] === "ivs" || kind[i] === "stdvs";
     if (
       allowCarveOut &&
       kind[i] !== null &&
       preservedTotal < maxPreserved &&
-      (!joiner || joinerRun < CONSECUTIVE_JOINER_CAP)
+      (!joiner || joinerRun < CONSECUTIVE_JOINER_CAP) &&
+      (!selector || selectorRun < CONSECUTIVE_SELECTOR_CAP)
     ) {
       if (joiner) joinerRun++;
+      if (selector) selectorRun++;
       preservedTotal++;
       prevVisible = false; // a joiner/selector keeps the cluster open
       out += cps[i];

--- a/test/confusables.test.mjs
+++ b/test/confusables.test.mjs
@@ -194,6 +194,20 @@ describe("foldConfusables", () => {
     );
   });
 
+  it("throws when char is empty (would insert without consuming and then crash)", () => {
+    // An empty char makes startsWith("", i) vacuously true for any index, so the
+    // splice inserts latinEquivalent without consuming a glyph (silent
+    // insertion-corruption) and describeFolds later crashes on "".codePointAt(0).
+    // Must fail loud, matching the other finding-shape guards.
+    assert.throws(
+      () =>
+        foldConfusables(`/${CYR_A}b`, [
+          { index: 1, char: "", latinEquivalent: "a" },
+        ]),
+      /empty char/,
+    );
+  });
+
   it("allows a multi-character ASCII canon (e.g. a ligature fold)", () => {
     // Precision: a legitimate one-to-many ASCII fold (½ → 1/2, œ → oe) must NOT
     // be rejected by the ASCII guard — only non-ASCII replacements are refused.

--- a/test/invisible-semantic-fuzz.test.mjs
+++ b/test/invisible-semantic-fuzz.test.mjs
@@ -74,6 +74,17 @@ const STRIP_TOKENS = [
   "Q" + ZWNJ + "K", // bare ZWNJ between plain ASCII
   "Q" + ZWSP + "K", // zero-width space, never preserved
   "Q" + cp(0xe0041) + cp(0xe0070) + "K", // Unicode tag characters (deniable ASCII channel)
+  // A GRAMMATICALLY-valid emoji tag sequence (🏴 + tag chars + CANCEL) whose
+  // decoded payload ("hi") is NOT a registered subdivision — the ASCII-smuggling
+  // shape. The visible flag base survives (so the full token string, which
+  // includes the stripped tag run + CANCEL, must NOT reappear); "Q…K" markers
+  // bracket it so the whole-token absence check is unambiguous.
+  "Q" +
+    cp(0x1f3f4) +
+    cp(0xe0000 + "h".charCodeAt(0)) +
+    cp(0xe0000 + "i".charCodeAt(0)) +
+    cp(0xe007f) +
+    "K",
 ];
 
 const pieceGen = fc.oneof(

--- a/test/invisible.test.mjs
+++ b/test/invisible.test.mjs
@@ -24,8 +24,10 @@ import {
   LONG_RUN_THRESHOLD,
   SCATTERED_THRESHOLD,
   CONSECUTIVE_JOINER_CAP,
+  CONSECUTIVE_SELECTOR_CAP,
   TOTAL_PRESERVED_JOINER_BUDGET,
   PRESERVED_JOINER_PER_VISIBLE,
+  PRESERVE_HARD_CAP,
   LINGUISTIC_SCRIPTS,
   describeStripped,
   payloadInvisibleView,
@@ -341,15 +343,24 @@ describe("stripInvisible: ZWNJ/ZWJ linguistic carve-out", () => {
     });
   }
 
-  it("preserves a keycap base + VS16 even with no trailing combining keycap (fail open on ambiguity)", () => {
-    // A keycap base followed by VS16 with nothing after it is not a complete
-    // keycap glyph, but per the fail-open doctrine we still do not strip the
-    // VS16 — an ambiguous case is better left as harmless "digit rendered
-    // with emoji presentation" than mangled.
+  it("strips a keycap base + VS16 with NO trailing combining keycap (fail closed)", () => {
+    // A keycap base + VS16 with nothing after it is NOT a complete keycap glyph;
+    // it is a bare presentation selector spliced after ordinary text — the top
+    // low-effort VS-smuggling shape. The carve-out fails CLOSED: preservation
+    // requires the mandatory U+20E3 keycap terminator, so this VS16 is stripped.
     const input = `1${cp(0xfe0f)}`;
     const { cleaned, found } = stripInvisibleWithReport(input);
-    assert.equal(cleaned, input);
-    assert.deepEqual(found, []);
+    assert.equal(cleaned, "1");
+    assert.deepEqual(found, [CATEGORY.VARIATION_SELECTORS]);
+  });
+
+  it("strips a VS15 after a lone digit with no keycap (fail closed)", () => {
+    // Same fail-closed rule for the text-presentation selector: `9` + VS15 with
+    // no U+20E3 is a hidden selector, not a glyph.
+    const input = `9${cp(0xfe0e)}`;
+    const { cleaned, found } = stripInvisibleWithReport(input);
+    assert.equal(cleaned, "9");
+    assert.deepEqual(found, [CATEGORY.VARIATION_SELECTORS]);
   });
 
   it("does not widen the ZWJ emoji-sequence carve-out to keycap bases", () => {
@@ -919,9 +930,52 @@ describe("stripInvisible: emoji tag sequences (subregional flags)", () => {
     assert.deepEqual(found, [CATEGORY.CF]);
   });
 
+  // A grammatically-valid tag run whose payload is NOT a registered subdivision
+  // is the ASCII-smuggling channel: tag chars decode to ASCII (cp − 0xE0000), so
+  // a well-formed 🏴 … CANCEL run can spell arbitrary text. Only a registered GB
+  // subdivision payload is preserved; every other run fails closed.
+  for (const [name, payload] of [
+    ["a short ASCII word", "hi"],
+    ["an injection phrase", "ignore"],
+    ["a US-state-shaped payload", "usca"],
+    ["a near-miss of a real subdivision", "gbxyz"],
+  ]) {
+    it(`strips a grammar-valid tag run with a non-subdivision payload (${name})`, () => {
+      const input = `a ${tagCode(payload)} b`;
+      const { cleaned, found } = stripInvisibleWithReport(input);
+      // Only the visible flag base survives; every tag char + CANCEL is stripped.
+      assert.equal(cleaned, `a ${cp(0x1f3f4)} b`);
+      assert.deepEqual(found, [CATEGORY.CF]);
+    });
+  }
+
+  it("strips a grammar-valid tag run that exceeds the tag-char cap", () => {
+    // Payload "gbengland" is a registered-prefix but 9 tag chars (> the ≤6 cap),
+    // so it fails closed even though it starts with a real subdivision code.
+    const input = tagCode("gbengland");
+    const { cleaned, found } = stripInvisibleWithReport(input);
+    assert.equal(cleaned, cp(0x1f3f4));
+    assert.deepEqual(found, [CATEGORY.CF]);
+  });
+
+  it("preserves a real England/Scotland/Wales flag next to a stripped fake flag (precision)", () => {
+    // The registered flag survives byte-for-byte; the adjacent fake-payload flag
+    // loses its tag run — precision counter-case to the strip assertions above.
+    const real = tagCode("gbeng");
+    const fake = tagCode("ignore");
+    const { cleaned, found } = stripInvisibleWithReport(`${real} ${fake}`);
+    assert.equal(cleaned, `${real} ${cp(0x1f3f4)}`);
+    assert.deepEqual(found, [CATEGORY.CF]);
+  });
+
   it("is idempotent on a mixed valid/invalid tag document", () => {
     const input = `${tagCode("gbsct")} ${cp(0x1f3f4)}${cp(0xe0067)} tail`;
     const once = stripInvisible(input);
+    assert.equal(stripInvisible(once), once);
+  });
+
+  it("is idempotent on a non-subdivision fake-flag run", () => {
+    const once = stripInvisible(`x ${tagCode("ignorerules")} y`);
     assert.equal(stripInvisible(once), once);
   });
 
@@ -1028,6 +1082,113 @@ describe("stripInvisible: ideographic variation sequences", () => {
     const { cleaned, found } = stripInvisibleWithReport(input);
     assert.equal(cleaned, cp(0x1f3f3));
     assert.deepEqual(found, [CATEGORY.VARIATION_SELECTORS]);
+  });
+});
+
+// ─── Carve-out hardening: absolute preserve cap, selector run cap, virama base ─
+// Three tightenings that close covert channels the earlier carve-out left open:
+// an absolute ceiling on the preserve budget (so cover text can't scale it), a
+// consecutive-run cap on ideographic/standardized variation selectors (so a
+// per-character variation-selected CJK run can't smuggle bits), and a real
+// Brahmic-consonant requirement before a virama (so a bare halant + ZWJ is not
+// mistaken for a conjunct). Each strip assertion is paired with a preserve one.
+describe("stripInvisible: preserve budget has an absolute hard cap", () => {
+  const ZWNJ_CH = cp(0x200c);
+  const countOf = (s, ch) => s.split(ch).length - 1;
+
+  it(`never preserves more than PRESERVE_HARD_CAP joiners no matter how much cover text`, () => {
+    // 200 space-separated Persian ZWNJ words: each ZWNJ is meaningful (so none
+    // counts toward the scatter floor) and every gap resets the per-cluster cap,
+    // so ONLY the document-wide limit bounds the total. visibleLen ≈ 800 ⇒
+    // ceil(visibleLen / PER_VISIBLE) = 100, which WITHOUT the hard cap would
+    // preserve 100; the cap holds it to PRESERVE_HARD_CAP (64).
+    const unit = cp(0x645) + cp(0x6cc) + ZWNJ_CH + cp(0x62e) + " ";
+    const { cleaned, found } = stripInvisibleWithReport(unit.repeat(200));
+    assert.equal(countOf(cleaned, ZWNJ_CH), PRESERVE_HARD_CAP);
+    assert.deepEqual(found, [CATEGORY.CF]);
+  });
+
+  it("preserves every joiner when the count sits under the hard cap (precision)", () => {
+    // 40 words ⇒ 40 ZWNJ, below PRESERVE_HARD_CAP (64) and below ceil(160/8)=20?
+    // visibleLen ≈ 160 ⇒ ceil/8 = 20, floored to TOTAL_PRESERVED_JOINER_BUDGET…
+    // 40 would still overrun that floor, so pad each gap to keep the allowance
+    // above 40: 20-space gaps ⇒ visibleLen ≈ 40*23 = 920 ⇒ allowance 64, so all
+    // 40 survive. Counter-case proving the cap only clips the SURPLUS.
+    const unit = cp(0x645) + cp(0x6cc) + ZWNJ_CH + cp(0x62e) + " ".repeat(20);
+    const { cleaned, found } = stripInvisibleWithReport(unit.repeat(40));
+    assert.equal(countOf(cleaned, ZWNJ_CH), 40);
+    assert.deepEqual(found, []);
+  });
+});
+
+describe("stripInvisible: consecutive variation-selector run cap", () => {
+  const IVS = cp(0xe0100);
+  const IDEO = cp(0x845b);
+  const countOf = (s, ch) => s.split(ch).length - 1;
+
+  it("caps a per-character variation-selected CJK run at CONSECUTIVE_SELECTOR_CAP", () => {
+    // `葛󠄀葛󠄀…` — every ideograph carries an IVS, an unbroken selector run with no
+    // gap. Each IVS is individually a valid ideographic variation sequence, so
+    // only the consecutive-run cap bounds the channel: past the cap the surplus
+    // selectors are stripped (the ideographs, being visible, all survive).
+    const runLen = CONSECUTIVE_SELECTOR_CAP + 6;
+    const { cleaned, found } = stripInvisibleWithReport(
+      (IDEO + IVS).repeat(runLen),
+    );
+    assert.equal(countOf(cleaned, IVS), CONSECUTIVE_SELECTOR_CAP);
+    assert.equal(countOf(cleaned, IDEO), runLen); // no ideograph is ever dropped
+    assert.deepEqual(found, [CATEGORY.VARIATION_SELECTORS]);
+  });
+
+  it("preserves a short variation-selected run under the cap (precision)", () => {
+    // Exactly CONSECUTIVE_SELECTOR_CAP selected ideographs: all survive verbatim.
+    const input = (IDEO + IVS).repeat(CONSECUTIVE_SELECTOR_CAP);
+    const { cleaned, found } = stripInvisibleWithReport(input);
+    assert.equal(cleaned, input);
+    assert.deepEqual(found, []);
+  });
+
+  it("resets the selector run at a genuine visible gap", () => {
+    // A space between two capped runs resets the counter, so each half preserves
+    // up to the cap independently — proof the reset (not just the cap) works.
+    const half = (IDEO + IVS).repeat(CONSECUTIVE_SELECTOR_CAP);
+    const { cleaned, found } = stripInvisibleWithReport(`${half}  ${half}`);
+    assert.equal(countOf(cleaned, IVS), CONSECUTIVE_SELECTOR_CAP * 2);
+    assert.deepEqual(found, []);
+  });
+});
+
+describe("stripInvisible: virama joiner requires a real consonant base", () => {
+  const VIRAMA = cp(0x94d); // Devanagari virama
+  const CONSONANT = cp(0x915); // Devanagari KA
+
+  it("strips a bare virama + ZWJ with no consonant base (fail closed)", () => {
+    // The virama itself (a combining mark) is not payload and remains; only the
+    // ZWJ, which does no conjunct work without a consonant, is stripped.
+    const { cleaned, found } = stripInvisibleWithReport(VIRAMA + ZWJ);
+    assert.equal(cleaned, VIRAMA);
+    assert.deepEqual(found, [CATEGORY.CF]);
+  });
+
+  it("strips a virama + ZWJ whose base is a non-Brahmic (ASCII) letter", () => {
+    const { cleaned, found } = stripInvisibleWithReport(`a${VIRAMA}${ZWJ}b`);
+    assert.equal(cleaned, `a${VIRAMA}b`);
+    assert.deepEqual(found, [CATEGORY.CF]);
+  });
+
+  it("strips a leading virama + ZWJ before a consonant (base is on the wrong side)", () => {
+    const { cleaned, found } = stripInvisibleWithReport(
+      VIRAMA + ZWJ + CONSONANT,
+    );
+    assert.equal(cleaned, VIRAMA + CONSONANT);
+    assert.deepEqual(found, [CATEGORY.CF]);
+  });
+
+  it("preserves a real consonant + virama + ZWJ + consonant conjunct (precision)", () => {
+    const conjunct = CONSONANT + VIRAMA + ZWJ + cp(0x937);
+    const { cleaned, found } = stripInvisibleWithReport(conjunct);
+    assert.equal(cleaned, conjunct);
+    assert.deepEqual(found, []);
   });
 });
 
@@ -1151,12 +1312,12 @@ describe("payloadInvisibleView + describeStripped: preserved runs don't alert", 
     assert.equal(view.includes(cp(0x200b)), true);
   });
 
-  it("no LONG RUN marker when a long invisible run is a preserved tag sequence", () => {
-    // A grammar-valid flag with 11 tag chars (> LONG_RUN_THRESHOLD) is preserved,
-    // so the injection marker must NOT fire even though a single ZWSP is stripped.
-    const bigFlag =
-      cp(0x1f3f4) + cp(0xe0041).repeat(LONG_RUN_THRESHOLD + 1) + CANCEL_TAG;
-    const deAnsi = bigFlag + cp(0x200b);
+  it("no LONG RUN marker when masking a preserved flag breaks an otherwise-long run", () => {
+    // A registered flag (6 preserved invisibles) immediately followed by 9 ZWSP
+    // payload: UNMASKED the 15 consecutive invisibles would trip LONG_RUN, but
+    // payloadInvisibleView masks the preserved flag chars to spaces, leaving only
+    // the 9 ZWSP (< LONG_RUN_THRESHOLD) — so the injection marker must NOT fire.
+    const deAnsi = tagCode("gbsct") + cp(0x200b).repeat(LONG_RUN_THRESHOLD - 1);
     const note = describeStripped([CATEGORY.CF], deAnsi);
     assert.doesNotMatch(note, /LONG RUN/);
   });

--- a/test/mutation-guards.test.mjs
+++ b/test/mutation-guards.test.mjs
@@ -12,6 +12,11 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
 import { sanitize, CATEGORY, CATEGORY_LABELS } from "../src/index.mjs";
+import {
+  stripInvisibleWithReport,
+  PRESERVE_HARD_CAP,
+  CONSECUTIVE_SELECTOR_CAP,
+} from "../src/invisible.mjs";
 import { cp } from "./test-helpers.mjs";
 import {
   spliceRanges,
@@ -336,5 +341,34 @@ describe("guard: srcset URL (first token, descriptor dropped) is scanned", () =>
     assert.equal(threats[0].target, "evil.example");
     assert.equal(threats[0].reason, "suspicious query parameter");
     assert.equal(threats[0].isImage, true);
+  });
+});
+
+// ─── invisible.mjs: carve-out preserve caps are the documented integers ───────
+// The Math.min(HARD_CAP, …) ceiling and the selector-run boundary comparison are
+// exact-integer contracts; an off-by-one or a dropped Math.min survives every
+// looser check, so pin the boundary behaviour to the named constant.
+
+describe("guard: carve-out preserve caps hold at the exact constant boundary", () => {
+  const countOf = (s, ch) => s.split(ch).length - 1;
+  const ZWNJ = cp(0x200c);
+
+  it("preserves EXACTLY PRESERVE_HARD_CAP joiners under unbounded cover text", () => {
+    // visibleLen ≈ 800 ⇒ ceil(visibleLen / 8) = 100; the Math.min ceiling clips
+    // that to PRESERVE_HARD_CAP. A mutant dropping the Math.min preserves 100,
+    // and an off-by-one shifts the count — both die on this exact-equality.
+    const unit = cp(0x645) + cp(0x6cc) + ZWNJ + cp(0x62e) + " ";
+    const { cleaned } = stripInvisibleWithReport(unit.repeat(200));
+    assert.equal(countOf(cleaned, ZWNJ), PRESERVE_HARD_CAP);
+  });
+
+  it("preserves EXACTLY CONSECUTIVE_SELECTOR_CAP selectors in an unbroken CJK run", () => {
+    // `<`ideograph`>`IVS repeated past the cap: the `selectorRun < CAP` boundary
+    // keeps exactly CONSECUTIVE_SELECTOR_CAP; a `<=` mutant keeps one more.
+    const input = (cp(0x845b) + cp(0xe0100)).repeat(
+      CONSECUTIVE_SELECTOR_CAP + 5,
+    );
+    const { cleaned } = stripInvisibleWithReport(input);
+    assert.equal(countOf(cleaned, cp(0xe0100)), CONSECUTIVE_SELECTOR_CAP);
   });
 });


### PR DESCRIPTION
**Stacked on #144** (base = `claude/ais-cf-charset-ssot`) — GitHub will re-target to `main` when #144 merges. The crown-jewel finding of the audit: the invisible-char carve-out preserved far more than legitimate rendering requires.

## Findings fixed
- **U1 (high) `invisible.mjs`** — `markTagSequences` preserved **any** grammatically-valid `🏴 + tag chars + CANCEL` run regardless of payload; tag chars decode to ASCII, so a fake-flag run spelling arbitrary text reached the model. Now a tag run is preserved only when its decoded payload is a **registered GB subdivision** (`gbeng`/`gbsct`/`gbwls`, ≤6 tag chars); anything else is stripped.
- **U2 (high) `invisible.mjs`** — `maxPreserved` had no ceiling and preserved bytes evaded the scatter gate, so the covert channel scaled with attacker cover text. Added an absolute `PRESERVE_HARD_CAP = 64`.
- **U3 (med)** — ideographic/standardized variation selectors were exempt from the consecutive cap (stego over CJK); added `CONSECUTIVE_SELECTOR_CAP`.
- **U4 (med)** — the Indic virama joiner-preserve used the raw previous codepoint with no consonant base; now requires a real Brahmic-consonant base via `effectiveNeighbor`.
- **U5 (low)** — keycap presentation selectors (`VS15/16` after a digit/`#`/`*`) now require a trailing `U+20E3`.
- **U6 (low) `confusables.mjs`** — `foldConfusables` now throws loudly on an empty-`char` finding (was silent insertion-corruption + a downstream crash).

## Tests
Targeted suite 347 pass; full suite **1662** pass; eslint clean. **Precision preserved** — legit Persian/Indic/emoji ZWJ, real England/Scotland/Wales flag emoji, and registered variation sequences all survive byte-for-byte (semantic-fuzz precision suite + per-script cases). Two existing tests were inverted to match the new fail-closed keycap/tag behavior.

## Decisions made
- `PRESERVE_HARD_CAP = 64` and tag-payload cap ≤ 6 chars (max real subdivision length). Under a larger cap the residual covert channel widens; under a smaller one a legitimate dense-conjunct script could lose a joiner.
- Tag runs are validated against the registered-subdivision list rather than merely length-capped — closes the smuggling channel fully rather than narrowing it.


---
_Generated by [Claude Code](https://claude.ai/code/session_013ey8pCsjgaK57apoRNCUuX)_