### PR TITLE
fix(ci): read the Claude key from GH_ACTION_ANTHROPIC_API_KEY

### DIFF
--- a/.github/workflows/auto-version.yaml
+++ b/.github/workflows/auto-version.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Bump version and publish if commits warrant a release
         id: release
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.GH_ACTION_ANTHROPIC_API_KEY }}
         run: bash .github/scripts/version-bump.sh
 
       # Coupled PyPI release (PRIMARY path). When version-bump.sh actually


### PR DESCRIPTION
`auto-version` passed `ANTHROPIC_API_KEY` from `secrets.ANTHROPIC_API_KEY`, but the valid key is stored under `GH_ACTION_ANTHROPIC_API_KEY`. Here the Claude call only drafts changelog prose (it degrades to a plain commit list on failure, so it wasn't blocking), but it means the drafted changelog silently fell back. Source the key from the correct secret so Claude-drafted changelog prose works again.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BnLd5qeoW88Ybe5u8JcYZt)_