### PR TITLE
feat(secrets): publish the credential-noun vocabulary as a shared export

### DIFF
--- a/.hooks/ssot-guard-pairs.json
+++ b/.hooks/ssot-guard-pairs.json
@@ -8,6 +8,9 @@
       "test/invisible-charset.test.mjs",
       "test/instructions.test.mjs"
     ],
-    "src/instructions.mjs": ["test/instructions.test.mjs"]
+    "src/instructions.mjs": ["test/instructions.test.mjs"],
+    "python/agent_sanitizer/secrets/data/credential-names.json": [
+      "test/credential-names-export.test.mjs"
+    ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -162,6 +162,27 @@ await rehydrateRedacted("Edit", toolInput, {
 }); // { updatedInput, context } | { deny } | null — a deny never exposes a secret
 ```
 
+The credential-noun vocabulary — the words that make an identifier name a secret —
+is published as data so a consumer with its own matcher derives it from one list
+instead of forking one. Each noun carries the `uses` it is valid for: `env-name`
+for a matcher that inspects a variable NAME only, `field-value` for one that
+redacts whatever follows `noun = ` (a broad noun there mangles ordinary text, so
+`key` and `pat` are name-only).
+
+```js
+import { createRequire } from "node:module";
+const vocabulary = createRequire(import.meta.url)(
+  "agent-sanitizer/credential-names",
+);
+vocabulary.nouns; // [{ parts: ["api", "key"], uses: ["env-name", "field-value"] }, …]
+```
+
+```python
+from agent_sanitizer.secrets import credential_name_segments
+
+credential_name_segments()  # ("API_KEY", "APIKEY", "ACCESS_KEY", …) — rendered for a NAME matcher
+```
+
 ## Limits
 
 The CLI (and the worker that backs the Python client) rejects any single request

--- a/package.json
+++ b/package.json
@@ -134,10 +134,12 @@
     "./rehydrate": {
       "types": "./types/rehydrate.d.mts",
       "default": "./src/rehydrate.mjs"
-    }
+    },
+    "./credential-names": "./python/agent_sanitizer/secrets/data/credential-names.json"
   },
   "files": [
     "src/*.mjs",
+    "python/agent_sanitizer/secrets/data/credential-names.json",
     "bin/sanitize-cli.mjs",
     "types",
     "LICENSE",

--- a/python/agent_sanitizer/secrets/__init__.py
+++ b/python/agent_sanitizer/secrets/__init__.py
@@ -16,9 +16,21 @@ Public entry points:
 * :func:`strip_invisible` — delete payload-capable invisible chars.
 * :func:`configure_plugins` / :func:`redact_configured` — configure once, redact
   many (the daemon's hot path).
+* :func:`credential_name_segments` / :func:`credential_field_name_patterns` /
+  :func:`non_secret_name_segments` — the published credential-noun vocabulary,
+  rendered for a name matcher or a ``field = value`` matcher. Exported so a
+  consumer with its own matcher (an env-var scrubber, a hook pre-gate) derives it
+  from this list instead of forking one; the same source is published to
+  JavaScript as the npm subpath export ``agent-sanitizer/credential-names``.
 """
 
 from .config import DEFAULT_MIN_SECRET_LEN, RedactorConfig
+from .credential_names import (
+    CREDENTIAL_NAMES_FILE,
+    credential_field_name_patterns,
+    credential_name_segments,
+    non_secret_name_segments,
+)
 from .engine import (
     configure_plugins,
     detected_secret_values,
@@ -37,6 +49,10 @@ from .invisible import (
 __all__ = [
     "RedactorConfig",
     "DEFAULT_MIN_SECRET_LEN",
+    "CREDENTIAL_NAMES_FILE",
+    "credential_name_segments",
+    "credential_field_name_patterns",
+    "non_secret_name_segments",
     "default_charset",
     "redact",
     "redact_map",

--- a/python/agent_sanitizer/secrets/credential_names.py
+++ b/python/agent_sanitizer/secrets/credential_names.py
@@ -1,0 +1,180 @@
+"""The published credential-noun vocabulary: the words that make a name a secret.
+
+``data/credential-names.json`` is the single source; this module validates it and
+renders it for the two matchers that need it, which are deliberately NOT unified:
+
+* an env-var **NAME** matcher inspects no value, so it wants whole-name segments
+  (``API_KEY``, ``APIKEY``) — :func:`credential_name_segments`;
+* a ``field = value`` **redaction** matcher wants regex fragments tolerant of the
+  separator the author wrote (``api[_-]?key``) — :func:`credential_field_name_patterns`,
+  which the engine's ``_FIELD_NAMES`` alternation is built from.
+
+Rendering the same nouns two ways is the point: unifying the *predicates* would
+either weaken the name scrub or flood the redactor with false positives, so only
+the vocabulary is shared. A noun the JSON marks ``env-name`` only is excluded from
+the field-value rendering for exactly that reason.
+
+A malformed spec raises rather than degrading: an empty list yields an alternation
+that matches nothing (every credential forwarded verbatim) and a part carrying a
+regex metacharacter yields one that matches everything (all output blanked), so
+neither may reach a consumer's pattern builder.
+
+The same file is published to JavaScript consumers as the npm subpath export
+``agent-sanitizer/credential-names``.
+"""
+
+import functools
+import json
+import re
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import NamedTuple
+
+CREDENTIAL_NAMES_FILE = (
+    Path(__file__).resolve().parent / "data" / "credential-names.json"
+)
+
+# a-z0-9 only is what lets a part interpolate into a consumer's pattern unescaped.
+# Matched with fullmatch, not `$`, because Python's `$` also matches just before a
+# trailing newline — `"token\n"` must be rejected here, not accepted and then
+# rejected by a JavaScript consumer applying the same rule to the same file.
+_PART_RE = re.compile(r"[a-z0-9]+")
+
+ENV_NAME_USE = "env-name"
+FIELD_VALUE_USE = "field-value"
+_USES = frozenset({ENV_NAME_USE, FIELD_VALUE_USE})
+
+_FILE_LABEL = "credential-names.json"
+
+
+class CredentialNames(NamedTuple):
+    """The renderings of a validated vocabulary spec."""
+
+    segments: tuple[str, ...]
+    field_name_patterns: tuple[str, ...]
+    non_secret_segments: tuple[str, ...]
+
+
+def _dedupe(values: Sequence[str]) -> tuple[str, ...]:
+    """``values`` with duplicates dropped, first-occurrence order preserved."""
+    return tuple(dict.fromkeys(values))
+
+
+def _segment_forms(parts: Sequence[str]) -> tuple[str, ...]:
+    """The whole-name forms of ``parts``: underscore-joined and bare-joined, upper.
+
+    Both are emitted because both spellings occur in the wild (``API_KEY`` and
+    ``APIKEY``) and a name matcher anchored on underscore-delimited segments sees
+    them as different tokens. A single-part noun collapses to one form.
+    """
+    return _dedupe(["_".join(parts).upper(), "".join(parts).upper()])
+
+
+def _parts(value: object, field: str) -> tuple[str, ...]:
+    """``value`` as a validated tuple of noun parts, or raise naming ``field``."""
+    parts = tuple(value) if isinstance(value, (list, tuple)) else ()
+    if not parts:
+        raise ValueError(f"{_FILE_LABEL}: {field} is empty or missing")
+    bad = [p for p in parts if not (isinstance(p, str) and _PART_RE.fullmatch(p))]
+    if bad:
+        raise ValueError(f"{_FILE_LABEL}: bad part(s) {bad} in {field}")
+    return parts
+
+
+def _uses(value: object, field: str) -> frozenset[str]:
+    """``value`` as a validated non-empty subset of the known uses, or raise.
+
+    An unknown use is a refusal, not a skip: silently ignoring it would drop the
+    noun from every rendering, which is how a credential noun becomes inert.
+    """
+    uses = tuple(value) if isinstance(value, (list, tuple)) else ()
+    if not uses:
+        raise ValueError(f"{_FILE_LABEL}: {field} is empty or missing")
+    unknown = sorted(set(uses) - _USES)
+    if unknown:
+        raise ValueError(f"{_FILE_LABEL}: unknown use(s) {unknown} in {field}")
+    return frozenset(uses)
+
+
+def _sequence(value: object, field: str) -> tuple[object, ...]:
+    """``value`` as a validated non-empty tuple, or raise naming ``field``."""
+    items = tuple(value) if isinstance(value, (list, tuple)) else ()
+    if not items:
+        raise ValueError(f"{_FILE_LABEL}: {field} is empty or missing")
+    return items
+
+
+def parse_credential_names(spec: Mapping[str, object]) -> CredentialNames:
+    """Validate ``spec`` and return its renderings.
+
+    Pure and public so a consumer — and the fail-closed tests — can drive the
+    validator with a substitute spec instead of only through the packaged file.
+    """
+    segments: list[str] = []
+    patterns: list[str] = []
+    for index, noun in enumerate(_sequence(spec.get("nouns"), "nouns")):
+        if not isinstance(noun, Mapping):
+            raise ValueError(f"{_FILE_LABEL}: nouns[{index}] is not an object")
+        parts = _parts(noun.get("parts"), f"nouns[{index}].parts")
+        uses = _uses(noun.get("uses"), f"nouns[{index}].uses")
+        if ENV_NAME_USE in uses:
+            segments.extend(_segment_forms(parts))
+        if FIELD_VALUE_USE in uses:
+            patterns.append("[_-]?".join(parts))
+
+    non_secret: list[str] = []
+    for index, suffix in enumerate(
+        _sequence(spec.get("nonSecretSuffixes"), "nonSecretSuffixes")
+    ):
+        non_secret.extend(_segment_forms(_parts(suffix, f"nonSecretSuffixes[{index}]")))
+
+    # A vocabulary that renders nothing for one matcher would hand that consumer an
+    # empty alternation, which matches nothing and forwards every credential.
+    if not segments:
+        raise ValueError(f"{_FILE_LABEL}: no noun is marked {ENV_NAME_USE}")
+    if not patterns:
+        raise ValueError(f"{_FILE_LABEL}: no noun is marked {FIELD_VALUE_USE}")
+    return CredentialNames(
+        segments=_dedupe(segments),
+        field_name_patterns=_dedupe(patterns),
+        non_secret_segments=_dedupe(non_secret),
+    )
+
+
+@functools.cache
+def _rendered() -> CredentialNames:
+    """The validated renderings of the packaged vocabulary. Raises if the data file
+    is absent (fail closed — a partial vocabulary silently under-matches)."""
+    return parse_credential_names(
+        json.loads(CREDENTIAL_NAMES_FILE.read_text(encoding="utf-8"))
+    )
+
+
+def credential_name_segments() -> tuple[str, ...]:
+    """Upper-case whole-name forms of every noun usable against a variable NAME.
+
+    A name whose trailing underscore-delimited segment is one of these holds a
+    credential (``DEPLOY_API_KEY``), so a consumer matching by trailing segment
+    self-populates from this list instead of curating its own.
+    """
+    return _rendered().segments
+
+
+def credential_field_name_patterns() -> tuple[str, ...]:
+    """Regex fragments for every noun usable as a ``field = value`` field name.
+
+    Each fragment tolerates the separator the author wrote (``api_key``,
+    ``api-key``, ``apikey``) and carries no metacharacter of its own, so a caller
+    may join them into an alternation directly.
+    """
+    return _rendered().field_name_patterns
+
+
+def non_secret_name_segments() -> tuple[str, ...]:
+    """Upper-case whole-name forms of the trailing words that mark a
+    credential-shaped name as holding a NON-secret (``KEY_ID``, ``PUBLIC_KEY``).
+
+    A consumer matching by trailing segment must decline these, or it redacts an
+    identifier or a public key out of legitimate output.
+    """
+    return _rendered().non_secret_segments

--- a/python/agent_sanitizer/secrets/data/credential-names.json
+++ b/python/agent_sanitizer/secrets/data/credential-names.json
@@ -1,0 +1,29 @@
+{
+  "$comment": "The credential-noun vocabulary: the words that make an identifier name a secret. Published so every consumer derives its own matcher from ONE list — a newly recognized noun reaches them all through a version bump instead of N hand edits. Read it from Python via agent_sanitizer.secrets (credential_name_segments / credential_field_name_patterns / non_secret_name_segments) or from JavaScript via the npm subpath export `agent-sanitizer/credential-names`. `parts` are the lowercase words of the noun; a consumer renders them for its own matcher (underscore-joined `API_KEY` and bare-joined `APIKEY` for an env-var NAME, `api[_-]?key` for a `field = value` regex). `uses` says which matcher may use the noun, because the two are not interchangeable: `env-name` matches a variable NAME and never inspects a value, so a broad noun there costs nothing, while `field-value` redacts whatever follows `noun = ` and a broad noun there mangles ordinary text — `key = <20 chars>` is a false-positive flood, so `key`, `pat`, `credential`, `credentials`, `secrets` and `passphrase` are env-name only. `nonSecretSuffixes` are the trailing words that make a credential-shaped name hold a NON-secret (a key's identifier, the public half of a keypair), which a consumer must not redact. Every part is restricted to a-z0-9 so it carries no regex metacharacter; the accessors enforce that and fail closed on a violation, an empty list, or an unknown `uses` value. It sits inside the Python package because a wheel can only ship data under its package directory, while npm's `files`/`exports` can name any path — so ONE physical file backs both ecosystems and there is no copy to drift.",
+  "nouns": [
+    { "parts": ["api", "key"], "uses": ["env-name", "field-value"] },
+    { "parts": ["access", "key"], "uses": ["env-name", "field-value"] },
+    { "parts": ["access", "token"], "uses": ["env-name", "field-value"] },
+    { "parts": ["secret", "key"], "uses": ["env-name", "field-value"] },
+    { "parts": ["client", "secret"], "uses": ["env-name", "field-value"] },
+    { "parts": ["private", "key"], "uses": ["env-name", "field-value"] },
+    { "parts": ["auth", "token"], "uses": ["env-name", "field-value"] },
+    { "parts": ["auth", "key"], "uses": ["env-name", "field-value"] },
+    { "parts": ["authorization"], "uses": ["env-name", "field-value"] },
+    { "parts": ["password"], "uses": ["env-name", "field-value"] },
+    { "parts": ["passwd"], "uses": ["env-name", "field-value"] },
+    { "parts": ["passphrase"], "uses": ["env-name"] },
+    { "parts": ["bearer"], "uses": ["env-name", "field-value"] },
+    { "parts": ["secret"], "uses": ["env-name", "field-value"] },
+    { "parts": ["secrets"], "uses": ["env-name"] },
+    { "parts": ["credential"], "uses": ["env-name"] },
+    { "parts": ["credentials"], "uses": ["env-name"] },
+    { "parts": ["token"], "uses": ["env-name", "field-value"] },
+    { "parts": ["pat"], "uses": ["env-name"] },
+    { "parts": ["key"], "uses": ["env-name"] }
+  ],
+  "nonSecretSuffixes": [
+    ["key", "id"],
+    ["public", "key"]
+  ]
+}

--- a/python/agent_sanitizer/secrets/engine.py
+++ b/python/agent_sanitizer/secrets/engine.py
@@ -31,6 +31,7 @@ from detect_secrets.settings import transient_settings
 
 from . import detectors
 from .config import RedactorConfig
+from .credential_names import credential_field_name_patterns
 from .invisible import invisible_run_pattern, strip_invisible_with_map
 
 PLUGINS = [
@@ -192,20 +193,12 @@ def _redact_env_bound(
 # detect-secrets' KeywordDetector knows only a fixed set of field names, omitting
 # the token family (token/access_token/authorization/bearer); this regex carries
 # them for both unquoted (`TOKEN=abc123…`) and quoted (`"token": "abc123…"`) forms.
-_FIELD_NAMES = "|".join(
-    [
-        r"api[_-]?key",
-        r"secret(?:[_-]?key)?",
-        r"client[_-]?secret",
-        r"access[_-]?(?:key|token)",
-        r"private[_-]?key",
-        r"auth(?:orization|[_-]?(?:key|token))",
-        r"password",
-        r"passwd",
-        r"bearer",
-        r"token",
-    ]
-)
+# The nouns come from the published vocabulary (data/credential-names.json), which
+# also feeds env-var-NAME matchers in other packages, so a newly recognized noun
+# reaches every consumer at once. Only nouns the vocabulary marks `field-value`
+# appear here: a noun broad enough for a name scrub (`key`, `pat`) would redact
+# whatever follows `key = ` throughout ordinary text.
+_FIELD_NAMES = "|".join(credential_field_name_patterns())
 FIELD_VALUE_RE = re.compile(
     # An optional quote after the field name absorbs a quoted KEY (`"token": …`),
     # and the value's own optional opening quote is captured so it can wrap

--- a/test/credential-names-export.test.mjs
+++ b/test/credential-names-export.test.mjs
@@ -1,0 +1,75 @@
+/**
+ * The credential-noun vocabulary is a PUBLIC export, reachable from JavaScript as
+ * the `agent-sanitizer/credential-names` subpath and from Python as the
+ * `agent_sanitizer.secrets` accessors — one file, so the two ecosystems cannot
+ * drift apart.
+ *
+ * These drive Node's real exports resolution (`import.meta.resolve` against the
+ * package's own name, which is what a consumer's bare import does) rather than
+ * reading the file by relative path: a broken `exports` entry is invisible to a
+ * relative read but breaks every consumer. The tarball half — that the resolved
+ * file is actually packed — is asserted in package-exports.test.mjs, which drives
+ * `npm pack`.
+ *
+ * The vocabulary's own contract (per-noun rendering, the env-name/field-value
+ * separation, fail-closed validation) is asserted in
+ * tests/secrets/test_credential_names.py, where the renderings and the redactor
+ * they feed both exist; this file deliberately does not restate it, and checks
+ * only what a JavaScript consumer depends on: that the data resolves, parses, and
+ * carries parts safe to interpolate into a pattern unescaped.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const SUBPATH = "agent-sanitizer/credential-names";
+const KNOWN_USES = new Set(["env-name", "field-value"]);
+
+// Self-reference: a package with an `exports` map can resolve its own name, so
+// this is the same resolution a consumer's `import "agent-sanitizer/credential-names"`
+// performs — an exports entry that points at a missing or unmapped file throws here.
+const resolved = fileURLToPath(import.meta.resolve(SUBPATH));
+const spec = JSON.parse(readFileSync(resolved, "utf8"));
+
+describe("credential-names is resolvable through the package exports map", () => {
+  it("resolves the subpath to a .json file", () => {
+    assert.match(resolved, /credential-names\.json$/);
+  });
+
+  it("carries a non-empty noun list and non-secret suffix list", () => {
+    assert.ok(Array.isArray(spec.nouns) && spec.nouns.length > 0);
+    assert.ok(
+      Array.isArray(spec.nonSecretSuffixes) &&
+        spec.nonSecretSuffixes.length > 0,
+    );
+  });
+});
+
+describe("every published noun is safe to interpolate into a pattern", () => {
+  for (const noun of spec.nouns) {
+    const label = noun.parts?.join("_") ?? JSON.stringify(noun);
+    it(`${label} has a-z0-9 parts and known uses`, () => {
+      assert.ok(Array.isArray(noun.parts) && noun.parts.length > 0);
+      for (const part of noun.parts) assert.match(part, /^[a-z0-9]+$/);
+      assert.ok(Array.isArray(noun.uses) && noun.uses.length > 0);
+      for (const use of noun.uses)
+        assert.ok(KNOWN_USES.has(use), `${label}: unknown use ${use}`);
+    });
+  }
+
+  for (const suffix of spec.nonSecretSuffixes) {
+    it(`non-secret suffix ${suffix.join("_")} has a-z0-9 parts`, () => {
+      assert.ok(Array.isArray(suffix) && suffix.length > 0);
+      for (const part of suffix) assert.match(part, /^[a-z0-9]+$/);
+    });
+  }
+
+  it("marks at least one noun for each use (else a rendering is empty)", () => {
+    for (const use of KNOWN_USES)
+      assert.ok(
+        spec.nouns.some((n) => n.uses.includes(use)),
+        `no noun is marked ${use}`,
+      );
+  });
+});

--- a/test/package-exports.test.mjs
+++ b/test/package-exports.test.mjs
@@ -35,6 +35,15 @@ function exportedFiles() {
   const types = [];
   const runtime = [];
   for (const target of Object.values(pkg.exports)) {
+    // A subpath may name its file directly instead of through a conditions
+    // object (`"./credential-names": "./…/credential-names.json"`). Iterating
+    // such a string with Object.entries yields character indices, none of which
+    // is a file condition — so the subpath would be skipped and its file left
+    // unguarded, which is the fail-open this branch closes.
+    if (typeof target === "string") {
+      runtime.push(target.replace(/^\.\//, ""));
+      continue;
+    }
     for (const [condition, value] of Object.entries(target)) {
       if (!FILE_CONDITIONS.includes(condition)) continue;
       const file = value.replace(/^\.\//, "");
@@ -52,7 +61,13 @@ function packedFiles() {
     ["pack", "--dry-run", "--json", "--ignore-scripts=false"],
     { cwd: repoRoot, encoding: "utf8" },
   );
-  return new Set(JSON.parse(out)[0].files.map((f) => f.path));
+  // `prepack` runs `pnpm build:types`, and pnpm's deps check writes its
+  // "Progress: resolved …" line to STDOUT — so npm's JSON is not necessarily the
+  // whole stream. Slice from the array start, or the test reds on a first
+  // invocation for a reason that has nothing to do with the packaging contract.
+  const start = out.indexOf("[");
+  assert.notEqual(start, -1, `npm pack emitted no JSON array:\n${out}`);
+  return new Set(JSON.parse(out.slice(start))[0].files.map((f) => f.path));
 }
 
 describe("packaging contract: exports map vs. published tarball", () => {

--- a/tests/secrets/test_credential_names.py
+++ b/tests/secrets/test_credential_names.py
@@ -1,0 +1,277 @@
+"""The published credential-noun vocabulary is one source, rendered two ways.
+
+``data/credential-names.json`` feeds an env-var-NAME matcher (whole-name segments)
+and the engine's ``field = value`` redactor (regex fragments). These tests
+enumerate the JSON **member by member**, so a noun added there is covered with no
+test edit, and pin the two properties a consumer depends on:
+
+* **rendering** — every part interpolates into a pattern unescaped, and each
+  rendered form is an instance of the noun it came from;
+* **separation** — a noun marked ``env-name`` only never reaches ``_FIELD_NAMES``.
+  That is not cosmetic: ``key = <20 chars>`` redacts a value in ordinary prose,
+  which is why the name scrub may carry ``key`` and the redactor may not.
+
+Both are asserted behaviourally where behaviour exists (through ``redact``), never
+by grepping source text. Fail-closed cases drive the pure validator directly: an
+empty list yields an alternation matching nothing (every credential forwarded) and
+a metacharacter part yields one matching everything (all output blanked), so both
+must raise rather than build a pattern.
+
+# covers: python/agent_sanitizer/secrets/credential_names.py
+# covers: python/agent_sanitizer/secrets/data/credential-names.json
+"""
+
+import json
+import re
+
+import pytest
+from agent_sanitizer.secrets import (
+    CREDENTIAL_NAMES_FILE,
+    credential_field_name_patterns,
+    credential_name_segments,
+    non_secret_name_segments,
+    redact,
+)
+from agent_sanitizer.secrets.credential_names import (
+    ENV_NAME_USE,
+    FIELD_VALUE_USE,
+    parse_credential_names,
+)
+
+SPEC = json.loads(CREDENTIAL_NAMES_FILE.read_text(encoding="utf-8"))
+NOUNS = SPEC["nouns"]
+NON_SECRET_SUFFIXES = SPEC["nonSecretSuffixes"]
+
+# Long enough to clear the engine's minimum-secret-length floor, and mixed-case
+# with digits so no placeholder/metavariable value-shape skip claims it.
+_NEEDLE = "A1b2C3d4E5f6G7h8I9j0"
+
+
+def _segment_forms(parts: list[str]) -> list[str]:
+    """The whole-name forms a consumer expects for ``parts`` — the same two
+    spellings the module renders, restated here so the test states the contract
+    rather than importing the implementation of it."""
+    return list(dict.fromkeys(["_".join(parts).upper(), "".join(parts).upper()]))
+
+
+# --------------------------------------------------------------------------
+# The vocabulary itself: every member, from the JSON.
+# --------------------------------------------------------------------------
+
+
+def test_the_vocabulary_is_not_empty() -> None:
+    """Non-vacuity for every enumeration below."""
+    assert NOUNS and NON_SECRET_SUFFIXES
+    assert credential_name_segments() and credential_field_name_patterns()
+    assert non_secret_name_segments()
+
+
+@pytest.mark.parametrize("noun", NOUNS, ids=lambda n: "_".join(n["parts"]))
+def test_every_noun_carries_metacharacter_free_parts_and_a_known_use(noun) -> None:
+    """A part must interpolate into a consumer's pattern unescaped, and a use must
+    be one the renderings act on — an unrecognized use would silently drop the
+    noun from both matchers."""
+    assert noun["parts"], noun
+    for part in noun["parts"]:
+        assert re.fullmatch(r"[a-z0-9]+", part), part
+    assert noun["uses"], noun
+    assert set(noun["uses"]) <= {ENV_NAME_USE, FIELD_VALUE_USE}, noun
+
+
+@pytest.mark.parametrize("noun", NOUNS, ids=lambda n: "_".join(n["parts"]))
+def test_env_name_nouns_render_both_whole_name_forms(noun) -> None:
+    """Both spellings of an env-name noun are segments (``API_KEY`` and
+    ``APIKEY``); a consumer matching by trailing segment sees them as different
+    tokens, so emitting only one leaves the other unscrubbed."""
+    if ENV_NAME_USE not in noun["uses"]:
+        pytest.skip(f"{noun['parts']} is not an env-name noun")
+    segments = credential_name_segments()
+    for form in _segment_forms(noun["parts"]):
+        assert form in segments, f"{form} missing from the rendered segments"
+
+
+@pytest.mark.parametrize("suffix", NON_SECRET_SUFFIXES, ids=lambda s: "_".join(s))
+def test_every_non_secret_suffix_renders_both_whole_name_forms(suffix) -> None:
+    """The non-secret markers render the same two spellings, so a consumer
+    declines ``APP_KEY_ID`` and ``APP_KEYID`` alike."""
+    for form in _segment_forms(suffix):
+        assert form in non_secret_name_segments(), form
+
+
+@pytest.mark.parametrize("noun", NOUNS, ids=lambda n: "_".join(n["parts"]))
+def test_field_value_nouns_redact_a_following_value(noun) -> None:
+    """Every ``field-value`` noun redacts the value after it, in all three
+    separator spellings the fragment claims to tolerate."""
+    if FIELD_VALUE_USE not in noun["uses"]:
+        pytest.skip(f"{noun['parts']} is not a field-value noun")
+    for separator in ("_", "-", ""):
+        field = separator.join(noun["parts"])
+        out, found = redact(f"{field} = {_NEEDLE}")
+        assert _NEEDLE not in out, f"{field} value survived redaction"
+        assert found, f"{field} reported no finding"
+
+
+def test_env_name_only_nouns_stay_out_of_the_field_value_rendering() -> None:
+    """A noun the JSON withholds from ``field-value`` must not appear in the
+    field-name fragments. ``key``/``pat`` are broad enough for a name scrub and a
+    false-positive flood for a value redactor, so the separation is the whole
+    reason ``uses`` exists — a rendering that ignored it would redact whatever
+    follows ``key = `` throughout ordinary text."""
+    fragments = set(credential_field_name_patterns())
+    env_only = [n for n in NOUNS if FIELD_VALUE_USE not in n["uses"]]
+    assert env_only, "no env-name-only noun — this separation is untested"
+    for noun in env_only:
+        assert "[_-]?".join(noun["parts"]) not in fragments, noun
+
+
+def test_uses_drives_the_rendering_not_the_noun_spelling() -> None:
+    """Non-vacuity for the assertion above: the rendering is driven by ``uses``,
+    not by the noun's spelling — the same parts render a fragment when marked
+    ``field-value`` and none when not."""
+    parts = ["token"]
+    spec = {
+        "nouns": [{"parts": parts, "uses": [ENV_NAME_USE]}],
+        "nonSecretSuffixes": [["key", "id"]],
+    }
+    with pytest.raises(ValueError, match="no noun is marked field-value"):
+        parse_credential_names(spec)
+    both = parse_credential_names(
+        {**spec, "nouns": [{"parts": parts, "uses": [ENV_NAME_USE, FIELD_VALUE_USE]}]}
+    )
+    assert both.field_name_patterns == ("token",)
+    assert both.segments == ("TOKEN",)
+
+
+# --------------------------------------------------------------------------
+# The renderings are what the accessors promise.
+# --------------------------------------------------------------------------
+
+
+def test_segments_are_interpolation_safe_upper_case_tokens() -> None:
+    """A consumer joins these into a regex alternation directly, so a segment must
+    carry no metacharacter."""
+    for segment in credential_name_segments() + non_secret_name_segments():
+        assert re.fullmatch(r"[A-Z0-9_]+", segment), segment
+
+
+def test_field_name_patterns_carry_no_unbounded_metacharacter() -> None:
+    """The only metacharacter a fragment may carry is the separator class it needs;
+    anything else would let one noun's fragment match beyond its own words."""
+    for fragment in credential_field_name_patterns():
+        assert re.fullmatch(r"[a-z0-9]+(?:\[_-\]\?[a-z0-9]+)*", fragment), fragment
+
+
+def test_renderings_are_deduplicated_and_ordered() -> None:
+    """Deterministic output: a generator materializing these into a committed file
+    needs a stable order, and a duplicate would inflate a consumer's alternation."""
+    for rendered in (
+        credential_name_segments(),
+        credential_field_name_patterns(),
+        non_secret_name_segments(),
+    ):
+        assert len(set(rendered)) == len(rendered), rendered
+
+
+# --------------------------------------------------------------------------
+# Fail closed on a bad spec.
+# --------------------------------------------------------------------------
+
+_GOOD = {
+    "nouns": [{"parts": ["api", "key"], "uses": [ENV_NAME_USE, FIELD_VALUE_USE]}],
+    "nonSecretSuffixes": [["key", "id"]],
+}
+
+_BAD_SPECS = [
+    ("nouns_missing", {"nonSecretSuffixes": [["key", "id"]]}, "nouns"),
+    ("nouns_empty", {**_GOOD, "nouns": []}, "nouns"),
+    ("nouns_not_a_list", {**_GOOD, "nouns": "api_key"}, "nouns"),
+    ("noun_not_an_object", {**_GOOD, "nouns": ["api_key"]}, "nouns[0]"),
+    (
+        "parts_missing",
+        {**_GOOD, "nouns": [{"uses": [FIELD_VALUE_USE]}]},
+        "nouns[0].parts",
+    ),
+    (
+        "parts_empty",
+        {**_GOOD, "nouns": [{"parts": [], "uses": [FIELD_VALUE_USE]}]},
+        "nouns[0].parts",
+    ),
+    (
+        "part_metacharacter",
+        {**_GOOD, "nouns": [{"parts": ["key|.*"], "uses": [FIELD_VALUE_USE]}]},
+        "nouns[0].parts",
+    ),
+    (
+        "part_upper_case",
+        {**_GOOD, "nouns": [{"parts": ["KEY"], "uses": [FIELD_VALUE_USE]}]},
+        "nouns[0].parts",
+    ),
+    (
+        "part_trailing_newline",
+        {**_GOOD, "nouns": [{"parts": ["key\n"], "uses": [FIELD_VALUE_USE]}]},
+        "nouns[0].parts",
+    ),
+    (
+        "part_not_a_string",
+        {**_GOOD, "nouns": [{"parts": [7], "uses": [FIELD_VALUE_USE]}]},
+        "nouns[0].parts",
+    ),
+    (
+        "uses_missing",
+        {**_GOOD, "nouns": [{"parts": ["token"]}]},
+        "nouns[0].uses",
+    ),
+    (
+        "uses_empty",
+        {**_GOOD, "nouns": [{"parts": ["token"], "uses": []}]},
+        "nouns[0].uses",
+    ),
+    (
+        "uses_unknown",
+        {**_GOOD, "nouns": [{"parts": ["token"], "uses": ["everything"]}]},
+        "nouns[0].uses",
+    ),
+    ("suffixes_missing", {"nouns": _GOOD["nouns"]}, "nonSecretSuffixes"),
+    ("suffixes_empty", {**_GOOD, "nonSecretSuffixes": []}, "nonSecretSuffixes"),
+    (
+        "suffix_metacharacter",
+        {**_GOOD, "nonSecretSuffixes": [["(?:.*)"]]},
+        "nonSecretSuffixes[0]",
+    ),
+    (
+        "no_env_name_noun",
+        {**_GOOD, "nouns": [{"parts": ["token"], "uses": [FIELD_VALUE_USE]}]},
+        "env-name",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "spec,field", [(s, f) for _, s, f in _BAD_SPECS], ids=[c[0] for c in _BAD_SPECS]
+)
+def test_the_validator_rejects_a_bad_spec(spec, field) -> None:
+    """Every field, every way of being wrong: the validator raises naming the file
+    and the offending field, rather than building a pattern that matches
+    everything or nothing."""
+    with pytest.raises(ValueError) as excinfo:
+        parse_credential_names(spec)
+    message = str(excinfo.value)
+    assert "credential-names.json" in message
+    assert field in message
+
+
+def test_the_validator_accepts_the_real_spec() -> None:
+    """Non-vacuity for the rejections above: the live vocabulary parses and
+    renders, so the raises refuse bad input and not all input."""
+    rendered = parse_credential_names(SPEC)
+    assert rendered.segments == credential_name_segments()
+    assert rendered.field_name_patterns == credential_field_name_patterns()
+    assert rendered.non_secret_segments == non_secret_name_segments()
+
+
+def test_an_empty_alternation_would_be_permissive_or_blind() -> None:
+    """Why the empty-list rejections above are security-relevant, not tidiness: an
+    empty alternation matches nothing, so every credential is forwarded verbatim,
+    and an interpolated metacharacter matches everything, so all output blanks."""
+    assert re.search(r"(?:^|_)(?:)$", "MY_TOKEN") is None
+    assert re.search(r"(?:^|_)(?:KEY|.*)$", "TOTALLY_INNOCENT") is not None

--- a/tests/secrets/test_credential_names.py
+++ b/tests/secrets/test_credential_names.py
@@ -161,9 +161,9 @@ def test_field_name_patterns_carry_no_unbounded_metacharacter() -> None:
         assert re.fullmatch(r"[a-z0-9]+(?:\[_-\]\?[a-z0-9]+)*", fragment), fragment
 
 
-def test_renderings_are_deduplicated_and_ordered() -> None:
-    """Deterministic output: a generator materializing these into a committed file
-    needs a stable order, and a duplicate would inflate a consumer's alternation."""
+def test_renderings_are_deduplicated() -> None:
+    """A duplicate would inflate a consumer's alternation, and a generator
+    materializing these into a committed file would emit it twice."""
     for rendered in (
         credential_name_segments(),
         credential_field_name_patterns(),

--- a/tests/secrets/test_secrets_engine.py
+++ b/tests/secrets/test_secrets_engine.py
@@ -14,6 +14,7 @@ import pytest
 import agent_sanitizer.secrets.engine as E
 from agent_sanitizer.secrets import (
     RedactorConfig,
+    credential_field_name_patterns,
     detected_secret_values,
     mask_secret_lines,
     redact,
@@ -1700,27 +1701,19 @@ def _top_level_alternatives(pattern: str) -> list[str]:
     return alts
 
 
-_FIELD_NAME_REPRESENTATIVES = [
-    "api_key",
-    "secret",
-    "client_secret",
-    "access_token",
-    "private_key",
-    "authorization",
-    "password",
-    "passwd",
-    "bearer",
-    "token",
-]
-
-
 def test_field_names_every_member_redacts():
+    """Every alternative in `_FIELD_NAMES` redacts a following value.
+
+    The alternation is built from the published vocabulary
+    (`credential_field_name_patterns()`), so its members are enumerated from that
+    accessor and a noun added there is covered with no edit here. Each member's
+    representative instance is derived by picking `_` for the fragment's optional
+    separator, and the fullmatch assertion is what proves the derivation still
+    names an instance of the fragment it came from."""
     alts = _top_level_alternatives(E._FIELD_NAMES)
-    assert len(alts) == len(_FIELD_NAME_REPRESENTATIVES), {
-        "members": alts,
-        "representatives": _FIELD_NAME_REPRESENTATIVES,
-    }
-    for alt, field in zip(alts, _FIELD_NAME_REPRESENTATIVES, strict=True):
+    assert alts == list(credential_field_name_patterns())
+    for alt in alts:
+        field = alt.replace("[_-]?", "_")
         assert re.fullmatch(alt, field), f"{field!r} is not an instance of {alt!r}"
         out, found = redact(f"{field} = {_BRACKET_NEEDLE}")
         assert _BRACKET_NEEDLE not in out, f"{field} value survived redaction"


### PR DESCRIPTION
## What & why

Publish the credential-noun vocabulary — the words that make an identifier name a secret — as one data file exported to both ecosystems, and derive the engine's `_FIELD_NAMES` from it.

Those nouns were duplicated across repos with no link: regex fragments here, an env-var-NAME segment list in agent-glovebox. A newly recognized noun had to be added twice, and one added to only one side leaks through the other path.

`python/agent_sanitizer/secrets/data/credential-names.json` is the single source, reachable as the npm subpath `agent-sanitizer/credential-names` and as the `agent_sanitizer.secrets` accessors. It sits inside the Python package because a wheel can only ship data under its package directory while npm's `files`/`exports` can name any path — one physical file, so there is no copy to drift and no drift guard.

Each noun records the `uses` it is valid for, because the two matchers are not interchangeable: a NAME matcher inspects no value, so a broad noun costs nothing, while a value redactor mangles ordinary text for one (`key = <20 chars>`). `_FIELD_NAMES` is derived from the `field-value` subset only.

## Review focus

`python/agent_sanitizer/secrets/credential_names.py` — the validator and the `uses` split, which is what keeps the redactor's false-positive surface unchanged. The invariant no single file shows: the derived `_FIELD_NAMES` must accept exactly what the hand-written alternation accepted.

## How it was tested

- `uv run --extra dev pytest tests/secrets -q` → **924 passed, 6 skipped** (includes the ReDoS static guard, which re-analyses the derived `_FIELD_NAMES`).
- `node --test test/credential-names-export.test.mjs test/package-exports.test.mjs` → **28 passed**. The packaging test drives `npm pack`, so it proves the JSON actually lands in the tarball rather than just being listed.
- `_FIELD_NAMES` equivalence, observed not inferred: compared the old alternation against the derived one over every one- and two-word combination of the vocabulary's own words in all three separator spellings (~9k candidates), on both `fullmatch` verdicts and leftmost-match spans — **zero differences**.
- `uv build --wheel` → `agent_sanitizer/secrets/data/credential-names.json` is in the wheel with no `pyproject.toml` change (hatchling auto-includes tracked data under `packages`).

## Decisions made

- **One file under `python/`, exported by npm from there** rather than a neutral copy generated into each tree. A wheel cannot ship data outside its package dir, npm has no such constraint, so the single-file arrangement follows — and it avoids the copies-agree guard a generated duplicate would need.
- **`passphrase`, `secrets`, `credential`, `credentials`, `pat`, `key` stay name-only.** Promoting them to `field-value` would change redaction behavior; this PR deliberately changes none.
- **Two fail-opens in `test/package-exports.test.mjs` fixed here**, both found while wiring the export: the guard skipped any `exports` subpath naming its file directly instead of through a conditions object (so the new export would have been unguarded), and it parsed npm's stdout whole, reddening when pnpm's deps check wrote a `Progress:` line ahead of the JSON.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qgiz8iJ1GprLFYHf4hh33d)_