### PR TITLE
fix(html): close browser-honored hidden-content detection gaps

### DIFF
--- a/src/html.mjs
+++ b/src/html.mjs
@@ -244,6 +244,12 @@ function isPositionedOffscreen(val) {
 // var()/inherit/currentColor are deliberately absent: they resolve via the
 // cascade and must fail OPEN, handled by isConcreteColor at the compare.
 /** @type {Record<string, string>} */
+// Stryker disable all — static CSS color data table (147 canonical name→hex
+// entries). Mutating each hex/name literal yields hundreds of low-value,
+// largely-equivalent mutants (no test can meaningfully pin every color) that
+// balloon the html shard past its CI timeout. The canonicalization LOGIC that
+// consumes this table stays under mutation. Same idiom as the Unicode data
+// tables in standardized-variants.mjs/joining-type.mjs/cf-charset.mjs.
 const NAMED_COLORS = {
   aliceblue: "#f0f8ff",
   antiquewhite: "#faebd7",
@@ -395,6 +401,7 @@ const NAMED_COLORS = {
   yellow: "#ffff00",
   yellowgreen: "#9acd32",
 };
+// Stryker restore all
 
 /**
  * True when a canonicalized color is a concrete value we can compare for

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -140,10 +140,21 @@ function isHidingTransform(transform) {
   // rotateX/rotateY by an odd multiple of 90deg turns the box edge-on (zero
   // projected area). Only the axis-specific rotations collapse to a line; a
   // plain rotate()/rotateZ() spins in-plane and stays visible.
-  const rotate = transform.match(/\brotate[xy]\(\s*(-?\d*\.?\d+)deg/i);
+  // The angle carries a mandatory unit (deg/grad/rad/turn — a unitless nonzero
+  // angle is invalid CSS a browser drops, staying visible) and an optional
+  // sign; hueDegrees normalizes any of those units to `[0,360)` degrees. A
+  // near-90/270 band (not exact ==) absorbs the float drift of rad→deg.
+  const rotate = transform.match(
+    /\brotate[xy]\(\s*([+-]?\d*\.?\d+(?:deg|grad|rad|turn))/i,
+  );
   if (rotate) {
-    const degrees = ((parseFloat(rotate[1]) % 360) + 360) % 360;
-    if (degrees === 90 || degrees === 270) return true;
+    const degrees = hueDegrees(rotate[1].toLowerCase());
+    if (
+      degrees !== null &&
+      (Math.abs(degrees - 90) < NEAR_ZERO_EPSILON ||
+        Math.abs(degrees - 270) < NEAR_ZERO_EPSILON)
+    )
+      return true;
   }
   // translateX/translateY/translate far off-screen. A two-axis `translate(x, y)`
   // hides when EITHER axis clears the viewport, so split the argument list and
@@ -210,22 +221,179 @@ function isClipRectHidden(clip) {
 
 /** @param {(key: string) => string} val */
 function isPositionedOffscreen(val) {
-  if (!/\babsolute\b|\bfixed\b/.test(val("position"))) return false;
+  const position = val("position");
+  // `relative`/`sticky` shift the rendered box off its normal spot just like
+  // `absolute`/`fixed` do, so a `left:-9999px` on any of them pushes the text
+  // off any viewport. `static` ignores offsets and is excluded.
+  if (!/\babsolute\b|\bfixed\b|\brelative\b|\bsticky\b/.test(position))
+    return false;
   for (const side of ["left", "top", "right", "bottom"])
     if (isOffscreenOffset(val(side))) return true;
+  // The legacy `clip` property only clips ABSOLUTELY-positioned boxes
+  // (absolute/fixed); a relative/sticky element ignores it, so reading its
+  // rect() as a hide there would splice visible text (fail open).
+  if (!/\babsolute\b|\bfixed\b/.test(position)) return false;
   const clip = val("clip");
   return Boolean(clip && isClipRectHidden(clip));
 }
 
-// CSS named colors that participate in a white-on-white / black-on-black style
-// of hiding. The full named-color set is unnecessary — only colors that
-// commonly back hidden text need a canonical form for the equality compare.
+// The full CSS named-color set canonicalized to `#rrggbb`, so any two identical
+// resolvable named colors (`color:blue;background:blue`) — not just the handful
+// that back white-on-white text — compare equal for the same-color hide test.
+// `transparent` maps to itself (the sentinel isConcreteColor also accepts).
+// var()/inherit/currentColor are deliberately absent: they resolve via the
+// cascade and must fail OPEN, handled by isConcreteColor at the compare.
 /** @type {Record<string, string>} */
 const NAMED_COLORS = {
-  white: "#ffffff",
+  aliceblue: "#f0f8ff",
+  antiquewhite: "#faebd7",
+  aqua: "#00ffff",
+  aquamarine: "#7fffd4",
+  azure: "#f0ffff",
+  beige: "#f5f5dc",
+  bisque: "#ffe4c4",
   black: "#000000",
+  blanchedalmond: "#ffebcd",
+  blue: "#0000ff",
+  blueviolet: "#8a2be2",
+  brown: "#a52a2a",
+  burlywood: "#deb887",
+  cadetblue: "#5f9ea0",
+  chartreuse: "#7fff00",
+  chocolate: "#d2691e",
+  coral: "#ff7f50",
+  cornflowerblue: "#6495ed",
+  cornsilk: "#fff8dc",
+  crimson: "#dc143c",
+  cyan: "#00ffff",
+  darkblue: "#00008b",
+  darkcyan: "#008b8b",
+  darkgoldenrod: "#b8860b",
+  darkgray: "#a9a9a9",
+  darkgreen: "#006400",
+  darkgrey: "#a9a9a9",
+  darkkhaki: "#bdb76b",
+  darkmagenta: "#8b008b",
+  darkolivegreen: "#556b2f",
+  darkorange: "#ff8c00",
+  darkorchid: "#9932cc",
+  darkred: "#8b0000",
+  darksalmon: "#e9967a",
+  darkseagreen: "#8fbc8f",
+  darkslateblue: "#483d8b",
+  darkslategray: "#2f4f4f",
+  darkslategrey: "#2f4f4f",
+  darkturquoise: "#00ced1",
+  darkviolet: "#9400d3",
+  deeppink: "#ff1493",
+  deepskyblue: "#00bfff",
+  dimgray: "#696969",
+  dimgrey: "#696969",
+  dodgerblue: "#1e90ff",
+  firebrick: "#b22222",
+  floralwhite: "#fffaf0",
+  forestgreen: "#228b22",
+  fuchsia: "#ff00ff",
+  gainsboro: "#dcdcdc",
+  ghostwhite: "#f8f8ff",
+  gold: "#ffd700",
+  goldenrod: "#daa520",
+  gray: "#808080",
+  green: "#008000",
+  greenyellow: "#adff2f",
+  grey: "#808080",
+  honeydew: "#f0fff0",
+  hotpink: "#ff69b4",
+  indianred: "#cd5c5c",
+  indigo: "#4b0082",
+  ivory: "#fffff0",
+  khaki: "#f0e68c",
+  lavender: "#e6e6fa",
+  lavenderblush: "#fff0f5",
+  lawngreen: "#7cfc00",
+  lemonchiffon: "#fffacd",
+  lightblue: "#add8e6",
+  lightcoral: "#f08080",
+  lightcyan: "#e0ffff",
+  lightgoldenrodyellow: "#fafad2",
+  lightgray: "#d3d3d3",
+  lightgreen: "#90ee90",
+  lightgrey: "#d3d3d3",
+  lightpink: "#ffb6c1",
+  lightsalmon: "#ffa07a",
+  lightseagreen: "#20b2aa",
+  lightskyblue: "#87cefa",
+  lightslategray: "#778899",
+  lightslategrey: "#778899",
+  lightsteelblue: "#b0c4de",
+  lightyellow: "#ffffe0",
+  lime: "#00ff00",
+  limegreen: "#32cd32",
+  linen: "#faf0e6",
+  magenta: "#ff00ff",
+  maroon: "#800000",
+  mediumaquamarine: "#66cdaa",
+  mediumblue: "#0000cd",
+  mediumorchid: "#ba55d3",
+  mediumpurple: "#9370db",
+  mediumseagreen: "#3cb371",
+  mediumslateblue: "#7b68ee",
+  mediumspringgreen: "#00fa9a",
+  mediumturquoise: "#48d1cc",
+  mediumvioletred: "#c71585",
+  midnightblue: "#191970",
+  mintcream: "#f5fffa",
+  mistyrose: "#ffe4e1",
+  moccasin: "#ffe4b5",
+  navajowhite: "#ffdead",
+  navy: "#000080",
+  oldlace: "#fdf5e6",
+  olive: "#808000",
+  olivedrab: "#6b8e23",
+  orange: "#ffa500",
+  orangered: "#ff4500",
+  orchid: "#da70d6",
+  palegoldenrod: "#eee8aa",
+  palegreen: "#98fb98",
+  paleturquoise: "#afeeee",
+  palevioletred: "#db7093",
+  papayawhip: "#ffefd5",
+  peachpuff: "#ffdab9",
+  peru: "#cd853f",
+  pink: "#ffc0cb",
+  plum: "#dda0dd",
+  powderblue: "#b0e0e6",
+  purple: "#800080",
+  rebeccapurple: "#663399",
   red: "#ff0000",
+  rosybrown: "#bc8f8f",
+  royalblue: "#4169e1",
+  saddlebrown: "#8b4513",
+  salmon: "#fa8072",
+  sandybrown: "#f4a460",
+  seagreen: "#2e8b57",
+  seashell: "#fff5ee",
+  sienna: "#a0522d",
+  silver: "#c0c0c0",
+  skyblue: "#87ceeb",
+  slateblue: "#6a5acd",
+  slategray: "#708090",
+  slategrey: "#708090",
+  snow: "#fffafa",
+  springgreen: "#00ff7f",
+  steelblue: "#4682b4",
+  tan: "#d2b48c",
+  teal: "#008080",
+  thistle: "#d8bfd8",
+  tomato: "#ff6347",
   transparent: "transparent",
+  turquoise: "#40e0d0",
+  violet: "#ee82ee",
+  wheat: "#f5deb3",
+  white: "#ffffff",
+  whitesmoke: "#f5f5f5",
+  yellow: "#ffff00",
+  yellowgreen: "#9acd32",
 };
 
 /**
@@ -491,11 +659,24 @@ function isTextPaintedVisible(val) {
 /** @param {(key: string) => string} val */
 function isOverflowHidden(val) {
   if (val("overflow") !== "hidden") return false;
-  for (const dim of ["height", "width", "max-height", "max-width"]) {
-    const value = val(dim);
-    if (value && parseFloat(value) === 0) return true;
-  }
+  for (const dim of ["height", "width", "max-height", "max-width"])
+    // Near-zero (epsilon band), not exact 0, so `height:0.0001px` still counts —
+    // matching the standalone size checks a browser renders as invisible.
+    if (isNearZeroLength(val(dim))) return true;
   return false;
+}
+
+// A length token in a `font` SHORTHAND whose font-size collapses the text. The
+// font-size sits just before the family, optionally as `font-size/line-height`;
+// only a length with an explicit font unit is a size (a bare number there is a
+// weight, a `%` a stretch), so those never misread as a zero size.
+const FONT_SHORTHAND_SIZE_RE =
+  /(?:^|\s)([+-]?\d*\.?\d+(?:px|em|rem|ex|ch|pt|pc|in|cm|mm|q))(?:\s*\/|\s|$)/i;
+
+/** @param {string} font lowercased, trimmed @returns {boolean} */
+function isFontShorthandHidden(font) {
+  const match = font.match(FONT_SHORTHAND_SIZE_RE);
+  return Boolean(match && isNearZeroLength(match[1]));
 }
 
 /**
@@ -722,6 +903,9 @@ export function isHiddenStyle(styleStr) {
   // DOES hide content — gated on `overflow:hidden` also being present.
   // `font-size:0`, in contrast, reliably collapses text to nothing on its own.
   if (isNearZeroLength(val("font-size"))) return true;
+  // The `font` shorthand also carries the font-size, so a `font:0px/1 serif`
+  // collapses text just like the longhand — check its size token too.
+  if (isFontShorthandHidden(val("font"))) return true;
 
   if (isPositionedOffscreen(val)) return true;
 
@@ -1663,13 +1847,17 @@ function checkUrlPath(parsed) {
  * @returns {string | null}
  */
 export function checkExfilUrl(url) {
-  if (/^\s*data:/i.test(url)) {
-    if (DATA_URI_ACTIVE_RE.test(url)) return "active-content data: URI";
+  // A browser strips tab/newline/CR ANYWHERE in a URL before resolving its
+  // scheme, so `java\tscript:alert(1)` navigates as `javascript:`. Strip them
+  // for the scheme tests (the payload/length checks below keep the raw string).
+  const schemeUrl = url.replace(/[\t\n\r]/g, "");
+  if (/^\s*data:/i.test(schemeUrl)) {
+    if (DATA_URI_ACTIVE_RE.test(schemeUrl)) return "active-content data: URI";
     if (url.length > DATA_URI_LENGTH_THRESHOLD)
       return "oversized inline data: payload";
     return null;
   }
-  if (SCRIPT_URI_RE.test(url)) return "script-executing URI";
+  if (SCRIPT_URI_RE.test(schemeUrl)) return "script-executing URI";
   // Template-injection shapes (`${…}`, `{{…}}`) only in the query/fragment: a
   // brace in the PATH or host is a legitimate templated doc URL
   // (`/api/{{version}}/guide`), and flagging it both false-positives and

--- a/test/html-property.test.mjs
+++ b/test/html-property.test.mjs
@@ -116,9 +116,18 @@ const arbitraryHtmlFragment = fc
   .map((parts) => parts.join(" "));
 
 describe("property: sanitizeHtml is idempotent", () => {
-  it("second pass changes nothing", () =>
+  it("second pass changes nothing AND pass one actually splices a hidden node", () =>
     checkProperty(arbitraryHtmlFragment, (input) => {
-      const passOne = applyHtml(input);
+      // Idempotence is vacuously true for a no-op, so wrap the fuzzed body in a
+      // guaranteed-hidden element and assert pass one removed it: the visible
+      // marker survives, the secret does not, and a HIDDEN_PLACEHOLDER appears.
+      // That positive postcondition proves the splice path ran; then assert the
+      // second pass is a fixed point.
+      const planted = `VISIBLE_MARK <div style="display:none">SECRET_PAYLOAD</div> ${input}`;
+      const passOne = applyHtml(planted);
+      assert.ok(passOne.includes("VISIBLE_MARK"));
+      assert.ok(!passOne.includes("SECRET_PAYLOAD"));
+      assert.ok(passOne.includes(HIDDEN_PLACEHOLDER));
       assert.equal(applyHtml(passOne), passOne);
     }));
 });

--- a/test/html.test.mjs
+++ b/test/html.test.mjs
@@ -101,6 +101,13 @@ const HIDDEN_STYLE_CASES = [
   ["font-size:11px", false],
   ["font-size:0.9em", false], // ordinary relative size
   ["font-size:14px", false],
+  // ── `font` SHORTHAND size (bug: only the font-size longhand was checked) ──
+  ["font:0px/1 serif", true], // size 0 via shorthand with line-height
+  ["font:0.005em/1 serif", true], // sub-epsilon shorthand size
+  ["font:italic bold 0px/1.4 Arial", true], // size token mid-shorthand
+  ["font:16px/1.5 serif", false], // ordinary size — visible
+  ["font:italic bold 14px Georgia", false], // no line-height, normal size
+  ["font:bold 100 12px sans-serif", false], // weight numbers are not the size token
   // ── positioned offscreen, any unit ──
   ["position:absolute;left:-9999px", true],
   ["position:fixed;top:-10000px", true],
@@ -133,6 +140,11 @@ const HIDDEN_STYLE_CASES = [
   ["position:absolute;left:calc(-100vw)", false], // unresolvable calc fails open (precision)
   ["position:absolute;left:calc(100% - 5px)", false], // ordinary in-flow calc must not splice
   ["position:static;left:-9999px", false],
+  // ── relative / sticky offscreen (bug: only absolute/fixed were gated) ──
+  ["position:relative;left:-9999px", true],
+  ["position:sticky;top:-10000px", true],
+  ["position:relative;left:-5px", false], // small relative nudge stays on screen
+  ["position:relative;clip:rect(1,1,1,1)", false], // `clip` ignores relative boxes — fail open
   ["position:absolute;left:auto", false], // non-length offset is not offscreen
   ["position:absolute;left:-1000", false], // unitless nonzero length is INVALID CSS; browser drops it, fails open
   ["position:absolute;left:-9999", false], // same, larger magnitude
@@ -148,6 +160,10 @@ const HIDDEN_STYLE_CASES = [
   ["overflow:hidden;max-height:0", true],
   ["overflow:visible;max-width:0", false],
   ["overflow:hidden;max-width:5px", false],
+  // near-zero (epsilon band), not exact 0 (bug: used parseFloat(value)===0)
+  ["overflow:hidden;height:0.0001px", true],
+  ["overflow:hidden;width:0.005em", true],
+  ["overflow:hidden;height:5px", false], // real height — visible
   // ── clip-path (fractional percentages) ──
   ["clip-path:inset(50%)", true],
   ["clip-path:inset(100%)", true],
@@ -180,6 +196,14 @@ const HIDDEN_STYLE_CASES = [
   ["transform:rotateX(90deg)", true],
   ["transform:rotateY(-90deg)", true],
   ["transform:rotateX(270deg)", true],
+  // ── rotate angle UNITS beyond deg + leading `+` (bug: hardcoded `deg`/`-?`) ──
+  ["transform:rotateX(0.25turn)", true], // 0.25turn === 90deg
+  ["transform:rotateY(100grad)", true], // 100grad === 90deg
+  ["transform:rotateX(1.5707963rad)", true], // ≈ π/2 rad === 90deg
+  ["transform:rotateY(+90deg)", true], // leading + sign
+  ["transform:rotateX(0.5turn)", false], // 180deg — in-plane, still visible
+  ["transform:rotateY(50grad)", false], // 45deg, projects area
+  ["transform:rotateX(90)", false], // unitless angle is invalid CSS — browser drops it, visible
   ["transform:translateX(-9999px)", true], // offscreen via transform (bug: position-only)
   ["transform:translatex(-100vw)", true], // a full viewport-width clears the screen
   ["transform:translate(0,-9999px)", true], // Y axis offscreen, X=0 (second arg was ignored)
@@ -211,6 +235,13 @@ const HIDDEN_STYLE_CASES = [
   ["color:rgb(255,255,255);background:white", true], // rgb vs named
   ["color:white;background-color:rgb(255, 255, 255)", true],
   ["color:#000;background:rgb(0,0,0)", true], // black on black
+  // ── non-primary named colors (bug: table had only white/black/red) ──
+  ["color:blue;background:blue", true], // any two identical resolvable names compare
+  ["color:teal;background-color:teal", true],
+  ["color:cyan;background:aqua", true], // cyan and aqua are the same #00ffff
+  ["color:rebeccapurple;background-color:rebeccapurple", true],
+  ["color:blue;background:white", false], // distinct named colors — visible text (precision)
+  ["color:navy;background:blue", false], // near but not equal — visible
   // CSS Color 4 notations canonicalize for the same-color compare.
   ["color:rgb(255 255 255);background:white", true], // space-separated rgb
   ["color:rgb(100% 100% 100%);background:#fff", true], // percentage channels
@@ -480,6 +511,22 @@ describe("unit: checkExfilUrl exact verdicts", () => {
     assert.equal(
       checkExfilUrl("  vbscript:Execute(x)"),
       "script-executing URI",
+    ));
+  // A browser strips tab/newline/CR from the URL before the scheme check, so a
+  // `java\tscript:` (or newline/CR-split) navigates as `javascript:`.
+  for (const [label, url] of [
+    ["tab", "java\tscript:alert(1)"],
+    ["newline", "java\nscript:alert(1)"],
+    ["CR", "java\rscript:alert(1)"],
+    ["vbscript newline", "vb\nscript:Execute(x)"],
+    ["mid-scheme tab", "javascri\tpt:alert(1)"],
+  ])
+    it(`flags a ${label}-split script URI (browser strips \\t\\n\\r first)`, () =>
+      assert.equal(checkExfilUrl(url), "script-executing URI"));
+  it("flags a tab-split active-content data: URI (whitespace-stripped scheme)", () =>
+    assert.equal(
+      checkExfilUrl("data:text/ht\tml,<b>x</b>"),
+      "active-content data: URI",
     ));
   it("flags a credential-shaped token value in a non-keyword param", () =>
     assert.equal(

--- a/test/mutation-guards.test.mjs
+++ b/test/mutation-guards.test.mjs
@@ -228,6 +228,57 @@ describe("guard: sanitizeHtml counts comments and hidden into the right buckets"
   });
 });
 
+// ─── html.mjs: browser-honored hides splice/flag end-to-end (exact output) ────
+// The isHiddenStyle unit suite pins the predicate; these drive the FULL splice
+// path so a mutant that keeps the verdict but drops the removal is caught. Each
+// style is a genuine browser-honored hide that older code missed; the secret
+// must be gone, replaced by exactly HIDDEN_PLACEHOLDER, marker text intact.
+
+describe("guard: browser-honored hides are spliced end-to-end", () => {
+  const BROWSER_HONORED_HIDES = [
+    ["named same-color", "color:blue;background:blue"],
+    ["font shorthand size 0", "font:0px/1 serif"],
+    ["relative offscreen", "position:relative;left:-9999px"],
+    ["turn rotate edge-on", "transform:rotateX(0.25turn)"],
+    ["grad rotate edge-on", "transform:rotateY(100grad)"],
+    ["near-zero overflow dim", "overflow:hidden;height:0.0001px"],
+  ];
+  for (const [label, style] of BROWSER_HONORED_HIDES)
+    it(`splices ${label} to exactly the placeholder`, () => {
+      const result = sanitizeHtml(
+        `MARK <div style="${style}">SECRET</div> END`,
+      );
+      assert.equal(result.text, `MARK ${HIDDEN_PLACEHOLDER} END`);
+      assert.deepEqual(result.removed, { comments: 0, hidden: 1 });
+    });
+
+  it("flags a tab-split javascript: URI as script-executing", () =>
+    assert.equal(
+      checkExfilUrl("java\tscript:alert(1)"),
+      "script-executing URI",
+    ));
+
+  // Precision: a legit gradient heading (`color:transparent` painted through a
+  // background-clip:text gradient) and ordinary visible colored text must NOT
+  // be spliced — the output is byte-for-byte the input (no placeholder).
+  for (const [label, style] of [
+    [
+      "gradient heading",
+      "color:transparent;-webkit-background-clip:text;background:linear-gradient(blue,red)",
+    ],
+    ["visible colored text", "color:blue;background:white"],
+  ])
+    it(`leaves ${label} untouched (precision)`, () => {
+      const input = `KEEP <div style="${style}">VISIBLE</div> DONE`;
+      const result = sanitizeHtml(input);
+      // sanitizeHtml returns null when nothing was removed/warned.
+      if (result !== null) {
+        assert.ok(result.text.includes("VISIBLE"));
+        assert.ok(!result.text.includes(HIDDEN_PLACEHOLDER));
+      }
+    });
+});
+
 // ─── html.mjs: rawParams name lowercasing + value splitting ───────────────────
 // A `name=value` exfil param must be matched case-insensitively, and the value
 // (everything after the first `=`) preserved verbatim including any `=`.

--- a/test/output.fuzz.test.mjs
+++ b/test/output.fuzz.test.mjs
@@ -68,10 +68,21 @@ describe("fuzz: sanitizeText is crash-resistant and idempotent", () => {
     );
   });
 
-  it("is idempotent: a second pass over cleaned text changes nothing", async () => {
+  it("is idempotent AND actually strips a planted invisible/ANSI payload", async () => {
+    // Idempotence alone is vacuously true for a no-op sanitizer, so every case
+    // also plants a guaranteed-invisible payload (ZWSP + a red-SGR ANSI run)
+    // around the fuzzed body and asserts the FIRST pass removed it (modified,
+    // and neither byte survives) — the positive marker proving the strip path
+    // ran — before asserting the SECOND pass is a fixed point.
+    const ZWSP = cp(0x200b);
+    const payload = `${ZWSP}${ESC}[31m`;
     await fc.assert(
       fc.asyncProperty(adversarialInput, async (input) => {
-        const first = await sanitizeText(input);
+        const first = await sanitizeText(`${payload}${input}${payload}`);
+        assert.equal(first.modified, true);
+        assert.ok(!first.cleaned.includes(ZWSP));
+        assert.ok(!first.cleaned.includes(ESC));
+
         const second = await sanitizeText(first.cleaned);
         assert.equal(second.cleaned, first.cleaned);
         assert.equal(second.modified, false);

--- a/test/sanitize.fuzz.test.mjs
+++ b/test/sanitize.fuzz.test.mjs
@@ -8,6 +8,7 @@ import assert from "node:assert/strict";
 import fc from "fast-check";
 
 import { sanitize } from "../src/index.mjs";
+import { HIDDEN_PLACEHOLDER } from "../src/html.mjs";
 import { fcRunOptions, cp } from "./test-helpers.mjs";
 
 const INVISIBLE_VALUES = [
@@ -117,10 +118,18 @@ describe("fuzz: crash resistance and no silent suppression", () => {
     );
   });
 
-  it("processes a huge flat input without throwing", async () => {
-    const huge = scaleTo("pre [t](/p?c=x) post _ok_ ", 50_000);
+  it("processes a huge flat input without throwing AND still splices a hidden node buried in it", async () => {
+    // A type/length-only assertion passes even if the huge input silently
+    // defeated the HTML layer (e.g. a size bail-out), so bury a guaranteed-
+    // hidden element deep inside and assert it was still spliced: its secret is
+    // gone, a placeholder replaced it, and the change carried a warning.
+    const filler = scaleTo("pre [t](/p?c=x) post _ok_ ", 50_000);
+    const huge = `${filler}<div style="display:none">SECRETHUGE</div>${filler}`;
     const result = await sanitize(huge, { html: true });
     assert.equal(typeof result.cleaned, "string");
     assert.ok(result.cleaned.length > 0);
+    assert.ok(!result.cleaned.includes("SECRETHUGE"));
+    assert.ok(result.cleaned.includes(HIDDEN_PLACEHOLDER));
+    assert.ok(result.warnings.length > 0);
   });
 });


### PR DESCRIPTION
Audit of the HTML hidden-content splicer + exfil/script-URI detector. Each finding is a **browser-honored way to hide text from a human that the model still reads**, which the splicer missed.

## Findings fixed (`src/html.mjs`)
- **H1 (high)** — same-color hide only resolved 4 named colors, so `color:blue;background:blue` (invisible, fully resolvable) wasn't spliced. Added the full CSS named-color→hex table; the `var()`/`inherit`/`currentColor` fail-open is preserved.
- **H2 (high)** — only the `font-size` longhand was checked; the `font` **shorthand** size (`font:0px/1 serif`) now runs through the near-zero check.
- **H3 (med)** — offscreen detection now includes `position:relative`/`sticky` (was `absolute`/`fixed` only); the `clip` legacy check stays gated to absolute/fixed where it's meaningful.
- **H4 (med)** — `rotateX/Y` hide now parses `grad`/`rad`/`turn` units and a leading `+`, not just `deg`.
- **H5 (med)** — tab/newline/CR are stripped before the `javascript:`/`vbscript:`/active-`data:` scheme tests, matching browser URL preprocessing (`java\tscript:` is now flagged).
- **H6 (low)** — `overflow:hidden` collapse uses the `NEAR_ZERO_EPSILON` band instead of exact `=== 0`.

## Tests
`node --test` → 655 pass, 0 fail. Each fix has positive-and-negative exact-verdict cases plus an end-to-end splice/flag guard in `mutation-guards.test.mjs`. The three previously-vacuous idempotence/type-only tests (`output.fuzz`, `html-property`, `sanitize.fuzz`) now pair their invariant with a positive "payload-removed" postcondition (audit findings AT1–AT3).

## Decisions made
- Commit subject shortened to satisfy the 100-char commitlint header cap (named-list detail in the body), not bypassed.


---
_Generated by [Claude Code](https://claude.ai/code/session_013ey8pCsjgaK57apoRNCUuX)_