### PR TITLE
feat: publish the claude-hooks composition surface as typed subpaths

### DIFF
--- a/.hooks/ssot-guard-pairs.json
+++ b/.hooks/ssot-guard-pairs.json
@@ -11,6 +11,7 @@
     "src/instructions.mjs": ["test/instructions.test.mjs"],
     "python/agent_sanitizer/secrets/data/credential-names.json": [
       "test/credential-names-export.test.mjs"
-    ]
+    ],
+    "package.json": ["test/claude-hooks-exports.test.mjs"]
   }
 }

--- a/README.md
+++ b/README.md
@@ -113,6 +113,28 @@ To wire them yourself instead, one entry dispatches all four modes on `--hook=`:
 `require.resolve("agent-sanitizer/claude-hooks")` gives the path without
 hardcoding a layout. Importing the module rather than spawning it is a no-op.
 
+**To compose the hooks instead of spawning them**, each module is a subpath of
+its own, typed, with the pieces exported individually:
+
+```js
+import {
+  sanitizeText,
+  evaluateToolOutput,
+} from "agent-sanitizer/claude-hooks/sanitize-output";
+import {
+  lazyImport,
+  makeDeadline,
+} from "agent-sanitizer/claude-hooks/lib/hook-io";
+```
+
+`agent-sanitizer/claude-hooks/<module>` for the four hooks
+(`sanitize-output`, `pretooluse-sanitize`, `sanitize-user-prompt`,
+`scan-invisible-chars`) and `agent-sanitizer/claude-hooks/lib/<module>` for the
+shared libs. Importing one runs no CLI and reads no stdin. Same stability
+posture as the `_AGENT_SANITIZER_*` variables below: reachable and typed, but
+the supported surface is the `--hook=` CLI, so these move between minor
+versions.
+
 **Layer 4 needs the Python engine** — `pip install 'agent-sanitizer[secrets]'`,
 version-matched to the npm package. Without it `sanitize-output` fails closed:
 secret-shaped output is suppressed, not shown unvetted. Layers 1–3 still run.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "coverage": "c8 node --test",
     "check": "tsc --noEmit && tsc -p tsconfig.hooks.json --noEmit",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.hooks.json --noEmit",
-    "build:types": "tsc -p tsconfig.build.json",
+    "build:types": "tsc -p tsconfig.build.json && tsc -p tsconfig.build-hooks.json",
     "prepack": "pnpm build:types",
     "gen:joining-type": "node scripts/gen-joining-type.mjs",
     "lint": "eslint .",
@@ -137,7 +137,14 @@
       "default": "./src/rehydrate.mjs"
     },
     "./credential-names": "./python/agent_sanitizer/secrets/data/credential-names.json",
-    "./claude-hooks": "./claude-hooks/plugin-hooks.mjs"
+    "./claude-hooks": {
+      "types": "./types/claude-hooks/plugin-hooks.d.mts",
+      "default": "./claude-hooks/plugin-hooks.mjs"
+    },
+    "./claude-hooks/*": {
+      "types": "./types/claude-hooks/*.d.mts",
+      "default": "./claude-hooks/*.mjs"
+    }
   },
   "files": [
     "src/*.mjs",

--- a/test/claude-hooks-exports.test.mjs
+++ b/test/claude-hooks-exports.test.mjs
@@ -1,0 +1,124 @@
+/**
+ * The hook modules are a PUBLIC composition surface, reachable as
+ * `agent-sanitizer/claude-hooks/<module>` and
+ * `agent-sanitizer/claude-hooks/lib/<module>`.
+ *
+ * 2.4.1 shipped the hooks with a single `"./claude-hooks"` subpath pointing at
+ * plugin-hooks.mjs, whose only export is the `--hook=` CLI dispatcher. Every
+ * composable piece — sanitizeText, evaluateToolOutput, the whole hook-io
+ * toolkit — was packed in the tarball but unreachable: an exports map with no
+ * matching subpath makes Node refuse the deep import outright
+ * (ERR_PACKAGE_PATH_NOT_EXPORTED), so a consumer wanting to reuse one of these
+ * hooks had to vendor a copy.
+ *
+ * These drive Node's real exports resolution via `import.meta.resolve` against
+ * the package's own name — the same resolution a consumer's bare import
+ * performs — and then import the resolved module, so both halves are asserted:
+ * the subpath resolves AND the module behind it loads. A relative import would
+ * pass even with the exports map broken, which is exactly the regression that
+ * shipped.
+ *
+ * The tarball half (declarations paired with every exposed module) is asserted
+ * in package-exports.test.mjs, which drives `npm pack`.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const hooksDir = fileURLToPath(new URL("../claude-hooks", import.meta.url));
+
+/**
+ * Every hook module on disk, as its `claude-hooks/*` subpath suffix
+ * (`sanitize-output`, `lib/hook-io`, …). Enumerated from the directory rather
+ * than hard-coded so a module added later is covered without editing this file
+ * — the failure mode a fixed list has is passing while the new module sits
+ * unreachable.
+ */
+function hookModules() {
+  const mjs = (dir, prefix) =>
+    readdirSync(dir, { withFileTypes: true })
+      .filter((e) => e.isFile() && e.name.endsWith(".mjs"))
+      .map((e) => `${prefix}${e.name.replace(/\.mjs$/u, "")}`);
+  return [
+    ...mjs(hooksDir, ""),
+    ...mjs(path.join(hooksDir, "lib"), "lib/"),
+  ].sort();
+}
+
+// A named export each module must carry, so the test asserts a usable surface
+// rather than "the import didn't throw". These are the entry points a consumer
+// composes with; a module that resolves but exports nothing is a fail-open this
+// closes.
+const REQUIRED_EXPORT = {
+  "plugin-hooks": "main",
+  "pretooluse-sanitize": "judgePreToolUseSanitize",
+  "sanitize-output": "sanitizeText",
+  "sanitize-user-prompt": "judgeSanitizeUserPrompt",
+  "scan-invisible-chars": "scanFile",
+  "lib/authored-content": "sanitizeAuthoredContent",
+  "lib/control-plane": "runJudgeCli",
+  "lib/env-config": "looksLikeCredentialVar",
+  "lib/hook-io": "lazyImport",
+  "lib/invisible-alert": "invisibleCharAlert",
+  "lib/redactor-client": "redactViaDaemon",
+  "lib/reveal": "persistReveal",
+  "lib/secret-annotate": "hasEnvBoundSecret",
+  "lib/trace": "trace",
+};
+
+describe("claude-hooks composition surface resolves through the exports map", () => {
+  const modules = hookModules();
+
+  it("finds hook modules to check (non-vacuous)", () => {
+    assert.ok(modules.length > 0, "no .mjs modules found under claude-hooks/");
+    // Every module on disk must be named above, or a new one silently escapes
+    // the per-module assertions below.
+    assert.deepEqual(
+      modules.filter((m) => !REQUIRED_EXPORT[m]),
+      [],
+      "hook modules with no REQUIRED_EXPORT entry — add one",
+    );
+  });
+
+  for (const name of modules) {
+    const subpath = `agent-sanitizer/claude-hooks/${name}`;
+    it(`${subpath} resolves and exports ${REQUIRED_EXPORT[name]}`, async () => {
+      // Self-reference: a package with an `exports` map resolves its own name,
+      // so this throws ERR_PACKAGE_PATH_NOT_EXPORTED on an unmapped subpath.
+      const resolved = import.meta.resolve(subpath);
+      assert.equal(fileURLToPath(resolved), path.join(hooksDir, `${name}.mjs`));
+      const mod = await import(resolved);
+      assert.ok(
+        typeof mod[REQUIRED_EXPORT[name]] === "function",
+        `${subpath} does not export ${REQUIRED_EXPORT[name]} as a function`,
+      );
+    });
+  }
+
+  // The one hazard a `*` subpath adds over a hand-listed set: it must not become
+  // a reader for arbitrary files in the package. Node refuses a `..` segment in
+  // the specifier itself, so the pattern cannot be walked out of `claude-hooks/`
+  // — asserted here because the guarantee lives in Node's resolver, not in our
+  // map, and a future move to a hand-rolled loader would silently lose it.
+  it("refuses a traversal out of claude-hooks/", () => {
+    assert.throws(
+      () =>
+        import.meta.resolve("agent-sanitizer/claude-hooks/../../package.json"),
+      { code: "ERR_INVALID_MODULE_SPECIFIER" },
+    );
+  });
+
+  // The bare `./claude-hooks` subpath is the documented CLI entry and stays
+  // resolvable on its own — the wildcard must not have displaced it.
+  it("keeps the bare ./claude-hooks entry pointing at the CLI dispatcher", async () => {
+    const resolved = import.meta.resolve("agent-sanitizer/claude-hooks");
+    assert.equal(
+      fileURLToPath(resolved),
+      path.join(hooksDir, "plugin-hooks.mjs"),
+    );
+    const { main } = await import(resolved);
+    assert.equal(typeof main, "function");
+  });
+});

--- a/test/package-exports.test.mjs
+++ b/test/package-exports.test.mjs
@@ -9,9 +9,13 @@
  *
  * `npm pack --dry-run --json` runs `prepack` exactly as a real publish does and
  * reports the resulting file list, so this asserts against what would actually
- * be shipped rather than the working tree. Each `types`/`default` target in the
- * exports map must appear in that list; the `.d.mts` half is asserted non-empty
- * so the check can never pass vacuously if the type targets disappear.
+ * be shipped rather than the working tree. Each literal `types`/`default` target
+ * in the exports map must appear in that list; the `.d.mts` half is asserted
+ * non-empty so the check can never pass vacuously if the type targets disappear.
+ *
+ * A `*` subpath (`"./claude-hooks/*"`) names a family rather than a file, so it
+ * gets the pairwise form instead: every packed file the pattern exposes must
+ * have its declaration packed under the same `*` substitution.
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
@@ -31,26 +35,58 @@ const pkg = JSON.parse(
 // set keeps the guard tracking the real map instead of a hard-coded pair.
 const FILE_CONDITIONS = ["types", "default", "import", "require", "node"];
 
+/** The condition → file map for one subpath, with the leading `./` stripped. */
+function conditionFiles(target) {
+  // A subpath may name its file directly instead of through a conditions
+  // object (`"./credential-names": "./…/credential-names.json"`). Iterating
+  // such a string with Object.entries yields character indices, none of which
+  // is a file condition — so the subpath would be skipped and its file left
+  // unguarded, which is the fail-open this branch closes.
+  if (typeof target === "string")
+    return { default: target.replace(/^\.\//, "") };
+  return Object.fromEntries(
+    Object.entries(target)
+      .filter(([condition]) => FILE_CONDITIONS.includes(condition))
+      .map(([condition, value]) => [condition, value.replace(/^\.\//, "")]),
+  );
+}
+
+/** Literal (non-pattern) subpath targets, split by condition kind. */
 function exportedFiles() {
   const types = [];
   const runtime = [];
-  for (const target of Object.values(pkg.exports)) {
-    // A subpath may name its file directly instead of through a conditions
-    // object (`"./credential-names": "./…/credential-names.json"`). Iterating
-    // such a string with Object.entries yields character indices, none of which
-    // is a file condition — so the subpath would be skipped and its file left
-    // unguarded, which is the fail-open this branch closes.
-    if (typeof target === "string") {
-      runtime.push(target.replace(/^\.\//, ""));
-      continue;
-    }
-    for (const [condition, value] of Object.entries(target)) {
-      if (!FILE_CONDITIONS.includes(condition)) continue;
-      const file = value.replace(/^\.\//, "");
+  for (const [subpath, target] of Object.entries(pkg.exports)) {
+    if (subpath.includes("*")) continue; // asserted by patternSubpaths below
+    for (const [condition, file] of Object.entries(conditionFiles(target)))
       (condition === "types" ? types : runtime).push(file);
-    }
   }
   return { types, runtime };
+}
+
+/** Subpath patterns (`"./claude-hooks/*"`), keyed by subpath. */
+function patternSubpaths() {
+  return Object.entries(pkg.exports)
+    .filter(([subpath]) => subpath.includes("*"))
+    .map(([subpath, target]) => ({ subpath, ...conditionFiles(target) }));
+}
+
+/**
+ * A regex matching the files a `*` target covers, capturing the substitution.
+ * `claude-hooks/*.mjs` → `/^claude-hooks\/(.+)\.mjs$/`, so the capture from a
+ * packed runtime file is the same `*` value that must fill the types target.
+ */
+function patternRe(pattern) {
+  const parts = pattern.split("*");
+  // Node substitutes only the first `*`; a second one would silently make the
+  // rest of this function match the wrong span.
+  assert.equal(
+    parts.length,
+    2,
+    `exports pattern needs exactly one *: ${pattern}`,
+  );
+  const [prefix, suffix] = parts;
+  const quote = (s) => s.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  return new RegExp(`^${quote(prefix)}(.+)${quote(suffix)}$`, "u");
 }
 
 // Pack list as it would publish: `--dry-run` runs `prepack` (building the
@@ -96,6 +132,40 @@ describe("packaging contract: exports map vs. published tarball", () => {
       [],
       `exports promise runtime files the tarball does not ship: ${missing.join(", ")}`,
     );
+  });
+
+  // A `*` subpath cannot be checked for exact membership — its target names a
+  // family, not a file. The contract that matters is pairwise: every runtime
+  // file the pattern actually exposes must have its declaration packed under
+  // the same `*` substitution. That is what a consumer's deep import needs, and
+  // it catches the half-shipped case (a hook module packed with no .d.mts)
+  // which an "at least one match" check would wave through.
+  it("ships a paired declaration for every file a `*` subpath exposes", () => {
+    const patterns = patternSubpaths();
+    assert.ok(patterns.length > 0, "no `*` subpaths found — guard is vacuous");
+    for (const {
+      subpath,
+      default: runtimePattern,
+      types: typesPattern,
+    } of patterns) {
+      assert.ok(typesPattern, `${subpath} has no types condition`);
+      const re = patternRe(runtimePattern);
+      const exposed = [...packed].filter((f) => re.test(f));
+      assert.ok(
+        exposed.length > 0,
+        `${subpath} exposes no packed file — is ${runtimePattern} in "files"?`,
+      );
+      const missing = exposed
+        // Replacer function, not a string: a `$` in a filename would otherwise
+        // be read as a substitution pattern and silently corrupt the path.
+        .map((f) => typesPattern.replace("*", () => f.match(re)[1]))
+        .filter((d) => !packed.has(d));
+      assert.deepEqual(
+        missing,
+        [],
+        `${subpath} exposes runtime files whose declarations are not packed: ${missing.join(", ")}`,
+      );
+    }
   });
 
   // Top-level docs a consumer reaches for from an installed copy: the license,

--- a/test/types-consumer.test.mjs
+++ b/test/types-consumer.test.mjs
@@ -8,10 +8,15 @@
  *
  * This test closes that gap: it emits the declarations the same way `prepack`
  * does, assembles a throwaway package install in a temp dir (real package.json,
- * so the real `exports` map drives resolution), and type-checks
- * `type-fixtures/consumer/consumer.mts` against it — a faithful, offline
- * downstream typecheck. The fixture imports the package by name and asserts the
- * public types via `IsAny` guards that fail closed on `any`.
+ * so the real `exports` map drives resolution), and type-checks the fixtures in
+ * `type-fixtures/consumer/` against it — a faithful, offline downstream
+ * typecheck. Each fixture imports the package by name and asserts the public
+ * types via `IsAny` guards that fail closed on `any`.
+ *
+ * The throwaway install deliberately runs WITHOUT `skipLibCheck`, so the shipped
+ * declarations are checked for internal resolution too: a `.d.mts` that names a
+ * module the package does not declare as a dependency — the failure a consumer
+ * hits and we never would — is a TS2307 here.
  *
  * The build emits into the temp dir, never the repo's `types/`, so it cannot
  * race the concurrent `npm pack` in package-exports.test.mjs (node:test runs
@@ -20,7 +25,14 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, copyFileSync, writeFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  copyFileSync,
+  writeFileSync,
+  symlinkSync,
+  realpathSync,
+} from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
@@ -41,25 +53,53 @@ function runTsc(args, cwd) {
   }
 }
 
+// Both declaration builds prepack runs, each with its outDir redirected into the
+// temp package. `types/claude-hooks` must land under the same `types/` root the
+// exports map names, so the hooks build's outDir is the subdirectory rather than
+// a second root.
+const BUILDS = [
+  { config: "tsconfig.build.json", outSubdir: "" },
+  { config: "tsconfig.build-hooks.json", outSubdir: "claude-hooks" },
+];
+
+// Fixtures type-checked together in one tsc run: the library subpaths and the
+// claude-hooks composition surface. tsc names the offending file in its
+// diagnostics, so one run still says which surface regressed.
+const FIXTURES = ["consumer.mts", "hooks-consumer.mts"];
+
+// What a real install of this package resolves alongside it, and nothing more:
+// agent-control-plane-core is a declared dependency (the hooks' judge signatures
+// are typed by its ToolCallEvent/Verdict), and @types/node backs the `node:*`
+// references the declarations carry. Linking exactly these is what makes the
+// no-skipLibCheck run meaningful — anything else a declaration reaches for is a
+// missing dependency, and reds.
+const LINKED_DEPS = ["agent-control-plane-core", "@types/node"];
+
 describe("public types: downstream consumer typecheck", () => {
-  it("type-checks a name-resolved consumer against the emitted declarations", () => {
+  it("type-checks name-resolved consumers against the emitted declarations", () => {
     const tmp = mkdtempSync(path.join(os.tmpdir(), "ais-consumer-"));
     // Lay the package out as it installs: node_modules/<name>/{package.json,types}.
-    const pkgDir = path.join(tmp, "node_modules", "agent-sanitizer");
+    const nodeModules = path.join(tmp, "node_modules");
+    const pkgDir = path.join(nodeModules, "agent-sanitizer");
     mkdirSync(path.join(pkgDir, "types"), { recursive: true });
 
-    // Emit declarations into the temp package, not the repo's types/ — same
-    // config prepack uses, just a redirected outDir.
-    const build = runTsc(
-      [
-        "-p",
-        path.join(repoRoot, "tsconfig.build.json"),
-        "--outDir",
-        path.join(pkgDir, "types"),
-      ],
-      repoRoot,
-    );
-    assert.ok(build.ok, `declaration emit failed:\n${build.output}`);
+    // Emit declarations into the temp package, never the repo's types/ — that
+    // would race the concurrent npm pack in package-exports.test.mjs.
+    for (const { config, outSubdir } of BUILDS) {
+      const build = runTsc(
+        [
+          "-p",
+          path.join(repoRoot, config),
+          "--outDir",
+          path.join(pkgDir, "types", outSubdir),
+        ],
+        repoRoot,
+      );
+      assert.ok(
+        build.ok,
+        `declaration emit failed (${config}):\n${build.output}`,
+      );
+    }
 
     // The real package.json so resolution honors the actual `exports` map
     // (subpath -> .d.mts), exactly as a downstream install would.
@@ -68,12 +108,23 @@ describe("public types: downstream consumer typecheck", () => {
       path.join(pkgDir, "package.json"),
     );
 
-    // Consumer + its tsconfig must sit inside tmp so bare-specifier resolution
+    for (const dep of LINKED_DEPS) {
+      const link = path.join(nodeModules, dep);
+      mkdirSync(path.dirname(link), { recursive: true }); // scoped name: @types/node
+      symlinkSync(
+        realpathSync(path.join(repoRoot, "node_modules", dep)),
+        link,
+        "dir",
+      );
+    }
+
+    // Fixtures + their tsconfig must sit inside tmp so bare-specifier resolution
     // finds tmp/node_modules/agent-sanitizer.
-    copyFileSync(
-      path.join(repoRoot, "type-fixtures", "consumer", "consumer.mts"),
-      path.join(tmp, "consumer.mts"),
-    );
+    for (const fixture of FIXTURES)
+      copyFileSync(
+        path.join(repoRoot, "type-fixtures", "consumer", fixture),
+        path.join(tmp, fixture),
+      );
     writeFileSync(
       path.join(tmp, "tsconfig.json"),
       JSON.stringify({
@@ -84,11 +135,10 @@ describe("public types: downstream consumer typecheck", () => {
           lib: ["ES2022"],
           strict: true,
           noEmit: true,
-          skipLibCheck: true,
           forceConsistentCasingInFileNames: true,
-          types: [],
+          types: ["node"],
         },
-        include: ["consumer.mts"],
+        include: FIXTURES,
       }),
     );
 

--- a/tsconfig.build-hooks.json
+++ b/tsconfig.build-hooks.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "rootDir": "claude-hooks",
+    "outDir": "types/claude-hooks"
+  },
+  "include": ["claude-hooks/**/*.mjs"]
+}

--- a/type-fixtures/consumer/hooks-consumer.mts
+++ b/type-fixtures/consumer/hooks-consumer.mts
@@ -1,0 +1,138 @@
+// Consumer-perspective type fixture for the `claude-hooks/*` composition
+// surface. Companion to consumer.mts (which covers the library subpaths); this
+// file imports each hook module BY NAME through the published `exports` map, so
+// it fails both when a subpath stops resolving and when its generated `.d.mts`
+// widens an export to `any`. The accompanying types-consumer.test.mjs builds the
+// declarations and type-checks this file against a real package layout.
+
+import { main } from "agent-sanitizer/claude-hooks";
+import {
+  sanitizeText,
+  evaluateToolOutput,
+  composeContext,
+  failClosedReplacement,
+  SECRET_HINT,
+} from "agent-sanitizer/claude-hooks/sanitize-output";
+import { judgePreToolUseSanitize } from "agent-sanitizer/claude-hooks/pretooluse-sanitize";
+import { judgeSanitizeUserPrompt } from "agent-sanitizer/claude-hooks/sanitize-user-prompt";
+import {
+  scanFile,
+  LONG_RUN_THRESHOLD,
+} from "agent-sanitizer/claude-hooks/scan-invisible-chars";
+import {
+  lazyImport,
+  registerLazyModules,
+  makeDeadline,
+  readFlag,
+  HookEvent,
+  PermissionDecision,
+} from "agent-sanitizer/claude-hooks/lib/hook-io";
+import { sanitizeAuthoredContent } from "agent-sanitizer/claude-hooks/lib/authored-content";
+import { runJudgeCli } from "agent-sanitizer/claude-hooks/lib/control-plane";
+import { looksLikeCredentialVar } from "agent-sanitizer/claude-hooks/lib/env-config";
+import { invisibleCharAlert } from "agent-sanitizer/claude-hooks/lib/invisible-alert";
+import { redactViaDaemon } from "agent-sanitizer/claude-hooks/lib/redactor-client";
+import { persistReveal } from "agent-sanitizer/claude-hooks/lib/reveal";
+import { hasEnvBoundSecret } from "agent-sanitizer/claude-hooks/lib/secret-annotate";
+import { trace } from "agent-sanitizer/claude-hooks/lib/trace";
+
+// `0 extends 1 & T` is only true when T is `any` — see consumer.mts for why a
+// plain annotation cannot catch a declaration that collapsed to `any`.
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+// One guard per module, so a single module's declaration collapsing to `any`
+// (or vanishing) is a compile error rather than a silently untyped import.
+const _mainNotAny: IsAny<typeof main> = false;
+const _sanitizeTextNotAny: IsAny<typeof sanitizeText> = false;
+const _evaluateToolOutputNotAny: IsAny<typeof evaluateToolOutput> = false;
+const _judgePreToolUseNotAny: IsAny<typeof judgePreToolUseSanitize> = false;
+const _judgePromptNotAny: IsAny<typeof judgeSanitizeUserPrompt> = false;
+const _scanFileNotAny: IsAny<typeof scanFile> = false;
+const _lazyImportNotAny: IsAny<typeof lazyImport> = false;
+const _authoredNotAny: IsAny<typeof sanitizeAuthoredContent> = false;
+const _runJudgeCliNotAny: IsAny<typeof runJudgeCli> = false;
+const _credentialVarNotAny: IsAny<typeof looksLikeCredentialVar> = false;
+const _alertNotAny: IsAny<typeof invisibleCharAlert> = false;
+const _redactNotAny: IsAny<typeof redactViaDaemon> = false;
+const _revealNotAny: IsAny<typeof persistReveal> = false;
+const _envSecretNotAny: IsAny<typeof hasEnvBoundSecret> = false;
+const _traceNotAny: IsAny<typeof trace> = false;
+
+// SECRET_HINT is re-exported from the package root through a destructured
+// lazyImport — the shape most at risk of emitting as `any`.
+const _secretNotAny: IsAny<typeof SECRET_HINT> = false;
+const _secret: RegExp = SECRET_HINT;
+
+// sanitize-output: the per-blob and whole-event entry points a composer wraps.
+// The deadline argument is the documented shared-budget shape.
+const _text = await sanitizeText("x", "Bash", { remainingMs: () => 1000 });
+const _textCleaned: string = _text.cleaned;
+const _textWarnings: string[] = _text.warnings;
+const _textModified: boolean = _text.modified;
+const _textSgrNote: boolean = _text.sgrNote;
+
+// evaluateToolOutput answers the PostToolUse contract fields, or null when the
+// output needed no intervention — the nullability is part of the contract.
+const _evaluated: {
+  mutated_output?: unknown;
+  additional_context?: string;
+} | null = await evaluateToolOutput({ tool_name: "Bash" });
+
+const _context: string = composeContext(true, ["w"], "Bash");
+const _failClosed = failClosedReplacement("raw", "why");
+
+// hook-io: the frozen enums must keep their literal-keyed types, so a typo is a
+// compile error rather than an undefined lookup.
+const _event: "PostToolUse" = HookEvent.POST_TOOL_USE;
+const _decision: "deny" = PermissionDecision.DENY;
+// @ts-expect-error — an unknown event key must not type-check.
+HookEvent.NOT_A_REAL_EVENT;
+
+const _remaining: number = makeDeadline(1000).remainingMs();
+const _flag: string | undefined = readFlag(["--hook=x"], "hook");
+const _lazy: Record<string, any> = await lazyImport("agent-sanitizer");
+registerLazyModules({});
+
+// The remaining libs, called at their documented signatures.
+const _threshold: number = LONG_RUN_THRESHOLD;
+const _credential: boolean = looksLikeCredentialVar("MY_API_TOKEN");
+const _envSecret: boolean = hasEnvBoundSecret("text");
+const _alerted: string | null = invisibleCharAlert();
+
+// Reference every binding so readers (and noUnusedLocals, if ever enabled) see
+// them as load-bearing assertions rather than dead code.
+export const _assertions = [
+  _mainNotAny,
+  _sanitizeTextNotAny,
+  _evaluateToolOutputNotAny,
+  _judgePreToolUseNotAny,
+  _judgePromptNotAny,
+  _scanFileNotAny,
+  _lazyImportNotAny,
+  _authoredNotAny,
+  _runJudgeCliNotAny,
+  _credentialVarNotAny,
+  _alertNotAny,
+  _redactNotAny,
+  _revealNotAny,
+  _envSecretNotAny,
+  _traceNotAny,
+  _secretNotAny,
+  _secret,
+  _textCleaned,
+  _textWarnings,
+  _textModified,
+  _textSgrNote,
+  _evaluated,
+  _context,
+  _failClosed,
+  _event,
+  _decision,
+  _remaining,
+  _flag,
+  _lazy,
+  _threshold,
+  _credential,
+  _envSecret,
+  _alerted,
+] as const;


### PR DESCRIPTION
## Summary

2.4.1 ships the four Claude Code hooks and their nine shared libs in the tarball, but the exports map lists exactly one claude-hooks subpath — `"./claude-hooks"` → `plugin-hooks.mjs`, whose only export is the `--hook=` CLI dispatcher. Node refuses any deeper import outright, so the entire composition surface (`sanitizeText`, `evaluateToolOutput`, `composeContext`, `failClosedReplacement`, the whole hook-io lazy-import/deadline toolkit) is packed and unreachable:

```
$ node -e "import('agent-sanitizer/claude-hooks/lib/hook-io.mjs')"
ERR_PACKAGE_PATH_NOT_EXPORTED: Package subpath './claude-hooks/lib/hook-io.mjs'
is not defined by "exports"
```

A consumer wanting to reuse one hook had to vendor a copy.

Fix: a `"./claude-hooks/*"` pattern subpath, plus declaration emit for the hook tree so each subpath is **typed** rather than resolving to untyped `.mjs`. `agent-sanitizer/claude-hooks/sanitize-output`, `.../lib/hook-io`, and so on now resolve and import; the bare `"./claude-hooks"` entry still points at the CLI dispatcher and gains a `types` condition it never had.

A pattern rather than a hand-listed set of 14 entries: `files` already ships the whole `claude-hooks` tree as one unit, and a per-module allowlist recreates a smaller version of the bug — the next lib added stays unreachable until someone remembers the second edit.

## Changes

| File | What |
| --- | --- |
| `package.json` | `"./claude-hooks/*"` subpath (typed); `types` condition on the bare `"./claude-hooks"`; `build:types` runs both declaration configs |
| `tsconfig.build-hooks.json` | new — emits `claude-hooks/**/*.mjs` declarations to `types/claude-hooks/` (`types/` is gitignored, built by `prepack`) |
| `test/claude-hooks-exports.test.mjs` | new — resolves every module on disk through `import.meta.resolve`, imports it, asserts a named export; plus a traversal-refusal case |
| `test/package-exports.test.mjs` | packaging contract now understands `*` subpaths (pairwise: every exposed runtime file must have its declaration packed) |
| `test/types-consumer.test.mjs` | throwaway install gets both declaration builds and both fixtures; runs **without** `skipLibCheck` |
| `type-fixtures/consumer/hooks-consumer.mts` | new — imports all 14 modules by name, `IsAny` guard per module |
| `.hooks/ssot-guard-pairs.json` | `package.json` → the new resolution test, so an exports edit can't break the surface silently |
| `README.md` | documents the composition subpaths and their stability posture |

Subpaths are **extensionless** (`.../lib/hook-io`, not `.../lib/hook-io.mjs`), matching the nine existing library subpaths. The `.mjs` spelling is not a second alias — it resolves to `hook-io.mjs.mjs` and fails at import.

## Tests / verification

Observed, not inferred — every claim below was run on this branch.

| Claim | Falsifying command | Result |
| --- | --- | --- |
| Full suite green | `pnpm test` | 1977 pass / 0 fail, exit 0, 75 s, 100% coverage |
| Lint + typecheck green | `pnpm lint` && `pnpm check` | clean (`tsc -p tsconfig.hooks.json` needs the real install; it is red in a devDeps-only tree) |
| Format clean | `pnpm format:check` | clean |
| Declarations emit for all 14 modules | `pnpm build:types && find types/claude-hooks -name '*.d.mts'` | 14 files, no `any` widening on the destructured re-exports (`SECRET_HINT: RegExp`, `applyLayer1: typeof import("agent-sanitizer").applyLayer1`) |
| Every module imports with no side effect | the new test's `await import(resolved)` per module | 17/17; no CLI runs, no stdin read |

Non-vacuity checks (predicted red, then ran):

- Restoring the 2.4.1 exports map → `claude-hooks-exports.test.mjs` **14 fail / 2 pass**. Restored → 16/16.
- Pointing the types pattern at a typo'd dir → the new pairwise packaging assertion **reds**; the other three still pass, so it is the pattern half doing the work.
- Breaking one annotation in `hooks-consumer.mts` → `TS2322` naming that fixture, so it is genuinely in the typecheck rather than silently skipped.
- Dropping `agent-control-plane-core` from the linked deps → `TS2307` from the shipped `control-plane.d.mts`, confirming the no-`skipLibCheck` run is load-bearing.

## Decisions made

**Pattern subpath vs. 14 explicit entries.** Chose the pattern. Under the alternative the surface is a deliberate allowlist and `package-exports.test.mjs` needs no change, at the cost of ~60 lines of `package.json` and a per-module edit forever.

**Stability posture.** Documented the composition subpaths as reachable-and-typed but not the supported surface — same stance the README already takes on the `_AGENT_SANITIZER_*` variables. Under the alternative these become semver-stable public API and every hook-internal rename is a breaking change.

**No `skipLibCheck` in the consumer typecheck.** The hooks declarations are the first to reference a third-party module (`agent-control-plane-core`) in type positions, so the "declaration names a module we don't declare as a dependency" failure was newly reachable and invisible to us. Linking exactly the real install's deps and dropping `skipLibCheck` makes it a TS2307 here. Under the alternative that class ships and only the consumer sees it.

**Dropped an unverifiable guard.** An earlier version guarded the judges' `Verdict` return type with `IsAny`, on the theory it would catch an unresolvable dependency. It does not — TS's error type is not `any` by that test, and the guard stayed green with the dependency removed. Deleted rather than kept with a comment claiming something it doesn't do; the no-`skipLibCheck` run covers it directly.

## Checklist

- [x] Commits follow Conventional Commits; each subject reads as a user-facing release note.
- [x] `pnpm test`, `pnpm lint`, and `pnpm check` pass locally.
- [x] New or changed detectors have negative tests — n/a, no detector changed; the new tests do carry negative cases (traversal refusal, non-vacuity reds above).
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version left untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DQLQtpidpswgARdaNuG2oE)_