### PR TITLE
ci: print PyPI's rejection reason on publish failures

### DIFF
--- a/.github/workflows/auto-version.yaml
+++ b/.github/workflows/auto-version.yaml
@@ -111,3 +111,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           packages-dir: python/dist/
+          # twine hides the registry's rejection reason (e.g. which metadata
+          # field or publisher mismatch caused a 400) unless verbose.
+          verbose: true

--- a/.github/workflows/publish-python.yaml
+++ b/.github/workflows/publish-python.yaml
@@ -108,3 +108,7 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        with:
+          # twine hides the registry's rejection reason (e.g. which metadata
+          # field or publisher mismatch caused a 400) unless verbose.
+          verbose: true


### PR DESCRIPTION
The break-glass PyPI publish (run 30333740371) got all the way to upload — tag `v2.0.0` resolved, `agent_sanitizer-2.0.0` wheel+sdist built, `twine check` PASSED, attestations signed — then died with a bare `HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/`. twine only prints the registry's response body, which names the actual cause (offending metadata field, publisher/project mismatch, disallowed name), under `--verbose`. Both publish steps (`publish-python.yaml` break-glass and `auto-version.yaml` primary) now pass `verbose: true` so the next failed dispatch is self-diagnosing.

## Verification

- Falsify: re-dispatch "Publish Python to PyPI (break-glass)" after merge — a failing upload's log should now include PyPI's response body naming the 400's cause (and a succeeding one is the real goal).
- `zizmor` static audits pass locally (`ZIZMOR_OFFLINE=true` — this sandbox's proxy blocks the advisories API; CI runs the online audit).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MNEMrPimpPVH8HUAGqzEMu)_