### PR TITLE
ci: notify on Sync from Template workflow failures

### DIFF
--- a/.github/workflows/build-publish-notify.yaml
+++ b/.github/workflows/build-publish-notify.yaml
@@ -1,6 +1,6 @@
-name: Build/publish failure notify
+name: Workflow failure notify
 
-# Push a phone notification (via ntfy) whenever a build or publish workflow
+# Push a phone notification (via ntfy) whenever a build, publish, or template-sync workflow
 # fails outside a pull request. Publish/release runs happen on push, tag, or
 # manual dispatch — no PR is in front of you — so a failure there otherwise rots
 # unseen. PR-triggered failures are excluded: they are already visible on the PR.
@@ -23,6 +23,7 @@ on: # zizmor: ignore[dangerous-triggers]
     workflows:
       - Auto version bump and publish
       - Publish Python to PyPI (break-glass)
+      - Sync from Template
 
 concurrency:
   # Keyed per triggering workflow so notifications never queue behind each other;


### PR DESCRIPTION
The failure-notify workflow only listed build/publish workflows, so a failing `Sync from Template` run (which runs on a weekly schedule with no PR in front of it) rotted unseen. Add `Sync from Template` to the `workflow_run` list and generalize the workflow name accordingly. No-op unless `GH_NTFY_SUBJECT` is set (unchanged gating).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BnLd5qeoW88Ybe5u8JcYZt)_