### PR TITLE
ci: add TEMPLATE_SYNC_TOKEN_ORG as template-sync token fallback

### DIFF
--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -98,14 +98,14 @@ jobs:
         with:
           repository: ${{ env.TEMPLATE_REPO }}
           path: _template
-          token: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
           filter: blob:none
           persist-credentials: false
 
       - name: Check token workflow scope
         env:
-          TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
+          TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.GITHUB_TOKEN }}
         # Run the child repo's own copy — never execute scripts directly from
         # the template checkout. Template script updates arrive via sync PRs
         # and go through human review before they can execute.
@@ -132,7 +132,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
-          token: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.GITHUB_TOKEN }}
           commit-message: "chore: sync from template repository (${{ steps.sync.outputs.template_sha_short }})"
           title: "chore: sync from template repository"
           body: |
@@ -179,7 +179,7 @@ jobs:
       - name: Request Claude to resolve conflicts
         if: inputs.dry-run != 'true' && (steps.sync.outputs.has_conflicts == 'true' || steps.sync.outputs.has_deletions == 'true') && steps.create-pr.outputs.pull-request-number
         env:
-          GH_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.TEMPLATE_SYNC_TOKEN_ORG || github.token }}
           HAS_CONFLICTS: ${{ steps.sync.outputs.has_conflicts }}
           HAS_DELETIONS: ${{ steps.sync.outputs.has_deletions }}
           CONFLICT_FILES: ${{ steps.sync.outputs.conflict_files }}


### PR DESCRIPTION
Adds the org-level secret `TEMPLATE_SYNC_TOKEN_ORG` as a fallback token source in `template-sync.yaml`, so the sync's PR-creation push works without a repo-level `TEMPLATE_SYNC_TOKEN`.

Token resolution is now `TEMPLATE_SYNC_TOKEN` (repo override) → `TEMPLATE_SYNC_TOKEN_ORG` (org secret) → `GITHUB_TOKEN`/`github.token`. The default `GITHUB_TOKEN` was hitting `403` on the `git push` in the Create-Pull-Request step.

---
_Generated by [Claude Code](https://claude.ai/code/session_013bNh3U66PYQxfaUeu1zcp7)_