### PR TITLE
test(ci): match release-token guard to the org ruleset-bypass form

### DIFF
--- a/scripts/version-bump.test.mjs
+++ b/scripts/version-bump.test.mjs
@@ -56,13 +56,16 @@ test("auto-version.yaml invokes exactly the live hardened release script", () =>
   assert.ok(existsSync(LIVE_SCRIPT), "the invoked script must exist on disk");
 });
 
-test("the release checkout pushes as github-actions[bot], never a cross-account PAT", () => {
+test("the release checkout pushes with the org ruleset-bypass token or GITHUB_TOKEN, never a cross-account PAT", () => {
   // The release-docs commit and vX.Y.Z tag are pushed with the credentials the
-  // checkout persists. A cross-account PAT (TEMPLATE_SYNC_TOKEN, minted for a
-  // different owner) is rejected 403 by this repo's remote, stranding every
-  // release: npm publishes but the tag never lands, so the next run re-reads the
-  // climbing npm version and bumps again. The push MUST ride GITHUB_TOKEN, whose
-  // `contents: write` authorizes github-actions[bot] on its own repo.
+  // checkout persists. github-actions[bot] (GITHUB_TOKEN) cannot push past this
+  // repo's branch-protection ruleset, so the checkout rides the in-org
+  // TEMPLATE_SYNC_TOKEN_ORG (authorized to bypass the ruleset on THIS repo) and
+  // falls back to GITHUB_TOKEN where that org secret is absent. What it must
+  // NEVER be is a cross-account PAT (TEMPLATE_SYNC_TOKEN, minted for a different
+  // owner): that is rejected 403 by this repo's remote, stranding every release —
+  // npm publishes but the tag never lands, so the next run re-reads the climbing
+  // npm version and bumps again.
   const yaml = readFileSync(AUTO_VERSION_YAML, "utf8");
   const tokenLines = yaml
     .split("\n")
@@ -70,8 +73,8 @@ test("the release checkout pushes as github-actions[bot], never a cross-account 
     .map((l) => l.trim());
   assert.deepEqual(
     tokenLines,
-    ["token: ${{ secrets.GITHUB_TOKEN }}"],
-    "the checkout must pin GITHUB_TOKEN, not a fallback to a cross-account PAT",
+    ["token: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.GITHUB_TOKEN }}"],
+    "the checkout must pin the in-org ruleset-bypass token with a GITHUB_TOKEN fallback, never a cross-account PAT",
   );
 });
 


### PR DESCRIPTION
## Summary

`main`'s `test` suite has a second stale-guard failure (separate from the dead-`cleanFile`-branch one in #154). `scripts/version-bump.test.mjs`'s "the release checkout pushes as github-actions[bot], never a cross-account PAT" asserts every `token:` line in `auto-version.yaml` is exactly `${{ secrets.GITHUB_TOKEN }}`. But commit **`b4da0b2` ("fix(ci): push release-docs + tag with the ruleset-bypass org token")** intentionally changed line 56 to `${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.GITHUB_TOKEN }}` — an in-org token that can push the release-docs commit + tag past the branch-protection ruleset `github-actions[bot]` can't bypass — and left this guard on the older rule, so it fails.

Update the guard to the form `b4da0b2` intends. It stays a strict `deepEqual`, so it still fails closed on any other value — including the cross-account `TEMPLATE_SYNC_TOKEN` PAT (a different owner's token) the test's rationale warns about.

## Changes

- `scripts/version-bump.test.mjs`: expected token line → `${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.GITHUB_TOKEN }}`; refreshed the test name, comment, and assertion message to explain the in-org ruleset-bypass token + `GITHUB_TOKEN` fallback (and that a cross-account PAT remains forbidden).

Test-only; no workflow/behavior change.

## Tests / verification

- `node --test scripts/version-bump.test.mjs` → 9 pass, 0 fail (was 1 fail).
- `prettier --check` and `eslint` clean on the file.

## Checklist

- [x] Commits follow Conventional Commits (`test` type keeps it out of release notes).
- [x] No real secrets/tokens in the diff or description.
- [x] `CHANGELOG.md` and `package.json` version left untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Di9VxiCE7SZKZytx6Jiimm)_