### PR TITLE
refactor(instructions): drop dead cleanFile return-null branch

### DIFF
--- a/src/instructions.mjs
+++ b/src/instructions.mjs
@@ -461,7 +461,7 @@ export function atomicReplaceFile(
  *   {@link atomicReplaceFile}'s `tmpName`): lets a test drive the concurrent
  *   write/symlink-swap that the TOCTOU guard exists to catch, which is otherwise
  *   unreachable from this fully-synchronous path. Defaults to `lstatSync`.
- * @returns {boolean | null}
+ * @returns {boolean}
  */
 export function cleanFile(absPath, lstat = lstatSync) {
   let fd;
@@ -505,13 +505,6 @@ export function cleanFile(absPath, lstat = lstatSync) {
     if (scanText(original).length === 0) return false;
 
     const stripped = stripInvisible(original);
-    // scanText can flag a run that stripInvisible PRESERVES — a well-formed but
-    // bogus emoji-tag run (a base pictograph + tag chars + CANCEL) trips the
-    // scanner yet is kept intact by the stripper. Rewriting identical bytes and
-    // returning `true` would falsely report the payload removed. Fail closed:
-    // the bytes did not change, so signal "flagged but not strippable" (null),
-    // never "cleaned" (true).
-    if (stripped === original) return null;
     // Re-verify the on-path file against the open-time snapshot before writing:
     // an inode/size/mtime change (or a swap to a symlink) means someone modified
     // it under us, so fail loud rather than clobber their write (lost update).

--- a/test/instructions.test.mjs
+++ b/test/instructions.test.mjs
@@ -28,11 +28,7 @@ import {
   cleanFile,
   atomicReplaceFile,
 } from "../src/instructions.mjs";
-import {
-  LONG_RUN_THRESHOLD,
-  SCATTERED_THRESHOLD,
-  stripInvisible,
-} from "../src/invisible.mjs";
+import { LONG_RUN_THRESHOLD, SCATTERED_THRESHOLD } from "../src/invisible.mjs";
 import { cp } from "./test-helpers.mjs";
 
 // The caller's instruction-file globs (the package bakes in no convention).

--- a/test/instructions.test.mjs
+++ b/test/instructions.test.mjs
@@ -734,31 +734,6 @@ describe("scan/clean contract", () => {
     assert.equal(cleanFile(file), true);
     assert.equal(readFileSync(file, "utf-8"), "xy\n");
   });
-
-  it("clean returns null (NOT true) for a flagged-but-preserved emoji-tag run", () => {
-    // A well-formed but bogus subregional-flag sequence: WAVING BLACK FLAG base
-    // + >=LONG_RUN_THRESHOLD spec tag chars + CANCEL TAG. The consecutive Cf tag
-    // chars trip scanText's long-run detector, but the sequence is a VALID tag
-    // grammar so stripInvisible PRESERVES it verbatim. cleanFile must not rewrite
-    // identical bytes and claim `true` (payload removed); it fails closed with
-    // `null` meaning "flagged but not strippable", and the file is untouched.
-    const flag = `${cp(0x1f3f4)}${cp(0xe0041).repeat(LONG_RUN_THRESHOLD)}${cp(0xe007f)}`;
-    const original = `region: ${flag}\n`;
-    assert.ok(scanText(original).length > 0, "precondition: scan flags it");
-    assert.equal(
-      stripInvisible(original),
-      original,
-      "precondition: stripInvisible preserves the well-formed tag run",
-    );
-    const file = join(tmpDir, "CLAUDE.md");
-    writeFileSync(file, original);
-    assert.equal(cleanFile(file), null);
-    assert.equal(
-      readFileSync(file, "utf-8"),
-      original,
-      "bytes must be untouched when nothing was stripped",
-    );
-  });
 });
 
 // ─── atomic write + mode preservation (bug #5) ───────────────────────────────


### PR DESCRIPTION
## Summary

`main`'s `test` job is red on a stale contract test. `423ecb3` ("tighten the tag/joiner/selector carve-out") intentionally changed `stripInvisible` to preserve a flag-tag run **only** when its decoded payload is a registered GB subdivision (`gbeng`/`gbsct`/`gbwls`, ≤6 tag chars) — a bogus `🏴 + AAAA… + CANCEL` run is now stripped. That hardening removed the one case `cleanFile`'s `if (stripped === original) return null` branch existed for ("scanText flags it, stripInvisible preserves it"), but the branch, its comment, and its test were left in place.

I confirmed the branch is now unreachable by probing the survivors: a registered flag is **not** flagged by scanText (`LONG_RUN_THRESHOLD` is 10; a real flag is discounted), and repeating flags to reach the threshold makes `stripInvisible` strip them. So after `423ecb3` no input is both flagged and preserved — the branch is dead, which is why its test's precondition (`stripInvisible preserves the well-formed tag run`) now fails and `instructions.mjs:514` shows as an uncovered branch (98.93%).

Remove the dead branch, its comment, and the now-impossible test. `cleanFile` returns `boolean`.

## Changes

- `src/instructions.mjs`: drop `if (stripped === original) return null` and its comment in `cleanFile`; JSDoc `@returns {boolean | null}` → `{boolean}`.
- `test/instructions.test.mjs`: remove `clean returns null (NOT true) for a flagged-but-preserved emoji-tag run` (no input can exercise it post-`423ecb3`).

No reachable behavior change: `bin/sanitize-cli.mjs` forwards `{ changed }` (now always boolean) and the Python `clean_file` was already typed `-> bool`.

## Tests / verification

- `node --test test/instructions.test.mjs` → 63 pass, 0 fail (was 64 with the 1 stale failure). Removing the branch also closes the `instructions.mjs:514` branch-coverage gap that failed the 100% gate.

## Checklist

- [x] Commits follow Conventional Commits.
- [x] No real secrets/tokens in the diff or description.
- [x] `CHANGELOG.md` and `package.json` version left untouched (`refactor` type keeps it out of release notes; no reachable behavior change).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Di9VxiCE7SZKZytx6Jiimm)_