### PR TITLE
fix(secrets): stop a lone PEM header from redacting the rest of the file

### DIFF
--- a/python/agent_sanitizer/secrets/engine.py
+++ b/python/agent_sanitizer/secrets/engine.py
@@ -653,19 +653,48 @@ def _is_version(value: str) -> bool:
 
 # detect-secrets' PrivateKeyDetector only matches the "-----BEGIN-----" header
 # line, so a per-line scan leaves the base64 body unredacted. Match and collapse
-# the whole PEM block. To FAIL SAFE on truncated output the body also terminates
-# at the next "-----BEGIN" or end-of-string. The keyword is "PRIVATE KEY" only,
-# so public material (certs, public keys, PGP messages) stays verbatim. The label
-# runs are length-capped so a crafted header can't drive O(n^2) backtracking.
+# the whole PEM block. The keyword is "PRIVATE KEY" only, so public material
+# (certs, public keys, PGP messages) stays verbatim. The label runs are
+# length-capped so a crafted header can't drive O(n^2) backtracking.
 _PEM_LABEL_RUN = r"[A-Z0-9 ]{0,40}?"
+# One line of PEM body: RFC 7468 base64, or an RFC 1421 "Field: value" header.
+# Env-bound redaction runs before this one, so a base64 run may already carry its
+# output — a sentinel in map mode, the placeholder itself in plain mode. Both
+# count as body, otherwise a key whose body embeds a configured env value would
+# end the block early and leave the rest of its base64 visible.
+_PEM_B64_ATOM = (
+    r"(?:[A-Za-z0-9+/=]"
+    + f"|{re.escape(_MARK_OPEN)}"
+    + r"\d+ "
+    + f"{re.escape(_MARK_CLOSE)}"
+    + r"|\[REDACTED[^\]\r\n]*\])"
+)
+_PEM_CONTENT = r"(?:" + _PEM_B64_ATOM + r"+|[A-Za-z][A-Za-z0-9-]*:[^\r\n]*)"
+# A block with no "-----END-----" still hides its body — truncated output must
+# FAIL SAFE — but only as far as the run of PEM-shaped lines after the header
+# (blank lines included, a truncated final line needing no newline). Stopping at
+# the first line that is neither is what keeps a lone header from swallowing the
+# rest of the file behind one placeholder: everything after it would vanish from
+# the caller's view of an otherwise secret-free document.
+_PEM_BODY = (
+    r"(?:[ \t]*(?:" + _PEM_CONTENT + r"[ \t]*)?\r?\n)*"
+    # A body line only counts when the PEM shape covers the WHOLE line, so the
+    # final unterminated line is anchored at end-of-text; without "\Z" it would
+    # match the leading word of an ordinary following line ("keep me" -> "keep").
+    r"(?:[ \t]*" + _PEM_CONTENT + r"[ \t]*\Z)?"
+)
 PEM_BLOCK_RE = re.compile(
     r"-----BEGIN (?P<label>"
     + _PEM_LABEL_RUN
     + r"PRIVATE KEY"
     + _PEM_LABEL_RUN
     + r")-----"
-    r"[\s\S]*?"
-    r"(?:-----END (?P=label)-----|(?=-----BEGIN )|\Z)",
+    # A terminated block wins, and its body may hold anything — a PEM embedded in
+    # a JSON string carries its whole body on one line as \n escapes. The
+    # tempered "(?!-----BEGIN )" keeps that scan from reaching a LATER block's
+    # END line and collapsing the text between them.
+    r"(?:(?:(?!-----BEGIN )[\s\S])*?-----END (?P=label)-----"
+    r"|" + _PEM_BODY + r")",
     re.IGNORECASE,
 )
 
@@ -675,7 +704,13 @@ def _redact_pem_blocks(
 ) -> str:
     def _repl(m: re.Match[str]) -> str:
         found.append("Private Key")
-        return _mark(entries, "[REDACTED: Private Key]", m.group(0))
+        # An unterminated body stops at a line break, so the match can end with
+        # the whitespace that separates the block from the following text. That
+        # whitespace is not key material: keep it outside the placeholder so the
+        # next line does not get pulled onto the placeholder's line.
+        block = m.group(0).rstrip(" \t\r\n")
+        trailing = m.group(0)[len(block) :]
+        return _mark(entries, "[REDACTED: Private Key]", block) + trailing
 
     return PEM_BLOCK_RE.sub(_repl, text)
 

--- a/src/rehydrate.mjs
+++ b/src/rehydrate.mjs
@@ -183,21 +183,31 @@ async function rehydrateEdit(
       // (the model supplied the secret's real bytes itself, e.g. a rotation)
       // extracts nothing and is left to the literal resolver below.
       const diskSpans = pairDiskSpans(view, deletions);
-      const intrudes = occurrences(content, oldS).some((matchStart) => {
+      let intrusion = null;
+      for (const matchStart of occurrences(content, oldS)) {
         const matchEnd = matchStart + oldS.length;
-        return diskSpans.some(
-          (secret) =>
-            matchStart < secret.end &&
-            secret.start < matchEnd &&
-            !(matchStart <= secret.start && secret.end <= matchEnd),
+        const secret = diskSpans.find(
+          (span) =>
+            matchStart < span.end &&
+            span.start < matchEnd &&
+            !(matchStart <= span.start && span.end <= matchEnd),
         );
-      });
-      if (intrudes)
+        if (secret) {
+          intrusion = { matchStart, matchEnd, secret };
+          break;
+        }
+      }
+      // Report both byte ranges. The refusal is conservative — it fires on an
+      // overlap with the redacted span the caller cannot see — so the caller
+      // needs the ranges to tell a true overlap from a mis-sized redaction.
+      if (intrusion)
         return {
           deny:
-            `old_string matches bytes inside a ${hint}…] redacted secret in ` +
-            `${ti.file_path} that are hidden from your view; edit only text you can ` +
-            `see (include each placeholder whole), or ask the user to make this change`,
+            `old_string does not appear in the sanitized view of ${ti.file_path}; on disk ` +
+            `it matches bytes ${intrusion.matchStart}-${intrusion.matchEnd}, which fall ` +
+            `inside a ${hint}…] redacted secret at bytes ${intrusion.secret.start}-` +
+            `${intrusion.secret.end} that are hidden from your view; edit only text you ` +
+            `can see (include each placeholder whole), or ask the user to make this change`,
         };
       const literalRes = rehydrateNewString(
         oldS,

--- a/test/rehydrate.test.mjs
+++ b/test/rehydrate.test.mjs
@@ -1081,6 +1081,33 @@ describe("rehydrate: hidden-span safety", () => {
     assert.equal(out.updatedInput, undefined);
   });
 
+  it("R1: the deny reports the disk byte range of both the match and the secret", async () => {
+    // The refusal is conservative, so the caller needs the two ranges to tell a
+    // real overlap from a redaction whose recorded span is too wide.
+    const content = `PASSWORD=${SECRET_A}\nDEBUG=1\n`;
+    const out = await rehydrateRedacted(
+      "Edit",
+      {
+        file_path: "/f",
+        old_string: FRAGMENT_ONLY_IN_SECRET,
+        new_string: "Z",
+      },
+      liveIo(content, [{ value: SECRET_A, placeholder: PH }], reRedact),
+    );
+    const matchStart = content.indexOf(FRAGMENT_ONLY_IN_SECRET);
+    const secretStart = content.indexOf(SECRET_A);
+    assert.match(
+      out.deny,
+      new RegExp(
+        `matches bytes ${matchStart}-${matchStart + FRAGMENT_ONLY_IN_SECRET.length},`,
+      ),
+    );
+    assert.match(
+      out.deny,
+      new RegExp(`at bytes ${secretStart}-${secretStart + SECRET_A.length} `),
+    );
+  });
+
   it("R1: denies a hint-free replace_all fragment that would splice inside the secret", async () => {
     // "2xA" is hint-free, invisible in the view, but on disk sits inside the
     // secret. replace_all would splice it there; deny (viewOcc===0 branch).

--- a/tests/secrets/test_secrets_engine.py
+++ b/tests/secrets/test_secrets_engine.py
@@ -288,6 +288,71 @@ def test_redact_pem_public_labels_survive_verbatim(label):
     assert found == [], label
 
 
+def test_redact_pem_lone_header_leaves_following_text_visible():
+    """A bare "-----BEGIN PRIVATE KEY-----" is not a truncated key whose body is
+    the rest of the document: everything after it stays visible."""
+    found: list[str] = []
+    tail = '\n(workspace / "deploy.pem").write_text(header)\nassert ok\n'
+    text = '("-----BEGIN PRIVATE KEY-----\\n")' + tail
+    assert E._redact_pem_blocks(text, found) == '("[REDACTED: Private Key]\\n")' + tail
+    assert found == ["Private Key"]
+
+
+def test_redact_pem_lone_header_keeps_its_line_break():
+    found: list[str] = []
+    text = "-----BEGIN PRIVATE KEY-----\nprint(1)\n"
+    assert E._redact_pem_blocks(text, found) == "[REDACTED: Private Key]\nprint(1)\n"
+
+
+def test_redact_pem_unterminated_body_still_collapses():
+    """Truncated output has no END line; its base64 body must not survive."""
+    found: list[str] = []
+    text = (
+        "-----BEGIN PRIVATE KEY-----\n"
+        "Proc-Type: 4,ENCRYPTED\n"
+        "\n"
+        "MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkSECRETBODYMATERIAL12345\n"
+        "Q29udGludWVkIGtleQ=="
+    )
+    assert E._redact_pem_blocks(text, found) == "[REDACTED: Private Key]"
+    assert found == ["Private Key"]
+
+
+def test_redact_pem_unterminated_body_survives_an_inner_env_redaction():
+    """Env-bound redaction runs first; its placeholder inside the base64 must not
+    end the unterminated block and leave the rest of the body visible."""
+    value = "venicekeyvenicekeyvenicekeyX"
+    text = f"-----BEGIN PRIVATE KEY-----\nZm9vYmFy{value}cXV4\nUExBSU5UQUlM\n"
+    result = run_plain(text, cfg(provider_vars={"VENICE_INFERENCE_KEY": value}))
+    assert result["text"] == "[REDACTED: Private Key]\n"
+
+
+def test_redact_pem_unterminated_block_does_not_reach_a_later_end_line():
+    found: list[str] = []
+    text = (
+        "-----BEGIN PRIVATE KEY-----\n"
+        "keep me\n"
+        "-----BEGIN RSA PRIVATE KEY-----\nQUJDREVG\n-----END RSA PRIVATE KEY-----"
+    )
+    assert (
+        E._redact_pem_blocks(text, found)
+        == "[REDACTED: Private Key]\nkeep me\n[REDACTED: Private Key]"
+    )
+    assert found == ["Private Key", "Private Key"]
+
+
+def test_redact_pem_single_line_block_collapses_whole_body():
+    """A PEM inside a JSON string keeps its body on one line as \\n escapes; the
+    terminated-block branch still swallows it."""
+    found: list[str] = []
+    body = "MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkSECRETBODYMATERIAL12345"
+    text = (
+        f'{{"key": "-----BEGIN PRIVATE KEY-----\\n{body}\\n-----END PRIVATE KEY-----"}}'
+    )
+    assert E._redact_pem_blocks(text, found) == '{"key": "[REDACTED: Private Key]"}'
+    assert body not in E._redact_pem_blocks(text, [])
+
+
 def test_redact_pem_label_length_is_bounded():
     found: list[str] = []
     runaway = "-----BEGIN " + "A" * 500 + "PRIVATE KEY" + "A" * 500 + "-----\nx\n"


### PR DESCRIPTION
## Summary

A `-----BEGIN PRIVATE KEY-----` with no matching `-----END-----` redacted every byte after it. `PEM_BLOCK_RE`'s truncated-output fallback terminated at `\Z`, so a bare header — a test fixture, a doc example — collapsed the whole rest of the document into one `[REDACTED: Private Key]` placeholder.

Observed on `agent-glovebox/tests/test_sbx_services_kcov.py` (98.5 kB, header at line 2082, no END anywhere): the recorded secret span was 12,843 chars long and the sanitized view stopped at byte 85,674, hiding ~13 kB of ordinary test source. Downstream, `rehydrateRedacted` then refused **every** Edit anchored after that line — the text was absent from the view yet present on disk inside the over-wide span, which is exactly the R1 intrusion deny. Edits before the header succeeded; edits after it never could.

An unterminated block now stops at the first line that is not PEM-shaped (base64, an RFC 1421 `Field: value` header, or blank). Genuinely truncated key output still collapses whole — its body *is* those lines — while a header with no body redacts only itself. A terminated block still matches through arbitrary content, so a PEM embedded in a JSON string (body on one line as `\n` escapes) collapses as before, and it can no longer run past a later block's `END` line.

## Changes

- `engine.py` — `PEM_BLOCK_RE` splits into two branches: terminated (tempered against crossing a later `-----BEGIN `, unchanged semantics) and unterminated (bounded to PEM-shaped lines). The base64 atom also accepts an already-substituted env-var redaction — env-bound redaction runs first, and without this an inner env value would end the block early and leave the rest of a real key's body visible. `_repl` keeps the block's trailing whitespace outside the placeholder so the following line does not get pulled onto the placeholder's line.
- `rehydrate.mjs` — the R1 intrusion deny now names both compared byte ranges (the disk match and the redacted span) and states plainly that `old_string` was absent from the sanitized view. The old text blamed `old_string` and told the caller to "edit only text you can see" when the text *was* visible and no placeholder was near it, naming no remedy that worked.

Risk tier: **medium** — narrows what the redactor collapses. The narrowing is bounded by shape, not by length, and the truncated-key case is pinned by test.

## Tests / verification

- `uv run pytest tests/secrets -q` → 930 passed, 6 skipped. Full `uv run pytest -q` → 1217 passed.
- `pnpm test` → green, `rehydrate.mjs` at 100% line/branch coverage. `pnpm lint`, `pnpm check` clean.
- Non-vacuity: 4 of the 6 new engine tests fail against the pre-fix regex (`git stash` on `engine.py`, re-run `-k pem` → 4 failed / 22 passed). The other two pin behavior the fix must preserve (terminated single-line block; truncated body still fully collapsed).
- Reproduction, before → after, on the real 98.5 kB file: `redact_map` private-key pair `original` length 12843 → 27; view length 85674 → 98490 (source is 98506).
- ReDoS: `_redact_pem_blocks` over a header followed by 100 kB of spaces / one 100 kB word / 1250 base64 lines runs in 29 ms / 24 ms / 7 ms — linear. `tests/secrets/test_redos_static_guard.py` passes.

## Decisions made

- **The terminated branch keeps its unbounded reach.** A stray `-----END PRIVATE KEY-----` far below a bare header still collapses everything between them. Bounding it by length would under-redact large PGP private-key blocks, and bounding it by line shape would break the single-line JSON-embedded PEM the branch exists to catch. A stray `END` with no `BEGIN` above it is far rarer than the stray `BEGIN` this PR fixes; under the alternative, that case would need a length cap chosen against the largest legitimate key.
- **The unterminated branch tolerates word-only lines.** A bare header followed by `foo\nbar\n` still swallows those lines, since they are indistinguishable from base64. That is the fail-safe direction and keeps truncated output covered.

## Review focus

`python/agent_sanitizer/secrets/engine.py` — the `_PEM_BODY` construction, specifically the `\Z` anchor on the final unterminated line. Without it the trailing optional matches the leading word of an ordinary following line (`keep me` → `keep`), which is the near-miss version of the bug being fixed and is what `test_redact_pem_unterminated_block_does_not_reach_a_later_end_line` pins. The cross-file invariant: the recorded `(placeholder, original)` pair must still reconstruct the source exactly — `rstrip` in `_repl` moves bytes out of the pair, and `tests/secrets/test_secrets_property.py`'s reconstruct round-trip is what proves it.

The part I am least sure of: whether the `[REDACTED…]`/sentinel atom in `_PEM_B64_ATOM` covers every shape a prior layer can leave inside a key body. It covers env-bound redaction in both plain and map mode, which is the only layer that runs before this one.

## Checklist

- [x] Commits follow Conventional Commits.
- [x] `pnpm test`, `pnpm lint`, `pnpm check` pass locally.
- [x] New/changed detector behavior has negative tests (a lone header leaves following text visible; an unterminated block does not reach a later END).
- [x] No real secrets in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CTUfskG7kba4XW3fTyMymy)_