### PR TITLE
ci: fix template-sync self-overwrite crash

### DIFF
--- a/.github/scripts/template-sync.sh
+++ b/.github/scripts/template-sync.sh
@@ -22,6 +22,23 @@
 
 set -euo pipefail
 
+# Re-exec from an immutable copy outside any synced path. This script lives
+# under .github/scripts, a synced path, so mid-run the sync overwrites its own
+# file. bash reads a running script incrementally and, after the trailing
+# `main "$@"` returns, resumes reading top-level input at a saved byte offset;
+# a longer replacement shifts that offset into the new file's bytes and bash
+# executes a truncated fragment ("unexpected EOF while looking for matching
+# quote"). The main() wrapper below defers execution but NOT that post-main
+# resume, so it is not sufficient on its own. Running from a $TMPDIR copy the
+# sync never touches removes the hazard entirely. The re-exec'd pass removes
+# its own copy on exit (guard: only when $0 is the copy we created).
+if [[ -z "${TEMPLATE_SYNC_REEXEC:-}" ]]; then
+  _self_copy="$(mktemp)"
+  cat "$0" >"$_self_copy"
+  TEMPLATE_SYNC_REEXEC="$_self_copy" exec bash "$_self_copy" "$@"
+fi
+[[ "${TEMPLATE_SYNC_REEXEC:-}" == "$0" ]] && trap 'rm -f "$0"' EXIT
+
 # Wrap all logic in main(), called as the final line. bash reads a running
 # script incrementally from disk, not all at once — this script overwrites
 # its own file when SYNC_PATHS includes the directory it lives in, so any

--- a/tests/test_template_sync.py
+++ b/tests/test_template_sync.py
@@ -342,3 +342,55 @@ def test_fails_loudly_without_github_output(workdir: Path) -> None:
     )
     assert result.returncode != 0
     assert "GITHUB_OUTPUT" in result.stderr
+
+def test_survives_self_overwrite_with_longer_file(workdir: Path) -> None:
+    """The script lives under a synced path, so a sync overwrites its own file
+    mid-run. When the replacement is LONGER than the running file, a bash that
+    keeps reading the on-disk script resumes at a stale byte offset and dies
+    with "unexpected EOF". The script must re-exec from an immutable copy so
+    self-overwrite (even with a longer, deliberately broken tail) is harmless.
+
+    Runs the CHILD's own committed copy (relative path, exactly like CI), not
+    the repo SCRIPT, because only overwriting the file bash is executing
+    triggers the bug. Removing the re-exec guard flips this test red.
+    """
+    child = workdir / "child"
+    template = workdir / "template"
+    script_rel = ".github/scripts/template-sync.sh"
+    script_bytes = SCRIPT.read_text()
+
+    # Base == the current script; child adopts it verbatim (Case 5 later).
+    write(template / script_rel, script_bytes)
+    prev_sha = commit_all(template)
+    write(child / script_rel, script_bytes)
+    (child / ".template-version").write_text(prev_sha)
+    commit_all(child)
+
+    # Template advances to an identical prefix + a longer, broken tail. Because
+    # the prefix is byte-identical, an unguarded bash resuming past `main "$@"`
+    # lands exactly on the broken tail and crashes.
+    broken_tail = '\n# padding past original EOF\necho "unterminated quote\n'
+    write(template / script_rel, script_bytes + broken_tail)
+    commit_all(template)
+
+    template_copy = child / "_template"
+    subprocess.run(["cp", "-a", str(template), str(template_copy)], check=True)
+    output_file = child.parent / "github_output_selfoverwrite.txt"
+    output_file.write_text("")
+    work = child.parent / "work_selfoverwrite"
+    work.mkdir(exist_ok=True)
+    env = {
+        **os.environ,
+        **GIT_IDENTITY_ENV,
+        "SYNC_PATHS": ".github/scripts",
+        "EXCLUDE_PATHS": "",
+        "GITHUB_OUTPUT": str(output_file),
+        "TEMPLATE_SYNC_WORK_DIR": str(work),
+    }
+    # Invoke the child's own copy relatively, the way template-sync.yaml does.
+    result = subprocess.run(
+        ["bash", script_rel], cwd=child, env=env, capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+    # The child's on-disk copy was overwritten with the longer template version.
+    assert (child / script_rel).read_text().endswith(broken_tail)


### PR DESCRIPTION
Template-sync has been failing on every scheduled run with:

```
.github/scripts/template-sync.sh: line 383: unexpected EOF while looking for matching `"'
```

## Root cause

`template-sync.sh` lives under `.github/scripts`, a synced path, so mid-run the sync overwrites its own file. bash reads a running script incrementally; after the trailing `main "$@"` returns it resumes reading top-level input at a saved byte offset. When the replacement is **longer** than the running file, that offset lands inside the new file's bytes and bash executes a truncated fragment → "unexpected EOF". The `main()` wrapper defers *execution* but not that post-main *resume*, so it never actually protected against this.

## Fix

Re-exec the script from an immutable copy in `$TMPDIR` (which the sync never touches) before doing any work, and remove the copy on exit. Overwriting the repo copy is then harmless.

Adds a deterministic regression test (`test_survives_self_overwrite_with_longer_file`) that runs the repo's own copy under a longer self-overwrite and asserts a clean exit; removing the guard turns it red.

---
_Generated by [Claude Code](https://claude.ai/code/session_013bNh3U66PYQxfaUeu1zcp7)_