### PR TITLE
docs(skills): require PR bodies to state the current head, never their own history

### DIFF
--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -91,9 +91,11 @@ reviewable diff (a ~10-line change is a few sentences, not a 500-word skeleton);
 ritual sections instead of spending a paragraph to say "None"; and add a **Review focus**
 line naming the file to read first, the cross-file invariant, and the part you're least sure
 of — the single element most correlated with a human actually engaging, which matters because
-agent-authored PRs are systematically _under_-reviewed. Use the exact headings from
-pr-templates.md (`What & why` / `Review focus` / `How it was tested` / `Decisions made` /
-`Lessons Learned`) so a reviewer can scan by habit.
+agent-authored PRs are systematically _under_-reviewed. Describe the diff **as it currently
+stands** — never the body's own drafting history, corrections of its earlier claims, or the
+chronology of the session that produced it (pr-templates.md carries the full rule). Use the
+exact headings from pr-templates.md (`What & why` / `Review focus` / `How it was tested` /
+`Decisions made` / `Lessons Learned`) so a reviewer can scan by habit.
 
 ### Step 3: Iterative Compress-Critique-Fix Loop
 

--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -91,9 +91,8 @@ reviewable diff (a ~10-line change is a few sentences, not a 500-word skeleton);
 ritual sections instead of spending a paragraph to say "None"; and add a **Review focus**
 line naming the file to read first, the cross-file invariant, and the part you're least sure
 of — the single element most correlated with a human actually engaging, which matters because
-agent-authored PRs are systematically _under_-reviewed. Describe the diff **as it currently
-stands** — never the body's own drafting history, corrections of its earlier claims, or the
-chronology of the session that produced it (pr-templates.md carries the full rule). Use the
+agent-authored PRs are systematically _under_-reviewed. Describe the diff as it currently
+stands, never its own history (pr-templates.md carries the rule). Use the
 exact headings from pr-templates.md (`What & why` / `Review focus` / `How it was tested` /
 `Decisions made` / `Lessons Learned`) so a reviewer can scan by habit.
 

--- a/.claude/skills/pr-creation/pr-templates.md
+++ b/.claude/skills/pr-creation/pr-templates.md
@@ -35,7 +35,10 @@ cross-file invariant the diff can't show on one screen, and the part you'd most 
 scrutinized ("the locking in `worker.ts:88`; the rest is a mechanical rename").>
 
 ## How it was tested
-<What you ran and the outcome. Always this exact heading — never rename it to
+<The checks that hold the CURRENT head: each claim paired with the command that would
+falsify it now, plus its outcome (a count, a run link on this head). Present tense about
+this head only — no session chronology (what broke on earlier heads, what was re-run,
+prediction-vs-actual stories). Always this exact heading — never rename it to
 "Tests"/"Verification"/"Testing"; one stable name lets a reviewer scan by habit.>
 
 ## Decisions made
@@ -103,6 +106,15 @@ to engage, not raise it. Concretely:
 - **Match the diff's vocabulary.** Use the same identifiers and file paths in the prose as in
   the diff, and link claims to specific files/lines — that lexical "scent" is how a reviewer
   navigates to the code (information foraging).
+- **A section describes the diff as it stands, never its own history.** When you rewrite a
+  body, replace the old text — don't narrate the replacement ("this section previously
+  said…", "an earlier version of this PR…"), and never keep a "Corrections to earlier
+  claims" section: a false claim is replaced by the true one, full stop. Evidence follows
+  the same rule — a kill test or red-then-fixed cycle appears as the current-state fact it
+  established ("this check reds on a hand-edited artifact — falsify: <command or run
+  link>"), not as the chronology of runs that established it. A decision still live in the
+  diff (a scope call, a rejected alternative a reviewer would re-propose) goes in
+  `## Decisions made` as a present-tense statement of the choice and its consequence.
 - Note any breaking changes.
 - **Default to NO “Lessons Learned” section.** It exists only for a genuinely novel, cross-project insight that would improve the template for a downstream repo sharing none of this code — a rare case; most PRs have none. Each lesson filed triggers the phone-home workflow (one issue per PR on the template repo), so a low-value or repo-specific “lesson” is triage noise, not a contribution. When you do include one, each lesson must specify **what** to change, **where**, and **why**. **Never write a negative placeholder** (“none applicable”, “N/A”, “nothing generalizable”): phone-home now drops those, so the sentence achieves nothing — omit the whole heading instead.
 - **Skip the Lessons Learned section entirely when the PR targets the `claude-automation-template` repo itself.** Phone-home propagates lessons _from_ downstream repos _into_ the template; a change made directly in the template is already there, so the section propagates nothing and is just noise.

--- a/.claude/skills/pr-creation/pr-templates.md
+++ b/.claude/skills/pr-creation/pr-templates.md
@@ -35,11 +35,9 @@ cross-file invariant the diff can't show on one screen, and the part you'd most 
 scrutinized ("the locking in `worker.ts:88`; the rest is a mechanical rename").>
 
 ## How it was tested
-<The checks that hold the CURRENT head: each claim paired with the command that would
-falsify it now, plus its outcome (a count, a run link on this head). Present tense about
-this head only — no session chronology (what broke on earlier heads, what was re-run,
-prediction-vs-actual stories). Always this exact heading — never rename it to
-"Tests"/"Verification"/"Testing"; one stable name lets a reviewer scan by habit.>
+<The claims that hold the current head, each with the command that falsifies it and its
+outcome. Always this exact heading — never rename it to "Tests"/"Verification"/"Testing";
+one stable name lets a reviewer scan by habit.>
 
 ## Decisions made
 <!-- Only if there are genuinely reviewer-owned judgments. Delete otherwise. -->
@@ -107,14 +105,10 @@ to engage, not raise it. Concretely:
   the diff, and link claims to specific files/lines — that lexical "scent" is how a reviewer
   navigates to the code (information foraging).
 - **A section describes the diff as it stands, never its own history.** When you rewrite a
-  body, replace the old text — don't narrate the replacement ("this section previously
-  said…", "an earlier version of this PR…"), and never keep a "Corrections to earlier
-  claims" section: a false claim is replaced by the true one, full stop. Evidence follows
-  the same rule — a kill test or red-then-fixed cycle appears as the current-state fact it
-  established ("this check reds on a hand-edited artifact — falsify: <command or run
-  link>"), not as the chronology of runs that established it. A decision still live in the
-  diff (a scope call, a rejected alternative a reviewer would re-propose) goes in
-  `## Decisions made` as a present-tense statement of the choice and its consequence.
+  body, replace the old text — don't narrate the replacement, keep a corrections section,
+  or recount the runs that established a fact; state the fact. A decision still live in
+  the diff goes in `## Decisions made` as a present-tense statement of the choice and its
+  consequence.
 - Note any breaking changes.
 - **Default to NO “Lessons Learned” section.** It exists only for a genuinely novel, cross-project insight that would improve the template for a downstream repo sharing none of this code — a rare case; most PRs have none. Each lesson filed triggers the phone-home workflow (one issue per PR on the template repo), so a low-value or repo-specific “lesson” is triage noise, not a contribution. When you do include one, each lesson must specify **what** to change, **where**, and **why**. **Never write a negative placeholder** (“none applicable”, “N/A”, “nothing generalizable”): phone-home now drops those, so the sentence achieves nothing — omit the whole heading instead.
 - **Skip the Lessons Learned section entirely when the PR targets the `claude-automation-template` repo itself.** Phone-home propagates lessons _from_ downstream repos _into_ the template; a change made directly in the template is already there, so the section propagates nothing and is just noise.

--- a/.claude/skills/pr-creation/pr-templates.md
+++ b/.claude/skills/pr-creation/pr-templates.md
@@ -131,7 +131,8 @@ gh pr edit --body "$(cat <<'EOF'
 <Reading order + least-certain part, updated for the current diff.>
 
 ## How it was tested
-<What you ran and the outcome, updated.>
+<The claims that hold the current head, each with the command that falsifies it and its
+outcome — re-stated for this head, not appended to the previous list.>
 
 ## Decisions made
 <!-- Delete if none. -->


### PR DESCRIPTION
## What & why

Points every body-content rule in the pr-creation skill at the current head.

- `pr-templates.md`: `## How it was tested` = "the claims that hold the current head, each with the command that falsifies it and its outcome" (was "what you ran and the outcome"); one new bullet: a section describes the diff as it stands, never its own history — replace superseded text, no corrections sections, state the fact a run established rather than the chronology of runs.
- `SKILL.md`: the Step-2 body-guidelines summary carries the same one-line clause.

Mirrors the identical change in the glovebox template's copy of this skill.

## Review focus

The new `pr-templates.md` bullet: confirm it doesn't forbid evidence itself — run links, counts, and falsifying commands stay; only chronology framing goes.

## How it was tested

Docs-only. Falsify by finding a remaining instruction in either file that requires narrating anything other than the current head.