### PR TITLE
fix(hooks): stop tag pushes from rebuilding the whole pre-commit suite

### DIFF
--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -23,16 +23,30 @@ if [[ -d "$git_root/.venv/bin" ]]; then
 fi
 export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
 
-# Mirror CI's invocation: pre-commit.yaml runs `uvx pre-commit==<pin>`, and that
-# workflow line is the one authoritative pin — read it from there so this hook
-# can't drift to a different version. Fall back to a PATH pre-commit when uvx is
-# absent; when neither exists, skip loudly (CI still runs the full suite on the
-# PR) rather than blocking the push on a tool the machine doesn't have.
+# Mirror CI's invocation: pre-commit.yaml's run line carries the one
+# authoritative pre-commit pin AND the Python version its hook environments are
+# built on — read both from there so this hook can't drift. Match the pin
+# wherever it sits on the line (`uvx pre-commit==X`, `uv run --with
+# pre-commit==X`, ...): the previous parser hard-coded the `uvx ` prefix, the
+# workflow moved to `uv run --with`, and the hook silently fell back to an
+# unpinned pre-commit on whatever Python uv defaulted to. An unparseable line is
+# a hard error — a silent fallback is exactly the drift this block exists to
+# prevent. Fall back to a PATH pre-commit when uvx is absent; when neither
+# exists, skip loudly (CI still runs the full suite on the PR) rather than
+# blocking the push on a tool the machine doesn't have.
 precommit_cmd=()
 if command -v uvx >/dev/null 2>&1; then
-  pin=$(sed -n 's/.*uvx \(pre-commit==[0-9][0-9.]*\).*/\1/p' \
-    "$git_root/.github/workflows/pre-commit.yaml" | head -n1)
-  precommit_cmd=(uvx "${pin:-pre-commit}")
+  workflow="$git_root/.github/workflows/pre-commit.yaml"
+  run_line=$(grep -m1 -E 'pre-commit==[0-9]' "$workflow") || run_line=''
+  pin=$(sed -n 's/.*pre-commit==\([0-9][0-9.]*\).*/\1/p' <<<"$run_line")
+  python_version=$(sed -n 's/.*--python \([0-9][0-9.]*\).*/\1/p' <<<"$run_line")
+  if [[ -z "$pin" || -z "$python_version" ]]; then
+    echo "pre-push: could not read the pre-commit pin and --python version from $workflow — the run line is missing or changed shape. Update the parser in .hooks/pre-push." >&2
+    exit 1
+  fi
+  # `uvx --from`, not `uv run`: this repo has a pyproject.toml and `uv run`
+  # would sync the project environment before running anything.
+  precommit_cmd=(uvx --python "$python_version" --from "pre-commit==$pin" pre-commit)
 elif command -v pre-commit >/dev/null 2>&1; then
   precommit_cmd=(pre-commit)
 else
@@ -49,9 +63,16 @@ default_branch=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/de
 # default branch, and to the empty tree on a repo with no origin/HEAD (first
 # push), so the whole history is checked exactly once.
 zero=0000000000000000000000000000000000000000
-while read -r _local_ref local_sha _remote_ref remote_sha; do
+while read -r _local_ref local_sha remote_ref remote_sha; do
   [[ "$local_sha" == "$zero" ]] && continue # branch deletion: nothing to check
   [[ ${#precommit_cmd[@]} -eq 0 ]] && continue
+  # A tag push introduces no commits — the tagged commit already reached the
+  # remote on some branch and was checked then. Tags also have no upstream to
+  # diff against, so without this they hit the new-ref fallback below and get
+  # swept against the merge base with origin/HEAD, which can point at a stale
+  # branch: `git push origin v2.0.0` then rebuilds every hook environment to
+  # re-lint history that is already on main.
+  [[ "$remote_ref" == refs/tags/* ]] && continue
   from_ref="$remote_sha"
   if [[ "$from_ref" == "$zero" ]]; then
     from_ref=$(git merge-base "$default_branch" "$local_sha" 2>/dev/null) ||
@@ -62,25 +83,27 @@ while read -r _local_ref local_sha _remote_ref remote_sha; do
   # and pre-commit (and the tools it drives) would otherwise inherit and consume
   # it, so a multi-ref push would check only the first range.
   #
-  # Capture output so a hook-ENVIRONMENT provisioning failure degrades to a loud
-  # skip instead of blocking the push: in a restricted-egress sandbox pre-commit
-  # can't download a linter's binary (e.g. shellcheck/shfmt fetch from GitHub
-  # releases -> HTTP 403) and hard-fails the install before running anything.
-  # That is not a lint failure and must not strand the push — CI (pre-commit.yaml)
-  # re-runs the full suite on the PR. A genuine lint/format failure still aborts:
-  # we swallow ONLY pre-commit's install-error signatures, never a normal
-  # non-zero from a hook that actually ran.
+  # A hook-ENVIRONMENT provisioning failure degrades to a loud skip instead of
+  # blocking the push: in a restricted-egress sandbox pre-commit can't reach an
+  # index or a linter's release tarball (HTTP 403, "No matching distribution
+  # found") and hard-fails the install before running anything. That is not a
+  # lint failure and must not strand the push — CI (pre-commit.yaml) re-runs the
+  # full suite on the PR.
+  #
+  # Exit code 3 is the precise signal: pre-commit's error_handler maps a hook
+  # failure to 1, ^C to 130, and everything else — including the
+  # CalledProcessError an install raises — to 3. Grepping the output for install
+  # signatures instead would be self-defeating, since --show-diff-on-failure can
+  # print a diff of THIS file containing those very strings.
   precommit_rc=0
   precommit_out=$("${precommit_cmd[@]}" run --from-ref "$from_ref" --to-ref "$local_sha" --show-diff-on-failure </dev/null 2>&1) ||
     precommit_rc=$?
   printf '%s\n' "$precommit_out"
-  if [[ "$precommit_rc" -ne 0 ]]; then
-    if grep -qE 'InstallError|failed-wheel-build-for-install|Failed building wheel|An error has occurred while installing|HTTP Error 40[37]' <<<"$precommit_out"; then
-      echo "pre-push: pre-commit could not PROVISION a hook environment (network/egress blocked, not a lint failure) — SKIPPING the pushed-range run. CI still enforces the full suite on the PR." >&2
-      continue
-    fi
-    exit "$precommit_rc"
+  if [[ "$precommit_rc" -eq 3 ]]; then
+    echo "pre-push: pre-commit could not PROVISION a hook environment (network/egress blocked, not a lint failure) — SKIPPING the pushed-range run. CI still enforces the full suite on the PR." >&2
+    continue
   fi
+  [[ "$precommit_rc" -eq 0 ]] || exit "$precommit_rc"
 done
 
 # Portable-symlink check: rejects a tracked symlink with an absolute target

--- a/tests/test_pre_push.py
+++ b/tests/test_pre_push.py
@@ -1,0 +1,160 @@
+"""Tests for .hooks/pre-push.
+
+The hook shells out to pre-commit, so every test replaces `uvx` with a stub that
+records its argv and exits with a caller-chosen code. The stub also proves the
+hook never spawns pre-commit at all on the paths that should short-circuit.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests._helpers import REPO_ROOT, commit_all, init_test_repo
+
+ZERO = "0" * 40
+WORKFLOW = Path(".github/workflows/pre-commit.yaml")
+
+FAKE_UVX = """#!/bin/bash
+printf '%s\\n' "$*" >>"$UVX_LOG"
+printf 'stub pre-commit output\\n'
+exit "${UVX_RC:-0}"
+"""
+
+
+def live_pin_and_python() -> tuple[str, str]:
+    """The pre-commit pin and Python version CI actually runs, read
+    independently of the hook's own parser."""
+    text = (REPO_ROOT / WORKFLOW).read_text()
+    line = next(ln for ln in text.splitlines() if "pre-commit==" in ln)
+    pin = re.search(r"pre-commit==(?P<pin>[0-9][0-9.]*)", line)
+    python_version = re.search(r"--python (?P<version>[0-9][0-9.]*)", line)
+    assert pin and python_version, f"no pin/--python in {WORKFLOW}: {line!r}"
+    return pin.group(1), python_version.group(1)
+
+
+@pytest.fixture
+def sandbox(tmp_path: Path) -> Path:
+    """Repo with two commits, the real hook, the real workflow, and a uvx stub."""
+    repo = tmp_path / "repo"
+    init_test_repo(repo)
+    commit_all(repo, "base")
+    commit_all(repo, "head")
+
+    hooks = repo / ".hooks"
+    hooks.mkdir()
+    shutil.copy2(REPO_ROOT / ".hooks" / "pre-push", hooks / "pre-push")
+    (hooks / "pre-push").chmod(0o755)
+
+    workflow = repo / WORKFLOW
+    workflow.parent.mkdir(parents=True)
+    shutil.copy2(REPO_ROOT / WORKFLOW, workflow)
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    (fake_bin / "uvx").write_text(FAKE_UVX)
+    (fake_bin / "uvx").chmod(0o755)
+    (tmp_path / "home").mkdir()
+    return repo
+
+
+def run_hook(sandbox: Path, refs: str, uvx_rc: int = 0) -> subprocess.CompletedProcess:
+    tmp_path = sandbox.parent
+    env = {
+        **os.environ,
+        "HOME": str(tmp_path / "home"),
+        "PATH": f"{tmp_path / 'bin'}:{os.environ['PATH']}",
+        "UVX_LOG": str(tmp_path / "uvx.log"),
+        "UVX_RC": str(uvx_rc),
+    }
+    return subprocess.run(
+        ["bash", str(sandbox / ".hooks" / "pre-push")],
+        cwd=sandbox,
+        input=refs,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def uvx_calls(sandbox: Path) -> list[str]:
+    log = sandbox.parent / "uvx.log"
+    return log.read_text().splitlines() if log.exists() else []
+
+
+def rev(repo: Path, ref: str) -> str:
+    return subprocess.run(
+        ["git", "rev-parse", ref], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def test_branch_push_runs_precommit_with_cis_pin(sandbox: Path) -> None:
+    pin, python_version = live_pin_and_python()
+    base, head = rev(sandbox, "HEAD~1"), rev(sandbox, "HEAD")
+    result = run_hook(sandbox, f"refs/heads/topic {head} refs/heads/topic {base}\n")
+    assert result.returncode == 0, result.stderr
+    assert uvx_calls(sandbox) == [
+        f"--python {python_version} --from pre-commit=={pin} pre-commit run "
+        f"--from-ref {base} --to-ref {head} --show-diff-on-failure"
+    ]
+
+
+def test_tag_push_skips_precommit(sandbox: Path) -> None:
+    """A tag adds no commits; running the suite would rebuild every hook env to
+    re-lint history that already passed on its branch."""
+    head = rev(sandbox, "HEAD")
+    # uvx_rc=1 so an accidental invocation fails the test loudly.
+    result = run_hook(sandbox, f"refs/tags/v2.0.0 {head} refs/tags/v2.0.0 {ZERO}\n", 1)
+    assert result.returncode == 0, result.stderr
+    assert uvx_calls(sandbox) == []
+
+
+def test_branch_deletion_skips_precommit(sandbox: Path) -> None:
+    result = run_hook(
+        sandbox, f"(delete) {ZERO} refs/heads/topic {rev(sandbox, 'HEAD')}\n", 1
+    )
+    assert result.returncode == 0, result.stderr
+    assert uvx_calls(sandbox) == []
+
+
+def test_every_pushed_ref_is_checked(sandbox: Path) -> None:
+    """pre-commit must not swallow the ref list git feeds the loop on stdin."""
+    base, head = rev(sandbox, "HEAD~1"), rev(sandbox, "HEAD")
+    result = run_hook(
+        sandbox,
+        f"refs/heads/a {head} refs/heads/a {base}\n"
+        f"refs/heads/b {head} refs/heads/b {base}\n",
+    )
+    assert result.returncode == 0, result.stderr
+    assert len(uvx_calls(sandbox)) == 2
+
+
+def test_provisioning_failure_skips_instead_of_blocking(sandbox: Path) -> None:
+    """pre-commit exits 3 when it cannot build a hook environment — a blocked
+    network, not a lint failure, so it must not strand the push."""
+    base, head = rev(sandbox, "HEAD~1"), rev(sandbox, "HEAD")
+    result = run_hook(sandbox, f"refs/heads/topic {head} refs/heads/topic {base}\n", 3)
+    assert result.returncode == 0, result.stderr
+    assert "PROVISION" in result.stderr
+    assert len(uvx_calls(sandbox)) == 1
+
+
+def test_lint_failure_aborts_the_push(sandbox: Path) -> None:
+    base, head = rev(sandbox, "HEAD~1"), rev(sandbox, "HEAD")
+    result = run_hook(sandbox, f"refs/heads/topic {head} refs/heads/topic {base}\n", 1)
+    assert result.returncode == 1
+    assert "stub pre-commit output" in result.stdout
+
+
+def test_unparseable_workflow_is_fatal(sandbox: Path) -> None:
+    """A silent fallback to an unpinned pre-commit is the drift the parser
+    exists to prevent, so an unrecognised run line must fail loudly."""
+    (sandbox / WORKFLOW).write_text("jobs:\n  pre-commit:\n    run: pre-commit run\n")
+    base, head = rev(sandbox, "HEAD~1"), rev(sandbox, "HEAD")
+    result = run_hook(sandbox, f"refs/heads/topic {head} refs/heads/topic {base}\n")
+    assert result.returncode == 1
+    assert "changed shape" in result.stderr
+    assert uvx_calls(sandbox) == []


### PR DESCRIPTION
## Summary

`.hooks/pre-push` now skips `refs/tags/*` and mirrors CI's pre-commit pin correctly. `git push origin v2.0.0` had been aborting: a tag ref has no upstream sha, so it fell through to the new-branch fallback and swept the merge base with `origin/HEAD` — which on a working clone can point at a stale branch. That turned a tag push into a full hook-environment build, and the build failed.

Two further defects surfaced along the way, both in the same file:

- **The pin parser had silently drifted.** It matched `uvx pre-commit==<pin>`, but `.github/workflows/pre-commit.yaml` now runs `uv run --python 3.11 --with pre-commit==4.6.0`. The `sed` matched nothing, `${pin:-pre-commit}` swallowed the miss, and the hook ran an unpinned pre-commit on uv's default interpreter (3.14 here) — where a hook env failed to install. The block's own comment claimed it "can't drift to a different version"; it had.
- **Provisioning failures were detected by grepping pre-commit's output** for install signatures (`Failed building wheel`, `HTTP Error 403`, …). `--show-diff-on-failure` prints hook-applied diffs, so a formatter touching `.hooks/pre-push` itself would print those very strings and silently swallow a real lint failure.

## Changes

- Skip `refs/tags/*` refs in the pushed-range loop.
- Read both the pin and `--python` from the workflow's run line wherever they sit on it; invoke `uvx --python <v> --from pre-commit==<pin> pre-commit`. An unparseable line is now a hard error instead of a silent fallback.
- Detect provisioning failures by exit code 3 — pre-commit's `error_handler` maps hook failures to 1, `^C` to 130, and everything else including a failed env install to 3 — and drop the output grep.
- New `tests/test_pre_push.py`: a `uvx` stub records argv and returns a chosen exit code, so each test asserts both the exact command and whether pre-commit was spawned at all.

## Review focus

The pin-parsing block in `.hooks/pre-push` is the part worth a second pair of eyes: it is now the single point of coupling to `.github/workflows/pre-commit.yaml`, and `tests/test_pre_push.py` copies the _live_ workflow into its sandbox, so editing that run line without updating the parser fails the suite rather than degrading quietly. `test_branch_push_runs_precommit_with_cis_pin` derives its expectation from the live file, and `live_pin_and_python()` asserts a non-empty parse so it can't pass vacuously.

## Tests / verification

- `uv run pytest tests/test_pre_push.py` — 7 passed.
- `uvx --python 3.11 --from pre-commit==4.6.0 pre-commit run --files .hooks/pre-push tests/test_pre_push.py` — all hooks pass; every hook environment provisioned cleanly on 3.11, which is the interpreter the drifted parser had stopped selecting.
- End to end: pushing this branch ran the pinned suite in seconds, and `git push origin v2.0.0` then succeeded with no pre-commit run at all.
- The rest of the local suite has 60 pre-existing failures from missing optional deps (`detect_secrets`, `hypothesis`) and unrelated tooling; identical counts with and without this diff.

## Decisions made

- **A tag pointing at a commit that never reached a branch is no longer checked.** There is no sane base to diff a tag against, and CI's `pre-commit.yaml` doesn't run on tag pushes either, so nothing regressed — but this is a real, if narrow, recall loss.
- **An unparseable workflow run line aborts the push** rather than falling back to an unpinned pre-commit. It only fires when someone edits that line, and the silent fallback is precisely the failure being fixed.
- **`uvx --from`, not `uv run`** as CI uses: this repo has a `pyproject.toml`, and `uv run` would sync the project environment before running anything.
