### PR TITLE
feat(ci): auto-regenerate conflicted lockfiles in auto-resolve instead of handing off

### DIFF
--- a/.github/scripts/auto-resolve-discover.sh
+++ b/.github/scripts/auto-resolve-discover.sh
@@ -47,10 +47,13 @@ raw_prs() {
 }
 
 # An emittable PR: open, not draft, non-bot, same-repo, CONFLICTING, and not
-# opted out via the auto-resolve-blocked label (finalize applies it when a
-# resolution cannot be pushed — e.g. the token can't carry workflow-file
-# changes — so every base push doesn't re-run a paid resolve into the same
-# wall; a human removes the label to re-enable).
+# opted out via the auto-resolve-blocked label. Two steps apply that label, both
+# for conflicts no base push can change: finalize when a computed resolution
+# cannot be pushed (the token can't carry workflow-file changes), and handoff
+# when a conflict is unmergeable with no owning tool to rerun (a binary, an
+# unsupported lockfile). Skipping them here is what stops every base push from
+# re-running a paid resolve into the same wall; a human removes the label to
+# re-enable.
 emit_filter='select(.state == "OPEN" and .isDraft == false
   and .isCrossRepository == false and ((.author.is_bot) | not)
   and .mergeable == "CONFLICTING"

--- a/.github/scripts/auto-resolve-finalize.sh
+++ b/.github/scripts/auto-resolve-finalize.sh
@@ -55,7 +55,8 @@ fi
 # left marker-less and at "ours" (a `-merge`-attributed lockfile, a binary)
 # would silently commit a wrong "ours" resolution — and refuse any such path
 # smuggled into the list itself, since an edit-based "resolution" of it can
-# never be verified (prepare hands those off to a human before the LLM runs).
+# never be verified (prepare defers known lockfiles to DEFERRED_LOCK
+# regeneration and hands the rest to a human before the LLM runs).
 for f in "${allowed_list[@]}"; do
   if is_unmergeable "$f"; then
     fail "unmergeable (lockfile/binary) path '${f}' in CONFLICT_LIST" "\`${f}\` cannot be merged textually; resolve it by hand (e.g. re-run the lockfile tool after merging)."
@@ -81,6 +82,23 @@ if [[ ${#deferred_list[@]} -gt 0 ]] && has_resolve_generated; then
   fi
 fi
 
+# Deferred lockfile regeneration: prepare routed every conflicted lockfile with
+# a known, available owning tool here. Git leaves such a conflict marker-less at
+# "ours" (`-merge`-attributed) or marker-laden (plain text), and neither state
+# is hand-mergeable — the only correct resolution is re-running the owning tool
+# against the manifests, which are resolved by now (staged above when they
+# conflicted, merged clean otherwise). Check the lockfile out at "ours" first so
+# the tool starts from parseable content, regenerate, stage. A regen failure
+# (tool error, unreachable registry) aborts loud and leaves the conflict for a
+# human — never a guessed lockfile.
+read -ra lock_list <<<"${DEFERRED_LOCK:-}"
+for f in "${lock_list[@]}"; do
+  if ! { git checkout --ours -- "$f" && regen_lockfile "$f"; }; then
+    fail "lockfile '${f}' could not be regenerated" "regenerating \`${f}\` with its owning tool failed. Merge \`${BASE_REF}\` locally, re-run the tool by hand (e.g. \`pnpm install --lockfile-only\` / \`uv lock\`), and push the merge commit."
+  fi
+  git add -- "$f"
+done
+
 # Nothing conflicted may survive: every conflicted path was either staged above
 # (LLM resolution) or regenerated — anything still unmerged was never resolved.
 if [[ -n "$(git ls-files -u)" ]]; then
@@ -91,7 +109,7 @@ fi
 # so a whole-tree scan would abort on a legitimate line in any committed doc. The
 # resolver is bounded to CONFLICT_LIST (the out-of-set guard above), so a genuine
 # leftover marker can only live in the resolved set.
-scan_paths=("${allowed_list[@]}" "${deferred_list[@]}")
+scan_paths=("${allowed_list[@]}" "${deferred_list[@]}" "${lock_list[@]}")
 if [[ ${#scan_paths[@]} -gt 0 ]] && git grep -nE "$marker_re" -- "${scan_paths[@]}" >/dev/null 2>&1; then
   echo "Conflict markers still present:"
   git grep -nE "$marker_re" -- "${scan_paths[@]}" || echo "[auto-resolve] conflict-marker re-scan errored" >&2

--- a/.github/scripts/auto-resolve-finalize.sh
+++ b/.github/scripts/auto-resolve-finalize.sh
@@ -24,6 +24,33 @@ fail() {
   exit 1
 }
 
+# The merge is pushed with TEMPLATE_SYNC_TOKEN_ORG — the template's workflow-capable
+# PAT. It is the only sanctioned push token here for two reasons: (1) as a PAT it
+# RETRIGGERS the PR's checks so the resolved head is re-validated before it can
+# auto-merge (a default GITHUB_TOKEN push does not retrigger — GitHub's recursion
+# guard — which would strand stale green checks on a tree they never ran against);
+# and (2) when the merge commit changes files under .github/workflows/ (the base
+# branch moved a workflow underneath the PR, or a workflow itself conflicted),
+# GitHub refuses the push from any token lacking the workflow scope — which the
+# Actions GITHUB_TOKEN can never hold. TEMPLATE_SYNC_TOKEN_ORG carries that scope by
+# construction. If it is ABSENT, there is no token that can reliably push this
+# merge (a plain GITHUB_TOKEN would fail on any workflow-file change and would not
+# retrigger CI even otherwise), so fail closed: label the PR auto-resolve-blocked
+# (which discover excludes, so every base push doesn't re-run a paid resolve into
+# the same wall) and stop until a human provisions the secret and removes the
+# label. Called BEFORE the regeneration stages and the merge commit: regeneration
+# runs network-hitting package managers over PR-authored manifests, which is
+# wasted (and needless) work for a resolution that can never be pushed.
+# fail()'s `git merge --abort` cleanly unwinds the in-progress merge from there.
+require_push_token() {
+  [[ -n "${TEMPLATE_SYNC_TOKEN_ORG:-}" ]] && return 0
+  gh label create auto-resolve-blocked --color e4e669 --force \
+    --description "Auto-resolve cannot push to this PR; remove the label to let it retry" || echo "[auto-resolve] gh label create failed" >&2
+  gh pr edit "$PR" --add-label auto-resolve-blocked || echo "[auto-resolve] failed to add auto-resolve-blocked label to PR #${PR}" >&2
+  fail "no push token configured (TEMPLATE_SYNC_TOKEN_ORG is unset)" \
+    "the resolution was computed but cannot be pushed: no \`TEMPLATE_SYNC_TOKEN_ORG\` secret is set (a PAT with the \`workflow\` scope is required to push a merge that may touch workflow files and to retrigger CI). Set it, then remove the \`auto-resolve-blocked\` label to let auto-resolve retry — while it is present this PR is skipped."
+}
+
 # Defense in depth: the resolver may only have touched the files it was asked to
 # resolve, checked BEFORE staging. The resolver (Claude, restricted to Edit/Write
 # over the working tree) removed conflict markers but staged nothing, so the
@@ -66,6 +93,11 @@ if [[ ${#allowed_list[@]} -gt 0 ]]; then
   git add -- "${allowed_list[@]}"
 fi
 
+# Fail closed BEFORE either regeneration stage: both re-run tools that hit the
+# network and execute PR-authored code, and a resolution that cannot be pushed
+# is wasted work either way. See the token rationale below the regen stages.
+require_push_token
+
 # Deferred regeneration: generator-owned outputs whose sources were among the
 # LLM-resolved conflicts. With the sources now staged clean, the regen pre-pass
 # resolves them deterministically (regenerate + stage). Only reachable when the
@@ -87,13 +119,25 @@ fi
 # "ours" (`-merge`-attributed) or marker-laden (plain text), and neither state
 # is hand-mergeable — the only correct resolution is re-running the owning tool
 # against the manifests, which are resolved by now (staged above when they
-# conflicted, merged clean otherwise). Check the lockfile out at "ours" first so
-# the tool starts from parseable content, regenerate, stage. A regen failure
-# (tool error, unreachable registry) aborts loud and leaves the conflict for a
-# human — never a guessed lockfile.
+# conflicted, merged clean otherwise). A regen failure (tool error, unreachable
+# registry) aborts loud and leaves the conflict for a human — never a guessed
+# lockfile.
+#
+# Seed from --theirs (the BASE side; we are on the PR head merging origin/BASE,
+# so --ours is the PR's own lockfile). Every one of these tools PRESERVES the
+# resolutions it finds on disk that still satisfy the manifests, and only adds
+# what is missing — so the seed decides which side's manifest-INVISIBLE lockfile
+# work survives. Base's is the side that must: a `pnpm dedupe`, a transitive
+# security bump, or a `uv lock --upgrade` on main changes no manifest, so
+# seeding from the PR's lockfile would regenerate it byte-identical and silently
+# revert main's work under an "auto-resolved" comment — the wrong-"ours"
+# resolution this script exists to prevent. Seeding from base loses only the
+# PR's own manifest-invisible churn, which its author sees missing on the next
+# CI run. A lockfile conflict with no base-side stage (base deleted it) fails
+# the checkout and escalates, rather than guessing.
 read -ra lock_list <<<"${DEFERRED_LOCK:-}"
 for f in "${lock_list[@]}"; do
-  if ! { git checkout --ours -- "$f" && regen_lockfile "$f"; }; then
+  if ! { git checkout --theirs -- "$f" && regen_lockfile "$f"; }; then
     fail "lockfile '${f}' could not be regenerated" "regenerating \`${f}\` with its owning tool failed. Merge \`${BASE_REF}\` locally, re-run the tool by hand (e.g. \`pnpm install --lockfile-only\` / \`uv lock\`), and push the merge commit."
   fi
   git add -- "$f"
@@ -125,30 +169,7 @@ if [[ ${#scan_paths[@]} -gt 0 ]] && git grep -nE "$marker_re" -- "${scan_paths[@
   fail "conflict markers still present in the tree" "the resolution left conflict markers behind."
 fi
 
-# The merge is pushed with TEMPLATE_SYNC_TOKEN_ORG — the template's workflow-capable
-# PAT. It is the only sanctioned push token here for two reasons: (1) as a PAT it
-# RETRIGGERS the PR's checks so the resolved head is re-validated before it can
-# auto-merge (a default GITHUB_TOKEN push does not retrigger — GitHub's recursion
-# guard — which would strand stale green checks on a tree they never ran against);
-# and (2) when the merge commit changes files under .github/workflows/ (the base
-# branch moved a workflow underneath the PR, or a workflow itself conflicted),
-# GitHub refuses the push from any token lacking the workflow scope — which the
-# Actions GITHUB_TOKEN can never hold. TEMPLATE_SYNC_TOKEN_ORG carries that scope by
-# construction. If it is ABSENT, there is no token that can reliably push this
-# merge (a plain GITHUB_TOKEN would fail on any workflow-file change and would not
-# retrigger CI even otherwise), so fail closed BEFORE building the merge commit:
-# label the PR auto-resolve-blocked (which discover excludes, so every base push
-# doesn't re-run a paid resolve into the same wall) and stop until a human
-# provisions the secret and removes the label. Checked before the commit so
-# fail()'s `git merge --abort` cleanly unwinds the in-progress merge.
-if [[ -z "${TEMPLATE_SYNC_TOKEN_ORG:-}" ]]; then
-  gh label create auto-resolve-blocked --color e4e669 --force \
-    --description "Auto-resolve cannot push to this PR; remove the label to let it retry" || echo "[auto-resolve] gh label create failed" >&2
-  gh pr edit "$PR" --add-label auto-resolve-blocked || echo "[auto-resolve] failed to add auto-resolve-blocked label to PR #${PR}" >&2
-  fail "no push token configured (TEMPLATE_SYNC_TOKEN_ORG is unset)" \
-    "the resolution was computed but cannot be pushed: no \`TEMPLATE_SYNC_TOKEN_ORG\` secret is set (a PAT with the \`workflow\` scope is required to push a merge that may touch workflow files and to retrigger CI). Set it, then remove the \`auto-resolve-blocked\` label to let auto-resolve retry — while it is present this PR is skipped."
-fi
-token="$TEMPLATE_SYNC_TOKEN_ORG"
+token="$TEMPLATE_SYNC_TOKEN_ORG" # presence enforced by require_push_token, above the regen stages
 
 # --no-verify: this commit COMPLETES a merge, so its index carries the whole
 # base<->head delta (every file the merge touched), not just the resolved

--- a/.github/scripts/auto-resolve-finalize.test.mjs
+++ b/.github/scripts/auto-resolve-finalize.test.mjs
@@ -20,8 +20,10 @@ const git = (cwd, ...args) =>
 
 // A work clone mid-merge: `main` and `feature` both edit `file` (default a.md),
 // and b.md exists cleanly on both. Merging main into feature conflicts on
-// `file` only. Returns { work, origin }.
-function midMerge(bContent = "b base\n", file = "a.md") {
+// `file` only. `extras` maps path → content committed cleanly on both sides —
+// a lockfile fixture needs the sibling manifest its tool requires, or
+// lockfile_tool correctly declines to claim it. Returns { work, origin }.
+function midMerge(bContent = "b base\n", file = "a.md", extras = {}) {
   const root = scratch();
   const origin = join(root, "origin.git");
   const work = join(root, "work");
@@ -30,8 +32,13 @@ function midMerge(bContent = "b base\n", file = "a.md") {
   git(work, "config", "user.email", "t@t");
   git(work, "config", "user.name", "t");
   git(work, "config", "commit.gpgsign", "false");
+  mkdirSync(dirname(join(work, file)), { recursive: true });
   writeFileSync(join(work, file), "base\n");
   writeFileSync(join(work, "b.md"), bContent);
+  for (const [p, content] of Object.entries(extras)) {
+    mkdirSync(dirname(join(work, p)), { recursive: true });
+    writeFileSync(join(work, p), content);
+  }
   git(work, "add", "-A");
   git(work, "commit", "-q", "-m", "base");
   git(work, "branch", "-M", "main");
@@ -216,17 +223,32 @@ test("a successful finalize with PROTECTED_PATHS folds the warning into the succ
   assert.ok(comments[0].includes(".github/workflows/ci.yaml"));
 });
 
-test("finalize regenerates a deferred lockfile with its owning tool and pushes", () => {
-  // Conflict on pnpm-lock.yaml only; a fake `pnpm` on PATH stands in for the
-  // real regeneration (the real one would hit the network). Finalize must check
-  // the file out at "ours", run the tool, stage the result, and push it.
-  const { work, origin } = midMerge("b base\n", "pnpm-lock.yaml");
+// A `pnpm` shim that refuses to behave like a tool run on a bad seed, so every
+// property finalize's regen stage depends on is load-bearing in the test:
+// deleting the `git checkout`, flipping it back to `--ours`, dropping a flag,
+// or dropping the credential scrubbing each turns this green run red.
+// `argvLog` lives OUTSIDE the work tree — an untracked file inside it would be
+// a different failure.
+const pnpmShim = (argvLog, lock = "pnpm-lock.yaml") => `
+printf '%s\\n' "$*" >> "${argvLog}"
+grep -q '<<<<<<<' "${lock}" && { echo "seeded with conflict markers" >&2; exit 3; }
+grep -q 'main side' "${lock}" || { echo "not seeded from the base side" >&2; exit 4; }
+[ -z "\${TEMPLATE_SYNC_TOKEN_ORG:-}\${GITHUB_TOKEN:-}\${GH_TOKEN:-}" ] || { echo "push credentials visible to the tool" >&2; exit 5; }
+printf 'lockfileVersion: regenerated\\n' > "${lock}"
+`;
+
+test("finalize regenerates a deferred lockfile from the BASE side, scrubbed, and pushes", () => {
+  const { work, origin } = midMerge("b base\n", "pnpm-lock.yaml", {
+    "package.json": "{}\n",
+  });
+  const argvLog = join(dirname(work), ".pnpm-argv");
+  writeFileSync(argvLog, "");
   const before = git(origin, "rev-parse", "feature").trim();
   const { error, merging, ghCalls } = runFinalize(
     work,
     "",
     { DEFERRED_LOCK: "pnpm-lock.yaml" },
-    { pnpm: `printf 'lockfileVersion: regenerated\\n' > pnpm-lock.yaml` },
+    { pnpm: pnpmShim(argvLog) },
   );
   assert.equal(error, null);
   assert.equal(merging, false);
@@ -235,13 +257,45 @@ test("finalize regenerates a deferred lockfile with its owning tool and pushes",
     git(origin, "show", "feature:pnpm-lock.yaml"),
     "lockfileVersion: regenerated\n", // the TOOL's output, not either side's
   );
+  // The flags are load-bearing: --lockfile-only keeps it off node_modules,
+  // --no-frozen-lockfile defeats pnpm's CI default (which would refuse the
+  // update), and --ignore-scripts keeps PR-authored lifecycle code from running
+  // in a job that holds a write token.
+  assert.equal(
+    readFileSync(argvLog, "utf8").trim(),
+    "install --lockfile-only --no-frozen-lockfile --ignore-scripts",
+  );
   const comments = ghCalls.filter((c) => c.startsWith("pr comment"));
   assert.equal(comments.length, 1);
   assert.ok(comments[0].includes("Auto-resolved the merge conflict"));
 });
 
+test("a deferred lockfile in a SUBDIRECTORY is regenerated in its own directory", () => {
+  // The only case that exercises regen_lockfile's `cd "$(dirname …)"`: the shim
+  // writes to a RELATIVE path, so it lands in the wrong place unless finalize
+  // ran the tool from sub/.
+  const { work, origin } = midMerge("b base\n", "sub/pnpm-lock.yaml", {
+    "sub/package.json": "{}\n",
+  });
+  const argvLog = join(dirname(work), ".pnpm-argv-sub");
+  writeFileSync(argvLog, "");
+  const { error } = runFinalize(
+    work,
+    "",
+    { DEFERRED_LOCK: "sub/pnpm-lock.yaml" },
+    { pnpm: pnpmShim(argvLog) },
+  );
+  assert.equal(error, null);
+  assert.equal(
+    git(origin, "show", "feature:sub/pnpm-lock.yaml"),
+    "lockfileVersion: regenerated\n",
+  );
+});
+
 test("a failing lockfile regeneration aborts loud and pushes nothing", () => {
-  const { work, origin } = midMerge("b base\n", "pnpm-lock.yaml");
+  const { work, origin } = midMerge("b base\n", "pnpm-lock.yaml", {
+    "package.json": "{}\n",
+  });
   const before = git(origin, "rev-parse", "feature").trim();
   const { error, merging, ghCalls } = runFinalize(
     work,

--- a/.github/scripts/auto-resolve-finalize.test.mjs
+++ b/.github/scripts/auto-resolve-finalize.test.mjs
@@ -18,10 +18,10 @@ const scratch = () => mkdtempSync(join(tmpdir(), "auto-resolve-fin-"));
 const git = (cwd, ...args) =>
   execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
 
-// A work clone mid-merge: `main` and `feature` both edit docs/a.md, and docs/b.md
-// exists cleanly on both. Merging main into feature conflicts on docs/a.md only.
-// Returns { work, origin }.
-function midMerge(bContent = "b base\n") {
+// A work clone mid-merge: `main` and `feature` both edit `file` (default a.md),
+// and b.md exists cleanly on both. Merging main into feature conflicts on
+// `file` only. Returns { work, origin }.
+function midMerge(bContent = "b base\n", file = "a.md") {
   const root = scratch();
   const origin = join(root, "origin.git");
   const work = join(root, "work");
@@ -30,18 +30,18 @@ function midMerge(bContent = "b base\n") {
   git(work, "config", "user.email", "t@t");
   git(work, "config", "user.name", "t");
   git(work, "config", "commit.gpgsign", "false");
-  writeFileSync(join(work, "a.md"), "base\n");
+  writeFileSync(join(work, file), "base\n");
   writeFileSync(join(work, "b.md"), bContent);
   git(work, "add", "-A");
   git(work, "commit", "-q", "-m", "base");
   git(work, "branch", "-M", "main");
   git(work, "push", "-q", "origin", "main");
   git(work, "checkout", "-q", "-b", "feature");
-  writeFileSync(join(work, "a.md"), "feature side\n");
+  writeFileSync(join(work, file), "feature side\n");
   git(work, "commit", "-q", "-am", "feature");
   git(work, "push", "-q", "origin", "feature");
   git(work, "checkout", "-q", "main");
-  writeFileSync(join(work, "a.md"), "main side\n");
+  writeFileSync(join(work, file), "main side\n");
   git(work, "commit", "-q", "-am", "main change");
   git(work, "checkout", "-q", "feature");
   try {
@@ -56,10 +56,12 @@ function midMerge(bContent = "b base\n") {
 // Run finalize.sh in `work` with a fake `gh` on PATH that records every
 // invocation, so a test can assert on the comment(s)/labels the script posts.
 // `env` overrides/extends the script's environment (e.g. PROTECTED_PATHS, or
-// TEMPLATE_SYNC_TOKEN_ORG: "" to exercise the fail-closed path). Returns the error
+// TEMPLATE_SYNC_TOKEN_ORG: "" to exercise the fail-closed path). `shims` maps
+// extra executable name → bash body, installed on PATH ahead of the real tool
+// (e.g. a fake `pnpm` standing in for lockfile regeneration). Returns the error
 // (null on success), whether a merge is still in progress (MERGE_HEAD present),
 // and the recorded gh argv lines.
-function runFinalize(work, conflictList, env = {}) {
+function runFinalize(work, conflictList, env = {}, shims = {}) {
   // The shim lives OUTSIDE the work clone: finalize.sh refuses any untracked
   // file inside the tree, so parking .fakebin/.gh-calls there would trip it.
   const root = dirname(work);
@@ -73,6 +75,11 @@ function runFinalize(work, conflictList, env = {}) {
     `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> "${ghLog}"\nexit 0\n`,
   );
   chmodSync(ghPath, 0o755);
+  for (const [name, body] of Object.entries(shims)) {
+    const p = join(ghBin, name);
+    writeFileSync(p, `#!/usr/bin/env bash\n${body}\n`);
+    chmodSync(p, 0o755);
+  }
   let error = null;
   try {
     execFileSync("bash", [SCRIPT], {
@@ -207,6 +214,48 @@ test("a successful finalize with PROTECTED_PATHS folds the warning into the succ
   assert.ok(comments[0].includes("Auto-resolved the merge conflict"));
   assert.ok(comments[0].includes("protected path"));
   assert.ok(comments[0].includes(".github/workflows/ci.yaml"));
+});
+
+test("finalize regenerates a deferred lockfile with its owning tool and pushes", () => {
+  // Conflict on pnpm-lock.yaml only; a fake `pnpm` on PATH stands in for the
+  // real regeneration (the real one would hit the network). Finalize must check
+  // the file out at "ours", run the tool, stage the result, and push it.
+  const { work, origin } = midMerge("b base\n", "pnpm-lock.yaml");
+  const before = git(origin, "rev-parse", "feature").trim();
+  const { error, merging, ghCalls } = runFinalize(
+    work,
+    "",
+    { DEFERRED_LOCK: "pnpm-lock.yaml" },
+    { pnpm: `printf 'lockfileVersion: regenerated\\n' > pnpm-lock.yaml` },
+  );
+  assert.equal(error, null);
+  assert.equal(merging, false);
+  assert.notEqual(git(origin, "rev-parse", "feature").trim(), before); // pushed
+  assert.equal(
+    git(origin, "show", "feature:pnpm-lock.yaml"),
+    "lockfileVersion: regenerated\n", // the TOOL's output, not either side's
+  );
+  const comments = ghCalls.filter((c) => c.startsWith("pr comment"));
+  assert.equal(comments.length, 1);
+  assert.ok(comments[0].includes("Auto-resolved the merge conflict"));
+});
+
+test("a failing lockfile regeneration aborts loud and pushes nothing", () => {
+  const { work, origin } = midMerge("b base\n", "pnpm-lock.yaml");
+  const before = git(origin, "rev-parse", "feature").trim();
+  const { error, merging, ghCalls } = runFinalize(
+    work,
+    "",
+    { DEFERRED_LOCK: "pnpm-lock.yaml" },
+    { pnpm: "exit 1" },
+  );
+  assert.notEqual(error, null); // failed rather than guessing a lockfile
+  assert.equal(merging, false); // merge aborted for a human
+  assert.equal(git(origin, "rev-parse", "feature").trim(), before); // no push
+  const comments = ghCalls.filter((c) => c.startsWith("pr comment"));
+  assert.equal(comments.length, 1);
+  assert.ok(comments[0].includes("could not finish"));
+  assert.ok(comments[0].includes("pnpm-lock.yaml"));
 });
 
 test("finalize FAILS CLOSED (labels auto-resolve-blocked, no push) when no push token is set", () => {

--- a/.github/scripts/auto-resolve-handoff.sh
+++ b/.github/scripts/auto-resolve-handoff.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 # Auto-resolve merge conflicts — HANDOFF step. Runs when PREPARE found
-# conflicted paths that cannot be merged textually: a `-merge`-attributed
-# lockfile (git leaves no markers and the working tree at "ours") or a binary.
-# No LLM edit can produce a correct resolution, so comment and fail loud BEFORE
-# any LLM cost is spent.
+# conflicted paths that cannot be merged textually AND that no owning tool can
+# regenerate: a binary, or a lockfile whose tool is not a known/available one
+# (known lockfiles — pnpm-lock.yaml, package-lock.json, uv.lock — are deferred
+# to owning-tool regeneration instead and never land here). No LLM edit can
+# produce a correct resolution, so comment and fail loud BEFORE any LLM cost.
+#
+# The PR is also labeled `auto-resolve-blocked` (which discover excludes):
+# nothing about a later push to the base branch changes an unmergeable
+# conflict, so retrying on every base push would only re-spend on the same
+# refusal and re-post the same comment. A human resolves by hand and removes
+# the label to re-enable auto-resolve for this PR.
 set -euo pipefail
 
 : "${PR:?PR required}"
@@ -16,10 +23,14 @@ for f in "${paths[@]}"; do
   bullets+="- \`${f}\`"$'\n'
 done
 
-gh pr comment "$PR" --body "⚠️ **Cannot auto-resolve the merge conflict with \`${BASE_REF}\`** — these files cannot be merged textually (lockfile/binary):
+gh label create auto-resolve-blocked --color e4e669 --force \
+  --description "Auto-resolve cannot push to this PR; remove the label to let it retry" || echo "[auto-resolve] gh label create failed" >&2
+gh pr edit "$PR" --add-label auto-resolve-blocked || echo "[auto-resolve] failed to add auto-resolve-blocked label to PR #${PR}" >&2
+
+gh pr comment "$PR" --body "⚠️ **Cannot auto-resolve the merge conflict with \`${BASE_REF}\`** — these files cannot be merged textually and no available tool can regenerate them (binary, or an unsupported lockfile):
 
 ${bullets}
-Resolve by hand: merge \`${BASE_REF}\` locally and re-run the tool that owns each file (e.g. \`pnpm install --lockfile-only\` / \`uv lock\` after merging the manifests), then push the merge commit." || echo "[auto-resolve] failed to post handoff comment on PR #${PR}" >&2
+Resolve by hand: merge \`${BASE_REF}\` locally and re-run the tool that owns each file (or re-export the asset), then push the merge commit. This PR is now labeled \`auto-resolve-blocked\` and auto-resolve will skip it — remove the label to re-enable." || echo "[auto-resolve] failed to post handoff comment on PR #${PR}" >&2
 
-echo "::error::unmergeable conflict(s) with ${BASE_REF}: ${UNRESOLVABLE} — a lockfile/binary conflict has no textual resolution; a human must relock/re-export and push the merge."
+echo "::error::unmergeable conflict(s) with ${BASE_REF}: ${UNRESOLVABLE} — no textual resolution and no owning tool to rerun; a human must resolve and push the merge."
 exit 1

--- a/.github/scripts/auto-resolve-handoff.test.mjs
+++ b/.github/scripts/auto-resolve-handoff.test.mjs
@@ -15,19 +15,24 @@ import { fileURLToPath } from "node:url";
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SCRIPT = join(HERE, "auto-resolve-handoff.sh");
 
-// Run handoff.sh with a fake `gh` that records every invocation. Returns the
-// error (handoff must ALWAYS exit non-zero — it exists to fail the run loud)
-// and the recorded gh argv lines.
-function runHandoff(unresolvable) {
+// Run handoff.sh with a fake `gh` that records every invocation. `failOn` makes
+// the shim exit non-zero for calls whose argv starts with that prefix, so a
+// test can exercise handoff's deliberate `|| echo` swallows. Returns the error
+// (handoff must ALWAYS exit non-zero — it exists to fail the run loud) and the
+// recorded gh argv lines.
+function runHandoff(unresolvable, { failOn } = {}) {
   const root = mkdtempSync(join(tmpdir(), "auto-resolve-handoff-"));
   const ghLog = join(root, ".gh-calls");
   writeFileSync(ghLog, "");
   const ghBin = join(root, ".fakebin");
   mkdirSync(ghBin, { recursive: true });
   const ghPath = join(ghBin, "gh");
+  const failClause = failOn
+    ? `case "$*" in "${failOn}"*) exit 9 ;; esac\n`
+    : "";
   writeFileSync(
     ghPath,
-    `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> "${ghLog}"\nexit 0\n`,
+    `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> "${ghLog}"\n${failClause}exit 0\n`,
   );
   chmodSync(ghPath, 0o755);
   let error = null;
@@ -55,7 +60,22 @@ function runHandoff(unresolvable) {
 
 test("handoff labels the PR auto-resolve-blocked, comments once, and fails the run", () => {
   const { error, ghCalls, ghRaw } = runHandoff("assets/logo.bin");
-  assert.notEqual(error, null); // the run must fail loud
+  // Exit 1 specifically, with the ::error:: annotation — `notEqual(error, null)`
+  // alone would also pass if the script died of a syntax error or a missing env
+  // var, which is the opposite of proving it refused deliberately.
+  assert.equal(error.status, 1);
+  // The `::error::` workflow annotation rides stdout, which is where GitHub
+  // Actions reads command annotations from.
+  assert.match(String(error.stdout), /::error::unmergeable conflict/);
+  // The label must be CREATED as well as applied: `gh pr edit --add-label`
+  // fails on a label the repo doesn't have yet.
+  assert.ok(
+    ghCalls.some(
+      (c) =>
+        c.startsWith("label create auto-resolve-blocked") &&
+        c.includes("--force"),
+    ),
+  );
   // Labeled so discover skips this PR until a human removes the label — a base
   // push cannot change an unmergeable conflict, so retrying only re-spends.
   assert.ok(
@@ -71,7 +91,20 @@ test("handoff labels the PR auto-resolve-blocked, comments once, and fails the r
 
 test("handoff bullets every unresolvable path", () => {
   const { error, ghRaw } = runHandoff("a.bin b.bin");
-  assert.notEqual(error, null);
+  assert.equal(error.status, 1);
   assert.ok(ghRaw.includes("- `a.bin`"));
   assert.ok(ghRaw.includes("- `b.bin`"));
+});
+
+test("a failing `gh label create` still leaves the human-handoff comment posted", () => {
+  // The `|| echo` after label create is a deliberate swallow: labeling is an
+  // optimization (it stops future re-spends), while the comment is the actual
+  // handoff. Losing the label must not take the comment — or the loud exit —
+  // down with it.
+  const { error, ghCalls, ghRaw } = runHandoff("assets/logo.bin", {
+    failOn: "label create",
+  });
+  assert.equal(error.status, 1);
+  assert.equal(ghCalls.filter((c) => c.startsWith("pr comment")).length, 1);
+  assert.ok(ghRaw.includes("assets/logo.bin"));
 });

--- a/.github/scripts/auto-resolve-handoff.test.mjs
+++ b/.github/scripts/auto-resolve-handoff.test.mjs
@@ -1,0 +1,77 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  mkdirSync,
+  chmodSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(HERE, "auto-resolve-handoff.sh");
+
+// Run handoff.sh with a fake `gh` that records every invocation. Returns the
+// error (handoff must ALWAYS exit non-zero — it exists to fail the run loud)
+// and the recorded gh argv lines.
+function runHandoff(unresolvable) {
+  const root = mkdtempSync(join(tmpdir(), "auto-resolve-handoff-"));
+  const ghLog = join(root, ".gh-calls");
+  writeFileSync(ghLog, "");
+  const ghBin = join(root, ".fakebin");
+  mkdirSync(ghBin, { recursive: true });
+  const ghPath = join(ghBin, "gh");
+  writeFileSync(
+    ghPath,
+    `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> "${ghLog}"\nexit 0\n`,
+  );
+  chmodSync(ghPath, 0o755);
+  let error = null;
+  try {
+    execFileSync("bash", [SCRIPT], {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PR: "7",
+        BASE_REF: "main",
+        UNRESOLVABLE: unresolvable,
+        PATH: `${ghBin}:${process.env.PATH ?? ""}`,
+      },
+    });
+  } catch (err) {
+    error = err;
+  }
+  // The comment body is multi-line, so per-line splitting would scatter it:
+  // expose the raw log for content assertions alongside the split lines.
+  const ghRaw = readFileSync(ghLog, "utf8");
+  const ghCalls = ghRaw.split("\n").filter(Boolean);
+  return { error, ghCalls, ghRaw };
+}
+
+test("handoff labels the PR auto-resolve-blocked, comments once, and fails the run", () => {
+  const { error, ghCalls, ghRaw } = runHandoff("assets/logo.bin");
+  assert.notEqual(error, null); // the run must fail loud
+  // Labeled so discover skips this PR until a human removes the label — a base
+  // push cannot change an unmergeable conflict, so retrying only re-spends.
+  assert.ok(
+    ghCalls.some(
+      (c) => c.startsWith("pr edit 7") && c.includes("auto-resolve-blocked"),
+    ),
+  );
+  const comments = ghCalls.filter((c) => c.startsWith("pr comment"));
+  assert.equal(comments.length, 1);
+  assert.ok(ghRaw.includes("assets/logo.bin"));
+  assert.ok(ghRaw.includes("remove the label to re-enable"));
+});
+
+test("handoff bullets every unresolvable path", () => {
+  const { error, ghRaw } = runHandoff("a.bin b.bin");
+  assert.notEqual(error, null);
+  assert.ok(ghRaw.includes("- `a.bin`"));
+  assert.ok(ghRaw.includes("- `b.bin`"));
+});

--- a/.github/scripts/auto-resolve-lib.sh
+++ b/.github/scripts/auto-resolve-lib.sh
@@ -11,6 +11,36 @@ is_unmergeable() {
     [[ "$(git diff --numstat HEAD MERGE_HEAD -- "$1" | cut -f1)" == "-" ]]
 }
 
+# Lockfiles auto-resolve regenerates deterministically instead of hand-merging:
+# maps a conflicted path to the tool that owns it (for a `command -v`
+# availability gate). Prints nothing for a path no known tool owns. Extend
+# together with regen_lockfile below — the two case tables must stay in sync.
+lockfile_tool() {
+  case "${1##*/}" in
+    pnpm-lock.yaml) echo pnpm ;;
+    package-lock.json) echo npm ;;
+    uv.lock) echo uv ;;
+  esac
+}
+
+# Regenerate one conflicted lockfile by re-running its owning tool against the
+# manifests in its directory — the exact by-hand fix, automated. Call mid-merge,
+# AFTER every manifest is resolved/staged, and after checking the lockfile out
+# at "ours" so the tool never parses conflict markers.
+# --no-frozen-lockfile: pnpm defaults to a frozen lockfile under CI=true, which
+# would refuse the very update this exists to make. --ignore-scripts: resolving
+# dependencies must never execute package lifecycle code in this job.
+regen_lockfile() {
+  local dir
+  dir="$(dirname "$1")"
+  case "${1##*/}" in
+    pnpm-lock.yaml) (cd "$dir" && pnpm install --lockfile-only --no-frozen-lockfile --ignore-scripts) ;;
+    package-lock.json) (cd "$dir" && npm install --package-lock-only --ignore-scripts) ;;
+    uv.lock) (cd "$dir" && uv lock) ;;
+    *) return 1 ;;
+  esac
+}
+
 # True when this repo defines a `resolve-generated` npm script — an OPTIONAL
 # deterministic pre-pass that regenerates/stages fully-generated conflicted
 # files so the LLM only ever sees genuine source conflicts. Most repos have no

--- a/.github/scripts/auto-resolve-lib.sh
+++ b/.github/scripts/auto-resolve-lib.sh
@@ -17,9 +17,9 @@ is_unmergeable() {
 # together with regen_lockfile below — the two case tables must stay in sync.
 lockfile_tool() {
   case "${1##*/}" in
-    pnpm-lock.yaml) echo pnpm ;;
-    package-lock.json) echo npm ;;
-    uv.lock) echo uv ;;
+  pnpm-lock.yaml) echo pnpm ;;
+  package-lock.json) echo npm ;;
+  uv.lock) echo uv ;;
   esac
 }
 
@@ -34,10 +34,10 @@ regen_lockfile() {
   local dir
   dir="$(dirname "$1")"
   case "${1##*/}" in
-    pnpm-lock.yaml) (cd "$dir" && pnpm install --lockfile-only --no-frozen-lockfile --ignore-scripts) ;;
-    package-lock.json) (cd "$dir" && npm install --package-lock-only --ignore-scripts) ;;
-    uv.lock) (cd "$dir" && uv lock) ;;
-    *) return 1 ;;
+  pnpm-lock.yaml) (cd "$dir" && pnpm install --lockfile-only --no-frozen-lockfile --ignore-scripts) ;;
+  package-lock.json) (cd "$dir" && npm install --package-lock-only --ignore-scripts) ;;
+  uv.lock) (cd "$dir" && uv lock) ;;
+  *) return 1 ;;
   esac
 }
 

--- a/.github/scripts/auto-resolve-lib.sh
+++ b/.github/scripts/auto-resolve-lib.sh
@@ -12,31 +12,56 @@ is_unmergeable() {
 }
 
 # Lockfiles auto-resolve regenerates deterministically instead of hand-merging:
-# maps a conflicted path to the tool that owns it (for a `command -v`
-# availability gate). Prints nothing for a path no known tool owns. Extend
-# together with regen_lockfile below — the two case tables must stay in sync.
+# maps a conflicted path to the tool that owns it (the caller gates on
+# `command -v "$tool"`). This is the SINGLE source of truth for which paths are
+# claimed — regen_lockfile below dispatches on what this returns, so there is no
+# second table to keep in sync.
+#
+# A path is claimed only when the manifest its tool needs sits beside it: a
+# committed fixture named `package-lock.json` with no adjacent `package.json`
+# is NOT a lockfile, and claiming it would be silent corruption rather than a
+# loud failure (`npm install --package-lock-only` in a manifest-less directory
+# succeeds and writes an empty-dependency lockfile over the fixture). Anything
+# unclaimed falls through to the LLM/unresolvable classification unchanged.
+# Always returns 0 — a non-zero return would abort the caller's `set -e` script
+# through the command substitution it is read with.
 lockfile_tool() {
+  local dir
+  dir="$(dirname "$1")"
   case "${1##*/}" in
-  pnpm-lock.yaml) echo pnpm ;;
-  package-lock.json) echo npm ;;
-  uv.lock) echo uv ;;
+  pnpm-lock.yaml) [[ -f "$dir/package.json" ]] && echo pnpm ;;
+  package-lock.json) [[ -f "$dir/package.json" ]] && echo npm ;;
+  uv.lock) [[ -f "$dir/pyproject.toml" ]] && echo uv ;;
   esac
+  return 0
+}
+
+# Run a dependency-resolution tool with every push/API credential stripped from
+# its environment. These tools execute PR-authored code by design: `uv lock`
+# invokes PEP 517 build backends for dynamic metadata, and npm/pnpm lifecycle
+# scripts are suppressed only by the `--ignore-scripts` flags below. The job
+# holds a workflow-scoped org PAT, so the subprocess must not be able to read
+# it — a same-repo PR author is trusted to propose a merge, not to hold the
+# org's push credentials. GIT_CONFIG_VALUE_0 embeds a token in an HTTP
+# extraheader, so it is stripped too.
+run_untrusted() {
+  env -u TEMPLATE_SYNC_TOKEN_ORG -u GITHUB_TOKEN -u GH_TOKEN -u GIT_CONFIG_VALUE_0 "$@"
 }
 
 # Regenerate one conflicted lockfile by re-running its owning tool against the
 # manifests in its directory — the exact by-hand fix, automated. Call mid-merge,
 # AFTER every manifest is resolved/staged, and after checking the lockfile out
-# at "ours" so the tool never parses conflict markers.
+# at a single side so the tool never parses conflict markers.
 # --no-frozen-lockfile: pnpm defaults to a frozen lockfile under CI=true, which
-# would refuse the very update this exists to make. --ignore-scripts: resolving
-# dependencies must never execute package lifecycle code in this job.
+# would refuse the very update this exists to make.
 regen_lockfile() {
-  local dir
+  local dir tool
   dir="$(dirname "$1")"
-  case "${1##*/}" in
-  pnpm-lock.yaml) (cd "$dir" && pnpm install --lockfile-only --no-frozen-lockfile --ignore-scripts) ;;
-  package-lock.json) (cd "$dir" && npm install --package-lock-only --ignore-scripts) ;;
-  uv.lock) (cd "$dir" && uv lock) ;;
+  tool="$(lockfile_tool "$1")"
+  case "$tool" in
+  pnpm) (cd "$dir" && run_untrusted pnpm install --lockfile-only --no-frozen-lockfile --ignore-scripts) ;;
+  npm) (cd "$dir" && run_untrusted npm install --package-lock-only --ignore-scripts) ;;
+  uv) (cd "$dir" && run_untrusted uv lock) ;;
   *) return 1 ;;
   esac
 }

--- a/.github/scripts/auto-resolve-prepare.sh
+++ b/.github/scripts/auto-resolve-prepare.sh
@@ -11,11 +11,15 @@
 #                       FINALIZE regenerates them after the LLM resolves the
 #                       sources — the LLM never sees a generated artifact
 #                       (always empty in a repo with no resolve-generated script)
-#   unresolvable=...    `-merge`-attributed (lockfile) or binary conflicts not
-#                       owned by a generator: git leaves NO text markers and the
-#                       working tree at "ours", so neither an LLM edit nor a
-#                       regen can produce a correct resolution — the workflow
-#                       hands off to a human BEFORE any LLM cost
+#   deferred_lock=...   conflicted lockfiles a known, available tool owns
+#                       (pnpm-lock.yaml, package-lock.json, uv.lock); FINALIZE
+#                       re-runs the owning tool against the resolved manifests —
+#                       a lockfile is never hand-merged, by an LLM or otherwise
+#   unresolvable=...    binary or `-merge`-attributed conflicts with no owning
+#                       tool (or whose tool is absent from PATH): git leaves NO
+#                       text markers and the working tree at "ours", so neither
+#                       an LLM edit nor a regen can produce a correct resolution
+#                       — the workflow hands off to a human BEFORE any LLM cost
 #   needs_llm=true      conflict_list is non-empty
 #   needs_commit=true   there is a resolution (deterministic and/or LLM) to commit
 #   protected_paths=... conflicted paths in PROTECTED areas
@@ -105,16 +109,24 @@ fi
 
 # Partition. An owned conflict means its source ALSO conflicted (the pre-pass
 # already resolved the clean-source ones) — finalize regenerates it after the
-# LLM resolves the source. A `-merge`-attributed or binary conflict has no
-# markers to resolve and no generator to rerun: only a human (relocking,
-# re-exporting the asset) can produce the right content.
+# LLM resolves the source. A lockfile with a known, available owning tool is
+# deferred the same way: finalize re-runs the tool against the resolved
+# manifests (never hand-merged — marker-edited lockfile content can't be
+# trusted, and a `-merge`-attributed one has no markers at all). What remains
+# unmergeable — a binary, or a lockfile whose tool is missing — has no
+# resolution this job can produce: only a human (relocking, re-exporting the
+# asset) can supply the right content.
 llm_list=()
 deferred_regen=()
+deferred_lock=()
 unresolvable=()
 for f in "${conflicts[@]}"; do
+  tool="$(lockfile_tool "$f")"
   if [[ -n "${owned["$f"]:-}" ]]; then
     deferred_regen+=("$f")
-  elif is_unmergeable "$f"; then
+  elif [[ -n "$tool" ]] && command -v "$tool" >/dev/null 2>&1; then
+    deferred_lock+=("$f")
+  elif [[ -n "$tool" ]] || is_unmergeable "$f"; then
     unresolvable+=("$f")
   else
     llm_list+=("$f")
@@ -151,10 +163,14 @@ echo "Handing ${#llm_list[@]} source conflict(s) to Claude: ${llm_list[*]:-<none
 if [[ ${#deferred_regen[@]} -gt 0 ]]; then
   echo "Deferring ${#deferred_regen[@]} generated file(s) to post-LLM regeneration: ${deferred_regen[*]}"
 fi
+if [[ ${#deferred_lock[@]} -gt 0 ]]; then
+  echo "Deferring ${#deferred_lock[@]} lockfile(s) to owning-tool regeneration: ${deferred_lock[*]}"
+fi
 {
   echo "needs_llm=${needs_llm}"
   echo "needs_commit=true"
   echo "conflict_list=${llm_list[*]:-}"
   echo "deferred_regen=${deferred_regen[*]:-}"
+  echo "deferred_lock=${deferred_lock[*]:-}"
   echo "protected_paths=${protected_hits[*]:-}"
 } >>"$out"

--- a/.github/scripts/auto-resolve-prepare.test.mjs
+++ b/.github/scripts/auto-resolve-prepare.test.mjs
@@ -66,7 +66,7 @@ function fixtureConflictingOn(files, baseExtras = {}) {
 // protected path is finalize's job, via the `protected_paths` output). Returns
 // the parsed $GITHUB_OUTPUT, whether a merge is still in progress (MERGE_HEAD
 // present), and the recorded gh argv lines.
-function runPrepare(work) {
+function runPrepare(work, { path, shims = {} } = {}) {
   const outFile = join(work, ".gh-output");
   writeFileSync(outFile, "");
   const ghLog = join(work, ".gh-calls");
@@ -79,6 +79,14 @@ function runPrepare(work) {
     `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> "${ghLog}"\nexit 0\n`,
   );
   chmodSync(ghPath, 0o755);
+  // Stub the lockfile tools rather than relying on the host's toolchain:
+  // prepare only probes them with `command -v`, so a stub is enough, and it
+  // keeps classification tests hermetic on a runner where (say) uv is absent.
+  for (const [name, body] of Object.entries(shims)) {
+    const p = join(ghBin, name);
+    writeFileSync(p, `#!/usr/bin/env bash\n${body}\n`);
+    chmodSync(p, 0o755);
+  }
   let error = null;
   try {
     execFileSync("bash", [SCRIPT], {
@@ -90,7 +98,7 @@ function runPrepare(work) {
         HEAD_REF: "feature",
         GITHUB_TOKEN: "x",
         GITHUB_OUTPUT: outFile,
-        PATH: `${ghBin}:${process.env.PATH ?? ""}`,
+        PATH: `${ghBin}:${path ?? process.env.PATH ?? ""}`,
       },
     });
   } catch (err) {
@@ -176,18 +184,94 @@ test("each protected prefix is reported and handed to the LLM, member by member"
   }
 });
 
-test("a conflicted lockfile is deferred to owning-tool regeneration, never the LLM", () => {
-  // pnpm is a hard dependency of this repo's toolchain, so `command -v pnpm`
-  // holds wherever this suite runs — the lockfile must classify as
-  // deferred_lock, with no LLM pass and no human handoff.
-  const work = fixtureConflictingOn("pnpm-lock.yaml");
-  const { outputs, merging, commented } = runPrepare(work);
-  assert.equal(outputs.needs_llm, "false");
-  assert.equal(outputs.needs_commit, "true");
+// Every lockfile in lib.sh's `lockfile_tool` table, with the manifest its tool
+// requires beside it. All three tools are present in this repo's toolchain, so
+// `command -v` holds wherever this suite runs. Kept in lockstep with the case
+// table: a lockfile added there without a case here classifies untested.
+const LOCKFILES = [
+  {
+    lock: "pnpm-lock.yaml",
+    tool: "pnpm",
+    manifest: "package.json",
+    manifestBody: "{}\n",
+  },
+  {
+    lock: "package-lock.json",
+    tool: "npm",
+    manifest: "package.json",
+    manifestBody: "{}\n",
+  },
+  {
+    lock: "uv.lock",
+    tool: "uv",
+    manifest: "pyproject.toml",
+    manifestBody: "[project]\nname = 'x'\n",
+  },
+];
+
+for (const { lock, tool, manifest, manifestBody } of LOCKFILES) {
+  test(`a conflicted ${lock} is deferred to owning-tool regeneration, never the LLM`, () => {
+    const work = fixtureConflictingOn(lock, { [manifest]: manifestBody });
+    const { outputs, merging, commented } = runPrepare(work, {
+      shims: { [tool]: "exit 0" },
+    });
+    assert.equal(outputs.needs_llm, "false");
+    assert.equal(outputs.needs_commit, "true");
+    assert.equal(outputs.conflict_list, "");
+    assert.equal(outputs.deferred_lock, lock);
+    assert.equal(outputs.unresolvable, undefined);
+    assert.equal(merging, true); // merge kept mid-flight for finalize's regen
+    assert.equal(commented, false);
+  });
+}
+
+test("a lockfile in a SUBDIRECTORY is claimed via its own sibling manifest", () => {
+  const work = fixtureConflictingOn("sub/pnpm-lock.yaml", {
+    "sub/package.json": "{}\n",
+  });
+  const { outputs } = runPrepare(work, { shims: { pnpm: "exit 0" } });
+  assert.equal(outputs.deferred_lock, "sub/pnpm-lock.yaml");
   assert.equal(outputs.conflict_list, "");
-  assert.equal(outputs.deferred_lock, "pnpm-lock.yaml");
+});
+
+test("a lockfile-NAMED file with no sibling manifest is NOT claimed — it goes to the LLM", () => {
+  // Precision over recall: a committed fixture named package-lock.json is not a
+  // lockfile. Claiming it would be SILENT corruption — `npm install
+  // --package-lock-only` in a manifest-less directory succeeds and writes an
+  // empty-dependency lockfile over the fixture while the run stays green.
+  const work = fixtureConflictingOn("test/fixtures/package-lock.json");
+  const { outputs, merging } = runPrepare(work, { shims: { npm: "exit 0" } });
+  assert.equal(outputs.deferred_lock, "");
+  assert.equal(outputs.conflict_list, "test/fixtures/package-lock.json");
   assert.equal(outputs.unresolvable, undefined);
-  assert.equal(merging, true); // merge kept mid-flight for finalize's regen
+  assert.equal(merging, true);
+});
+
+test("a lockfile whose owning tool is ABSENT from PATH is unresolvable, not sent to the LLM", () => {
+  // The `command -v` gate's other branch: with no tool to rerun, an edit-based
+  // "resolution" can never be verified, so it must hand off to a human rather
+  // than fall through to the LLM.
+  const work = fixtureConflictingOn("pnpm-lock.yaml", {
+    "package.json": "{}\n",
+  });
+  // No pnpm shim, and every real pnpm stripped from PATH.
+  const pnpmDirs = new Set(
+    execFileSync("bash", ["-c", "command -v pnpm || true"], {
+      encoding: "utf8",
+    })
+      .split("\n")
+      .filter(Boolean)
+      .map((p) => dirname(p)),
+  );
+  const path = (process.env.PATH ?? "")
+    .split(":")
+    .filter((d) => d && !pnpmDirs.has(d))
+    .join(":");
+  const { outputs, commented } = runPrepare(work, { path });
+  assert.equal(outputs.needs_llm, "false");
+  assert.equal(outputs.needs_commit, "false");
+  assert.equal(outputs.unresolvable, "pnpm-lock.yaml");
+  assert.equal(outputs.conflict_list, undefined);
   assert.equal(commented, false);
 });
 

--- a/.github/scripts/auto-resolve-prepare.test.mjs
+++ b/.github/scripts/auto-resolve-prepare.test.mjs
@@ -19,10 +19,13 @@ const scratch = () => mkdtempSync(join(tmpdir(), "auto-resolve-"));
 const git = (cwd, ...args) =>
   execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
 
-// Build an origin repo whose `main` and `feature` branches both edit `file`, so
-// merging main into feature conflicts on exactly that path. Returns a `work`
-// clone checked out on feature (with `origin` pointing at the bare repo).
-function fixtureConflictingOn(file) {
+// Build an origin repo whose `main` and `feature` branches both edit every path
+// in `files` (a string or array), so merging main into feature conflicts on
+// exactly those paths. `baseExtras` maps extra path → content committed on the
+// base only (e.g. a .gitattributes marking a path unmergeable). Returns a
+// `work` clone checked out on feature (with `origin` pointing at the bare repo).
+function fixtureConflictingOn(files, baseExtras = {}) {
+  files = Array.isArray(files) ? files : [files];
   const root = scratch();
   const origin = join(root, "origin.git");
   const work = join(root, "work");
@@ -31,20 +34,26 @@ function fixtureConflictingOn(file) {
   git(work, "config", "user.email", "t@t");
   git(work, "config", "user.name", "t");
 
-  mkdirSync(dirname(join(work, file)), { recursive: true });
-  writeFileSync(join(work, file), "base\n");
+  for (const [p, content] of Object.entries(baseExtras)) {
+    mkdirSync(dirname(join(work, p)), { recursive: true });
+    writeFileSync(join(work, p), content);
+  }
+  for (const file of files) {
+    mkdirSync(dirname(join(work, file)), { recursive: true });
+    writeFileSync(join(work, file), "base\n");
+  }
   git(work, "add", "-A");
   git(work, "commit", "-q", "-m", "base");
   git(work, "branch", "-M", "main");
   git(work, "push", "-q", "origin", "main");
 
   git(work, "checkout", "-q", "-b", "feature");
-  writeFileSync(join(work, file), "feature side\n");
+  for (const file of files) writeFileSync(join(work, file), "feature side\n");
   git(work, "commit", "-q", "-am", "feature");
   git(work, "push", "-q", "origin", "feature");
 
   git(work, "checkout", "-q", "main");
-  writeFileSync(join(work, file), "main side\n");
+  for (const file of files) writeFileSync(join(work, file), "main side\n");
   git(work, "commit", "-q", "-am", "main change");
   git(work, "push", "-q", "origin", "main");
 
@@ -165,6 +174,44 @@ test("each protected prefix is reported and handed to the LLM, member by member"
     );
     assert.equal(commented, false, `${path} must not comment from prepare`);
   }
+});
+
+test("a conflicted lockfile is deferred to owning-tool regeneration, never the LLM", () => {
+  // pnpm is a hard dependency of this repo's toolchain, so `command -v pnpm`
+  // holds wherever this suite runs — the lockfile must classify as
+  // deferred_lock, with no LLM pass and no human handoff.
+  const work = fixtureConflictingOn("pnpm-lock.yaml");
+  const { outputs, merging, commented } = runPrepare(work);
+  assert.equal(outputs.needs_llm, "false");
+  assert.equal(outputs.needs_commit, "true");
+  assert.equal(outputs.conflict_list, "");
+  assert.equal(outputs.deferred_lock, "pnpm-lock.yaml");
+  assert.equal(outputs.unresolvable, undefined);
+  assert.equal(merging, true); // merge kept mid-flight for finalize's regen
+  assert.equal(commented, false);
+});
+
+test("a manifest+lockfile conflict splits: manifest to the LLM, lockfile to regen", () => {
+  const work = fixtureConflictingOn(["package.json", "pnpm-lock.yaml"]);
+  const { outputs, merging } = runPrepare(work);
+  assert.equal(outputs.needs_llm, "true");
+  assert.equal(outputs.needs_commit, "true");
+  assert.equal(outputs.conflict_list, "package.json");
+  assert.equal(outputs.deferred_lock, "pnpm-lock.yaml");
+  assert.equal(outputs.unresolvable, undefined);
+  assert.equal(merging, true);
+});
+
+test("a `-merge`-attributed conflict with no owning tool is handed off as unresolvable", () => {
+  const work = fixtureConflictingOn("assets/logo.bin", {
+    ".gitattributes": "*.bin -merge\n",
+  });
+  const { outputs, commented } = runPrepare(work);
+  assert.equal(outputs.needs_llm, "false");
+  assert.equal(outputs.needs_commit, "false");
+  assert.equal(outputs.unresolvable, "assets/logo.bin");
+  // Prepare never talks to GitHub — the handoff comment is the HANDOFF step's.
+  assert.equal(commented, false);
 });
 
 test("a clean merge (no conflict) is a no-op", () => {

--- a/.github/scripts/auto-resolve-prepare.test.mjs
+++ b/.github/scripts/auto-resolve-prepare.test.mjs
@@ -1,12 +1,13 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import {
   mkdtempSync,
   writeFileSync,
   readFileSync,
   mkdirSync,
   chmodSync,
+  existsSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
@@ -254,19 +255,28 @@ test("a lockfile whose owning tool is ABSENT from PATH is unresolvable, not sent
   const work = fixtureConflictingOn("pnpm-lock.yaml", {
     "package.json": "{}\n",
   });
-  // No pnpm shim, and every real pnpm stripped from PATH.
-  const pnpmDirs = new Set(
-    execFileSync("bash", ["-c", "command -v pnpm || true"], {
-      encoding: "utf8",
-    })
-      .split("\n")
-      .filter(Boolean)
-      .map((p) => dirname(p)),
-  );
+  // No pnpm shim, and EVERY directory holding a pnpm dropped from PATH —
+  // `command -v` names only the first match, so filtering by its answer alone
+  // leaves a second pnpm reachable on runners that install more than one.
   const path = (process.env.PATH ?? "")
     .split(":")
-    .filter((d) => d && !pnpmDirs.has(d))
+    .filter((d) => d && !existsSync(join(d, "pnpm")))
     .join(":");
+  // Prove the premise instead of assuming it: this test is about the
+  // tool-absent branch, so a PATH that still resolves pnpm silently tests the
+  // deferred-lock branch and passes for the wrong reason. Assert prepare's own
+  // helpers survived the surgery too — losing `dirname` would make
+  // lockfile_tool decline the path and route it to the LLM, a third wrong
+  // branch that also looks like a pass on the first assertion.
+  const reachable = (bin) =>
+    spawnSync("bash", ["-c", `command -v ${bin}`], {
+      env: { ...process.env, PATH: path },
+      encoding: "utf8",
+    }).status === 0;
+  assert.equal(reachable("pnpm"), false, "premise: pnpm must be unreachable");
+  for (const bin of ["git", "dirname"]) {
+    assert.equal(reachable(bin), true, `premise: ${bin} must stay reachable`);
+  }
   const { outputs, commented } = runPrepare(work, { path });
   assert.equal(outputs.needs_llm, "false");
   assert.equal(outputs.needs_commit, "false");

--- a/.github/workflows/auto-resolve-conflicts.yaml
+++ b/.github/workflows/auto-resolve-conflicts.yaml
@@ -9,8 +9,9 @@
 # hand-merged; a conflict with no textual resolution AND no owning tool (a binary,
 # an unsupported lockfile) fails the run with a PR comment BEFORE any LLM cost and
 # labels the PR `auto-resolve-blocked` so base pushes don't retry into the same
-# refusal. Safety
-# rails: same-repo PRs only (a fork's token is read-only and its author is
+# refusal.
+#
+# Safety rails: same-repo PRs only (a fork's token is read-only and its author is
 # untrusted), non-bot / non-draft authors, conflicts in protected paths (this
 # repo's Claude config and CI machinery) are still resolved by the LLM but flagged
 # for human review in the pushed-resolution comment, and the resolved head is

--- a/.github/workflows/auto-resolve-conflicts.yaml
+++ b/.github/workflows/auto-resolve-conflicts.yaml
@@ -3,8 +3,13 @@
 # repo defines that script) plus an LLM pass over the remaining SOURCE conflicts,
 # pushed back as a normal merge commit. Generated files whose sources also
 # conflicted are excluded from the LLM prompt and regenerated in finalize once the
-# sources are resolved; a conflict with no textual resolution (a `-merge`-attributed
-# lockfile, a binary) fails the run with a PR comment BEFORE any LLM cost. Safety
+# sources are resolved; a conflicted lockfile with a known owning tool
+# (pnpm-lock.yaml, package-lock.json, uv.lock) is regenerated deterministically in
+# finalize by re-running that tool against the resolved manifests — never
+# hand-merged; a conflict with no textual resolution AND no owning tool (a binary,
+# an unsupported lockfile) fails the run with a PR comment BEFORE any LLM cost and
+# labels the PR `auto-resolve-blocked` so base pushes don't retry into the same
+# refusal. Safety
 # rails: same-repo PRs only (a fork's token is read-only and its author is
 # untrusted), non-bot / non-draft authors, conflicts in protected paths (this
 # repo's Claude config and CI machinery) are still resolved by the LLM but flagged
@@ -215,9 +220,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash "${{ steps.resolver.outputs.dir }}/auto-resolve-prepare.sh" # zizmor: ignore[template-injection] — dir is ${RUNNER_TEMP}/resolver, set by the trusted resolver step from the base ref; not attacker-controllable
 
-      - name: Hand off unmergeable (lockfile/binary) conflicts to a human
-        # Fails the run loud BEFORE any LLM cost: a `-merge`-attributed or
-        # binary conflict has no textual resolution an LLM could produce.
+      - name: Hand off unmergeable (binary/unsupported-lockfile) conflicts to a human
+        # Fails the run loud BEFORE any LLM cost: a binary (or a lockfile with
+        # no known/available owning tool) has no resolution this job can
+        # produce. Known lockfiles never land here — prepare defers them to
+        # owning-tool regeneration in finalize.
         if: steps.prepare.outputs.unresolvable != ''
         env:
           UNRESOLVABLE: ${{ steps.prepare.outputs.unresolvable }}
@@ -286,6 +293,9 @@ jobs:
           TEMPLATE_SYNC_TOKEN_ORG: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG }}
           CONFLICT_LIST: ${{ steps.prepare.outputs.conflict_list }}
           DEFERRED_REGEN: ${{ steps.prepare.outputs.deferred_regen }}
+          # Conflicted lockfiles finalize regenerates by re-running their owning
+          # tool (pnpm/npm/uv) against the resolved manifests.
+          DEFERRED_LOCK: ${{ steps.prepare.outputs.deferred_lock }}
           PROTECTED_PATHS: ${{ steps.prepare.outputs.protected_paths }}
           # Empty when the LLM step was skipped (deterministic-only resolution);
           # finalize defaults it to 0. Non-zero + leftover markers ⇒ the resolver

--- a/.github/workflows/node-tests.yaml
+++ b/.github/workflows/node-tests.yaml
@@ -41,6 +41,15 @@ jobs:
         if: steps.check.outputs.configured == 'true'
         run: pnpm test
 
+      # `node --test`'s default discovery skips dot-directories, so nothing
+      # under .github/scripts runs via `pnpm test`. Run the auto-resolve suites
+      # explicitly: they gate a workflow that pushes merge commits to PR
+      # branches with a workflow-scoped PAT, so they must not be decorative.
+      # Scoped to auto-resolve-* rather than the whole directory — the other
+      # suites there have unmet dependencies and would fail this required check.
+      - name: Run auto-resolve workflow-script tests
+        run: node --test .github/scripts/auto-resolve-*.test.mjs
+
   # Stable Required check: runs even when `test` is cancelled/skipped, so a
   # protected branch never gets stuck on a check that never reports.
   node-tests-passed: # required-check: true


### PR DESCRIPTION
Claimed area: `.github/scripts/auto-resolve-*` + `.github/workflows/auto-resolve-conflicts.yaml`.

## What & why
Teach auto-resolve to resolve lockfile conflicts deterministically instead of refusing them. Prepare classifies a conflicted lockfile with a known owning tool (`pnpm-lock.yaml`, `package-lock.json`, `uv.lock`) into a new `deferred_lock` set, and finalize resolves each one by seeding it from the base side and re-running the owning tool against the by-then-resolved manifests — the exact fix the old handoff comment told a human to perform. A lockfile is never hand-merged, by the LLM or otherwise; a regen failure aborts loud with a PR comment rather than committing a guessed lockfile. A lockfile-only conflict now costs no LLM call at all.

The human handoff now fires only for binaries and lockfiles with no available owning tool, and it labels the PR `auto-resolve-blocked` (which discover already excludes), so base-branch pushes stop re-running — and re-commenting — into the same refusal.

## Review focus
Read `.github/scripts/auto-resolve-lib.sh` first (`lockfile_tool` is the single source of truth for what gets claimed, and gates `regen_lockfile`'s dispatch), then the deferred-lock stage at `auto-resolve-finalize.sh:136-144`.

The cross-file invariant: every path prepare emits in `deferred_lock` must be regenerated-or-fail in finalize before the "nothing unmerged survives" check — the wire between them is the `DEFERRED_LOCK` env in `auto-resolve-conflicts.yaml`. Because `regen_lockfile` dispatches on `lockfile_tool`, a path that prepare declines to claim also cannot be regenerated, so the two ends cannot drift apart silently.

Least certain: the `--theirs` seeding decision (see below) — it is the one place where a correct-looking resolution can still lose someone's work, and which side loses it is a judgment call.

## Decisions made
- **Regeneration is seeded from `--theirs` (the base side), not `--ours`.** This started as `--ours` and review caught it. We are on the PR head merging `origin/BASE`, so `--ours` is the PR's own lockfile — and every one of these tools *preserves* the on-disk resolutions that still satisfy the manifests. When the base's lockfile delta is manifest-invisible (a `pnpm dedupe`, a transitive security bump, a `uv lock --upgrade`), seeding from the PR's lockfile regenerates it byte-identical and silently reverts main's work under an "auto-resolved" comment — precisely the wrong-"ours" resolution this script exists to prevent. Seeding from base loses only the PR's own manifest-invisible churn, which its author sees missing on the next CI run. A lockfile conflict with no base-side stage (base deleted it) fails the checkout and escalates rather than guessing.
- **The regen tools run with `TEMPLATE_SYNC_TOKEN_ORG`/`GITHUB_TOKEN`/`GH_TOKEN`/`GIT_CONFIG_VALUE_0` stripped** (`run_untrusted`). `uv lock` invokes PEP 517 build backends for dynamic metadata and npm/pnpm lifecycle code is suppressed only by `--ignore-scripts`, so these tools execute PR-authored code in a job holding a workflow-scoped org PAT. Forks are already excluded, so this needs a collaborator — but "can open a PR" should not reach "holds the org's push credentials."
- **A lockfile is claimed only when the manifest its tool needs sits beside it.** Matching on basename alone would claim a committed fixture named `package-lock.json`; `npm install --package-lock-only` in a manifest-less directory *succeeds* and writes an empty-dependency lockfile over it, so that failure mode is silent corruption rather than a loud error. Unclaimed paths fall through to the existing LLM/unresolvable classification.
- **Supported set is pnpm/npm/uv only** (precision over recall). `yarn.lock` is omitted because the regen command differs between Yarn classic and Berry and a wrong guess commits a wrong lockfile; it hands off to a human instead. Adding one is a single case arm.
- **A regen failure does *not* label `auto-resolve-blocked`**, unlike the binary handoff: a lockfile regen can fail transiently (registry hiccup) and a later base push genuinely changes the input, so retrying is worth the cost there. Nothing currently *removes* the label after a human resolves a binary conflict by hand — that stays a manual step, as it already was for the token case.
- **The push-token check moved above both regeneration stages.** Both run network-hitting tools that execute PR-authored code; doing that for a resolution that can never be pushed is wasted and needless work.
- **CI wiring is scoped to the auto-resolve suites.** `node --test`'s default discovery skips dot-directories, so *nothing* under `.github/scripts` runs via `pnpm test` — these tests were decorative, as were the pre-existing ones. `node-tests.yaml` now runs `auto-resolve-*.test.mjs` explicitly. It is deliberately not the whole directory: `npm-max-stable.mjs` imports `semver`, which is not a declared dependency, so those suites fail today and would take the required check red. That is a real pre-existing gap, reported rather than fixed here.

## How it was tested
31 tests across the four `auto-resolve-*` suites pass (`node --test`), and they are hermetic — the lockfile tools are stubbed, so classification no longer depends on the host toolchain. New coverage: all three lockfile types; a subdirectory lockfile (the only case that exercises `cd "$(dirname …)"`); a lockfile-named file with no sibling manifest (must go to the LLM, not be regenerated); a lockfile whose tool is absent from `PATH` (must be unresolvable, not sent to the LLM); and a mixed `package.json`+`pnpm-lock.yaml` split.

The finalize regen test asserts the tool's exact argv (so dropping `--ignore-scripts`, `--lockfile-only`, or `--no-frozen-lockfile` turns it red), that the seed contains the *base* side's content and no conflict markers, and that no push credential is visible in the tool's environment — each rail fails the test if removed. The handoff tests assert exit status 1 plus the `::error::` annotation rather than "some error", and cover a failing `gh label create` not taking the comment down with it.

`shellcheck` clean on all five scripts; `zizmor`'s offline audits clean on `.github/` (its online advisories audit cannot reach `api.github.com` from this sandbox; the repo's own zizmor workflow runs the full audit on this PR).

## Lessons Learned
- **What**: When an auto-merge/auto-resolve helper regenerates a lockfile, seed it from the **base** side (`git checkout --theirs`) before re-running the tool, and add a test asserting the seeded content came from base. Lockfile tools preserve on-disk resolutions that still satisfy the manifests, so seeding from the PR head silently reverts any manifest-invisible work on the base branch (dedupes, transitive security bumps) while reporting success.
- **Where**: `.github/scripts/auto-resolve-finalize.sh` and `auto-resolve-lib.sh` in the template's auto-resolve pipeline.
- **Why**: The first cut of this feature used `--ours` and would have silently reverted `main`'s dependency updates under an "auto-resolved" comment — a wrong resolution that no existing rail catches, because the tree is clean, marker-free, and fully merged.
- **What**: Route dependency-resolution tools invoked by CI through a credential-scrubbing wrapper (`env -u` the push/API tokens), not just `--ignore-scripts`.
- **Where**: any template workflow that runs `uv lock` / `npm install` / `pnpm install` in a job holding a PAT — `auto-resolve-lib.sh`'s `run_untrusted` is the pattern.
- **Why**: `--ignore-scripts` covers npm/pnpm lifecycle scripts but nothing equivalent exists for `uv lock`, which executes PEP 517 build backends from PR-authored `pyproject.toml`; the tokens were previously inherited by that subprocess.
- **What**: Don't assume `.github/scripts/*.test.mjs` run in CI — `node --test`'s default discovery skips dot-directories, so a repo whose test script is a bare `node --test` never executes them. Either pass the directory explicitly or keep such tests elsewhere.
- **Where**: `node-tests.yaml` / the `test` script in `package.json`.
- **Why**: Every auto-resolve test in this template — including the pre-existing ones guarding a workflow that pushes commits with a workflow-scoped PAT — had never run in CI.