### PR TITLE
fix(secrets): read URL userinfo with the URL parser, not a user:pass@ regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,6 @@
     "rehype-parse": "9.0.1",
     "remark-gfm": "4.0.1",
     "remark-parse": "11.0.0",
-    "style-to-object": "1.0.14",
     "unified": "11.0.5",
     "unist-util-visit": "5.1.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       remark-parse:
         specifier: 11.0.0
         version: 11.0.0
-      style-to-object:
-        specifier: 1.0.14
-        version: 1.0.14
       unified:
         specifier: 11.0.5
         version: 11.0.5

--- a/python/agent_sanitizer/secrets/engine.py
+++ b/python/agent_sanitizer/secrets/engine.py
@@ -23,6 +23,7 @@ import functools
 import json
 import re
 from pathlib import Path
+from urllib.parse import urlsplit
 
 from detect_secrets.core.plugins.util import get_mapping_from_secret_type_to_class
 from detect_secrets.core.potential_secret import PotentialSecret
@@ -553,9 +554,6 @@ def _is_filesystem_path(m: re.Match[str]) -> bool:
 # strips a public endpoint for no security gain. Skip a URL that carries no
 # credential material; keep redacting one that DOES embed a secret.
 _ENDPOINT_URL_RE = re.compile(r"https?://[^\s]+\Z", re.IGNORECASE)
-# Userinfo credentials in the authority (`https://user:pass@host/…`): a password
-# before the `@` is a real secret, so such a URL is never skipped.
-_URL_USERINFO_RE = re.compile(r"https?://[^/@\s]*:[^/@\s]*@", re.IGNORECASE)
 # An opaque credential-shaped run: >=20 CONTIGUOUS base64/hex-alphabet chars
 # mixing letters AND digits (a Slack webhook token path, a bearer blob) — the
 # high-entropy shape a benign path segment (`token`, `authorize`, `v2`,
@@ -574,16 +572,37 @@ def _has_opaque_run(value: str) -> bool:
     )
 
 
+def _has_userinfo(value: str) -> bool:
+    """True when the URL's authority carries userinfo — credential material.
+
+    The authority is delimited by the URL grammar, so ``urlsplit`` is asked for it
+    rather than a pattern being written for it. That matters for what it catches:
+    userinfo needs no colon to be a credential (``https://ghp_…@github.com`` is a
+    bare-token clone URL), and a ``user:pass@`` pattern requiring one lets exactly
+    that spelling through. It also matters for what it does NOT catch — an ``@``
+    later in the path or query (``/@scope/pkg``) is not userinfo, and only the
+    grammar knows where the authority ends.
+    """
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        # An authority `urlsplit` refuses to read (a bracketed-host/port error) is
+        # one we cannot clear, so it is not a public endpoint. This is the fail-safe
+        # direction: the value stays redacted.
+        return True
+    return bool(parsed.username or parsed.password)
+
+
 def _is_public_endpoint_url(value: str) -> bool:
     """True when the value is a bare origin/endpoint URL carrying no credential
-    material (no userinfo password, no opaque high-entropy token in the
-    path/query), so redacting it would strip a public endpoint. A URL that DOES
-    embed a secret (a Slack ``webhook_url`` token path, ``user:pass@``) is not
+    material (no userinfo, no opaque high-entropy token in the path/query), so
+    redacting it would strip a public endpoint. A URL that DOES embed a secret (a
+    Slack ``webhook_url`` token path, ``user:pass@``, a bare ``token@``) is not
     skipped. Attacker-safe on web ingress: a clean URL hides no secret, and a
     smuggled token in the path trips the opaque-run gate."""
     if _ENDPOINT_URL_RE.fullmatch(value) is None:
         return False
-    if _URL_USERINFO_RE.match(value):
+    if _has_userinfo(value):
         return False
     return not _has_opaque_run(value)
 

--- a/test/html.test.mjs
+++ b/test/html.test.mjs
@@ -365,10 +365,10 @@ const HIDDEN_STYLE_CASES = [
   ["display:none !\\69mportant", true], // with a space before the escaped flag
   ["display:block!\\69mportant", false], // decodes to "block!important" -> stripped -> "block", visible
   ["visibility:hi\\64 den!important", true], // escaped value AND a plain important flag
-  // ── raw fallback for declarations style-to-object cannot parse at all ──
+  // ── raw fallback for declarations the declaration parser cannot read at all ──
   // An escape in the PROPERTY NAME is valid CSS a browser applies, but a parse
-  // error to style-to-object even in isolation; the raw first-colon fallback
-  // must still detect it (previously a hidden-content bypass).
+  // error to the declaration parser even in isolation; the raw first-colon
+  // fallback must still detect it (a hidden-content bypass otherwise).
   ["\\64 isplay:none", true], // `\64` -> 'd': browser reads `display:none`
   ["\\76 isibility:hidden", true], // `\76` -> 'v': browser reads `visibility:hidden`
   ["color:red;\\64 isplay:none", true], // valid decl first, escaped hider second
@@ -387,7 +387,7 @@ const HIDDEN_STYLE_CASES = [
 ];
 
 // Negative corpus for the raw-declaration fallback: realistic legitimate
-// styles — including parse-breaking ones style-to-object rejects — must
+// styles — including parse-breaking ones the declaration parser rejects — must
 // produce ZERO hidden verdicts, or the fallback would splice real content
 // (precision-over-recall doctrine).
 const LEGIT_STYLE_CORPUS = [

--- a/tests/secrets/test_secrets_engine.py
+++ b/tests/secrets/test_secrets_engine.py
@@ -1235,6 +1235,29 @@ _SLACK_WEBHOOK = (
             "https://user:s3cr3tpassw0rd@example.com/api",
             False,
         ),
+        # Userinfo needs no colon to be a credential: a bare-token clone URL is
+        # exactly this shape, and its all-letter token trips no opaque-run gate.
+        (
+            "bare-token userinfo, no colon",
+            "https://ghptokenabcdefghijklmn@github.com/owner/repo.git",
+            False,
+        ),
+        (
+            "bare-token userinfo on a webhook host",
+            "https://xoxbslacktokenletters@hooks.slack.com/services",
+            False,
+        ),
+        # ...while an `@` outside the authority is not userinfo at all. Only the URL
+        # grammar knows where the authority ends.
+        (
+            "scoped package path, @ in the path",
+            "https://registry.npmjs.org/@scope/pkg",
+            True,
+        ),
+        ("@ in the query", "https://example.com/cb?next=user@example.com", True),
+        # An authority the URL parser refuses to read is one we cannot clear, so the
+        # value stays redacted rather than being waved through as public.
+        ("unparseable authority fails safe", "https://[::1/api", False),
         (
             "opaque token in query",
             "https://example.com/cb?access=aB3xK9mN2pQ7rT4wY1cV5bZ8",
@@ -1250,12 +1273,16 @@ def test_is_public_endpoint_url(label, value, expected):
 
 @pytest.mark.parametrize(
     "field",
-    ["token_url", "access_token_url", "secret_endpoint", "auth_url"],
+    ["token_url", "access_token_url", "secret_endpoint"],
 )
 def test_public_endpoint_url_skipped_after_keyword(field):
     # A public endpoint under a credential-named field is NOT a secret; skip it
     # on BOTH local and web ingress (a clean URL smuggles no credential).
     text = f"{field} = https://oauth2.googleapis.com/token"
+    # The skip is only meaningful if the field-value matcher reached the value at
+    # all — without this, a field name the vocabulary does not carry would make
+    # `out == text` true for the wrong reason and assert nothing.
+    assert E.FIELD_VALUE_RE.search(text) is not None, field
     for web in (False, True):
         out, found = redact(text, cfg(web_ingress=web))
         assert out == text, (field, web)
@@ -1277,6 +1304,11 @@ def test_public_endpoint_url_skipped_after_keyword(field):
             "userinfo password",
             "auth_url = https://user:s3cr3tpassw0rd@example.com/api",
             "s3cr3tpassw0rd",
+        ),
+        (
+            "bare-token userinfo",
+            "token_url = https://ghptokenabcdefghijklmn@github.com/owner/repo.git",
+            "ghptokenabcdefghijklmn",
         ),
     ],
 )


### PR DESCRIPTION
Risk tier: high

## What & why

Ask `urllib.parse.urlsplit` for a URL's userinfo instead of matching `https?://[^/@\s]*:[^/@\s]*@`, so a bare-token credential URL under a credential-named field is redacted.

`_is_public_endpoint_url` skips redaction for a bare endpoint URL, so a public `token_url` is not stripped from model context. Its userinfo guard required a **colon** — but userinfo needs no colon to be a credential, and the colon-less spelling is the common one:

```
token_url = https://ghptokenabcdefghijklmn@github.com/owner/repo.git
```

No `:` before the `@`, and the all-letter token trips no opaque-run gate, so the whole URL — token included — was cleared as a public endpoint and reached the model verbatim.

## Review focus

`python/agent_sanitizer/secrets/engine.py`, the new `_has_userinfo`. It is also load-bearing for what it must *not* catch: an `@` in the path (`/@scope/pkg`) or query is not userinfo, and only the URL grammar knows where the authority ends — a widened regex would have splice-redacted legitimate registry URLs, against the precision-over-recall doctrine.

The judgment I'd most like checked is the `except ValueError` arm: an authority `urlsplit` refuses to read now fails **safe** (not a public endpoint → stays redacted), which is the opposite of this repo's usual fail-open-on-ambiguity rule. Reasoning: fail-open elsewhere means "treat as visible/benign" for a *removal* layer, where a false positive deletes real content; here the ambiguous value is already captured by a credential-named field, and the cost of clearing it wrongly is a leaked secret rather than mangled prose.

## How it was tested

- `uv run --extra dev pytest tests/secrets/ -q` → 934 passed, 6 skipped. New cases in `test_secrets_engine.py`: bare-token userinfo (with and without a webhook host), `@` in path and in query still public, unparseable authority fails safe, plus the end-to-end `test_secret_bearing_url_still_redacted[bare-token userinfo]` asserting the token is gone from the output on both local and web ingress.
- Red on the unfixed code: the same end-to-end case against `main`'s `engine.py` leaves `ghptokenabcdefghijklmn` in the output.
- `pnpm test` → 1977 passed, 0 failed; `pnpm check` clean (the `style-to-object` removal).

## Decisions made

- **Dropped the vestigial `style-to-object` dependency.** css-tree owns inline-style declaration parsing and nothing imports style-to-object, so it only shipped weight in the published closure; two test comments still named it as the parser and now name the live one. Confirmed unreferenced in `src/`, `claude-hooks/`, `bin/`, `scripts/`, and not required by rehype/remark/unified.
- **`test_public_endpoint_url_skipped_after_keyword` lost its `auth_url` case and gained a non-vacuity assertion.** `auth_url` is not a field-value noun, so `FIELD_VALUE_RE` never matched it and the test's `out == text` held for the wrong reason — it asserted nothing. It now asserts the matcher reached the value first.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M7doUqevH9Sadw2TU9Rdqw)_