### PR TITLE
fix(release): tag the published SHA so a raced merge still releases

### DIFF
--- a/.github/scripts/version-bump.sh
+++ b/.github/scripts/version-bump.sh
@@ -167,14 +167,21 @@ log "Highest live npm version: $CURRENT_VERSION"
 # Find the latest version tag to determine which commits to analyze
 LAST_TAG=$(git describe --tags --match "v*" --abbrev=0 HEAD 2>/dev/null || echo "")
 
-# Skip when HEAD's release already happened. The tag lands on the release-docs
-# commit, a CHILD of the published SHA, so a re-run against that published SHA
-# sees only ANCESTOR tags: `git describe` reports the PREVIOUS release, so the
-# run re-cuts the same commit range under a fresh version number (this is how
-# 2.0.2 shipped as a byte-identical duplicate of 2.0.1). `--contains` looks the
-# other way down the history and is the only view that sees a tag written after
-# HEAD. It also subsumes the "is HEAD itself tagged?" case: a tag ON HEAD
-# contains HEAD.
+# Skip when HEAD's tree is already released. Every tag sits on the SHA that was
+# PUBLISHED (see the tag step below), so a tag containing HEAD means HEAD is that
+# published commit or an ancestor of it — either way its content already shipped,
+# and re-cutting the range would republish it under a fresh number (this is how
+# 2.0.2 shipped as a byte-identical duplicate of 2.0.1). `git describe` cannot
+# answer this: it reports the previous release when HEAD is itself the published
+# SHA. `--contains` looks down the history instead, and subsumes the "is HEAD
+# itself tagged?" case, since a tag ON HEAD contains HEAD.
+#
+# This is only sound because the tag marks the published SHA rather than the
+# release-docs commit. Tagging the docs commit made the guard mistake "a release
+# was pushed after my merge landed" for "my merge was released": push_with_rebase
+# replays that docs commit onto whatever tip it finds, so a release of tree A
+# ends up tagged on a DESCENDANT of an unrelated merge B that raced it, and B
+# then skips its own release forever. That is what stranded #192.
 #
 # Ascending: with several releases since, the tag that actually released HEAD is
 # the LOWEST one containing it, so a descending sort would name the wrong version
@@ -486,6 +493,12 @@ push_with_rebase() {
 # the branch name — that would push to the bogus ref "HEAD:HEAD". GITHUB_REF_NAME
 # is the actual triggering branch in Actions; only fall back to git for local runs.
 RELEASE_DOCS_PUSH_FAILED=0
+# The SHA whose tree was published, captured BEFORE the release-docs commit and
+# before any rebase can move that commit. This is the one fact the tag must
+# record, and topology cannot carry it: push_with_rebase replays the docs commit
+# onto whatever tip it finds, so after a racing merge the docs commit's position
+# says nothing about what shipped.
+PUBLISHED_SHA=$(git rev-parse HEAD)
 DEFAULT_BRANCH="${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -512,17 +525,18 @@ if [[ "$RELEASE_DOCS_PUSH_FAILED" = "1" ]]; then
   exit 1
 fi
 
-# Tag the release for future commit-range detection. Tag HEAD, which now includes
-# the release-docs commit — so the tag sits on a CHILD of the SHA that was
-# published, and a re-trigger against that published SHA sees the tag only via
-# `git tag --contains` (the already-released guard near the top), NOT via
-# `git describe` and NOT as HEAD == tag SHA. Assuming the latter is what shipped
-# 2.0.2 as a duplicate of 2.0.1.
+# Tag the SHA that was PUBLISHED, not the local HEAD. The two differ whenever a
+# release-docs commit was made, and they diverge unrecoverably when that commit
+# was rebased onto a racing merge — tagging the local HEAD there certifies a tree
+# that was never published, and makes the already-released guard skip the racing
+# merge's own release. Pinning the tag to PUBLISHED_SHA keeps the tag meaning
+# exactly "this tree shipped as vX.Y.Z", which is what both the guard and
+# `git describe`'s commit-range cut read it as.
 # Guard against an existing tag: BASE_VERSION already keeps NEW_VERSION ahead of
 # every tag, but a re-run of the same release must stay idempotent rather than
 # abort under `set -e` when the local tag already exists.
 if ! git rev-parse -q --verify "refs/tags/v$NEW_VERSION" >/dev/null; then
-  git tag "v$NEW_VERSION"
+  git tag "v$NEW_VERSION" "$PUBLISHED_SHA"
 fi
 # Fail loudly if the tag never lands: the tag is what stops the next run from
 # re-analyzing these commits (re-drafting the changelog, re-pushing release

--- a/tests/test_version_bump_tag_placement.py
+++ b/tests/test_version_bump_tag_placement.py
@@ -1,0 +1,126 @@
+"""The release tag must mark the SHA that was PUBLISHED, not the local HEAD.
+
+version-bump.sh decides "has HEAD already been released?" with
+``git tag --contains HEAD``. That predicate is only sound if every tag sits on the
+commit whose tree actually shipped.
+
+It did not. The script committed release docs on top of the published SHA, pushed
+with ``push_with_rebase``, and tagged the local HEAD. When a second merge landed
+mid-run the docs commit was replayed onto it, so a tag certifying tree A came to
+sit on a DESCENDANT of unrelated merge B. ``git tag --contains B`` then reported B
+as released, and B never published — observed on 2026-07-30, when the agent-
+sanitizer #192 merge (caa1fb1) was skipped with "HEAD is already released as
+v2.7.1" while the shipped 2.7.1 tarball contained none of its changes.
+
+These build the real topology with real git rather than asserting on the script's
+source text, so they keep testing the property if the implementation moves.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(
+    subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+)
+SCRIPT = REPO_ROOT / ".github" / "scripts" / "version-bump.sh"
+
+
+def _git(repo: Path, *args: str) -> str:
+    """Run git in ``repo`` and return stdout, raising on a non-zero exit."""
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def _commit(repo: Path, message: str) -> str:
+    """Create an empty commit and return its SHA."""
+    _git(repo, "commit", "--allow-empty", "-m", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+@pytest.fixture
+def raced_release(tmp_path: Path) -> dict[str, str]:
+    """The exact shape of the stranding: publish A, merge B, rebase A's docs onto B.
+
+    Returns the published SHA of release A and the SHA of the racing merge B.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.invalid")
+    _git(repo, "config", "user.name", "t")
+
+    _commit(repo, "chore: base")
+    published_a = _commit(repo, "Merge pull request #194")
+    # B lands on the branch while A's run is still publishing.
+    merge_b = _commit(repo, "Merge pull request #192")
+    # push_with_rebase replays A's release-docs commit onto the new tip, B.
+    docs = _commit(repo, "docs: release 2.7.1 [skip ci]")
+
+    return {
+        "repo": str(repo),
+        "published_a": published_a,
+        "merge_b": merge_b,
+        "docs": docs,
+    }
+
+
+def test_tagging_the_docs_commit_strands_the_racing_merge(raced_release):
+    """The old placement: the guard reports B released, though B never shipped."""
+    repo = Path(raced_release["repo"])
+    _git(repo, "tag", "v2.7.1", raced_release["docs"])
+
+    contains_b = _git(
+        repo, "tag", "--contains", raced_release["merge_b"], "--list", "v*"
+    )
+    assert contains_b == "v2.7.1", (
+        "fixture must reproduce the stranding: a tag on the rebased docs commit "
+        "has to look like it contains the racing merge"
+    )
+
+
+def test_tagging_the_published_sha_lets_the_racing_merge_release(raced_release):
+    """The fixed placement: B is not claimed by A's tag, so B publishes."""
+    repo = Path(raced_release["repo"])
+    _git(repo, "tag", "v2.7.1", raced_release["published_a"])
+
+    contains_b = _git(
+        repo, "tag", "--contains", raced_release["merge_b"], "--list", "v*"
+    )
+    assert contains_b == "", (
+        f"merge B is claimed by {contains_b!r}; its release would be skipped"
+    )
+
+    # ...and the guard still fires for a genuine re-trigger against A, which is
+    # the duplicate-publish the guard exists to prevent.
+    contains_a = _git(
+        repo, "tag", "--contains", raced_release["published_a"], "--list", "v*"
+    )
+    assert contains_a == "v2.7.1"
+
+
+def test_script_tags_the_published_sha_not_local_head():
+    """The tag command names the pre-docs-commit SHA.
+
+    Paired with the topology tests above: those prove which placement is correct,
+    this proves the script asks for that one. A bare source grep would pass
+    vacuously if the tag step were deleted, so the captured variable and its use
+    are both asserted.
+    """
+    source = SCRIPT.read_text(encoding="utf-8")
+    assert "PUBLISHED_SHA=$(git rev-parse HEAD)" in source, (
+        "the published SHA must be captured before the release-docs commit"
+    )
+    assert 'git tag "v$NEW_VERSION" "$PUBLISHED_SHA"' in source, (
+        "the tag must be pinned to the published SHA, not to the local HEAD"
+    )


### PR DESCRIPTION
Claimed area: `.github/scripts/version-bump.sh` tag placement.

A merge that lands while another release is publishing never releases at all. #192 hit this: its run logged `HEAD is already released as v2.7.1` and skipped every publish step, while the shipped 2.7.1 tarball contained none of its changes.

## The race

`version-bump.sh` decides "is HEAD already released?" with `git tag --contains HEAD`. That is sound only if every tag sits on the commit whose tree actually shipped — and it did not. The script committed release docs on top of the published SHA, pushed with `push_with_rebase`, then tagged the **local HEAD**.

`push_with_rebase` exists so a merge landing mid-run cannot strand a release, but it replays the docs commit onto whatever tip it finds:

```
43379bf  Merge #194        <- tree that was published as 2.7.1
caa1fb1  Merge #192        <- landed while #194's run was publishing
30e5451  docs: release 2.7.1 [skip ci]   <- rebased onto caa1fb1; v2.7.1 tagged HERE
```

So a tag certifying #194's tree became a **descendant** of #192's merge. `git tag --contains caa1fb1` returns `v2.7.1`, the guard reads that as "released", and #192 skips its own release permanently.

Observed, from run 30560293078 (job 90931383769):

```
Highest live npm version: 2.7.1
HEAD is already released as v2.7.1. Skipping.
```

The bump step took **1 second** and every publish step after it reports `skipped`. Three merges landed within two minutes (#193 16:09:07, #194 16:10:35, #192 16:11:11), serialized by `concurrency: auto-version`, and only two versions exist on npm.

Concurrency was not the problem — `cancel-in-progress: false` already queues correctly. The problem is that after a rebase, topology no longer encodes which tree was published.

## The fix

Capture the published SHA **before** the release-docs commit and tag that:

```bash
PUBLISHED_SHA=$(git rev-parse HEAD)      # before any docs commit or rebase
...
git tag "v$NEW_VERSION" "$PUBLISHED_SHA"
```

The tag now means exactly "this tree shipped as vX.Y.Z" no matter where a rebase later moves the docs commit — which is already how both readers interpret it. The guard keeps working for the case it was written for: a re-trigger against a published SHA still finds a tag on that SHA (a tag ON HEAD contains HEAD), so the duplicate-publish that shipped 2.0.2 as a byte-identical copy of 2.0.1 stays blocked. `git describe`'s commit-range cut is unaffected — the tag is still on the mainline, one commit earlier.

No new metadata and no inference: the one fact topology cannot carry is recorded directly.

## Verification

| Claim | Falsifying command | Result |
| --- | --- | --- |
| New tests pass | `uv run --python 3.10 --extra dev pytest tests/test_version_bump_tag_placement.py -q` | 3 passed (observed) |
| Red on the unfixed script | `git stash push .github/scripts/version-bump.sh && pytest tests/test_version_bump_tag_placement.py` | 1 failed, 2 passed — the failure is the placement assertion (observed) |
| Existing release guards still hold | `node --test scripts/version-bump.test.mjs` (ran via the pre-commit SSOT pairing) | 11/11 pass, including *a re-run against an already-released SHA skips instead of republishing* and *release-docs push rebases onto a branch that advanced mid-run* (observed) |
| Shell clean | `shellcheck .github/scripts/version-bump.sh` / `bash -n` | clean (observed) |

`tests/test_version_bump_tag_placement.py` builds the raced topology with **real git** rather than asserting on source text, and pins both directions: a tag on the rebased docs commit claims the racing merge (the bug), a tag on the published SHA does not (the fix), and a genuine re-trigger is still caught (the guard's original job). The two topology tests would keep testing the property if the implementation moved; the third asserts the script actually asks for that placement, and checks both the captured variable and its use so it cannot pass vacuously if the tag step were deleted.

Why the existing suite missed it: `release-docs push rebases onto a branch that advanced mid-run` covers the push surviving the race, but nothing covered where the tag lands afterwards or what the next run's guard then concludes.

## Consequence that needs a human decision

This prevents recurrence; it does not retroactively publish #192. `v2.7.1` still points at `30e5451`, so on the next release the commit range `v2.7.1..HEAD` **excludes** #192's commits. Its code will ship (publishing ships HEAD's tree, not a diff) but under a version whose bump was computed without it, and with no changelog entry for it — including the Layer-4 credential-vocabulary fail-open fix, which is currently unpublished on npm.

Retagging or forcing a bump is a destructive history operation on a published release, so I have not done it. The clean options are to move `v2.7.1` back to `43379bf` before the next release, or to accept the missing notes and let the next release carry the code.

## Decisions made

- **Tag the published SHA rather than recording it in the tag message or a commit trailer.** Both would work, but the trailer needs a parser and leaves existing tags unreadable, while moving the tag makes the existing `--contains` predicate correct as written. The trade-off: the tag no longer sits on the changelog commit, so `git show v2.7.1` shows the merge rather than the release notes.
- **Left the `RELEASE_DOCS_PUSH_FAILED` early-exit alone.** Tagging `PUBLISHED_SHA` is now safe even when the docs push fails (that SHA is on the branch regardless), so the exit could be relaxed to tag-then-warn. That is a real improvement but a separate behavior change, and the current loud failure is not wrong.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DQLQtpidpswgARdaNuG2oE)_