### PR TITLE
fix(instructions): realign stale tests with the tightened tag carve-out and org release token

### DIFF
--- a/scripts/version-bump.test.mjs
+++ b/scripts/version-bump.test.mjs
@@ -56,13 +56,13 @@ test("auto-version.yaml invokes exactly the live hardened release script", () =>
   assert.ok(existsSync(LIVE_SCRIPT), "the invoked script must exist on disk");
 });
 
-test("the release checkout pushes as github-actions[bot], never a cross-account PAT", () => {
+test("the release checkout pushes with the ruleset-bypass org token, GITHUB_TOKEN only as a fork fallback", () => {
   // The release-docs commit and vX.Y.Z tag are pushed with the credentials the
-  // checkout persists. A cross-account PAT (TEMPLATE_SYNC_TOKEN, minted for a
-  // different owner) is rejected 403 by this repo's remote, stranding every
-  // release: npm publishes but the tag never lands, so the next run re-reads the
-  // climbing npm version and bumps again. The push MUST ride GITHUB_TOKEN, whose
-  // `contents: write` authorizes github-actions[bot] on its own repo.
+  // checkout persists. main is protected by a required-status-checks ruleset and
+  // the release-docs commit is `[skip ci]`, so the stock GITHUB_TOKEN (not a
+  // ruleset bypass actor) is rejected GH013 and strands every release. The push
+  // MUST ride TEMPLATE_SYNC_TOKEN_ORG — the org PAT registered as a ruleset
+  // bypass actor — falling back to GITHUB_TOKEN only when it is UNSET (a fork).
   const yaml = readFileSync(AUTO_VERSION_YAML, "utf8");
   const tokenLines = yaml
     .split("\n")
@@ -70,8 +70,8 @@ test("the release checkout pushes as github-actions[bot], never a cross-account 
     .map((l) => l.trim());
   assert.deepEqual(
     tokenLines,
-    ["token: ${{ secrets.GITHUB_TOKEN }}"],
-    "the checkout must pin GITHUB_TOKEN, not a fallback to a cross-account PAT",
+    ["token: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.GITHUB_TOKEN }}"],
+    "the checkout must pin the org ruleset-bypass PAT with a GITHUB_TOKEN fork fallback",
   );
 });
 

--- a/src/instructions.mjs
+++ b/src/instructions.mjs
@@ -421,10 +421,10 @@ export function atomicReplaceFile(
  * Strip payload-capable invisible characters from `absPath` in place. Returns
  * `true` when the file's bytes actually changed (a payload {@link scanText}
  * flags was removed), `false` when {@link scanText} reports nothing, and `null`
- * when scan flagged a payload but {@link stripInvisible} removes nothing — a
- * fail-closed signal that the flagged run was PRESERVED (e.g. a well-formed
- * emoji-tag sequence the stripper keeps), so the caller must not treat it as
- * cleaned. `true` means and only means "bytes changed".
+ * as a defensive fail-closed signal for the (currently unreachable) case where
+ * scan flagged a payload but {@link stripInvisible} removes nothing — see the
+ * shared-SSOT note at the guard below. `true` means and only means "bytes
+ * changed".
  *
  * Contract (scan/clean coherence): clean strips exactly what scan flags. A
  * write happens ONLY when `scanText` reports a finding, so the "scan, then
@@ -505,12 +505,16 @@ export function cleanFile(absPath, lstat = lstatSync) {
     if (scanText(original).length === 0) return false;
 
     const stripped = stripInvisible(original);
-    // scanText can flag a run that stripInvisible PRESERVES — a well-formed but
-    // bogus emoji-tag run (a base pictograph + tag chars + CANCEL) trips the
-    // scanner yet is kept intact by the stripper. Rewriting identical bytes and
-    // returning `true` would falsely report the payload removed. Fail closed:
-    // the bytes did not change, so signal "flagged but not strippable" (null),
-    // never "cleaned" (true).
+    // Defensive fail-closed: if the stripper leaves identical bytes for a run
+    // scanText flagged, signal "flagged but not strippable" (null) rather than
+    // rewrite nothing and falsely report the payload removed (true). scanText
+    // and stripInvisible now share one payload SSOT — both classify chars via
+    // invisible.mjs's carve-out (`analyzeCarve`), and every char scan counts as
+    // payload (`kind === null`) is stripped by carveStrip/bulkStrip — so a
+    // flagged run is always strippable and this branch is unreachable today.
+    // Kept (and c8-ignored, mirroring closingTagName) as defense-in-depth
+    // against a future divergence between the scanner and the stripper.
+    /* c8 ignore next */
     if (stripped === original) return null;
     // Re-verify the on-path file against the open-time snapshot before writing:
     // an inode/size/mtime change (or a swap to a symlink) means someone modified

--- a/test/instructions.test.mjs
+++ b/test/instructions.test.mjs
@@ -735,29 +735,26 @@ describe("scan/clean contract", () => {
     assert.equal(readFileSync(file, "utf-8"), "xy\n");
   });
 
-  it("clean returns null (NOT true) for a flagged-but-preserved emoji-tag run", () => {
-    // A well-formed but bogus subregional-flag sequence: WAVING BLACK FLAG base
-    // + >=LONG_RUN_THRESHOLD spec tag chars + CANCEL TAG. The consecutive Cf tag
-    // chars trip scanText's long-run detector, but the sequence is a VALID tag
-    // grammar so stripInvisible PRESERVES it verbatim. cleanFile must not rewrite
-    // identical bytes and claim `true` (payload removed); it fails closed with
-    // `null` meaning "flagged but not strippable", and the file is untouched.
+  it("clean strips a bogus emoji-tag run down to its base pictograph", () => {
+    // A well-formed but UNREGISTERED subregional-flag sequence: WAVING BLACK FLAG
+    // base + spec tag chars + CANCEL TAG. Its tag grammar is valid, but it is not
+    // one of the registered GB subdivisions (gbeng/gbsct/gbwls), so the tightened
+    // carve-out fails it closed: scanText flags the tag-char run and stripInvisible
+    // removes it, leaving only the base pictograph. cleanFile therefore rewrites
+    // the file and reports `true` (bytes changed), NOT `null` — the tag payload is
+    // now strippable, so the flagged-but-preserved branch cannot be reached here.
     const flag = `${cp(0x1f3f4)}${cp(0xe0041).repeat(LONG_RUN_THRESHOLD)}${cp(0xe007f)}`;
     const original = `region: ${flag}\n`;
     assert.ok(scanText(original).length > 0, "precondition: scan flags it");
     assert.equal(
       stripInvisible(original),
-      original,
-      "precondition: stripInvisible preserves the well-formed tag run",
+      `region: ${cp(0x1f3f4)}\n`,
+      "precondition: stripInvisible removes the bogus tag run",
     );
     const file = join(tmpDir, "CLAUDE.md");
     writeFileSync(file, original);
-    assert.equal(cleanFile(file), null);
-    assert.equal(
-      readFileSync(file, "utf-8"),
-      original,
-      "bytes must be untouched when nothing was stripped",
-    );
+    assert.equal(cleanFile(file), true);
+    assert.equal(readFileSync(file, "utf-8"), `region: ${cp(0x1f3f4)}\n`);
   });
 });
 


### PR DESCRIPTION
## Summary

CI is red on `main` (and therefore every branch off it, including PR #147). Two changes landed whose behavior outran their guard tests, so the suite fails and Stryker's initial dry-run aborts. This repoints the two stale tests at the behavior that is actually intended now, restoring a green `node --test` + 100% coverage.

Root causes:

- **Tightened tag carve-out (`423ecb3`)** made an *unregistered* emoji-tag run get stripped rather than preserved. `test/instructions.test.mjs` still asserted `stripInvisible` preserves such a run and that `cleanFile` returns `null` ("flagged but not strippable"). That precondition is now false, so the test failed and `cleanFile`'s `stripped === original` branch lost its only cover (branch coverage dropped to 99.93%, below the 100% gate).
- **Org release token (`b4da0b2`)** switched `auto-version.yaml`'s checkout to `TEMPLATE_SYNC_TOKEN_ORG || secrets.GITHUB_TOKEN` (the ruleset-bypass PAT with a fork fallback) but its SSOT contract test still pinned the old bare `GITHUB_TOKEN`.

## Changes

- `src/instructions.mjs`: `cleanFile`'s `stripped === original` guard is now genuinely unreachable — `scanText` and `stripInvisible` share one payload SSOT (`analyzeCarve`), so any char scan counts as payload (`kind === null`) is always stripped by `carveStrip`/`bulkStrip`. Kept the fail-closed `return null` as defense-in-depth against a future scanner/stripper divergence and marked it `/* c8 ignore next */`, mirroring the existing `closingTagName` precedent. Updated the guard comment and the `cleanFile` JSDoc so the `null` case is described as defensive, not the (now-stale) emoji-tag example.
- `test/instructions.test.mjs`: rewrote the emoji-tag test to pin the new contract — a bogus/unregistered tag run is stripped down to its base pictograph and `cleanFile` returns `true`.
- `scripts/version-bump.test.mjs`: updated the token SSOT contract test to assert the current `TEMPLATE_SYNC_TOKEN_ORG || secrets.GITHUB_TOKEN` line, with the rationale (ruleset bypass actor + `GITHUB_TOKEN` fork fallback) in the comment.

## Tests / verification

- `pnpm test` → 1672 pass, 0 fail; coverage back to 100% branches/lines/functions/statements (previously 99.93% branches, `instructions.mjs:514`).
- `pnpm lint` and `pnpm check` (`tsc --noEmit`) pass.
- Verified the "Mutation tests" job failure was the same stale test aborting Stryker's initial dry-run, so this fix clears it too.

## Decisions made

- **Kept the unreachable `return null` guard rather than deleting it.** The `null` tri-state is a documented part of the public `cleanFile` contract (surfaced by `bin/sanitize-cli.mjs` as `{ changed: null }`), and the codebase already `c8 ignore`s unreachable defensive paths. Alternative considered: delete the branch as dead code — rejected because it removes a fail-closed safety net for a file-writing security tool and changes the public tri-state.
- **Treated the two landed commits as the source of truth over their older tests.** Both `423ecb3` and `b4da0b2` are intentional, more-recent behavior changes; the failing tests predate them. Updated the tests to match, rather than reverting the behavior.

## Checklist

- [x] Commits follow Conventional Commits; subject reads as a user-facing release note.
- [x] `pnpm test`, `pnpm lint`, and `pnpm check` pass locally.
- [x] Changed guard keeps its negative/positive coverage; test pins the new invariant with an exact-verdict assertion.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version left untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzawWGxtYtawqbYxE7bq6p)_