### PR TITLE
fix(secrets): stop redacting shell parameter-expansion defaults and secret-location fields

### DIFF
--- a/python/agent_sanitizer/secrets/engine.py
+++ b/python/agent_sanitizer/secrets/engine.py
@@ -234,10 +234,18 @@ FIELD_VALUE_RE = re.compile(
     # `$(...)`/`foo(...)` still begin with `$`/a letter, never the peeled bracket,
     # so they neither match here nor (as before) reach the length floor.
     # The assignment operator is `:` `=` or one of the multi-char forms `:=`
-    # `=>` `==` (Go/Pascal walrus, Ruby/PHP hash-rocket, comparison-as-config).
-    # A bare `[:=]` matched only the first char of `:=`/`=>`, leaving the value
-    # to start at the second operator byte (`= "v"` / `> "v"`), which is <20
-    # contiguous chars, so the arm failed and the secret leaked.
+    # `=>` `==` (Go/Pascal walrus, Ruby/PHP hash-rocket, comparison-as-config)
+    # and the shell parameter-expansion operators `:-` `:+` `:?`
+    # (`${SECRET_FILE:-/etc/app/secret}`). A bare `[:=]` matched only the first
+    # char of these, leaving the value to start at the second operator byte
+    # (`= "v"` / `> "v"` / `-/etc/app/secret`). For `:=`/`=>` that value was <20
+    # contiguous chars, so the arm failed and the secret leaked; for `:-`/`:+`/`:?`
+    # the operator byte glued onto the front of the value instead, so a shell
+    # default the value-shape skips below would have passed (a filesystem path, an
+    # env reference, a placeholder) no longer matched its shape and was redacted —
+    # the FALSE POSITIVE that mangles ordinary shell source. Consuming the whole
+    # operator hands each skip the value the author actually wrote, while a real
+    # hardcoded default (`${TOKEN:-ghp_…}`) still redacts.
     #
     # `(?:[_-][A-Za-z0-9]+)*` after the keyword lets it be a PREFIX of a longer
     # underscore/hyphen-segmented identifier (`api_key_prod`, `secret_value`,
@@ -252,7 +260,7 @@ FIELD_VALUE_RE = re.compile(
     # Disjoint separator/body classes make each `[_-]`-delimited segment parse
     # exactly one way, so the match is linear in the input length (see
     # tests/secrets/test_secrets_engine.py::test_field_value_re_linear_on_underscore_run).
-    rf"(?P<field_prefix>(?:{_FIELD_NAMES})(?:[_-][A-Za-z0-9]+)*[\"']?\s*(?::=|==|=>|[:=])\s*"
+    rf"(?P<field_prefix>(?:{_FIELD_NAMES})(?:[_-][A-Za-z0-9]+)*[\"']?\s*(?::=|==|=>|:[-+?]|[:=])\s*"
     r"(?:(?:Bearer|Token|Basic)\s+)?)"
     r"(?P<openbracket>[(\[{]?)"
     r"(?P<quote>[\"']?)"
@@ -434,10 +442,14 @@ def _is_placeholder_value(value: str) -> bool:
 # A field named `secret_type` / `token_name` / `key_label` holds metadata *about*
 # a secret (its kind, its display name), not the secret itself — `secret_type =
 # "Anthropic API Key"` trips KeywordDetector and corrupts ordinary code/test
-# output. Skip when the identifier directly before the matched value's
-# assignment ends in a metadata suffix. Real secrets live under the bare
-# keyword fields, which have no such suffix.
-_METADATA_SUFFIXES = ("type", "name", "label", "keyword", "kind")
+# output. Likewise `secret_path` / `ssh_private_key_file` name WHERE a secret
+# lives (`secret_path="$RUN_DIR/secret"`, `key_file=args.ssh_private_key_path`),
+# not its bytes — and the location value (a relative path, a variable-rooted
+# path, an attribute chain) routinely escapes the value-shape skips, which only
+# know absolute paths and anchored env references. Skip when the identifier
+# directly before the matched value's assignment ends in a metadata suffix. Real
+# secrets live under the bare keyword fields, which have no such suffix.
+_METADATA_SUFFIXES = ("type", "name", "label", "keyword", "kind", "path", "file")
 _ASSIGN_OP_CHARS = "=:!>"
 
 

--- a/tests/secrets/test_secrets_engine.py
+++ b/tests/secrets/test_secrets_engine.py
@@ -631,6 +631,11 @@ def test_is_metadata_field_uses_explicit_offset():
         ("secret_type", 'secret_type = "Anthropic API Key"'),
         ("kubernetes secret type", 'secret_type: "kubernetes.io/tls"'),
         ("token_kind", 'token_kind = "refresh-token-v2-long"'),
+        # *_path / *_file fields hold WHERE a secret lives — a variable-rooted or
+        # relative location the absolute-path/env-reference value skips miss.
+        ("secret_path var-rooted", 'secret_path="$SBX_RS_RUN_DIR/secret-file"'),
+        ("key path attr chain", "key_path = args.ssh_private_key_path,"),
+        ("token_file relative", "token_file: state/rotating/current-token"),
     ],
 )
 def test_metadata_fields_not_redacted(label, text):
@@ -941,6 +946,55 @@ def test_unforgeable_env_root_trusted_on_web_ingress(value):
 )
 def test_code_constructs_not_redacted(label, text):
     assert run_plain(text) is None, label
+
+
+# A shell parameter expansion `${VAR:-default}` / `${VAR:+alt}` is not an
+# assignment: the operator is two bytes, so a one-byte `:` left the `-`/`+` glued
+# to the front of the value and every value-shape skip (path, env reference,
+# placeholder) stopped matching — redacting an ordinary shell default. These are
+# the exact shapes that broke.
+@pytest.mark.parametrize(
+    "label, text",
+    [
+        (
+            "default path",
+            "F=${GLOVEBOX_MONITOR_SECRET_FILE:-/etc/glovebox/monitor-secret}",
+        ),
+        ("alternate path", "echo ${API_KEY_OVERRIDE:+/var/lib/glovebox/override-key}"),
+        ("default env ref", "api_key=${API_KEY:-$FALLBACK_API_KEY_FOR_LOCAL_DEV}"),
+        ("default placeholder", "token=${GH_TOKEN:-<paste-your-token-here-ok>}"),
+        # `:=` already consumed both bytes; pinned so the arm can't regress.
+        (
+            "assign-default path",
+            'X="${MONITOR_SECRET_PATH:=/etc/glovebox/monitor-secret}"',
+        ),
+    ],
+)
+def test_shell_parameter_expansion_defaults_not_redacted(label, text):
+    assert run_plain(text) is None, label
+
+
+# The precision fix must not cost recall: a credential hardcoded as the default
+# still redacts, and the operator itself is never swallowed into the placeholder.
+@pytest.mark.parametrize(
+    "label, text, expected",
+    [
+        (
+            "prefix-detected token default",
+            "TOKEN=${GH_TOKEN:-ghp_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8}",
+            "TOKEN=${GH_TOKEN:-[" + "REDACTED: GitHub Token]}",
+        ),
+        (
+            "keyword-field opaque default",
+            "url=${API_KEY:-a1b2c3d4e5f6g7h8i9j0k1l2}",
+            "url=${API_KEY:-[" + "REDACTED]}",
+        ),
+    ],
+)
+def test_shell_parameter_expansion_secret_default_still_redacted(label, text, expected):
+    result = run_plain(text)
+    assert result is not None, label
+    assert result["text"] == expected, label
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Claimed area: `FIELD_VALUE_RE` operator handling + `_METADATA_SUFFIXES` in `python/agent_sanitizer/secrets/engine.py`.

## What & why
Two precision fixes in the field-value detector, both from a reported false positive: `${GLOVEBOX_MONITOR_SECRET_FILE:-/etc/glovebox/monitor-secret}` came back as `${VAR:[REDACTED]}`, which an auditor reads as a *missing* default — a redaction that manufactured an apparent fail-open bug.

1. **Shell parameter-expansion operators.** The regex treated the `:` in `${VAR:-default}` as a one-byte assignment, gluing the `-`/`+`/`?` byte onto the captured value, so every value-shape skip (filesystem path, env reference, placeholder) stopped matching its shape. The operator alternation now consumes `:-` `:+` `:?` whole, handing each skip the value the author wrote. A hardcoded credential default (`${GH_TOKEN:-ghp_…}`) still redacts — pinned by test.
2. **Secret-location fields.** `path`/`file` join the metadata suffixes: `secret_path="$RUN_DIR/secret"` / `key_file=args.ssh_private_key_path` name *where* a secret lives, and their variable-rooted or relative values escape the absolute-path and env-reference skips. Name-based, so per the existing rule it applies only off web ingress.

## Review focus
The operator alternation in `FIELD_VALUE_RE` (`engine.py`) — verify `:[-+?]` can't absorb an operator byte a real credential could start with (the value class already excludes none of `-+?`, but the operator is only consumed immediately after `keyword:`). The suffix addition is one tuple entry.

## How it was tested
`uv run pytest tests/secrets -q` — 796 pass (was 786), including the ReDoS static guard; `pnpm test` — 1890 pass. New tests pin the five broken expansion shapes, the two still-redacts recall cases, and three location-field shapes. Also swept both this repo's and agent-glovebox's full trees through the redactor: the reported class is gone; remaining diffs are credential-shaped test needles (correct redactions) plus known FP families listed below.

## Decisions made
- `:?` consumes the operator but its message-value can still redact (`${X:?missing-credential-file-path}` → value is the message; redacted if ≥20 chars and no skip matches). Left as-is: erring toward redaction on `:?` messages is the safe side, and the reported edge was `:-`.
- A tree-sweep found three FP families this PR does **not** fix (kept out deliberately — each needs its own precision/recall argument): dotted entry-point values under keyword-named keys (`agent-secret-redactor = "pkg.mod:main"`), regex/pattern literals assigned to keyword-ish names (`SECRET_HINT = /secret|token|…/`), and lowercase descriptive labels (`# -g-secret: static-host-credential`) which collide with the diceware-passphrase concern.

## Proposed guards
A benign-corpus regression test: run `redact()` over a committed corpus of real-world shell/config/source lines that use credential *keywords* without credentials (seeded from the tree-sweep above) and assert zero findings. Class: precision regressions in keyword-anchored detection — this PR's bug would have been caught the day the operator list was written. Benefit: the class recurs (every operator/skip interaction found so far shipped broken first); cost: one fast test, maintenance only when a corpus line becomes genuinely credential-shaped. Expected FP rate of the guard itself: near zero if the corpus only contains lines already verified benign.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EEfEA4E22qjWp4RovfU8QF)_