### PR TITLE
fix(ci): make the PR reviewer able to run, and loud when it cannot

### DIFF
--- a/.github/actions/claude-conflict-resolve/action.yaml
+++ b/.github/actions/claude-conflict-resolve/action.yaml
@@ -64,7 +64,7 @@ runs:
         # outside the conflict list — so the LLM stays bounded to the conflicted
         # files it was asked to resolve.
         claude_args: >-
-          --model claude-opus-4-8
+          --model claude-opus-5
           --permission-mode acceptEdits
           --allowedTools "Read,Edit,Write,Grep,Glob"
         prompt: |

--- a/.github/actions/claude-conflict-resolve/action.yaml
+++ b/.github/actions/claude-conflict-resolve/action.yaml
@@ -6,14 +6,30 @@ description: >-
   set, the github-actions bot allowance, the file-scope prompt) has a single
   source of truth. All of the resolve job's safety rails (base-ref-staged
   scripts, the out-of-set edit guard in finalize, the fail-loud assert) live in
-  the calling workflow; this action only runs the agent. The credential and the
-  primary->fallback retry live in the shared claude-run action.
+  the calling workflow; this action only runs the agent. The credential ladder
+  lives in the shared claude-run action.
 inputs:
   oauth_token:
     description: "Primary Claude Code OAuth token this resolve is billed against."
     required: true
-  fallback_oauth_token:
-    description: "Backup Claude Code OAuth token; a failed primary attempt retries with it."
+  oauth_token_fallback:
+    description: "Second-tier token; empty skips the second attempt."
+    required: false
+    default: ""
+  oauth_token_fallback_3:
+    description: "Third-tier token; empty skips the third attempt."
+    required: false
+    default: ""
+  oauth_token_fallback_4:
+    description: "Fourth-tier token; empty skips the fourth attempt."
+    required: false
+    default: ""
+  oauth_token_fallback_5:
+    description: "Fifth-tier token; empty skips the fifth attempt."
+    required: false
+    default: ""
+  oauth_token_fallback_6:
+    description: "Sixth-tier token; empty skips the sixth attempt."
     required: false
     default: ""
   github_token:
@@ -41,10 +57,14 @@ runs:
       uses: ./.github/actions/claude-run
       with:
         # A wrong/missing token makes the run error on init (is_error, $0, 1 turn);
-        # claude-run retries once with the fallback token, and the caller's assert
-        # step turns a genuine double-failure into a loud failure.
+        # claude-run walks its credential ladder, and the caller's assert step
+        # turns an exhausted ladder into a loud failure.
         oauth_token: ${{ inputs.oauth_token }}
-        fallback_oauth_token: ${{ inputs.fallback_oauth_token }}
+        oauth_token_fallback: ${{ inputs.oauth_token_fallback }}
+        oauth_token_fallback_3: ${{ inputs.oauth_token_fallback_3 }}
+        oauth_token_fallback_4: ${{ inputs.oauth_token_fallback_4 }}
+        oauth_token_fallback_5: ${{ inputs.oauth_token_fallback_5 }}
+        oauth_token_fallback_6: ${{ inputs.oauth_token_fallback_6 }}
         github_token: ${{ inputs.github_token }}
         # The relay dispatches with github.token, so a relayed run's initiating
         # actor is github-actions (a Bot) — which the action rejects by default
@@ -63,8 +83,8 @@ runs:
         # and finalize's out-of-set guard still rejects any edit to a file
         # outside the conflict list — so the LLM stays bounded to the conflicted
         # files it was asked to resolve.
+        model: claude-opus-5
         claude_args: >-
-          --model claude-opus-5
           --permission-mode acceptEdits
           --allowedTools "Read,Edit,Write,Grep,Glob"
         prompt: |

--- a/.github/actions/claude-run/action.yaml
+++ b/.github/actions/claude-run/action.yaml
@@ -22,10 +22,6 @@ inputs:
       exchange. Empty lets the action resolve its own default.
     required: false
     default: ""
-  model:
-    description: "Passthrough for claude-code-action's top-level model input (when not set via claude_args)."
-    required: false
-    default: ""
   prompt:
     description: "Prompt for the agent. Empty runs the action in its event-driven (tag) mode."
     required: false
@@ -61,7 +57,6 @@ runs:
       with:
         claude_code_oauth_token: ${{ inputs.oauth_token }}
         github_token: ${{ inputs.github_token }}
-        model: ${{ inputs.model }}
         prompt: ${{ inputs.prompt }}
         claude_args: ${{ inputs.claude_args }}
         allowed_non_write_users: ${{ inputs.allowed_non_write_users }}
@@ -77,7 +72,6 @@ runs:
       with:
         claude_code_oauth_token: ${{ inputs.fallback_oauth_token }}
         github_token: ${{ inputs.github_token }}
-        model: ${{ inputs.model }}
         prompt: ${{ inputs.prompt }}
         claude_args: ${{ inputs.claude_args }}
         allowed_non_write_users: ${{ inputs.allowed_non_write_users }}

--- a/.github/actions/claude-run/action.yaml
+++ b/.github/actions/claude-run/action.yaml
@@ -22,6 +22,15 @@ inputs:
       exchange. Empty lets the action resolve its own default.
     required: false
     default: ""
+  model:
+    description: >-
+      Model id for the run. Forwarded as `--model` in claude_args, NOT as
+      claude-code-action's top-level `model` input: the pinned action does not
+      accept that input and warns "Unexpected input(s) 'model'" while silently
+      running on its default (Opus) tier. Leave empty only when claude_args
+      already carries its own `--model`.
+    required: false
+    default: ""
   prompt:
     description: "Prompt for the agent. Empty runs the action in its event-driven (tag) mode."
     required: false
@@ -58,7 +67,10 @@ runs:
         claude_code_oauth_token: ${{ inputs.oauth_token }}
         github_token: ${{ inputs.github_token }}
         prompt: ${{ inputs.prompt }}
-        claude_args: ${{ inputs.claude_args }}
+        # `--model` first so a caller that also spells one inside claude_args
+        # wins (claude-code-action honours the LAST --model), and so the model is
+        # always explicit here — the action's own default is Opus.
+        claude_args: ${{ inputs.model && format('--model {0} ', inputs.model) || '' }}${{ inputs.claude_args }}
         allowed_non_write_users: ${{ inputs.allowed_non_write_users }}
         allowed_bots: ${{ inputs.allowed_bots }}
     # Fallback attempt: only when the primary actually failed AND a backup token
@@ -73,7 +85,10 @@ runs:
         claude_code_oauth_token: ${{ inputs.fallback_oauth_token }}
         github_token: ${{ inputs.github_token }}
         prompt: ${{ inputs.prompt }}
-        claude_args: ${{ inputs.claude_args }}
+        # `--model` first so a caller that also spells one inside claude_args
+        # wins (claude-code-action honours the LAST --model), and so the model is
+        # always explicit here — the action's own default is Opus.
+        claude_args: ${{ inputs.model && format('--model {0} ', inputs.model) || '' }}${{ inputs.claude_args }}
         allowed_non_write_users: ${{ inputs.allowed_non_write_users }}
         allowed_bots: ${{ inputs.allowed_bots }}
     # Propagate a hard failure only when no attempt succeeded: the primary failed

--- a/.github/actions/claude-run/action.yaml
+++ b/.github/actions/claude-run/action.yaml
@@ -1,104 +1,472 @@
-name: "Run Claude with OAuth failover"
+name: "Claude Code with credential fallback"
 description: >-
-  Single source of truth for invoking anthropics/claude-code-action across this
-  template's workflows: it pins the action once and runs it with the primary
-  Claude Code OAuth token, transparently retrying once with a fallback token when
-  the primary attempt fails (a subscription-quota exhaustion or a transient
-  outage). Callers pass their own prompt / claude_args / tool gating; the
-  credential and retry logic live only here so no workflow re-implements them.
+  Run anthropics/claude-code-action with an ordered credential ladder: a primary
+  OAuth token, then up to five fallbacks. A rung is attempted when NO earlier rung
+  has produced a non-errored run and that rung's own token is non-empty, so an
+  unset middle tier is stepped over instead of ending the ladder (claude-code-action
+  exits 0 even on a failure, so the execution log is the only signal). Each retry
+  waits out a short escalating backoff first, so one provider-side blip cannot
+  consume every credential at once. Between the primary rung and the second tier
+  sits one extra attempt, after its own wait, on the PRIMARY credential — taken
+  only when the primary's failure billed nothing (zero_cost) and so costs nothing
+  to repeat, and the only retry a caller that configures no fallback tokens at all
+  can get. This is the SINGLE place the
+  retry-on-credential-failure ladder lives; callers pass the tokens + the per-use
+  action config and read one execution_file / errored back, instead of hand-rolling
+  the primary/fallback steps in every job. To add a tier, add one input plus one
+  backoff/attempt/check/state group here, chaining its state step off the last one
+  — no caller changes; the free same-credential retry is deliberately not repeated
+  per tier, since a blip that survives it is not transient. Detection is delegated
+  to the shared claude-run-errored.sh (workspace-relative), so this action REQUIRES
+  the caller to have checked out a TRUSTED tree (base ref) — never run it off an
+  untrusted PR head.
 inputs:
   oauth_token:
-    description: "Primary Claude Code OAuth token (secrets.CLAUDE_CODE_OAUTH_TOKEN)."
+    description: "Primary Claude subscription OAuth token."
     required: true
-  fallback_oauth_token:
-    description: >-
-      Backup Claude Code OAuth token. When set, a failed primary attempt is
-      retried once with this token; leave empty to disable the retry.
+  oauth_token_fallback:
+    description: "Second-tier token; empty skips the second attempt."
+    required: false
+    default: ""
+  oauth_token_fallback_3:
+    description: "Third-tier token; empty skips the third attempt."
+    required: false
+    default: ""
+  oauth_token_fallback_4:
+    description: "Fourth-tier token (the CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_4 secret); empty skips the fourth attempt."
+    required: false
+    default: ""
+  oauth_token_fallback_5:
+    description: "Fifth-tier token (the CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_5 secret); empty skips the fifth attempt."
+    required: false
+    default: ""
+  oauth_token_fallback_6:
+    description: "Sixth-tier token (the CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_6 secret); empty skips the sixth attempt."
     required: false
     default: ""
   github_token:
     description: >-
-      Token handed to the action directly so it skips the OIDC->GitHub-App
-      exchange. Empty lets the action resolve its own default.
+      The workflow GITHUB_TOKEN, handed to the action directly so it skips the
+      OIDC->GitHub-App token exchange that isn't authorized here.
+    required: true
+  gh_token:
+    description: >-
+      Exported as GH_TOKEN into every attempt, for the `gh` calls the agent's own
+      Bash tool makes (a caller whose agent pushes a branch needs a PAT here, so
+      the push retriggers checks). Set as an input rather than left to the calling
+      step's `env:`, which a composite action's steps do not reliably inherit.
+      Empty falls back to github_token, so GH_TOKEN is never exported empty.
     required: false
     default: ""
   model:
     description: >-
-      Model id for the run. Forwarded as `--model` in claude_args, NOT as
-      claude-code-action's top-level `model` input: the pinned action does not
-      accept that input and warns "Unexpected input(s) 'model'" while silently
-      running on its default (Opus) tier. Leave empty only when claude_args
-      already carries its own `--model`.
-    required: false
-    default: ""
-  prompt:
-    description: "Prompt for the agent. Empty runs the action in its event-driven (tag) mode."
-    required: false
-    default: ""
+      Model slug (e.g. claude-opus-5). Rendered into the action's --model flag
+      here, ahead of claude_args, so every attempt pins the tier explicitly and the
+      action never rides its Opus default; keep the slug OUT of claude_args.
+    required: true
   claude_args:
-    description: "CLI args forwarded to claude-code-action (--model, --allowedTools, ...)."
-    required: false
-    default: ""
+    description: "The --effort/--allowedTools/--add-dir/... arg string (NO --model — pass that as `model`)."
+    required: true
+  prompt:
+    description: "The prompt handed to claude-code-action."
+    required: true
   allowed_non_write_users:
-    description: "Passthrough for claude-code-action allowed_non_write_users."
+    description: 'Passed through to claude-code-action (e.g. "*" to review fork PRs); empty = default.'
     required: false
     default: ""
   allowed_bots:
-    description: "Passthrough for claude-code-action allowed_bots."
+    description: 'Passed through to claude-code-action (e.g. "claude"); empty = default.'
     required: false
     default: ""
 outputs:
   execution_file:
+    description: "Execution-log path of the LAST attempt that ran (newest first)."
+    value: ${{ steps.a6.outputs.execution_file || steps.a5.outputs.execution_file || steps.a4.outputs.execution_file || steps.a3.outputs.execution_file || steps.a2.outputs.execution_file || steps.a1r.outputs.execution_file || steps.a1.outputs.execution_file }}
+  errored:
     description: >-
-      Execution-log path of the attempt that ran (the fallback's when it fired,
-      otherwise the primary's). Callers read it to detect an is_error run.
-    value: ${{ steps.fallback.outputs.execution_file || steps.primary.outputs.execution_file }}
+      'true'/'false' from the LAST attempt that ran. A skipped attempt's check
+      emits nothing, so the newest-first `||` resolves to the final attempt's
+      verdict. The primary's check always runs, so this is never empty and a
+      ladder that never reached a working credential reports 'true'. The final
+      step below fails the composite loud on 'true'.
+
+      An attempt that writes NO execution log is 'true' as well, and the ladder
+      then walks every remaining credential. Some of those failures are
+      credential-independent — the action's actor gate (allowed_bots /
+      allowed_non_write_users) throws before it ever validates the Anthropic
+      token, so a bot-authored PR burns all six rungs — plus the free
+      same-credential retry, since a run that writes no log billed nothing and so
+      reads as zero_cost — on one unchangeable verdict. The ladder cannot tell
+      that case from a genuinely empty token, which fails the same way:
+      claude-code-action exports no reason/conclusion output, so the only signal
+      separating them lives in the job log. Reading it would mean log scraping,
+      and re-deriving the actor verdict here would fork the gate; both are worse
+      than seven wasted attempts.
+    value: ${{ steps.c6.outputs.errored || steps.c5.outputs.errored || steps.c4.outputs.errored || steps.c3.outputs.errored || steps.c2.outputs.errored || steps.c1r.outputs.errored || steps.c1.outputs.errored }}
 runs:
   using: "composite"
   steps:
-    # Primary attempt. continue-on-error so a credential/quota failure doesn't
-    # abort the composite before the fallback can run; the propagate step below
-    # turns a genuine double-failure back into a hard error.
-    - name: Claude (primary credential)
-      id: primary
+    # An empty `model` renders `--model` with no value, and claude-code-action
+    # then runs on ITS default (Opus, ~5x Sonnet). Refusing here is the choke
+    # point: every caller reaches the action through these six rungs, so no
+    # present or future one can spend an unpinned model.
+    - name: Refuse an unpinned model
+      shell: bash
+      env:
+        MODEL: ${{ inputs.model }}
+      run: |
+        set -euo pipefail
+        # Stripped, not just unset: `--model` followed by whitespace renders the
+        # same flag-with-no-value as the empty string does.
+        [[ -n "${MODEL//[[:space:]]/}" ]] || {
+          echo "::error::model input is empty — claude-code-action would run on its own default." >&2
+          exit 1
+        }
+
+    - name: Attempt with the primary credential
+      id: a1
       continue-on-error: true
       uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1.0.157
+      env:
+        GH_TOKEN: ${{ inputs.gh_token || inputs.github_token }}
       with:
         claude_code_oauth_token: ${{ inputs.oauth_token }}
         github_token: ${{ inputs.github_token }}
-        prompt: ${{ inputs.prompt }}
-        # `--model` first so a caller that also spells one inside claude_args
-        # wins (claude-code-action honours the LAST --model), and so the model is
-        # always explicit here — the action's own default is Opus.
-        claude_args: ${{ inputs.model && format('--model {0} ', inputs.model) || '' }}${{ inputs.claude_args }}
         allowed_non_write_users: ${{ inputs.allowed_non_write_users }}
         allowed_bots: ${{ inputs.allowed_bots }}
-    # Fallback attempt: only when the primary actually failed AND a backup token
-    # is configured. Uses outcome (not conclusion — continue-on-error rewrites
-    # conclusion to success), so it fires exactly on a real primary failure.
-    - name: Claude (fallback credential)
-      id: fallback
-      if: steps.primary.outcome == 'failure' && inputs.fallback_oauth_token != ''
+        claude_args: >-
+          --model ${{ inputs.model }}
+          ${{ inputs.claude_args }}
+        prompt: ${{ inputs.prompt }}
+
+    - name: Did the primary credential run?
+      id: c1
+      shell: bash
+      env:
+        EXECUTION_FILE: ${{ steps.a1.outputs.execution_file }}
+      run: bash .github/scripts/claude-run-errored.sh
+
+    # `still_needs_attempt` is the ladder's cumulative state and the only gate a
+    # CREDENTIAL rung reads (the free same-credential retry below adds one further
+    # condition). It stays 'true' until some rung reports a non-errored run,
+    # which is what keeps a gap in the token list from truncating the ladder: a
+    # skipped rung's check emits an EMPTY errored, and empty is not success, so the
+    # pending state passes through to the tiers that do hold a credential. Gating a
+    # rung on its immediate predecessor's check instead would strand every tier
+    # after the first unset one, however many live credentials follow it.
+    - name: Ladder state after the primary attempt
+      id: s1
+      shell: bash
+      env:
+        PRIOR: "true"
+        ERRORED: ${{ steps.c1.outputs.errored }}
+      run: |
+        set -euo pipefail
+        still="false"
+        if [[ "$PRIOR" == "true" && "$ERRORED" != "false" ]]; then
+          still="true"
+        fi
+        echo "still_needs_attempt=${still}" >>"$GITHUB_OUTPUT"
+
+    # The free retry. claude-run-errored.sh reports zero_cost=true only when the
+    # attempt billed nothing (total_cost_usd == 0, or no log at all), which proves
+    # inference was never reached — so a transient provider-side blip and a dead
+    # token look identical here, and one more attempt on the SAME credential costs
+    # nothing either way: it succeeds if the fault was the blip and fails the same
+    # way if the token is dead. Without it a blip is answered only by walking to the
+    # NEXT credential, which a caller configuring no fallback secrets does not have
+    # — the attempt is then lost with zero retries. A failure that DID bill reached
+    # inference and failed on the work itself, so zero_cost=false skips this rung
+    # rather than spend real money failing the same way twice.
+    - name: Back off before the free same-credential retry
+      if: steps.s1.outputs.still_needs_attempt == 'true' && steps.c1.outputs.zero_cost == 'true'
+      shell: bash
+      env:
+        # Straddling the blip is the entire point: the failure returns in well under
+        # a second, so a back-to-back retry hits the same broken instant. Ten seconds
+        # is the credential ladder's own first step — long enough to outlast a
+        # transient fault, short enough that a free retry cannot dominate wall clock.
+        BACKOFF_SECONDS: "10"
+      run: sleep "$BACKOFF_SECONDS"
+
+    - name: Retry on the primary credential
+      id: a1r
+      if: steps.s1.outputs.still_needs_attempt == 'true' && steps.c1.outputs.zero_cost == 'true'
       continue-on-error: true
       uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1.0.157
+      env:
+        GH_TOKEN: ${{ inputs.gh_token || inputs.github_token }}
       with:
-        claude_code_oauth_token: ${{ inputs.fallback_oauth_token }}
+        claude_code_oauth_token: ${{ inputs.oauth_token }}
         github_token: ${{ inputs.github_token }}
-        prompt: ${{ inputs.prompt }}
-        # `--model` first so a caller that also spells one inside claude_args
-        # wins (claude-code-action honours the LAST --model), and so the model is
-        # always explicit here — the action's own default is Opus.
-        claude_args: ${{ inputs.model && format('--model {0} ', inputs.model) || '' }}${{ inputs.claude_args }}
         allowed_non_write_users: ${{ inputs.allowed_non_write_users }}
         allowed_bots: ${{ inputs.allowed_bots }}
-    # Propagate a hard failure only when no attempt succeeded: the primary failed
-    # and either no fallback was configured or the fallback also failed. Otherwise
-    # the composite exits 0 and the caller inspects execution_file as usual.
-    - name: Propagate failover result
+        claude_args: >-
+          --model ${{ inputs.model }}
+          ${{ inputs.claude_args }}
+        prompt: ${{ inputs.prompt }}
+
+    - name: Did the same-credential retry run?
+      id: c1r
+      if: steps.s1.outputs.still_needs_attempt == 'true' && steps.c1.outputs.zero_cost == 'true'
+      shell: bash
+      env:
+        EXECUTION_FILE: ${{ steps.a1r.outputs.execution_file }}
+      run: bash .github/scripts/claude-run-errored.sh
+
+    # The free retry joins the same cumulative state the credential rungs use, so a
+    # retry that WORKED ends the ladder and a retry that did not leaves the pending
+    # state untouched for the fallback tiers. Every rung below therefore gates on
+    # s1r, not s1; a skipped retry emits an empty errored, which is not success, so
+    # the gap handling that lets an unset tier be stepped over covers this rung too.
+    - name: Ladder state after the free same-credential retry
+      id: s1r
+      shell: bash
+      env:
+        PRIOR: ${{ steps.s1.outputs.still_needs_attempt }}
+        ERRORED: ${{ steps.c1r.outputs.errored }}
+      run: |
+        set -euo pipefail
+        still="false"
+        if [[ "$PRIOR" == "true" && "$ERRORED" != "false" ]]; then
+          still="true"
+        fi
+        echo "still_needs_attempt=${still}" >>"$GITHUB_OUTPUT"
+
+    # A dead/expired credential is rejected in roughly half a second without ever
+    # reaching inference, so back-to-back rungs spend the whole ladder inside a few
+    # seconds — long enough for one provider-side blip to take out all six tokens
+    # on a request the same config serves fine a minute later. The waits escalate
+    # 10/20/30/45/60s, so the last rung lands ~165s after the first and the ladder
+    # straddles a blip, while the added wall clock stays under three minutes.
+    - name: Back off before the second-tier attempt
+      if: steps.s1r.outputs.still_needs_attempt == 'true' && inputs.oauth_token_fallback != ''
+      shell: bash
+      env:
+        BACKOFF_SECONDS: "10"
+      run: sleep "$BACKOFF_SECONDS"
+
+    - name: Retry with the second-tier credential
+      id: a2
+      if: steps.s1r.outputs.still_needs_attempt == 'true' && inputs.oauth_token_fallback != ''
+      continue-on-error: true
+      uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1.0.157
+      env:
+        GH_TOKEN: ${{ inputs.gh_token || inputs.github_token }}
+      with:
+        claude_code_oauth_token: ${{ inputs.oauth_token_fallback }}
+        github_token: ${{ inputs.github_token }}
+        allowed_non_write_users: ${{ inputs.allowed_non_write_users }}
+        allowed_bots: ${{ inputs.allowed_bots }}
+        claude_args: >-
+          --model ${{ inputs.model }}
+          ${{ inputs.claude_args }}
+        prompt: ${{ inputs.prompt }}
+
+    - name: Did the second-tier credential run?
+      id: c2
+      # Same gate as a2, so a skipped attempt's check emits nothing and the
+      # newest-first output resolution keeps reporting the attempt that did run.
+      if: steps.s1r.outputs.still_needs_attempt == 'true' && inputs.oauth_token_fallback != ''
+      shell: bash
+      env:
+        EXECUTION_FILE: ${{ steps.a2.outputs.execution_file }}
+      run: bash .github/scripts/claude-run-errored.sh
+
+    - name: Ladder state after the second-tier attempt
+      id: s2
+      shell: bash
+      env:
+        PRIOR: ${{ steps.s1r.outputs.still_needs_attempt }}
+        ERRORED: ${{ steps.c2.outputs.errored }}
+      run: |
+        set -euo pipefail
+        still="false"
+        if [[ "$PRIOR" == "true" && "$ERRORED" != "false" ]]; then
+          still="true"
+        fi
+        echo "still_needs_attempt=${still}" >>"$GITHUB_OUTPUT"
+
+    - name: Back off before the third-tier attempt
+      if: steps.s2.outputs.still_needs_attempt == 'true' && inputs.oauth_token_fallback_3 != ''
+      shell: bash
+      env:
+        BACKOFF_SECONDS: "20"
+      run: sleep "$BACKOFF_SECONDS"
+
+    - name: Retry with the third-tier credential
+      id: a3
+      if: steps.s2.outputs.still_needs_attempt == 'true' && inputs.oauth_token_fallback_3 != ''
+      continue-on-error: true
+      uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1.0.157
+      env:
+        GH_TOKEN: ${{ inputs.gh_token || inputs.github_token }}
+      with:
+        claude_code_oauth_token: ${{ inputs.oauth_token_fallback_3 }}
+        github_token: ${{ inputs.github_token }}
+        allowed_non_write_users: ${{ inputs.allowed_non_write_users }}
+        allowed_bots: ${{ inputs.allowed_bots }}
+        claude_args: >-
+          --model ${{ inputs.model }}
+          ${{ inputs.claude_args }}
+        prompt: ${{ inputs.prompt }}
+
+    - name: Did the third-tier credential run?
+      id: c3
+      if: steps.s2.outputs.still_needs_attempt == 'true' && inputs.oauth_token_fallback_3 != ''
+      shell: bash
+      env:
+        EXECUTION_FILE: ${{ steps.a3.outputs.execution_file }}
+      run: bash .github/scripts/claude-run-errored.sh
+
+    - name: Ladder state after the third-tier attempt
+      id: s3
+      shell: bash
+      env:
+        PRIOR: ${{ steps.s2.outputs.still_needs_attempt }}
+        ERRORED: ${{ steps.c3.outputs.errored }}
+      run: |
+        set -euo pipefail
+        still="false"
+        if [[ "$PRIOR" == "true" && "$ERRORED" != "false" ]]; then
+          still="true"
+        fi
+        echo "still_needs_attempt=${still}" >>"$GITHUB_OUTPUT"
+
+    - name: Back off before the fourth-tier attempt
+      if: steps.s3.outputs.still_needs_attempt == 'true' && inputs.oauth_token_fallback_4 != ''
+      shell: bash
+      env:
+        BACKOFF_SECONDS: "30"
+      run: sleep "$BACKOFF_SECONDS"
+
+    - name: Retry with the fourth-tier credential
+      id: a4
+      if: steps.s3.outputs.still_needs_attempt == 'true' && inputs.oauth_token_fallback_4 != ''
+      continue-on-error: true
+      uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1.0.157
+      env:
+        GH_TOKEN: ${{ inputs.gh_token || inputs.github_token }}
+      with:
+        claude_code_oauth_token: ${{ inputs.oauth_token_fallback_4 }}
+        github_token: ${{ inputs.github_token }}
+        allowed_non_write_users: ${{ inputs.allowed_non_write_users }}
+        allowed_bots: ${{ inputs.allowed_bots }}
+        claude_args: >-
+          --model ${{ inputs.model }}
+          ${{ inputs.claude_args }}
+        prompt: ${{ inputs.prompt }}
+
+    - name: Did the fourth-tier credential run?
+      id: c4
+      if: steps.s3.outputs.still_needs_attempt == 'true' && inputs.oauth_token_fallback_4 != ''
+      shell: bash
+      env:
+        EXECUTION_FILE: ${{ steps.a4.outputs.execution_file }}
+      run: bash .github/scripts/claude-run-errored.sh
+
+    - name: Ladder state after the fourth-tier attempt
+      id: s4
+      shell: bash
+      env:
+        PRIOR: ${{ steps.s3.outputs.still_needs_attempt }}
+        ERRORED: ${{ steps.c4.outputs.errored }}
+      run: |
+        set -euo pipefail
+        still="false"
+        if [[ "$PRIOR" == "true" && "$ERRORED" != "false" ]]; then
+          still="true"
+        fi
+        echo "still_needs_attempt=${still}" >>"$GITHUB_OUTPUT"
+
+    - name: Back off before the fifth-tier attempt
+      if: steps.s4.outputs.still_needs_attempt == 'true' && inputs.oauth_token_fallback_5 != ''
+      shell: bash
+      env:
+        BACKOFF_SECONDS: "45"
+      run: sleep "$BACKOFF_SECONDS"
+
+    - name: Retry with the fifth-tier credential
+      id: a5
+      if: steps.s4.outputs.still_needs_attempt == 'true' && inputs.oauth_token_fallback_5 != ''
+      continue-on-error: true
+      uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1.0.157
+      env:
+        GH_TOKEN: ${{ inputs.gh_token || inputs.github_token }}
+      with:
+        claude_code_oauth_token: ${{ inputs.oauth_token_fallback_5 }}
+        github_token: ${{ inputs.github_token }}
+        allowed_non_write_users: ${{ inputs.allowed_non_write_users }}
+        allowed_bots: ${{ inputs.allowed_bots }}
+        claude_args: >-
+          --model ${{ inputs.model }}
+          ${{ inputs.claude_args }}
+        prompt: ${{ inputs.prompt }}
+
+    - name: Did the fifth-tier credential run?
+      id: c5
+      if: steps.s4.outputs.still_needs_attempt == 'true' && inputs.oauth_token_fallback_5 != ''
+      shell: bash
+      env:
+        EXECUTION_FILE: ${{ steps.a5.outputs.execution_file }}
+      run: bash .github/scripts/claude-run-errored.sh
+
+    - name: Ladder state after the fifth-tier attempt
+      id: s5
+      shell: bash
+      env:
+        PRIOR: ${{ steps.s4.outputs.still_needs_attempt }}
+        ERRORED: ${{ steps.c5.outputs.errored }}
+      run: |
+        set -euo pipefail
+        still="false"
+        if [[ "$PRIOR" == "true" && "$ERRORED" != "false" ]]; then
+          still="true"
+        fi
+        echo "still_needs_attempt=${still}" >>"$GITHUB_OUTPUT"
+
+    - name: Back off before the sixth-tier attempt
+      if: steps.s5.outputs.still_needs_attempt == 'true' && inputs.oauth_token_fallback_6 != ''
+      shell: bash
+      env:
+        BACKOFF_SECONDS: "60"
+      run: sleep "$BACKOFF_SECONDS"
+
+    - name: Retry with the sixth-tier credential
+      id: a6
+      if: steps.s5.outputs.still_needs_attempt == 'true' && inputs.oauth_token_fallback_6 != ''
+      continue-on-error: true
+      uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1.0.157
+      env:
+        GH_TOKEN: ${{ inputs.gh_token || inputs.github_token }}
+      with:
+        claude_code_oauth_token: ${{ inputs.oauth_token_fallback_6 }}
+        github_token: ${{ inputs.github_token }}
+        allowed_non_write_users: ${{ inputs.allowed_non_write_users }}
+        allowed_bots: ${{ inputs.allowed_bots }}
+        claude_args: >-
+          --model ${{ inputs.model }}
+          ${{ inputs.claude_args }}
+        prompt: ${{ inputs.prompt }}
+
+    - name: Did the sixth-tier credential run?
+      id: c6
+      if: steps.s5.outputs.still_needs_attempt == 'true' && inputs.oauth_token_fallback_6 != ''
+      shell: bash
+      env:
+        EXECUTION_FILE: ${{ steps.a6.outputs.execution_file }}
+      run: bash .github/scripts/claude-run-errored.sh
+
+    # Sanitizer's callers rely on the composite itself failing when no credential
+    # worked: they read execution_file for the cost footer and would otherwise
+    # carry on as if the agent had run. This is the hard gate the ladder's own
+    # `errored` output only reports.
+    - name: Propagate the ladder result
       if: >-
-        steps.primary.outcome == 'failure' &&
-        (inputs.fallback_oauth_token == '' || steps.fallback.outcome == 'failure')
+        (steps.c6.outputs.errored || steps.c5.outputs.errored || steps.c4.outputs.errored ||
+         steps.c3.outputs.errored || steps.c2.outputs.errored || steps.c1r.outputs.errored ||
+         steps.c1.outputs.errored) == 'true'
       shell: bash
       run: |
-        echo "::error::claude-run: the primary Claude credential failed and no working fallback was available (set CLAUDE_CODE_OAUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN_FALLBACK)." >&2
+        echo "::error::claude-run: every configured Claude credential failed (set CLAUDE_CODE_OAUTH_TOKEN and CLAUDE_CODE_OAUTH_TOKEN_FALLBACK[_3..6])." >&2
         exit 1

--- a/.github/scripts/claude-run-errored.sh
+++ b/.github/scripts/claude-run-errored.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Decide whether a claude-code-action attempt failed hard enough to retry on the
+# fallback credential. claude-code-action exits 0 even on an is_error run, so the
+# step `outcome` cannot distinguish a dead/expired token from a real result — the
+# execution log is the only signal. errored=true on a missing/empty log (a crash)
+# OR is_error true; a genuine "nothing to do" run has is_error false and is NOT
+# retried. This is the retry DECISION, not the gate: it never fails the step
+# (the composite's own propagate step is the hard gate).
+#
+# Also emits zero_cost=true when the run billed nothing (total_cost_usd == 0, or a
+# missing/empty log where no inference ran): a PROVEN zero-billed failure the
+# caller may retry for free on the SAME credential (the ladder's same-token
+# retry). A genuine run that tried and failed on the work itself carries a cost, so
+# zero_cost=false there and the caller does not burn a paid retry. Callers that
+# only need the retry decision read errored and ignore zero_cost.
+set -euo pipefail
+
+errored=true
+zero_cost=true
+if [[ -n "${EXECUTION_FILE:-}" && -s "$EXECUTION_FILE" ]]; then
+  result_jq='if type == "array" then (map(select(.type == "result")) | last) else . end'
+  if ! jq -e "${result_jq} | .is_error == true" "$EXECUTION_FILE" >/dev/null; then
+    errored=false
+  fi
+  if ! jq -e "${result_jq} | .total_cost_usd == 0" "$EXECUTION_FILE" >/dev/null; then
+    zero_cost=false
+  fi
+fi
+echo "errored=${errored}" >>"$GITHUB_OUTPUT"
+echo "zero_cost=${zero_cost}" >>"$GITHUB_OUTPUT"

--- a/.github/scripts/decide-pr-review-trigger.sh
+++ b/.github/scripts/decide-pr-review-trigger.sh
@@ -102,7 +102,11 @@ fi
 # that page's reviews array), so the filter must flatten BOTH levels (`.[][]`) to
 # walk every review across every page. A single `.[]` iterates PAGES, so
 # `.user.login`/`.state` index a page ARRAY — jq errors and the recheck silently
-# misbehaves. `--slurp` keeps the whole result in one document so `--jq` runs ONCE.
+# misbehaves. The filter runs in a SEPARATE `jq`, not gh's `--jq`: gh rejects
+# `--slurp` together with `--jq`/`--template` outright ("the `--slurp` option is
+# not supported with `--jq`"), and it exits 1 before issuing the request, so the
+# fail-closed branch below would swallow that as a transient API error and this
+# trigger would never fire.
 #
 # The exit STATUS is captured separately from the state, because the two empty
 # results mean opposite things: a successful query returning "" means nobody ever
@@ -110,8 +114,11 @@ fi
 # yields "" and must not be read that way — folding them together would review on
 # every push forever whenever the API is flaky or the filter is malformed.
 reviews_rc=0
-state="$(gh api "repos/$REPO/pulls/${PR:-}/reviews" --paginate --slurp \
-  --jq "[.[][] | select(.user.login == \"$REVIEWER\") | select((.body // \"\") != \"\")] | last | .state // empty" 2>/dev/null)" || reviews_rc=$?
+state=""
+pages="$(gh api "repos/$REPO/pulls/${PR:-}/reviews" --paginate --slurp 2>/dev/null)" || reviews_rc=$?
+if [[ "$reviews_rc" -eq 0 ]]; then
+  state="$(jq -r "[.[][] | select(.user.login == \"$REVIEWER\") | select((.body // \"\") != \"\")] | last | .state // empty" <<<"$pages")" || reviews_rc=$?
+fi
 if [[ "$reviews_rc" -ne 0 ]]; then
   emit false "could not read $REPO#${PR:-} reviews (rc=$reviews_rc) — not reviewing rather than guessing"
 elif [[ -z "$state" ]]; then

--- a/.github/scripts/decide-pr-review-trigger.sh
+++ b/.github/scripts/decide-pr-review-trigger.sh
@@ -15,7 +15,7 @@
 #          commit that carries the tag and NOT again on later untagged pushes
 #          (re-tag to run again).
 #       2. The reviewer has NEVER reviewed this PR — the first whole-diff pass,
-#          on HAIKU, for a PR whose earlier events all skipped. A push is never a
+#          on the cheap tier, for a PR whose earlier events all skipped. A push is never a
 #          RE-read: the reviewer reads a PR once, and later pushes make progress
 #          by the thread resolver closing findings out, which is what the
 #          review-findings gate reads. This automatic pass NEVER spends Opus —
@@ -34,8 +34,8 @@ KEYWORD="[opus-review]"
 REVIEW_LABEL="needs-auto-review"
 # The reviewer posts with GITHUB_TOKEN, so its reviews are authored by this bot.
 REVIEWER="github-actions[bot]"
-OPUS_MODEL="claude-opus-4-8"
-HAIKU_MODEL="claude-haiku-4-5"
+OPUS_MODEL="claude-opus-5"
+CHEAP_MODEL="claude-sonnet-5"
 
 emit() {
   # $1 run, $2 reason, $3 model (defaults to Opus — the thorough first-look model)
@@ -122,7 +122,7 @@ fi
 if [[ "$reviews_rc" -ne 0 ]]; then
   emit false "could not read $REPO#${PR:-} reviews (rc=$reviews_rc) — not reviewing rather than guessing"
 elif [[ -z "$state" ]]; then
-  emit true "$REVIEWER has never reviewed this PR — running the first pass this push" "$HAIKU_MODEL"
+  emit true "$REVIEWER has never reviewed this PR — running the first pass this push" "$CHEAP_MODEL"
 else
   emit false "$REVIEWER already reviewed this PR (latest: $state) — a push is not re-read; put $KEYWORD in a commit title for a full re-read"
 fi

--- a/.github/scripts/lib-review-cost.mjs
+++ b/.github/scripts/lib-review-cost.mjs
@@ -1,31 +1,49 @@
-// Shared cost accounting for the PR-review footnote — used by both the reviewer
-// (post-pr-review.mjs, which posts the original cost line) and the Haiku
-// thread-resolver (compute-haiku-cost-footer.mjs, which tallies each follow-up
-// run onto that same footnote). One source for reading a Claude run's cost,
-// formatting dollars, and rendering the "how many PRs fit in a Max 20x weekly
-// allowance" line, so the two producers can never drift.
+// Shared reader for a Claude run's execution log, plus the PR-review cost
+// footnote built from it — used by the reviewer (post-pr-review.mjs, which posts
+// the original cost line) and the Haiku thread-resolver
+// (compute-haiku-cost-footer.mjs, which tallies each follow-up run onto that same
+// footnote). One source for parsing the log, reading a run's cost and its
+// error flag, formatting dollars, and rendering the "how many PRs fit in a Max
+// 20x weekly allowance" line, so the consumers can never drift.
 import { readFileSync } from "node:fs";
 
-// Pull `total_cost_usd` (and the model that ran) out of the Claude action's
-// execution log — an array of streamed events whose terminal `type: "result"`
-// carries the API-equivalent cost, or an object with the field directly. Returns
-// {} when the log is missing/unparsable so callers simply omit the cost; a
-// missing cost must never break posting.
-export function readRunCost(executionFile) {
+// The Claude action's execution log as a flat event list — an array of streamed
+// events, or a single object. `[]` when the log is missing/unparsable.
+function readRunEvents(executionFile) {
   const file =
     executionFile ||
     process.env.EXECUTION_FILE ||
     (process.env.RUNNER_TEMP
       ? `${process.env.RUNNER_TEMP}/claude-execution-output.json`
       : "");
-  if (!file) return {};
+  if (!file) return [];
   let parsed;
   try {
     parsed = JSON.parse(readFileSync(file, "utf8"));
   } catch {
-    return {};
+    return [];
   }
-  const events = Array.isArray(parsed) ? parsed : [parsed];
+  return Array.isArray(parsed) ? parsed : [parsed];
+}
+
+// True when the run reported `is_error` — the session failed (a dead credential,
+// an unavailable model, a hard API error) rather than completing with nothing to
+// say. The action EXITS 0 either way and its own `result` event still reads
+// `subtype: "success"`, so this flag is the only signal separating "reviewed and
+// found nothing" from "never reviewed at all"; a caller that does not check it
+// reports green for a review that never happened.
+export function runErrored(executionFile) {
+  return readRunEvents(executionFile).some(
+    (ev) => ev && typeof ev === "object" && ev.is_error === true,
+  );
+}
+
+// Pull `total_cost_usd` (and the model that ran) out of the execution log — its
+// terminal `type: "result"` event carries the API-equivalent cost. Returns {}
+// when the log is missing/unparsable so callers simply omit the cost; a missing
+// cost must never break posting.
+export function readRunCost(executionFile) {
+  const events = readRunEvents(executionFile);
   let cost;
   let model;
   for (const ev of events) {

--- a/.github/scripts/post-pr-review.mjs
+++ b/.github/scripts/post-pr-review.mjs
@@ -15,7 +15,12 @@
 // or no findings and no summary). Diagnostics go to stderr.
 import { readFileSync, writeFileSync } from "node:fs";
 import { sanitize } from "agent-sanitizer";
-import { readRunCost, formatDollars, plansLine } from "./lib-review-cost.mjs";
+import {
+  readRunCost,
+  runErrored,
+  formatDollars,
+  plansLine,
+} from "./lib-review-cost.mjs";
 
 // The review text is MODEL output derived from the (untrusted) PR diff, so run
 // every string bound for a posted GitHub comment through the same Layer-1
@@ -39,6 +44,20 @@ const summaryPath = `${dir}/review-summary.txt`;
 function skip(msg) {
   process.stdout.write("SKIP\n");
   process.stderr.write(`::warning::${msg}\n`);
+  process.exit(0);
+}
+
+// A run that reported `is_error` never reviewed anything, so its ABSENCE of
+// findings means nothing — reporting SKIP for it would post a green check for a
+// review that did not happen. Checked before the review is read at all, because
+// an errored run's partial output is not evidence either way.
+if (runErrored()) {
+  process.stdout.write("ERRORED\n");
+  process.stderr.write(
+    "::error::the review agent's run reported is_error — it did not review this PR " +
+      "(a dead or unentitled credential, an unavailable model, or a hard API error). " +
+      "Re-run with `show_full_output: true` on the claude-run step to see why.\n",
+  );
   process.exit(0);
 }
 

--- a/.github/scripts/post-pr-review.sh
+++ b/.github/scripts/post-pr-review.sh
@@ -16,6 +16,12 @@ set -euo pipefail
 : "${PR_INPUT_DIR:?PR_INPUT_DIR required}"
 
 status="$(node .github/scripts/post-pr-review.mjs)"
+# ERRORED means the agent's session failed, so it never reviewed. Fail the job:
+# the action exits 0 on an errored session, so without this the PR shows a green
+# reviewer that silently looked at nothing.
+if [[ "$status" == "ERRORED" ]]; then
+  exit 1
+fi
 if [[ "$status" != "PAYLOAD" ]]; then
   echo "no structured review to post" >&2
   exit 0

--- a/.github/scripts/post-pr-review.test.mjs
+++ b/.github/scripts/post-pr-review.test.mjs
@@ -673,3 +673,73 @@ describe("post-pr-review: output sanitization", () => {
     assert.equal(payload.body, "all good here");
   });
 });
+
+// The failure this exists to stop: claude-code-action EXITS 0 when the agent's
+// session dies (a dead credential, an unentitled model, a hard API error), and
+// its own terminal event still reads `subtype: "success"`. Only `is_error`
+// separates "reviewed and found nothing" from "never reviewed". Without the
+// check, that run reports SKIP and the PR shows a green reviewer that looked at
+// nothing — observed live on agent-sanitizer#194, where both OAuth credentials
+// failed in 472ms at $0 and the job stayed green.
+describe("post-pr-review: an errored agent run is not a clean review", () => {
+  function executionLog(events) {
+    const dir = mkdtempSync(join(tmpdir(), "prr-exec-"));
+    dirs.push(dir);
+    const file = join(dir, "claude-execution-output.json");
+    writeFileSync(file, JSON.stringify(events));
+    return file;
+  }
+
+  it("reports ERRORED when the run set is_error, whatever the review says", () => {
+    const { status, payload } = run(
+      { findings: [], summary: "looks good to me" },
+      {
+        executionFile: executionLog([
+          { type: "system", subtype: "init", model: "claude-opus-4-8" },
+          {
+            type: "result",
+            subtype: "success",
+            is_error: true,
+            num_turns: 1,
+            total_cost_usd: 0,
+          },
+        ]),
+      },
+    );
+    assert.equal(status, "ERRORED");
+    assert.equal(payload, null, "an errored run must post nothing");
+  });
+
+  it("still posts a real review when the run did not error", () => {
+    const { status } = run(
+      {
+        findings: [
+          {
+            path: "src/foo.js",
+            line: 4,
+            side: "RIGHT",
+            severity: "warning",
+            body: "a real finding",
+          },
+        ],
+        summary: "s",
+      },
+      {
+        executionFile: executionLog([
+          {
+            type: "result",
+            subtype: "success",
+            is_error: false,
+            total_cost_usd: 1.2,
+          },
+        ]),
+      },
+    );
+    assert.equal(status, "PAYLOAD");
+  });
+
+  it("leaves the no-log case alone (SKIP, not a failure)", () => {
+    const { status } = run({ findings: [], summary: "" });
+    assert.equal(status, "SKIP");
+  });
+});

--- a/.github/scripts/version-bump.sh
+++ b/.github/scripts/version-bump.sh
@@ -309,7 +309,7 @@ Use the changelog_draft tool to report the result."
     -d "$(jq -n \
       --arg prompt "$PROMPT" \
       '{
-        model: "claude-haiku-4-5-20251001",
+        model: "claude-sonnet-5",
         max_tokens: 2048,
         tool_choice: {type: "tool", name: "changelog_draft"},
         tools: [{

--- a/.github/workflows/auto-resolve-conflicts.yaml
+++ b/.github/workflows/auto-resolve-conflicts.yaml
@@ -242,7 +242,11 @@ jobs:
         uses: ./.github/actions/claude-conflict-resolve
         with:
           oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          fallback_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK }}
+          oauth_token_fallback: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK }}
+          oauth_token_fallback_3: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_3 }}
+          oauth_token_fallback_4: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_4 }}
+          oauth_token_fallback_5: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_5 }}
+          oauth_token_fallback_6: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_6 }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pr_number: ${{ matrix.pr.number }}
           conflict_list: ${{ steps.prepare.outputs.conflict_list }}

--- a/.github/workflows/claude-merge-delta-review.yaml
+++ b/.github/workflows/claude-merge-delta-review.yaml
@@ -81,7 +81,11 @@ jobs:
         uses: ./.github/actions/claude-run
         with:
           oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          fallback_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK }}
+          oauth_token_fallback: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK }}
+          oauth_token_fallback_3: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_3 }}
+          oauth_token_fallback_4: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_4 }}
+          oauth_token_fallback_5: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_5 }}
+          oauth_token_fallback_6: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_6 }}
           # Give the action the workflow token directly. Without it, the action
           # tries to mint one via an OIDC→GitHub-App token exchange that isn't
           # authorized here and fails with "401 Invalid OIDC token" before Claude
@@ -91,8 +95,8 @@ jobs:
           # first-pass reviewer (base-only checkout, least-privilege token,
           # sanitized data-only input).
           allowed_non_write_users: "*"
+          model: claude-sonnet-5
           claude_args: >-
-            --model claude-sonnet-5
             --setting-sources user
             --allowedTools "Read,Grep,Glob,Write"
             --add-dir "${{ runner.temp }}/pr-input"

--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -186,7 +186,11 @@ jobs:
         uses: ./.github/actions/claude-run
         with:
           oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          fallback_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK }}
+          oauth_token_fallback: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK }}
+          oauth_token_fallback_3: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_3 }}
+          oauth_token_fallback_4: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_4 }}
+          oauth_token_fallback_5: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_5 }}
+          oauth_token_fallback_6: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_6 }}
           # Give the action the workflow token directly. Without it, the action
           # tries to mint one via an OIDC→GitHub-App token exchange that isn't
           # authorized here and fails with "401 Invalid OIDC token" before Claude
@@ -209,8 +213,8 @@ jobs:
           # grants read+write to the sanitized-input dir under runner.temp
           # (Claude Code sandboxes reads and writes outside the checked-out
           # workspace).
+          model: ${{ needs.decide.outputs.model || 'claude-opus-5' }}
           claude_args: >-
-            --model ${{ needs.decide.outputs.model || 'claude-opus-5' }}
             --effort medium
             --setting-sources user
             --allowedTools "Read,Grep,Glob,Write"

--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -210,7 +210,7 @@ jobs:
           # (Claude Code sandboxes reads and writes outside the checked-out
           # workspace).
           claude_args: >-
-            --model ${{ needs.decide.outputs.model || 'claude-opus-4-8' }}
+            --model ${{ needs.decide.outputs.model || 'claude-opus-5' }}
             --effort medium
             --setting-sources user
             --allowedTools "Read,Grep,Glob,Write"

--- a/.github/workflows/claude-review-thread-resolve.yaml
+++ b/.github/workflows/claude-review-thread-resolve.yaml
@@ -103,7 +103,7 @@ jobs:
           # Haiku is enough for a per-thread yes/no "does the diff address this?"
           # judgement — far cheaper than the Opus reviewer that raises the concerns.
           claude_args: >-
-            --model claude-haiku-4-5-20251001
+            --model claude-sonnet-5
             --setting-sources user
             --allowedTools "Read,Grep,Glob,Write"
             --add-dir "${{ runner.temp }}/pr-input"

--- a/.github/workflows/claude-review-thread-resolve.yaml
+++ b/.github/workflows/claude-review-thread-resolve.yaml
@@ -98,12 +98,16 @@ jobs:
         uses: ./.github/actions/claude-run
         with:
           oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          fallback_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK }}
+          oauth_token_fallback: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK }}
+          oauth_token_fallback_3: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_3 }}
+          oauth_token_fallback_4: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_4 }}
+          oauth_token_fallback_5: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_5 }}
+          oauth_token_fallback_6: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_6 }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Haiku is enough for a per-thread yes/no "does the diff address this?"
           # judgement — far cheaper than the Opus reviewer that raises the concerns.
+          model: claude-sonnet-5
           claude_args: >-
-            --model claude-sonnet-5
             --setting-sources user
             --allowedTools "Read,Grep,Glob,Write"
             --add-dir "${{ runner.temp }}/pr-input"

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -74,6 +74,10 @@ jobs:
         uses: ./.github/actions/claude-run
         with:
           oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          fallback_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK }}
+          oauth_token_fallback: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK }}
+          oauth_token_fallback_3: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_3 }}
+          oauth_token_fallback_4: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_4 }}
+          oauth_token_fallback_5: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_5 }}
+          oauth_token_fallback_6: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_6 }}
           github_token: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.GITHUB_TOKEN }}
           model: claude-sonnet-5

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -76,4 +76,4 @@ jobs:
           oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           fallback_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK }}
           github_token: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.GITHUB_TOKEN }}
-          claude_args: --model claude-sonnet-4-6
+          model: claude-sonnet-4-6

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -76,4 +76,4 @@ jobs:
           oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           fallback_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK }}
           github_token: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.GITHUB_TOKEN }}
-          model: claude-sonnet-4-6
+          model: claude-sonnet-5

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -75,5 +75,5 @@ jobs:
         with:
           oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           fallback_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK }}
-          model: claude-sonnet-4-6
           github_token: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.GITHUB_TOKEN }}
+          claude_args: --model claude-sonnet-4-6

--- a/.github/workflows/node-tests.yaml
+++ b/.github/workflows/node-tests.yaml
@@ -56,6 +56,13 @@ jobs:
       # only thing standing between a broken credential and a green reviewer that
       # read nothing — a decorative test file here would restore exactly the
       # silent pass it exists to prevent.
+      # post-pr-review.mjs imports agent-sanitizer by name, and
+      # .github/scripts/package.json ends the package scope there, so the
+      # self-reference never resolves — the import needs the same
+      # .github/scripts/node_modules install the review workflow does.
+      - name: Install the input sanitizer
+        run: bash .github/scripts/install-sanitizer.sh
+
       - name: Run PR-review script tests
         run: node --test .github/scripts/post-pr-review.test.mjs
 

--- a/.github/workflows/node-tests.yaml
+++ b/.github/workflows/node-tests.yaml
@@ -50,6 +50,15 @@ jobs:
       - name: Run auto-resolve workflow-script tests
         run: node --test .github/scripts/auto-resolve-*.test.mjs
 
+      # Same reason, same dot-directory blind spot: this suite pins that an agent
+      # run which reported `is_error` fails the job instead of reporting a clean
+      # review. claude-code-action exits 0 on a dead session, so that check is the
+      # only thing standing between a broken credential and a green reviewer that
+      # read nothing — a decorative test file here would restore exactly the
+      # silent pass it exists to prevent.
+      - name: Run PR-review script tests
+        run: node --test .github/scripts/post-pr-review.test.mjs
+
       # Named explicitly rather than left to `pnpm test`'s discovery. This suite
       # gates the shipped plugin artifact — the reproducibility byte-compare and
       # every hook's fail-closed verdict — so which invocation reaches it must be

--- a/.github/workflows/pr-desc-accuracy.yaml
+++ b/.github/workflows/pr-desc-accuracy.yaml
@@ -51,9 +51,13 @@ jobs:
         uses: ./.github/actions/claude-run
         with:
           oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          fallback_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK }}
+          oauth_token_fallback: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK }}
+          oauth_token_fallback_3: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_3 }}
+          oauth_token_fallback_4: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_4 }}
+          oauth_token_fallback_5: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_5 }}
+          oauth_token_fallback_6: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_6 }}
+          model: claude-sonnet-5
           claude_args: >-
-            --model claude-sonnet-5
             --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr edit:*)"
           prompt: |
             PR #${{ github.event.pull_request.number }} in ${{ github.repository }} just merged.

--- a/.github/workflows/pr-desc-accuracy.yaml
+++ b/.github/workflows/pr-desc-accuracy.yaml
@@ -53,7 +53,7 @@ jobs:
           oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           fallback_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK }}
           claude_args: >-
-            --model claude-haiku-4-5
+            --model claude-sonnet-5
             --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr edit:*)"
           prompt: |
             PR #${{ github.event.pull_request.number }} in ${{ github.repository }} just merged.

--- a/.github/workflows/security-vulnerability-scan.yaml
+++ b/.github/workflows/security-vulnerability-scan.yaml
@@ -69,7 +69,7 @@ jobs:
         uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1.0.157
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          model: claude-sonnet-4-6
+          model: claude-sonnet-5
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Follow the instructions in .github/prompts/security-vulnerability-scan.md — it is the single source of truth for this job.

--- a/tests/test_decide_pr_review_trigger.py
+++ b/tests/test_decide_pr_review_trigger.py
@@ -27,8 +27,11 @@ SCRIPT = REPO_ROOT / ".github" / "scripts" / "decide-pr-review-trigger.sh"
 
 _FAKE_GH = r"""#!/usr/bin/env python3
 # gh stub: serves `repos/.../pulls/N/reviews` and `repos/.../commits/SHA` from
-# canned files, running the caller's --jq through real jq. REVIEWS_RC forces the
-# reviews read to fail so the fail-safe branch can be tested.
+# canned files, running the caller's --jq through real jq and printing raw JSON
+# when there is none. It rejects --slurp alongside --jq exactly as the real gh
+# does, so a caller that pairs them is caught here instead of failing closed in
+# CI. REVIEWS_RC forces the reviews read to fail so the fail-safe branch can be
+# tested.
 import json, os, shutil, subprocess, sys
 
 JQ = shutil.which("jq")
@@ -38,11 +41,13 @@ if JQ is None:
 
 args = sys.argv[1:]
 assert args and args[0] == "api", args
-args, jq, path = args[1:], None, None
+args, jq, path, slurp = args[1:], None, None, False
 i = 0
 while i < len(args):
     a = args[i]
-    if a in ("--paginate", "--slurp"):
+    if a == "--slurp":
+        slurp, i = True, i + 1
+    elif a == "--paginate":
         i += 1
     elif a == "--jq":
         jq, i = args[i + 1], i + 2
@@ -51,8 +56,17 @@ while i < len(args):
     else:
         i += 1
 
+if slurp and jq is not None:
+    sys.stderr.write(
+        "the `--slurp` option is not supported with `--jq` or `--template`\n"
+    )
+    sys.exit(1)
+
 
 def emit(doc):
+    if jq is None:
+        sys.stdout.write(json.dumps(doc))
+        sys.exit(0)
     r = subprocess.run(
         [JQ, "-r", jq], input=json.dumps(doc), text=True, capture_output=True
     )
@@ -155,7 +169,8 @@ def test_a_push_runs_the_first_pass_when_nothing_ever_reviewed(
     got = _decide(tmp_path, action="synchronize", reviews=[])
     assert got["run"] == "true"
     # The automatic pass never spends Opus; only the [opus-review] opt-in does.
-    assert "haiku" in got["model"]
+    assert "opus" not in got["model"]
+    assert got["model"]
 
 
 def test_a_push_is_not_a_re_read_once_the_reviewer_has_reviewed(


### PR DESCRIPTION
Risk tier: medium

## Blocked on a credential I don't hold

**Both Claude OAuth secrets on this repo are dead.** With the reviewer finally invoked (see below), job [90934157023](https://github.com/AlexanderMattTurner/agent-sanitizer/actions/runs/30561131086/job/90934157023) ends:

```
::error::claude-run: the primary Claude credential failed and no working fallback
was available (set CLAUDE_CODE_OAUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN_FALLBACK).
```

Primary failed, fallback failed, `ANTHROPIC_API_KEY` empty. So `Review findings resolved` cannot go green until `CLAUDE_CODE_OAUTH_TOKEN` (and ideally `..._FALLBACK`) are re-issued. Everything in this PR is upstream of that: it makes the reviewer *reachable* and makes its death *visible*. It cannot repair the token.

## What & why

Three independent defects, all of which let a broken reviewer read as a working one.

**1. The reviewer could never run on a push.** `decide-pr-review-trigger.sh` looked up the PR's prior reviews with `gh api … --paginate --slurp --jq …`, but gh rejects `--slurp` alongside `--jq` and exits 1 *before issuing the request*. The script's fail-closed branch read that as a transient API error, so every `synchronize` event emitted `run=false` — the "reviewer has never reviewed this PR, do the first pass" trigger was unreachable code. Observed on this PR before the fix: `decision: run=false … could not read …#195 reviews (rc=1)`. After: `decision: run=true model=claude-sonnet-5 (github-actions[bot] has never reviewed this PR — running the first pass this push)`.

**2. An errored run reported a clean review.** Observed on #194: both credentials failed, the session died in 472 ms on its first turn at $0, wrote no `review.json` — and the job went green. `claude-code-action` exits 0 on a dead session and its own terminal event still reads `subtype: "success"`, so `is_error` is the one signal separating *reviewed and found nothing* from *never reviewed*. `claude-run` already exposed `execution_file` "so callers can detect an is_error run" — and no caller did.

**3. The `model` input was discarded.** `claude-run` forwarded a `model` input the pinned `claude-code-action` no longer accepts. Every run logged `Unexpected input(s) 'model'` and nothing failed, so `claude.yaml`'s request for Sonnet silently billed Opus.

## Partitions

- **The dead review trigger** (`decide-pr-review-trigger.sh`) — the reason no review has ever landed on a pushed-to PR.
- **The fail-open** (`post-pr-review.mjs`, `post-pr-review.sh`, `lib-review-cost.mjs`) — behaviour change; read closely.
- **The dead `model` input** (`.github/actions/claude-run/action.yaml`, `claude.yaml`).
- **Model floor** — every agent this repo runs moves to at least Sonnet 5: `claude-opus-5` for the deep review / conflict resolution, `claude-sonnet-5` for the automatic pass, thread resolver, PR-description check, security scan, `@claude` responder and release-notes drafter.
- **CI wiring** (`node-tests.yaml`) — `post-pr-review.test.mjs` ran nowhere (`node --test` discovery skips dot-directories), and once wired it needed `install-sanitizer.sh`: `post-pr-review.mjs` imports `agent-sanitizer` by name, and `.github/scripts/package.json` ends the package scope, so Node's self-reference never applies.
- **Tests** — 3 added for the fail-open; the `gh` stub corrected.

## Review focus

**The `gh` stub was vacuous.** `tests/test_decide_pr_review_trigger.py` faked `gh` with a double that happily accepted `--slurp` *and* `--jq` — the pair real gh refuses. Three tests covering the never-reviewed first pass were green against a stub that could not reproduce the bug. The stub now rejects that pair with gh's own message and prints raw JSON when no `--jq` is given.

`lib-review-cost.mjs`: the log parse it already did for the cost footer is factored into `readRunEvents`, with `runErrored` beside `readRunCost`. The asymmetry is deliberate — a missing or unparsable log yields *no cost* (unchanged: a missing cost must never block posting) but also *not errored*, so this adds no failure mode for runs that simply have no log.

The judgement I'd most like checked is the **ordering** in `post-pr-review.mjs`: `runErrored()` is checked before the review is read at all, so an errored run that left a partial `review.json` is still refused. That discards a possibly-valid review. I judged it correct — an errored session's output is not evidence either way — but it is a judgement, not a fact.

## How it was tested

- **Trigger fix, red on unfixed:** reverting `decide-pr-review-trigger.sh` to its `--slurp --jq` form reds exactly three tests (`3 failed, 9 passed`); restored, `12 passed`. `uv run pytest tests/test_decide_pr_review_trigger.py -q`. Those same three passed against the old stub in both states — that gap is the point.
- **Trigger fix, against the live API:** ran the script with the real `REPO`/`PR=195`/`ACTION=synchronize`; before/after decisions quoted above.
- **Fail-open, red on unfixed:** deleting the guard from `post-pr-review.mjs` turns `reports ERRORED when the run set is_error` red (48 pass / 1 fail); restoring returns 49/49. `node --test .github/scripts/post-pr-review.test.mjs`.
- **The CI-wiring fix reproduced first:** moving `.github/scripts/node_modules` aside reproduces CI exactly (49 fail, `ERR_MODULE_NOT_FOUND: agent-sanitizer`); `bash .github/scripts/install-sanitizer.sh` → 49 pass.
- `pnpm test` → 1977 passed. `pnpm lint` clean. `prettier --check` clean on the diff.

## Decisions made

- **`model` is forwarded as `--model` inside `claude_args`, not restored as a top-level input.** Deleting the input outright left no explicit model on either step, so the action defaults to Opus (~5× Sonnet) — `check-extras` correctly rejected that. Routing through `claude_args` is the only spelling that works and keeps the guard meaningful. It is prepended so a caller that also spells `--model` inside `claude_args` still wins (the action honours the last one), which `claude-pr-review.yaml` relies on.
- **`claude.yaml` has been running on Opus, not Sonnet.** It set `model:` through the dead input, so the request was discarded. This PR makes that line take effect — a real behaviour change, and a cost reduction.
- **`node-tests.yaml` names `post-pr-review.test.mjs` rather than globbing `.github/scripts`.** `npm-max-stable.test.mjs` fails on unmet dependencies (10 tests), exactly as the existing comment says. Naming one file keeps this required check honest; that breakage is pre-existing and untouched.
- **The `needs-auto-review` label was added to this PR by hand.** `pull_request_target` loads the decide script from the *base* branch, so the trigger fix cannot apply to its own PR. The `labeled` branch never touches the broken query, which is how the reviewer was invoked at all here.
- **`HAIKU_MODEL` was renamed `CHEAP_MODEL`.** The variable now holds a Sonnet id; a model-tier name in an identifier is the drift this repo bans.

## Lessons Learned

- **What**: A `PATH` stub standing in for a CLI must reject the flag combinations the real tool rejects, or every test resting on it certifies only the author's reading of that tool.
- **Where**: any test double under `tests/` or `.github/scripts/` that fakes `gh`, `curl`, `docker` or similar.
- **Why**: the `gh` stub here accepted `--slurp --jq`, a pair real gh refuses outright. Three tests covering the review trigger's main branch passed for months while that branch was unreachable in production. The stub agreed with the code, and the code was wrong.
- **What**: When a composite action wraps a third-party action, assert that every input it forwards is one the pinned version still accepts.
- **Where**: `.github/actions/claude-run/action.yaml` and any sibling wrapper in the template.
- **Why**: an unknown input is a `##[warning]`, not an error, so it is discarded silently while the workflow reads as configured. A workflow that asked for Sonnet quietly billed Opus for months; the warning is in every job log, and nothing reads job logs.
