### PR TITLE
fix(ci): push release-docs + tag with the ruleset-bypass org token

### DIFF
--- a/.github/workflows/auto-version.yaml
+++ b/.github/workflows/auto-version.yaml
@@ -37,18 +37,23 @@ jobs:
     steps:
       - name: Checkout
         # Credentials stay persisted: version-bump.sh pushes the release-docs
-        # commit and the vX.Y.Z tag with them as github-actions[bot]. The
-        # workflow's `contents: write` authorizes that bot to push to the default
-        # branch and tags of its own repo — do NOT swap in a cross-account PAT
-        # (e.g. TEMPLATE_SYNC_TOKEN, minted for a different owner), which the
-        # remote rejects with a 403 and silently strands every release: npm is
-        # published but the docs commit and tag never land, so the next run
-        # re-reads the climbing npm version and bumps again.
+        # commit and the vX.Y.Z tag with them. main is protected by a
+        # required-status-checks ruleset, and the release-docs commit is
+        # `[skip ci]`, so it can never satisfy those checks — the stock
+        # GITHUB_TOKEN is not a ruleset bypass actor and its push is rejected with
+        # GH013, stranding every release (npm publishes but the docs commit and
+        # tag never land, so the next run re-reads the climbing npm version and
+        # bumps again). TEMPLATE_SYNC_TOKEN_ORG is the org PAT registered as a
+        # ruleset bypass actor; use it, falling back to GITHUB_TOKEN only when it
+        # is UNSET (a fork). NOTE: `||` falls back only on an empty value — a
+        # token that is SET but unauthorized for this repo is still truthy and
+        # will 403, so keep TEMPLATE_SYNC_TOKEN_ORG authorized here (or unset it
+        # on a fork to take the GITHUB_TOKEN path).
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 # zizmor: ignore[artipacked]
         with:
           # Need full history so `git describe`/`git log` can find the last tag.
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.GITHUB_TOKEN }}
 
       - name: Setup base environment
         uses: ./.github/actions/setup-base-env


### PR DESCRIPTION
## Problem
`auto-version` publishes to npm, then fails pushing the release-docs commit + `vX.Y.Z` tag to `main` with `GH013 ... 10 of 10 required status checks are expected`. The checkout used `GITHUB_TOKEN`, which is not a ruleset bypass actor, so every recent run failed with npm climbing while the tag/docs never landed.

## Fix
Check out (and thus push) with `TEMPLATE_SYNC_TOKEN_ORG` — the org PAT registered as a ruleset bypass actor — falling back to `GITHUB_TOKEN` when unset (forks). Corrected the stale comment that claimed `GITHUB_TOKEN` could push to protected `main`.

## Note
Requires `TEMPLATE_SYNC_TOKEN_ORG` to be present and authorized as a bypass actor on this repo's `main` ruleset. If it is set but unauthorized, the push will 403 (already the failing state), so no regression.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BnLd5qeoW88Ybe5u8JcYZt)_