### PR TITLE
fix(secrets): make unknown assignment operators fail wholesale, never partially match

### DIFF
--- a/python/agent_sanitizer/secrets/engine.py
+++ b/python/agent_sanitizer/secrets/engine.py
@@ -260,7 +260,15 @@ FIELD_VALUE_RE = re.compile(
     # Disjoint separator/body classes make each `[_-]`-delimited segment parse
     # exactly one way, so the match is linear in the input length (see
     # tests/secrets/test_secrets_engine.py::test_field_value_re_linear_on_underscore_run).
-    rf"(?P<field_prefix>(?:{_FIELD_NAMES})(?:[_-][A-Za-z0-9]+)*[\"']?\s*(?::=|==|=>|:[-+?]|[:=])\s*"
+    # The one-byte `[:=]` arm carries a negative lookahead over the operator
+    # CONTINUATION bytes (`-+?=>~`): an operator this alternation doesn't know
+    # (`=~`, a future `:@`) must fail to match AT ALL — a false negative — never
+    # match its first byte and glue the rest onto the value, where the stray byte
+    # breaks every fullmatch-anchored value-shape skip at once and produces the
+    # false positive that mangles real content. `===` is explicit for the same
+    # reason: `==` alone would leave the third `=` on the value.
+    rf"(?P<field_prefix>(?:{_FIELD_NAMES})(?:[_-][A-Za-z0-9]+)*[\"']?\s*"
+    r"(?::=|===|==|=>|:[-+?]|[:=](?![-+?=>~]))\s*"
     r"(?:(?:Bearer|Token|Basic)\s+)?)"
     r"(?P<openbracket>[(\[{]?)"
     r"(?P<quote>[\"']?)"

--- a/tests/secrets/test_secrets_engine.py
+++ b/tests/secrets/test_secrets_engine.py
@@ -997,6 +997,47 @@ def test_shell_parameter_expansion_secret_default_still_redacted(label, text, ex
     assert result["text"] == expected, label
 
 
+# ─── Operator × skip-shape grid ──────────────────────────────────────────────
+# Every value-shape skip is a fullmatch, so ONE operator byte glued onto the
+# value defeats all of them at once — the shape of both shipped instances of
+# this bug (`:=` matching as `:` + `=value`, `:-` matching as `:` + `-/path`).
+# The grid crosses every accepted operator with every skip family: a new
+# operator or a new skip that mishandles the boundary goes red here the day it
+# is written, not when a consumer hits the false positive.
+_GRID_OPERATORS = [":", "=", ":=", "==", "===", "=>", ":-", ":+", ":?"]
+_GRID_BENIGN_VALUES = [
+    ("env reference", "$MY_SERVICE_CREDENTIAL_ENV_VAR"),
+    ("placeholder", "<paste-your-token-here-now>"),
+    ("uuid", "12345678-90ab-cdef-1234-567890abcdef"),
+    ("filesystem path", "/etc/vault/agent/current-token"),
+]
+_GRID_OPAQUE = "q9X2mN7pK4rT8wY1cV5bZ3dF6gH0jL2e"
+
+
+@pytest.mark.parametrize("op", _GRID_OPERATORS)
+@pytest.mark.parametrize("label, value", _GRID_BENIGN_VALUES)
+def test_operator_grid_benign_shapes_not_redacted(op, label, value):
+    assert run_plain(f"token{op}{value}") is None, f"{label} after {op!r}"
+
+
+# The positive marker proving each grid operator is actually recognized — an
+# operator the regex silently stopped matching would make the benign half of
+# the grid pass vacuously.
+@pytest.mark.parametrize("op", _GRID_OPERATORS)
+def test_operator_grid_opaque_value_redacted(op):
+    result = run_plain(f"token{op}{_GRID_OPAQUE}")
+    assert result is not None, f"operator {op!r} not recognized"
+    assert _GRID_OPAQUE not in result["text"], op
+
+
+# An operator the alternation does NOT know must fail wholesale (a false
+# negative), never match its first byte and glue the rest onto the value.
+@pytest.mark.parametrize("op", ["=~", ":~"])
+def test_unknown_operator_fails_wholesale(op):
+    m = E.FIELD_VALUE_RE.search(f"token{op}/etc/vault/agent/current-token")
+    assert m is None, f"operator {op!r} partially matched"
+
+
 @pytest.mark.parametrize(
     "label, value",
     [


### PR DESCRIPTION
Claimed area: `FIELD_VALUE_RE` operator alternation + operator×skip grid tests in `python/agent_sanitizer/secrets/engine.py` / `tests/secrets/test_secrets_engine.py`. Follow-up hardening to #178, which fixed two instances of this class; this PR closes the class.

## What & why
An operator the field-value alternation doesn't know had its first byte matched by the one-byte `[:=]` arm, gluing the remainder onto the captured value — where one stray byte defeats every fullmatch-anchored value-shape skip (path, env reference, placeholder, UUID…) at once. That is the mechanism behind both shipped false positives (`:=` in #2822-era, `:-` in #178), and `===` / `:~` were live latent instances (`token === "…"` comparisons; `secret:~/home/path`). Two changes:

- The one-byte arm now carries a negative lookahead over operator-continuation bytes (`[-+?=>~]`), so an unknown multi-char operator fails to match **at all** — a false negative, the direction this repo's precision doctrine prefers — instead of partially matching into a content-mangling false positive.
- `===` joins the alternation explicitly (`==` alone left the third `=` on the value).

## Review focus
The lookahead byte set in `FIELD_VALUE_RE`: each excluded byte must be an operator-continuation character, never the first byte of a real credential following a bare `:`/`=` (none of `-+?=>~` starts any issuer's token format; the grid's per-operator positive markers pin that recognition survived).

## How it was tested
`uv run pytest tests/secrets -q` — 843 pass (was 796). The new grid crosses every accepted operator (`:` `=` `:=` `==` `===` `=>` `:-` `:+` `:?`) with four benign skip shapes (zero findings) plus an opaque value (must redact — the vacuity guard), and pins that `=~`/`:~` fail wholesale.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EEfEA4E22qjWp4RovfU8QF)_