### PR TITLE
fix(ci): give the conflict resolver uvx so the pre-push hook can run

### DIFF
--- a/.github/workflows/auto-resolve-conflicts.yaml
+++ b/.github/workflows/auto-resolve-conflicts.yaml
@@ -169,6 +169,16 @@ jobs:
       - name: Set up Node + install deps
         uses: ./.github/actions/setup-base-env
 
+      # The resolution push runs the checked-out branch's .hooks/pre-push
+      # (pnpm install sets core.hooksPath), which drives the pushed-range
+      # pre-commit suite through uvx. Without uv on PATH the hook degrades —
+      # and a PR head carrying an older hook fails CLOSED, rejecting every
+      # resolution push with "required tool 'pre-commit' not found".
+      - name: Set up uv (pre-push hook runs pre-commit via uvx)
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+
       - name: Stage the resolver scripts from the trusted base ref
         # The checkout above is the PR HEAD. Running its copy of the resolver
         # scripts would (a) fail with 127 on any PR whose branch predates them and


### PR DESCRIPTION
Fixes the red `Auto-resolve merge conflicts` run on main (PR #169's resolution): the resolver computes the merge, then pushes — and that push executes the checked-out PR head's `.hooks/pre-push`, which runs the pushed-range pre-commit suite through `uvx`. The resolver job never installed uv, so:

- on branches with the current hook, the range check silently degraded to the loud-skip path — the hook never actually checked anything in this workflow;
- on a PR head carrying the older hook revision (e.g. `template-sync` in #169), the hook **fails closed** and rejects the resolution push with `required tool 'pre-commit' not found`, so the resolver errors after doing all the work.

One step added to the resolver job: the repo's pinned `astral-sh/setup-uv` (same SHA as `setup-base-env`/`publish-python.yaml`), no cache. With `uvx` present the hook runs the pushed-range checks for real on any branch vintage.

Not touched: the npm-publish failure on main is a separate root cause (the `agent-sanitizer` package doesn't exist on the registry yet; OIDC has nothing to attach to) — that's the manual first-publish bootstrap, not a workflow defect.

## Verification

- Falsify: re-run the failed `Auto-resolve merge conflicts` run for PR #169 after merge — the finalize step should push instead of dying in the pre-push hook. (Not triggerable pre-merge: the workflow runs the base-ref's scripts but the job definition comes from the default branch.)
- `zizmor` static audits pass locally (`ZIZMOR_OFFLINE=true` — this sandbox's proxy blocks the advisories API; CI runs the online audit).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MNEMrPimpPVH8HUAGqzEMu)_