### PR TITLE
ci: run template sync daily instead of weekly

### DIFF
--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -35,8 +35,8 @@ on:
         default: "false"
         type: boolean
   schedule:
-    # Run weekly on Mondays at 9am UTC
-    - cron: "0 9 * * 1"
+    # Run daily at 9am UTC
+    - cron: "0 9 * * *"
 
 env:
   TEMPLATE_REPO: "${{ vars.TEMPLATE_SYNC_ORG || 'alexander-turner' }}/claude-automation-template"


### PR DESCRIPTION
Change the Sync from Template schedule from weekly (Mondays) to daily at 9am UTC, so template updates land promptly instead of waiting up to a week. The header comment already described it as daily; the cron now matches.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BnLd5qeoW88Ybe5u8JcYZt)_