### PR TITLE
feat(claude-hooks): let a host inject its own fail-closed reasons and deny gates

### DIFF
--- a/claude-hooks/lib/control-plane.mjs
+++ b/claude-hooks/lib/control-plane.mjs
@@ -8,14 +8,15 @@
  * (runJudgeCli).
  */
 import {
+  awaitLazyDependency,
   errMessage,
+  hookgateMarkerPath,
   lazyImport,
   markerIsTrusted,
   missingPackageError,
+  probeSetupAlive,
   readStdinJson,
 } from "./hook-io.mjs";
-
-import { readFileSync } from "node:fs";
 
 // Loaded via a *caught* dynamic import — never a bare static `import … from`.
 // A static npm import resolves before any try/catch, so a missing node_modules
@@ -31,144 +32,13 @@ let Decision;
 /** @type {typeof import("agent-control-plane-core").EventKind | undefined} */
 let EventKind;
 
-/** The marker filename stem; the project directory is appended to it. */
-const HOOKGATE_MARKER_STEM = "agent-sanitizer-hookgate-inflight-";
-
-/**
- * Path of the cold-start in-flight marker a host's setup script writes
- * SYNCHRONOUSLY before it starts installing deps (its own PID as the contents)
- * and removes once the hook dependencies are provisioned. A hook that fires
- * before setup finishes finds the marker and WAITS for its dependency rather
- * than failing closed on it — so the first turn is merely delayed, never
- * blocked, for as long as setup is still alive (the PID lets the hook tell a
- * live install from a stale marker left by a killed setup). Derived purely from
- * the raw CLAUDE_PROJECT_DIR the harness sets for both processes (no
- * canonicalization — the two must produce byte-identical paths), so no env has
- * to propagate from setup to the hook. Null when CLAUDE_PROJECT_DIR is unset (no
- * setup ran → nothing to wait on).
- * @param {string | undefined} [projectDir]
- * @param {string | undefined} [runtimeDir]
- * @returns {string | null}
- */
-export function hookgateMarkerPath(
-  projectDir = process.env.CLAUDE_PROJECT_DIR,
-  runtimeDir = process.env.XDG_RUNTIME_DIR,
-) {
-  if (!projectDir) return null;
-  // Prefer the per-user, mode-0700 runtime dir when the harness gives an
-  // absolute one; else the world-writable /tmp, where markerIsTrusted() — not
-  // the path — defends against a squatted marker.
-  const base = runtimeDir && runtimeDir.startsWith("/") ? runtimeDir : "/tmp";
-  return `${base}/${HOOKGATE_MARKER_STEM}${projectDir.replace(/[^A-Za-z0-9]/g, "_")}`;
-}
-
-/**
- * Is the setup process that wrote `markerPath` still alive? `process.kill(pid, 0)`
- * probes liveness without signalling: it throws ESRCH once the process is gone (a
- * killed setup → stale marker, so stop waiting) and EPERM when it exists but isn't
- * ours (still alive). An unreadable / not-yet-written marker is treated as alive —
- * favouring a brief wait over a premature give-up during setup's write race. A null
- * markerPath (no project dir → no setup to wait on) reads as alive so the caller's
- * own grace/ceiling bound governs.
- * @param {string | null} markerPath
- * @returns {boolean}
- */
-export function probeSetupAlive(markerPath) {
-  if (markerPath === null) return true;
-  let pid;
-  try {
-    pid = parseInt(readFileSync(markerPath, "utf8"), 10);
-  } catch {
-    return true;
-  }
-  if (!Number.isInteger(pid) || pid <= 0) return true;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (err) {
-    return /** @type {NodeJS.ErrnoException} */ (err).code === "EPERM";
-  }
-}
-
-/**
- * Resolve a lazily-loaded dependency, blocking through the cold-start window while
- * setup is still installing it. Returns the loaded value, or null once it gives up
- * (the caller leaves its bindings undefined so the hook fails closed). It waits for
- * as long as setup is genuinely alive, so a slow install is never cut off; the only
- * bound on that wait is a backstop ceiling that stays under the hook's harness
- * timeout — a hook killed for running over is a fail-OPEN, the opposite of what a
- * gate wants. The give-up cases are the honest ones (setup finished/died without the
- * dep, or no setup at all), so a genuinely-absent dep fails closed fast, never after
- * a long block:
- *   - import succeeds                 → return immediately (warm session: no wait).
- *   - marker present AND setup alive  → setup is working; wait it out (ceilingMs is a
- *                                        backstop only, for a hung-but-alive setup).
- *   - was installing, now not (marker cleared, or a stale marker from a killed setup)
- *                                     → settleMs grace for a just-orphaned install to
- *                                        land, then give up: the dep is absent.
- *   - no live setup ever seen         → wait only graceMs (tolerating setup not having
- *                                        written the marker yet), then give up.
- * @param {{
- *   tryImport: () => Promise<object | null>,
- *   markerPresent: () => boolean,
- *   setupAlive: () => boolean,
- *   now?: () => number,
- *   sleep?: (ms: number) => Promise<void>,
- *   graceMs?: number,
- *   settleMs?: number,
- *   ceilingMs?: number,
- *   intervalMs?: number,
- * }} deps
- * @returns {Promise<object | null>}
- */
-export async function awaitControlPlaneBindings({
-  tryImport,
-  markerPresent,
-  setupAlive,
-  now = () => Date.now(),
-  sleep = (ms) =>
-    new Promise((resolve) => {
-      setTimeout(resolve, ms);
-    }),
-  graceMs = 5000,
-  settleMs = 1000,
-  ceilingMs = 900000,
-  intervalMs = 250,
-}) {
-  const start = now();
-  let sawInstalling = false;
-  let enteredDone = false;
-  let doneAt = 0;
-  for (;;) {
-    const bindings = await tryImport();
-    if (bindings) return bindings;
-    const installing = markerPresent() && setupAlive();
-    let giveUp;
-    if (installing) {
-      sawInstalling = true;
-      enteredDone = false;
-      giveUp = now() - start > ceilingMs;
-    } else if (sawInstalling) {
-      if (!enteredDone) {
-        enteredDone = true;
-        doneAt = now();
-      }
-      giveUp = now() - doneAt > settleMs;
-    } else {
-      giveUp = now() - start > graceMs;
-    }
-    if (giveUp) return null;
-    await sleep(intervalMs);
-  }
-}
-
 /* c8 ignore start -- module-load boundary: the real import resolves in every
    in-process test and spawned CLI run, and a missing node_modules can't be
    simulated in-process, so this glue's failure arm is unobservable here. The
-   observable logic lives in awaitControlPlaneBindings, unit-tested directly. */
+   observable logic lives in awaitLazyDependency, unit-tested directly. */
 // Stryker disable all
 const marker = hookgateMarkerPath();
-const loaded = await awaitControlPlaneBindings({
+const loaded = await awaitLazyDependency({
   tryImport: async () => {
     // lazyImport is the shared caught npm import (see hook-io): it returns the
     // module on success and {} on a failed load, so a missing binding is the

--- a/claude-hooks/lib/control-plane.mjs
+++ b/claude-hooks/lib/control-plane.mjs
@@ -7,7 +7,15 @@
  * transport rule (nativeStdout), and the shared judge-CLI transport
  * (runJudgeCli).
  */
-import { errMessage, lazyImport, readStdinJson } from "./hook-io.mjs";
+import {
+  errMessage,
+  lazyImport,
+  markerIsTrusted,
+  missingPackageError,
+  readStdinJson,
+} from "./hook-io.mjs";
+
+import { readFileSync } from "node:fs";
 
 // Loaded via a *caught* dynamic import — never a bare static `import … from`.
 // A static npm import resolves before any try/catch, so a missing node_modules
@@ -23,23 +31,170 @@ let Decision;
 /** @type {typeof import("agent-control-plane-core").EventKind | undefined} */
 let EventKind;
 
+/** The marker filename stem; the project directory is appended to it. */
+const HOOKGATE_MARKER_STEM = "agent-sanitizer-hookgate-inflight-";
+
+/**
+ * Path of the cold-start in-flight marker a host's setup script writes
+ * SYNCHRONOUSLY before it starts installing deps (its own PID as the contents)
+ * and removes once the hook dependencies are provisioned. A hook that fires
+ * before setup finishes finds the marker and WAITS for its dependency rather
+ * than failing closed on it — so the first turn is merely delayed, never
+ * blocked, for as long as setup is still alive (the PID lets the hook tell a
+ * live install from a stale marker left by a killed setup). Derived purely from
+ * the raw CLAUDE_PROJECT_DIR the harness sets for both processes (no
+ * canonicalization — the two must produce byte-identical paths), so no env has
+ * to propagate from setup to the hook. Null when CLAUDE_PROJECT_DIR is unset (no
+ * setup ran → nothing to wait on).
+ * @param {string | undefined} [projectDir]
+ * @param {string | undefined} [runtimeDir]
+ * @returns {string | null}
+ */
+export function hookgateMarkerPath(
+  projectDir = process.env.CLAUDE_PROJECT_DIR,
+  runtimeDir = process.env.XDG_RUNTIME_DIR,
+) {
+  if (!projectDir) return null;
+  // Prefer the per-user, mode-0700 runtime dir when the harness gives an
+  // absolute one; else the world-writable /tmp, where markerIsTrusted() — not
+  // the path — defends against a squatted marker.
+  const base = runtimeDir && runtimeDir.startsWith("/") ? runtimeDir : "/tmp";
+  return `${base}/${HOOKGATE_MARKER_STEM}${projectDir.replace(/[^A-Za-z0-9]/g, "_")}`;
+}
+
+/**
+ * Is the setup process that wrote `markerPath` still alive? `process.kill(pid, 0)`
+ * probes liveness without signalling: it throws ESRCH once the process is gone (a
+ * killed setup → stale marker, so stop waiting) and EPERM when it exists but isn't
+ * ours (still alive). An unreadable / not-yet-written marker is treated as alive —
+ * favouring a brief wait over a premature give-up during setup's write race. A null
+ * markerPath (no project dir → no setup to wait on) reads as alive so the caller's
+ * own grace/ceiling bound governs.
+ * @param {string | null} markerPath
+ * @returns {boolean}
+ */
+export function probeSetupAlive(markerPath) {
+  if (markerPath === null) return true;
+  let pid;
+  try {
+    pid = parseInt(readFileSync(markerPath, "utf8"), 10);
+  } catch {
+    return true;
+  }
+  if (!Number.isInteger(pid) || pid <= 0) return true;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return /** @type {NodeJS.ErrnoException} */ (err).code === "EPERM";
+  }
+}
+
+/**
+ * Resolve a lazily-loaded dependency, blocking through the cold-start window while
+ * setup is still installing it. Returns the loaded value, or null once it gives up
+ * (the caller leaves its bindings undefined so the hook fails closed). It waits for
+ * as long as setup is genuinely alive, so a slow install is never cut off; the only
+ * bound on that wait is a backstop ceiling that stays under the hook's harness
+ * timeout — a hook killed for running over is a fail-OPEN, the opposite of what a
+ * gate wants. The give-up cases are the honest ones (setup finished/died without the
+ * dep, or no setup at all), so a genuinely-absent dep fails closed fast, never after
+ * a long block:
+ *   - import succeeds                 → return immediately (warm session: no wait).
+ *   - marker present AND setup alive  → setup is working; wait it out (ceilingMs is a
+ *                                        backstop only, for a hung-but-alive setup).
+ *   - was installing, now not (marker cleared, or a stale marker from a killed setup)
+ *                                     → settleMs grace for a just-orphaned install to
+ *                                        land, then give up: the dep is absent.
+ *   - no live setup ever seen         → wait only graceMs (tolerating setup not having
+ *                                        written the marker yet), then give up.
+ * @param {{
+ *   tryImport: () => Promise<object | null>,
+ *   markerPresent: () => boolean,
+ *   setupAlive: () => boolean,
+ *   now?: () => number,
+ *   sleep?: (ms: number) => Promise<void>,
+ *   graceMs?: number,
+ *   settleMs?: number,
+ *   ceilingMs?: number,
+ *   intervalMs?: number,
+ * }} deps
+ * @returns {Promise<object | null>}
+ */
+export async function awaitControlPlaneBindings({
+  tryImport,
+  markerPresent,
+  setupAlive,
+  now = () => Date.now(),
+  sleep = (ms) =>
+    new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    }),
+  graceMs = 5000,
+  settleMs = 1000,
+  ceilingMs = 900000,
+  intervalMs = 250,
+}) {
+  const start = now();
+  let sawInstalling = false;
+  let enteredDone = false;
+  let doneAt = 0;
+  for (;;) {
+    const bindings = await tryImport();
+    if (bindings) return bindings;
+    const installing = markerPresent() && setupAlive();
+    let giveUp;
+    if (installing) {
+      sawInstalling = true;
+      enteredDone = false;
+      giveUp = now() - start > ceilingMs;
+    } else if (sawInstalling) {
+      if (!enteredDone) {
+        enteredDone = true;
+        doneAt = now();
+      }
+      giveUp = now() - doneAt > settleMs;
+    } else {
+      giveUp = now() - start > graceMs;
+    }
+    if (giveUp) return null;
+    await sleep(intervalMs);
+  }
+}
+
 /* c8 ignore start -- module-load boundary: the real import resolves in every
    in-process test and spawned CLI run, and a missing node_modules can't be
    simulated in-process, so this glue's failure arm is unobservable here. The
-   observable behaviour is controlPlane()'s throw, unit-tested directly. */
+   observable logic lives in awaitControlPlaneBindings, unit-tested directly. */
 // Stryker disable all
-{
-  const { claudeAdapter: adapter } =
-    /** @type {Partial<typeof import("agent-control-plane-core/claude")>} */ (
-      await lazyImport("agent-control-plane-core/claude")
+const marker = hookgateMarkerPath();
+const loaded = await awaitControlPlaneBindings({
+  tryImport: async () => {
+    // lazyImport is the shared caught npm import (see hook-io): it returns the
+    // module on success and {} on a failed load, so a missing binding is the
+    // null signal the poll loop waits on — no bare import()/try-catch here.
+    const { claudeAdapter: adapter } =
+      /** @type {Partial<typeof import("agent-control-plane-core/claude")>} */ (
+        await lazyImport("agent-control-plane-core/claude")
+      );
+    const { Decision: decision, EventKind: eventKind } =
+      /** @type {Partial<typeof import("agent-control-plane-core")>} */ (
+        await lazyImport("agent-control-plane-core")
+      );
+    if (!adapter || !decision || !eventKind) return null;
+    return { claudeAdapter: adapter, Decision: decision, EventKind: eventKind };
+  },
+  markerPresent: () => markerIsTrusted(marker),
+  setupAlive: () => probeSetupAlive(marker),
+});
+if (loaded) {
+  const bound =
+    /** @type {{ claudeAdapter: typeof claudeAdapter, Decision: typeof Decision, EventKind: typeof EventKind }} */ (
+      loaded
     );
-  const { Decision: decision, EventKind: eventKind } =
-    /** @type {Partial<typeof import("agent-control-plane-core")>} */ (
-      await lazyImport("agent-control-plane-core")
-    );
-  claudeAdapter = adapter;
-  Decision = decision;
-  EventKind = eventKind;
+  claudeAdapter = bound.claudeAdapter;
+  Decision = bound.Decision;
+  EventKind = bound.EventKind;
 }
 // Stryker restore all
 /* c8 ignore stop */
@@ -58,7 +213,7 @@ let EventKind;
 export function controlPlane(overrides = {}) {
   const bindings = { claudeAdapter, Decision, EventKind, ...overrides };
   if (!bindings.claudeAdapter || !bindings.Decision || !bindings.EventKind)
-    throw new Error("agent-control-plane-core is unavailable");
+    throw missingPackageError("agent-control-plane-core");
   return /** @type {ReturnType<typeof controlPlane>} */ (bindings);
 }
 

--- a/claude-hooks/lib/hook-io.mjs
+++ b/claude-hooks/lib/hook-io.mjs
@@ -9,6 +9,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { userInfo } from "node:os";
+import { createHash } from "node:crypto";
 import { pathToFileURL } from "node:url";
 
 let cliEntryClaimed = false;
@@ -246,6 +247,8 @@ export const DEFAULT_MISSING_PACKAGE_REMEDY =
  * reasons shown to user and model) and its cap is COMPUTED so that
  * prefix + cause + remedy always fits the downstream 300-char safeErrMessage
  * re-scrub — the remedy can never be truncated off, whatever the package name.
+ * A remedy that alone exceeds that budget (roughly 260 characters) leaves the
+ * cause nothing to spend and still overruns; keep host remedies to a sentence.
  * @param {string} pkg
  * @param {unknown} [err]
  * @param {string} [remedy]
@@ -258,8 +261,13 @@ export function missingPackageMessage(
 ) {
   const prefix = `${pkg} is unavailable: `;
   // 2 for the "; " joiner; 12 for safeErrMessage's own "…[truncated]" marker,
-  // which lands past its cap when the cause is cut.
-  const causeCap = 300 - prefix.length - remedy.length - 2 - 12;
+  // which lands past its cap when the cause is cut. Clamped at 0 because the
+  // remedy is host text: a long one drives the budget negative, and
+  // safeErrMessage does not clamp — `slice(0, -n)` trims from the END, returning
+  // nearly the whole cause and pushing the joined message past 300, so the
+  // downstream re-scrub cuts the remedy off. At 0 the cause degrades to the
+  // truncation marker and the remedy always survives.
+  const causeCap = Math.max(0, 300 - prefix.length - remedy.length - 2 - 12);
   const cause =
     err === undefined
       ? "no load error recorded — the package likely loaded but lacks an expected export (version skew)"
@@ -411,7 +419,18 @@ export function hookgateMarkerPath(
   // absolute one; else the world-writable /tmp, where markerIsTrusted() — not
   // the path — defends against a squatted marker.
   const base = runtimeDir && runtimeDir.startsWith("/") ? runtimeDir : "/tmp";
-  return `${base}/${HOOKGATE_MARKER_STEM}${projectDir.replace(/[^A-Za-z0-9]/g, "_")}`;
+  // The flattened dir is for a human reading `ls /tmp`; the digest of the RAW
+  // dir is the identity. Flattening alone is lossy — /work/a-b, /work/a_b and
+  // "/work/a b" all collapse to one name — and two such projects on one machine
+  // would then share a marker: B's hook waits out A's install for a dependency A
+  // is not installing, and A clearing the marker aborts B's legitimate wait. Both
+  // directions are silent. A setup script reproduces the digest with sha256sum.
+  const digest = createHash("sha256")
+    .update(projectDir)
+    .digest("hex")
+    .slice(0, 8);
+  const flattened = projectDir.replace(/[^A-Za-z0-9]/g, "_");
+  return `${base}/${HOOKGATE_MARKER_STEM}${flattened}-${digest}`;
 }
 
 /**

--- a/claude-hooks/lib/hook-io.mjs
+++ b/claude-hooks/lib/hook-io.mjs
@@ -4,6 +4,7 @@ import {
   openSync,
   closeSync,
   lstatSync,
+  readFileSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -380,6 +381,137 @@ export function emitHookResponse(hookEventName, fields) {
   process.stdout.write(
     JSON.stringify({ hookSpecificOutput: { hookEventName, ...fields } }),
   );
+}
+
+/** The marker filename stem; the project directory is appended to it. */
+const HOOKGATE_MARKER_STEM = "agent-sanitizer-hookgate-inflight-";
+
+/**
+ * Path of the cold-start in-flight marker a host's setup script writes
+ * SYNCHRONOUSLY before it starts installing deps (its own PID as the contents)
+ * and removes once the hook dependencies are provisioned. A hook that fires
+ * before setup finishes finds the marker and WAITS for its dependency rather
+ * than failing closed on it — so the first turn is merely delayed, never
+ * blocked, for as long as setup is still alive (the PID lets the hook tell a
+ * live install from a stale marker left by a killed setup). Derived purely from
+ * the raw CLAUDE_PROJECT_DIR the harness sets for both processes (no
+ * canonicalization — the two must produce byte-identical paths), so no env has
+ * to propagate from setup to the hook. Null when CLAUDE_PROJECT_DIR is unset (no
+ * setup ran → nothing to wait on).
+ * @param {string | undefined} [projectDir]
+ * @param {string | undefined} [runtimeDir]
+ * @returns {string | null}
+ */
+export function hookgateMarkerPath(
+  projectDir = process.env.CLAUDE_PROJECT_DIR,
+  runtimeDir = process.env.XDG_RUNTIME_DIR,
+) {
+  if (!projectDir) return null;
+  // Prefer the per-user, mode-0700 runtime dir when the harness gives an
+  // absolute one; else the world-writable /tmp, where markerIsTrusted() — not
+  // the path — defends against a squatted marker.
+  const base = runtimeDir && runtimeDir.startsWith("/") ? runtimeDir : "/tmp";
+  return `${base}/${HOOKGATE_MARKER_STEM}${projectDir.replace(/[^A-Za-z0-9]/g, "_")}`;
+}
+
+/**
+ * Is the setup process that wrote `markerPath` still alive? `process.kill(pid, 0)`
+ * probes liveness without signalling: it throws ESRCH once the process is gone (a
+ * killed setup → stale marker, so stop waiting) and EPERM when it exists but isn't
+ * ours (still alive). An unreadable / not-yet-written marker is treated as alive —
+ * favouring a brief wait over a premature give-up during setup's write race. A null
+ * markerPath (no project dir → no setup to wait on) reads as alive so the caller's
+ * own grace/ceiling bound governs.
+ * @param {string | null} markerPath
+ * @returns {boolean}
+ */
+export function probeSetupAlive(markerPath) {
+  if (markerPath === null) return true;
+  let pid;
+  try {
+    pid = parseInt(readFileSync(markerPath, "utf8"), 10);
+  } catch {
+    return true;
+  }
+  if (!Number.isInteger(pid) || pid <= 0) return true;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return /** @type {NodeJS.ErrnoException} */ (err).code === "EPERM";
+  }
+}
+
+/**
+ * Resolve a lazily-loaded dependency, blocking through the cold-start window while
+ * setup is still installing it. Returns the loaded value, or null once it gives up
+ * (the caller leaves its bindings undefined so the hook fails closed). It waits for
+ * as long as setup is genuinely alive, so a slow install is never cut off; the only
+ * bound on that wait is a backstop ceiling that stays under the hook's harness
+ * timeout — a hook killed for running over is a fail-OPEN, the opposite of what a
+ * gate wants. The give-up cases are the honest ones (setup finished/died without the
+ * dep, or no setup at all), so a genuinely-absent dep fails closed fast, never after
+ * a long block:
+ *   - import succeeds                 → return immediately (warm session: no wait).
+ *   - marker present AND setup alive  → setup is working; wait it out (ceilingMs is a
+ *                                        backstop only, for a hung-but-alive setup).
+ *   - was installing, now not (marker cleared, or a stale marker from a killed setup)
+ *                                     → settleMs grace for a just-orphaned install to
+ *                                        land, then give up: the dep is absent.
+ *   - no live setup ever seen         → wait only graceMs (tolerating setup not having
+ *                                        written the marker yet), then give up.
+ * @param {{
+ *   tryImport: () => Promise<object | null>,
+ *   markerPresent: () => boolean,
+ *   setupAlive: () => boolean,
+ *   now?: () => number,
+ *   sleep?: (ms: number) => Promise<void>,
+ *   graceMs?: number,
+ *   settleMs?: number,
+ *   ceilingMs?: number,
+ *   intervalMs?: number,
+ * }} deps
+ * @returns {Promise<object | null>}
+ */
+export async function awaitLazyDependency({
+  tryImport,
+  markerPresent,
+  setupAlive,
+  now = () => Date.now(),
+  sleep = (ms) =>
+    new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    }),
+  graceMs = 5000,
+  settleMs = 1000,
+  ceilingMs = 900000,
+  intervalMs = 250,
+}) {
+  const start = now();
+  let sawInstalling = false;
+  let enteredDone = false;
+  let doneAt = 0;
+  for (;;) {
+    const bindings = await tryImport();
+    if (bindings) return bindings;
+    const installing = markerPresent() && setupAlive();
+    let giveUp;
+    if (installing) {
+      sawInstalling = true;
+      enteredDone = false;
+      giveUp = now() - start > ceilingMs;
+    } else if (sawInstalling) {
+      if (!enteredDone) {
+        enteredDone = true;
+        doneAt = now();
+      }
+      giveUp = now() - doneAt > settleMs;
+    } else {
+      giveUp = now() - start > graceMs;
+    }
+    if (giveUp) return null;
+    await sleep(intervalMs);
+  }
 }
 
 /**

--- a/claude-hooks/lib/hook-io.mjs
+++ b/claude-hooks/lib/hook-io.mjs
@@ -155,6 +155,14 @@ export function registeredLazyModule(specifier) {
 }
 
 /**
+ * Last load error per specifier, recorded when {@link lazyImport} swallows a
+ * failed import. Read by {@link lazyImportErrorFor} so a fail-closed hook can
+ * say WHY its dependency is absent instead of a bare "unavailable".
+ * @type {Map<string, unknown>}
+ */
+const lazyImportErrors = new Map();
+
+/**
  * Dynamic-import `specifier`, yielding `{}` when the module cannot be loaded.
  * Hooks bind their npm packages through this instead of a bare static import: a
  * static npm import resolves before any try/catch, so a missing node_modules
@@ -169,12 +177,112 @@ export function registeredLazyModule(specifier) {
  */
 export async function lazyImport(specifier) {
   const registered = registeredLazyModules[specifier];
-  if (registered) return registered;
+  if (registered) {
+    lazyImportErrors.delete(specifier);
+    return registered;
+  }
   try {
-    return await import(specifier);
-  } catch {
+    const loaded = await import(specifier);
+    lazyImportErrors.delete(specifier);
+    return loaded;
+  } catch (err) {
+    // Delete before set: a Map keeps a re-set key at its ORIGINAL insertion
+    // position, and both readers below are recency-ordered — so re-recording in
+    // place would let a stale first failure outrank the one that just happened.
+    lazyImportErrors.delete(specifier);
+    lazyImportErrors.set(specifier, err);
     return {};
   }
+}
+
+/**
+ * The most recently recorded load error for `pkg` under any of its specifiers —
+ * the bare package or a subpath export (`pkg/output`, `pkg/invisible`) — or
+ * undefined when none is recorded. Hooks import a package through several
+ * subpaths; any one of them names why the package is absent, and the newest
+ * record reflects the current failure when they differ.
+ * @param {string} pkg
+ * @returns {unknown}
+ */
+export function lazyImportErrorFor(pkg) {
+  for (const [specifier, err] of [...lazyImportErrors].reverse())
+    if (specifier === pkg || specifier.startsWith(`${pkg}/`)) return err;
+  return undefined;
+}
+
+/**
+ * Package names (never relative-path specifiers) with a recorded load error,
+ * newest first — so a fail-closed reason can name whichever dependency actually
+ * failed instead of consulting a hardcoded package list.
+ * @returns {string[]}
+ */
+export function failedLazyPackages() {
+  const pkgs = new Set();
+  for (const specifier of [...lazyImportErrors.keys()].reverse()) {
+    // Only bare package names: relative/absolute paths and URL specifiers
+    // (file:, node:) are not npm packages a reinstall could restore.
+    if (!/^[\w@]/.test(specifier) || specifier.includes(":")) continue;
+    const parts = specifier.split("/");
+    pkgs.add(
+      specifier.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0],
+    );
+  }
+  return [...pkgs];
+}
+
+/**
+ * The remedy {@link missingPackageMessage} states when the host does not supply
+ * one of its own. A host whose install has a specific entry point (a setup
+ * script, a devcontainer rebuild) passes that instead, so the reason names the
+ * command the reader should actually run.
+ */
+export const DEFAULT_MISSING_PACKAGE_REMEDY =
+  "reinstall the hook dependencies (pnpm install) and retry.";
+
+/**
+ * The fail-closed reason for a package a hook could not load: the recorded
+ * loader error plus the remedy. The cause is scrubbed (it is spliced into
+ * reasons shown to user and model) and its cap is COMPUTED so that
+ * prefix + cause + remedy always fits the downstream 300-char safeErrMessage
+ * re-scrub — the remedy can never be truncated off, whatever the package name.
+ * @param {string} pkg
+ * @param {unknown} [err]
+ * @param {string} [remedy]
+ * @returns {string}
+ */
+export function missingPackageMessage(
+  pkg,
+  err = lazyImportErrorFor(pkg),
+  remedy = DEFAULT_MISSING_PACKAGE_REMEDY,
+) {
+  const prefix = `${pkg} is unavailable: `;
+  // 2 for the "; " joiner; 12 for safeErrMessage's own "…[truncated]" marker,
+  // which lands past its cap when the cause is cut.
+  const causeCap = 300 - prefix.length - remedy.length - 2 - 12;
+  const cause =
+    err === undefined
+      ? "no load error recorded — the package likely loaded but lacks an expected export (version skew)"
+      : safeErrMessage(err, causeCap);
+  return `${prefix}${cause}; ${remedy}`;
+}
+
+/**
+ * {@link missingPackageMessage} as a throwable, tagged `code: "DEP_UNAVAILABLE"`
+ * so downstream reason-builders can recognize it structurally and not append a
+ * second copy of the same cause.
+ * @param {string} pkg
+ * @param {unknown} [err]
+ * @param {string} [remedy]
+ * @returns {Error}
+ */
+export function missingPackageError(
+  pkg,
+  err = lazyImportErrorFor(pkg),
+  remedy = DEFAULT_MISSING_PACKAGE_REMEDY,
+) {
+  return Object.assign(new Error(missingPackageMessage(pkg, err, remedy)), {
+    code: "DEP_UNAVAILABLE",
+  });
 }
 
 /**

--- a/claude-hooks/pretooluse-sanitize.mjs
+++ b/claude-hooks/pretooluse-sanitize.mjs
@@ -284,11 +284,19 @@ function assembleResponse({
  * fail-closed posture holds even when the adapter never loaded.
  * @param {import("agent-control-plane-core").ToolCallEvent} event
  * @param {(tool: string, toolInput: any) => ReturnType<typeof rehydrateRedacted>} [rehydrate]
- * @param {{ messages?: typeof PRE_TOOL_USE_MESSAGES, gates?: HostGate[] }} [opts]
+ * @param {{ messages?: Partial<typeof PRE_TOOL_USE_MESSAGES>, gates?: HostGate[] }} [opts]
+ *   messages are merged over the defaults, so a partial table is supported
  * @returns {Promise<import("agent-control-plane-core").Verdict>}
  */
 export async function judgePreToolUseSanitize(event, rehydrate, opts = {}) {
-  const { messages = PRE_TOOL_USE_MESSAGES, gates = [] } = opts;
+  const { gates = [] } = opts;
+  // MERGED over the defaults, never substituted for them. A host that overrides
+  // one field would otherwise leave the rest undefined, and the miss lands in
+  // the fail-closed path: failClosedFields runs inside runJudgeCli's catch, so a
+  // TypeError on a missing field escapes the handler, the hook exits with no
+  // stdout, and Claude reads a PreToolUse hook that produced no response as
+  // non-blocking — the fail-closed ask becomes a fail-OPEN pass.
+  const messages = { ...PRE_TOOL_USE_MESSAGES, ...opts.messages };
   const { Decision, EventKind } = controlPlane();
   // A payload the adapter cannot classify (a missing/unexpected hook_event_name)
   // would drive the pipeline with an empty event and no-op to ALLOW — a silent
@@ -350,6 +358,14 @@ export function depLoadHint(
 ) {
   if (/** @type {{code?: unknown}} */ (err)?.code === "DEP_UNAVAILABLE")
     return "";
+  // Only a TypeError. The recorded-failure set is process-wide and carries no
+  // link to THIS error, so naming a package from it is an inference — sound only
+  // for the failure this hint exists to explain, where an unloaded binding is
+  // called and V8 raises a TypeError ("X is not a function", "Cannot read
+  // properties of undefined"). Any other throw is a layer engine reporting its
+  // own problem, and appending a package name there sends the reader to a
+  // reinstall that fixes nothing.
+  if (!(err instanceof TypeError)) return "";
   const [pkg] = failedPackages();
   return pkg === undefined
     ? ""
@@ -366,11 +382,14 @@ export function depLoadHint(
  * so it ASKS to keep a human in the loop rather than hard-block on infrastructure.
  * @param {boolean} parsedOk whether the input parsed before the failure
  * @param {unknown} err
- * @param {{ messages?: typeof PRE_TOOL_USE_MESSAGES, hint?: string }} [opts]
+ * @param {{ messages?: Partial<typeof PRE_TOOL_USE_MESSAGES>, hint?: string }} [opts]
  * @returns {Record<string, unknown>}
  */
 export function failClosedFields(parsedOk, err, opts = {}) {
-  const { messages = PRE_TOOL_USE_MESSAGES, hint = depLoadHint(err) } = opts;
+  const { hint = depLoadHint(err) } = opts;
+  // Merged, not substituted — see judgePreToolUseSanitize. This is the call site
+  // where a missing field would throw out of the catch and fail OPEN.
+  const messages = { ...PRE_TOOL_USE_MESSAGES, ...opts.messages };
   const cause = `${safeErrMessage(err)}${hint}`;
   return {
     permissionDecision: parsedOk
@@ -392,14 +411,15 @@ export function failClosedFields(parsedOk, err, opts = {}) {
  * loads) can run the exact same wiring instead of duplicating the onError
  * posture.
  * @param {{
- *   messages?: typeof PRE_TOOL_USE_MESSAGES,
+ *   messages?: Partial<typeof PRE_TOOL_USE_MESSAGES>,
  *   gates?: HostGate[],
  *   remedy?: string,
  * }} [opts]
  * @returns {Promise<void>}
  */
 export async function cliMain(opts = {}) {
-  const { messages = PRE_TOOL_USE_MESSAGES, gates = [], remedy } = opts;
+  const { gates = [], remedy } = opts;
+  const messages = { ...PRE_TOOL_USE_MESSAGES, ...opts.messages };
   await runJudgeCli(
     HOOK_NAME,
     (event) => judgePreToolUseSanitize(event, undefined, { messages, gates }),

--- a/claude-hooks/pretooluse-sanitize.mjs
+++ b/claude-hooks/pretooluse-sanitize.mjs
@@ -27,6 +27,10 @@ import { readFileSync } from "node:fs";
 import {
   isMain,
   lazyImport,
+  lazyImportErrorFor,
+  failedLazyPackages,
+  missingPackageMessage,
+  DEFAULT_MISSING_PACKAGE_REMEDY,
   registeredLazyModule,
   emitHookResponse,
   safeErrMessage,
@@ -49,6 +53,33 @@ import { redactViaDaemon } from "./lib/redactor-client.mjs";
 import { trace, TraceEvent } from "./lib/trace.mjs";
 
 const HOOK_NAME = "pretooluse-sanitize";
+
+/**
+ * A host-supplied deny gate: given the PreToolUse input, the reason this call
+ * must be blocked, or null to let the pipeline continue. Hosts use these for
+ * policy the package has no view of (a required workflow step, a project-local
+ * rule); the package ships none.
+ * @typedef {(input: { tool_name: string | null, tool_input: any, session_id?: string })
+ *   => string | null | undefined} HostGate
+ */
+
+/**
+ * The reasons this hook emits, as a table a host overrides. A host that knows
+ * which of ITS files wires the adapter, and what a reader should do about a
+ * failure, can say so — the package cannot, since it has no idea where it is
+ * installed.
+ * @type {Readonly<{
+ *   unknownEvent: string,
+ *   failed: (cause: string) => string,
+ *   unparsable: (cause: string) => string,
+ * }>}
+ */
+export const PRE_TOOL_USE_MESSAGES = Object.freeze({
+  unknownEvent:
+    "PreToolUse sanitization blocked (fail-closed): unrecognized hook payload.",
+  failed: (cause) => `PreToolUse sanitization failed (fail-closed): ${cause}`,
+  unparsable: (cause) => `PreToolUse input unparsable (fail-closed): ${cause}`,
+});
 
 // Layers 2 & 4 come from the agent-sanitizer package, bound via lazyImport (see
 // its doc for the fail-OPEN hazard of a bare static npm import); a failed load
@@ -253,9 +284,11 @@ function assembleResponse({
  * fail-closed posture holds even when the adapter never loaded.
  * @param {import("agent-control-plane-core").ToolCallEvent} event
  * @param {(tool: string, toolInput: any) => ReturnType<typeof rehydrateRedacted>} [rehydrate]
+ * @param {{ messages?: typeof PRE_TOOL_USE_MESSAGES, gates?: HostGate[] }} [opts]
  * @returns {Promise<import("agent-control-plane-core").Verdict>}
  */
-export async function judgePreToolUseSanitize(event, rehydrate) {
+export async function judgePreToolUseSanitize(event, rehydrate, opts = {}) {
+  const { messages = PRE_TOOL_USE_MESSAGES, gates = [] } = opts;
   const { Decision, EventKind } = controlPlane();
   // A payload the adapter cannot classify (a missing/unexpected hook_event_name)
   // would drive the pipeline with an empty event and no-op to ALLOW — a silent
@@ -264,15 +297,23 @@ export async function judgePreToolUseSanitize(event, rehydrate) {
   // never a real call: deny-when-blind. Rewarding an unclassifiable payload with
   // a pass is the one incentive a gate must never create.
   if (event.event === EventKind.UNKNOWN)
-    return {
-      decision: Decision.DENY,
-      reason:
-        "PreToolUse sanitization blocked (fail-closed): unrecognized hook payload.",
-    };
-  const fields = await buildPreToolUseResponse(
-    { tool_name: event.tool, tool_input: event.input },
-    rehydrate,
-  );
+    return { decision: Decision.DENY, reason: messages.unknownEvent };
+  // The session identity travels in `meta`, not alongside the tool input; a host
+  // gate keyed on the session (a once-per-session checkpoint) cannot tell two
+  // sessions apart without it.
+  const input = {
+    tool_name: event.tool,
+    tool_input: event.input,
+    session_id: event.meta?.session_id,
+  };
+  // Host gates run BEFORE any rewriting layer, because they decide whether the
+  // call may happen at all rather than what its input contains — and returning
+  // early keeps a denied call from also being reported as a sanitized one.
+  for (const gate of gates) {
+    const denyReason = gate(input);
+    if (denyReason) return { decision: Decision.DENY, reason: denyReason };
+  }
+  const fields = await buildPreToolUseResponse(input, rehydrate);
   if (fields === null) return { decision: Decision.ALLOW };
   /** @type {Record<string, unknown>} */
   const verdict = {
@@ -288,6 +329,34 @@ export async function judgePreToolUseSanitize(event, rehydrate) {
 }
 
 /**
+ * The dependency-load failure hiding behind a hook error, or "". A binding that
+ * never loaded surfaces at use time as a bare TypeError ("X is not a function")
+ * that names neither the package nor the remedy; when any lazily-loaded package
+ * has a recorded load error, name it — the failed set is derived from the
+ * loader's own records, so a future dependency is covered without editing a list
+ * here. An error already reporting a missing package (missingPackageError's
+ * `DEP_UNAVAILABLE` tag) gets no second copy.
+ * @param {unknown} err
+ * @param {string} [remedy]  what a reader should run; hosts pass their own
+ * @param {() => string[]} [failedPackages]
+ * @param {(pkg: string) => unknown} [loadErrorFor]
+ * @returns {string}
+ */
+export function depLoadHint(
+  err,
+  remedy = DEFAULT_MISSING_PACKAGE_REMEDY,
+  failedPackages = failedLazyPackages,
+  loadErrorFor = lazyImportErrorFor,
+) {
+  if (/** @type {{code?: unknown}} */ (err)?.code === "DEP_UNAVAILABLE")
+    return "";
+  const [pkg] = failedPackages();
+  return pkg === undefined
+    ? ""
+    : ` ${missingPackageMessage(pkg, loadErrorFor(pkg), remedy)}`;
+}
+
+/**
  * The fail-closed hookSpecificOutput fields for a hook-level failure, chosen by
  * WHICH failure it was. Corrupt/unparsable INPUT (`parsedOk` false — a JSON parse
  * error or the oversize-body cap) is a state an adversary can induce with no
@@ -297,16 +366,19 @@ export async function judgePreToolUseSanitize(event, rehydrate) {
  * so it ASKS to keep a human in the loop rather than hard-block on infrastructure.
  * @param {boolean} parsedOk whether the input parsed before the failure
  * @param {unknown} err
+ * @param {{ messages?: typeof PRE_TOOL_USE_MESSAGES, hint?: string }} [opts]
  * @returns {Record<string, unknown>}
  */
-export function failClosedFields(parsedOk, err) {
+export function failClosedFields(parsedOk, err, opts = {}) {
+  const { messages = PRE_TOOL_USE_MESSAGES, hint = depLoadHint(err) } = opts;
+  const cause = `${safeErrMessage(err)}${hint}`;
   return {
     permissionDecision: parsedOk
       ? PermissionDecision.ASK
       : PermissionDecision.DENY,
     permissionDecisionReason: parsedOk
-      ? `PreToolUse sanitization failed (fail-closed): ${safeErrMessage(err)}`
-      : `PreToolUse input unparsable (fail-closed): ${safeErrMessage(err)}`,
+      ? messages.failed(cause)
+      : messages.unparsable(cause),
   };
 }
 
@@ -319,21 +391,34 @@ export function failClosedFields(parsedOk, err) {
  * Exported so a bundle entry (which must claim the CLI slot before this module
  * loads) can run the exact same wiring instead of duplicating the onError
  * posture.
+ * @param {{
+ *   messages?: typeof PRE_TOOL_USE_MESSAGES,
+ *   gates?: HostGate[],
+ *   remedy?: string,
+ * }} [opts]
  * @returns {Promise<void>}
  */
-export async function cliMain() {
-  await runJudgeCli("pretooluse-sanitize", judgePreToolUseSanitize, {
-    // Fail closed WITHOUT the package: unparsable INPUT (`input` undefined)
-    // hard-denies (adversary-inducible, no benefit to failing); any throw
-    // after a clean parse — a layer engine down or the control-plane package
-    // unavailable — asks to keep a human in the loop. emitHookResponse renders
-    // natively, so this posture holds even when the adapter never loaded.
-    onError: (err, input) =>
-      emitHookResponse(
-        HookEvent.PRE_TOOL_USE,
-        failClosedFields(input !== undefined, err),
-      ),
-  });
+export async function cliMain(opts = {}) {
+  const { messages = PRE_TOOL_USE_MESSAGES, gates = [], remedy } = opts;
+  await runJudgeCli(
+    HOOK_NAME,
+    (event) => judgePreToolUseSanitize(event, undefined, { messages, gates }),
+    {
+      // Fail closed WITHOUT the package: unparsable INPUT (`input` undefined)
+      // hard-denies (adversary-inducible, no benefit to failing); any throw
+      // after a clean parse — a layer engine down or the control-plane package
+      // unavailable — asks to keep a human in the loop. emitHookResponse renders
+      // natively, so this posture holds even when the adapter never loaded.
+      onError: (err, input) =>
+        emitHookResponse(
+          HookEvent.PRE_TOOL_USE,
+          failClosedFields(input !== undefined, err, {
+            messages,
+            hint: depLoadHint(err, remedy),
+          }),
+        ),
+    },
+  );
 }
 
 if (isMain(import.meta.url)) {

--- a/claude-hooks/sanitize-output.mjs
+++ b/claude-hooks/sanitize-output.mjs
@@ -28,6 +28,9 @@ import {
   errMessage,
   safeErrMessage,
   makeDeadline,
+  lazyImportErrorFor,
+  missingPackageMessage,
+  DEFAULT_MISSING_PACKAGE_REMEDY,
   HookEvent,
 } from "./lib/hook-io.mjs";
 import { controlPlane, runJudgeCli } from "./lib/control-plane.mjs";
@@ -478,13 +481,6 @@ const FAIL_CLOSED_CONTEXT =
   "(replaced with a placeholder) to fail closed -- the unsanitized output was " +
   "not shown. Investigate the hook error before relying on this tool.";
 
-// The one cause that is a broken INSTALL rather than a broken hook: the
-// sanitizer's bindings are absent, so every subsequent tool call fails closed
-// with no visible cause. Name the remedy in the emission itself.
-const MISSING_DEPS_HINT =
-  " The cause is a missing dependency (agent-sanitizer did not load), not a" +
-  " hook defect: reinstall the plugin, then retry the tool call.";
-
 /**
  * Whether the sanitizer's bindings actually loaded. lazyImport swallows a
  * missing package and yields `{}`, so the absence shows up as an undefined
@@ -501,15 +497,22 @@ export function sanitizerDepsLoaded() {
 }
 
 /**
- * The model-facing note for a fail-closed emission, with the missing-dependency
- * remedy appended when the sanitizer's bindings are the thing that is absent.
+ * The model-facing note for a fail-closed emission. When the sanitizer's own
+ * bindings are what is absent — a broken INSTALL rather than a broken hook, and
+ * otherwise invisible because every later tool call then fails closed with no
+ * stated cause — the recorded loader error and its remedy ride along. The text
+ * comes from missingPackageMessage so this hook, the PreToolUse gate and the
+ * prompt gate cannot drift apart on what a missing dependency reads like.
  * @param {() => boolean} [depsLoaded]  injectable seam for testing
+ * @param {string} [remedy]  what a reader should run; hosts pass their own
  * @returns {string}
  */
-export function failClosedContext(depsLoaded = sanitizerDepsLoaded) {
-  return depsLoaded()
-    ? FAIL_CLOSED_CONTEXT
-    : FAIL_CLOSED_CONTEXT + MISSING_DEPS_HINT;
+export function failClosedContext(
+  depsLoaded = sanitizerDepsLoaded,
+  remedy = DEFAULT_MISSING_PACKAGE_REMEDY,
+) {
+  if (depsLoaded()) return FAIL_CLOSED_CONTEXT;
+  return `${FAIL_CLOSED_CONTEXT} ${missingPackageMessage("agent-sanitizer", lazyImportErrorFor("agent-sanitizer"), remedy)}`;
 }
 
 /**

--- a/claude-hooks/sanitize-user-prompt.mjs
+++ b/claude-hooks/sanitize-user-prompt.mjs
@@ -90,14 +90,20 @@ try {
  * @param {import("agent-control-plane-core").ToolCallEvent} event
  * @param {((s: string) => string) | null} [strip]  the ANSI stripper (defaults
  *   to the package's stripAnsiFully; injectable so the fail-closed path is testable)
- * @param {typeof USER_PROMPT_MESSAGES} [messages]  host-facing reason overrides
+ * @param {Partial<typeof USER_PROMPT_MESSAGES>} [overrides]  reason overrides,
+ *   merged over the defaults so a partial table can never leave a field unset
  * @returns {import("agent-control-plane-core").Verdict}
  */
 export function judgeSanitizeUserPrompt(
   event,
   strip = stripAnsiFully,
-  messages = USER_PROMPT_MESSAGES,
+  overrides = USER_PROMPT_MESSAGES,
 ) {
+  // MERGED over the defaults, never substituted for them — a host that overrides
+  // one field would otherwise leave the rest undefined. main() threads the same
+  // object into its onError, where a missing field throws out of the catch and
+  // the gate emits nothing, which the harness reads as a pass: fail OPEN.
+  const messages = { ...USER_PROMPT_MESSAGES, ...overrides };
   const { Decision, EventKind } = controlPlane();
   // A payload the adapter cannot classify carries no readable prompt, so an
   // abstain would fail OPEN on harness contract drift; this gate's posture is
@@ -136,15 +142,19 @@ export function judgeSanitizeUserPrompt(
  * @param {(chunk: string) => void} write
  * @param {((s: string) => string) | null} [strip]  the ANSI stripper (defaults
  *   to the package's stripAnsiFully; injectable so the fail-closed path is testable)
- * @param {typeof USER_PROMPT_MESSAGES} [messages]  host-facing reason overrides
+ * @param {Partial<typeof USER_PROMPT_MESSAGES>} [overrides]  reason overrides,
+ *   merged over the defaults so a partial table can never leave a field unset
  * @returns {Promise<void>}
  */
 export async function main(
   read,
   write,
   strip = stripAnsiFully,
-  messages = USER_PROMPT_MESSAGES,
+  overrides = USER_PROMPT_MESSAGES,
 ) {
+  // Merged, not substituted — see judgeSanitizeUserPrompt. onError below is the
+  // call site where a missing field would throw out of the catch and fail OPEN.
+  const messages = { ...USER_PROMPT_MESSAGES, ...overrides };
   // Delegate the parse → judge → render → write contract to the shared
   // runJudgeCli so this hook doesn't re-implement the control-plane boundary:
   // runJudgeCli reads stdin BEFORE loading the control-plane package, so a

--- a/claude-hooks/sanitize-user-prompt.mjs
+++ b/claude-hooks/sanitize-user-prompt.mjs
@@ -18,7 +18,12 @@
  * (cursor movement, erase, OSC title-set, DCS/APC/PM) still blocks, as do the
  * invisible-char thresholds, which are the actual web-paste payload defense.
  */
-import { readStdinJson, safeErrMessage, isMain } from "./lib/hook-io.mjs";
+import {
+  readStdinJson,
+  safeErrMessage,
+  isMain,
+  missingPackageError,
+} from "./lib/hook-io.mjs";
 import { controlPlane, runJudgeCli } from "./lib/control-plane.mjs";
 import { trace, TraceEvent } from "./lib/trace.mjs";
 // classifyPrompt (the user-prompt verdict) and stripAnsiFully (its ANSI stripper)
@@ -33,10 +38,28 @@ export let classifyPrompt;
 /** @type {typeof import("agent-sanitizer").stripAnsiFully} */
 let stripAnsiFully;
 
-const BLOCK_CONTEXT =
-  "User prompt blocked: payload-capable invisible/ANSI characters detected.";
-const SGR_NOTE =
-  "The prompt contains ANSI SGR color codes (pasted terminal output). They are display-only formatting noise; read through them.";
+/**
+ * The reasons this gate emits, as a table a host overrides. A host that knows
+ * which of ITS files wires the adapter, and what a reader should do about a
+ * failure, can say so — the package cannot, since it has no idea where it is
+ * installed. Every field is a plain string or a string-returning function, so
+ * an override is auditable next to the default it replaces.
+ * @type {Readonly<{
+ *   unknownEvent: string,
+ *   blockContext: string,
+ *   sgrNote: string,
+ *   hookFailed: (cause: string) => string,
+ * }>}
+ */
+export const USER_PROMPT_MESSAGES = Object.freeze({
+  unknownEvent: "User prompt blocked (fail-closed): unrecognized hook payload.",
+  blockContext:
+    "User prompt blocked: payload-capable invisible/ANSI characters detected.",
+  sgrNote:
+    "The prompt contains ANSI SGR color codes (pasted terminal output). They are display-only formatting noise; read through them.",
+  hookFailed: (cause) =>
+    `sanitize-user-prompt hook failed (fail-closed): ${cause}`,
+});
 
 /* c8 ignore start — module-load boundary: the imports resolve in every real
  * run, and their failure (the package absent) can't be simulated in-process, so
@@ -67,9 +90,14 @@ try {
  * @param {import("agent-control-plane-core").ToolCallEvent} event
  * @param {((s: string) => string) | null} [strip]  the ANSI stripper (defaults
  *   to the package's stripAnsiFully; injectable so the fail-closed path is testable)
+ * @param {typeof USER_PROMPT_MESSAGES} [messages]  host-facing reason overrides
  * @returns {import("agent-control-plane-core").Verdict}
  */
-export function judgeSanitizeUserPrompt(event, strip = stripAnsiFully) {
+export function judgeSanitizeUserPrompt(
+  event,
+  strip = stripAnsiFully,
+  messages = USER_PROMPT_MESSAGES,
+) {
   const { Decision, EventKind } = controlPlane();
   // A payload the adapter cannot classify carries no readable prompt, so an
   // abstain would fail OPEN on harness contract drift; this gate's posture is
@@ -77,18 +105,14 @@ export function judgeSanitizeUserPrompt(event, strip = stripAnsiFully) {
   // channel — a non-PRE_TOOL event has no permissionDecision body — which Claude
   // honors on UserPromptSubmit.)
   if (event.event === EventKind.UNKNOWN)
-    return {
-      decision: Decision.DENY,
-      reason: "User prompt blocked (fail-closed): unrecognized hook payload.",
-    };
+    return { decision: Decision.DENY, reason: messages.unknownEvent };
   if (event.event !== EventKind.PROMPT_SUBMIT)
     return { decision: Decision.ALLOW };
   // The module-load guard: a missing stripper means agent-sanitizer never
   // loaded. Guarding on the stripper alone is sufficient — it loads AFTER
   // classifyPrompt in the same try, so a present stripper proves the classifier
   // loaded too.
-  if (typeof strip !== "function")
-    throw new Error("agent-sanitizer is unavailable");
+  if (typeof strip !== "function") throw missingPackageError("agent-sanitizer");
   // The contract guarantees a string here: every adapter normalizes the
   // prompt-submit input (Claude's parse coerces a missing/non-string prompt to
   // "" via asString), so a defensive typeof re-check is a dead branch.
@@ -97,13 +121,13 @@ export function judgeSanitizeUserPrompt(event, strip = stripAnsiFully) {
   const verdict = classifyPrompt(prompt, strip);
   if (verdict.action === "pass") return { decision: Decision.ALLOW };
   if (verdict.action === "note")
-    return { decision: Decision.ALLOW, additional_context: SGR_NOTE };
+    return { decision: Decision.ALLOW, additional_context: messages.sgrNote };
   // block: carry the reason AND a context note — UserPromptSubmit can't rewrite
   // the prompt, so the context is the only forward signal about why it dropped.
   return {
     decision: Decision.DENY,
     reason: verdict.reason,
-    additional_context: BLOCK_CONTEXT,
+    additional_context: messages.blockContext,
   };
 }
 
@@ -112,9 +136,15 @@ export function judgeSanitizeUserPrompt(event, strip = stripAnsiFully) {
  * @param {(chunk: string) => void} write
  * @param {((s: string) => string) | null} [strip]  the ANSI stripper (defaults
  *   to the package's stripAnsiFully; injectable so the fail-closed path is testable)
+ * @param {typeof USER_PROMPT_MESSAGES} [messages]  host-facing reason overrides
  * @returns {Promise<void>}
  */
-export async function main(read, write, strip = stripAnsiFully) {
+export async function main(
+  read,
+  write,
+  strip = stripAnsiFully,
+  messages = USER_PROMPT_MESSAGES,
+) {
   // Delegate the parse → judge → render → write contract to the shared
   // runJudgeCli so this hook doesn't re-implement the control-plane boundary:
   // runJudgeCli reads stdin BEFORE loading the control-plane package, so a
@@ -125,7 +155,7 @@ export async function main(read, write, strip = stripAnsiFully) {
   await runJudgeCli(
     "sanitize-user-prompt",
     (event) => {
-      const verdict = judgeSanitizeUserPrompt(event, strip);
+      const verdict = judgeSanitizeUserPrompt(event, strip, messages);
       // Announce engagement on the trace channel like the other stdin hooks —
       // a prompt gate that silently stopped running is otherwise invisible.
       trace(TraceEvent.HOOK_RAN, {
@@ -146,7 +176,7 @@ export async function main(read, write, strip = stripAnsiFully) {
         write(
           JSON.stringify({
             decision: "block",
-            reason: `sanitize-user-prompt hook failed (fail-closed): ${safeErrMessage(err)}`,
+            reason: messages.hookFailed(safeErrMessage(err)),
           }),
         ),
     },

--- a/claude-hooks/scan-invisible-chars.mjs
+++ b/claude-hooks/scan-invisible-chars.mjs
@@ -7,19 +7,31 @@
  */
 import { readFileSync, globSync, writeFileSync, unlinkSync } from "node:fs";
 import { join, relative } from "node:path";
-import { isMain, lazyImport, writeFileNoFollow } from "./lib/hook-io.mjs";
+import {
+  isMain,
+  lazyImport,
+  markerIsTrusted,
+  writeFileNoFollow,
+} from "./lib/hook-io.mjs";
 import {
   ALERT_FILE,
   ALERT_ACK_FILE,
   PROJECT_DIR,
 } from "./lib/invisible-alert.mjs";
+import {
+  awaitControlPlaneBindings,
+  hookgateMarkerPath,
+  probeSetupAlive,
+} from "./lib/control-plane.mjs";
 import { trace, TraceEvent } from "./lib/trace.mjs";
 
 // Layer-1 primitives, bound via lazyImport (see its doc for the fail-OPEN
 // hazard of a bare static npm import — here the instruction files would load
-// UNSCANNED). A failed load leaves the bindings undefined, and cliMain's guard
-// below fails loud rather than silently passing.
-const {
+// UNSCANNED). A failed load leaves the bindings undefined; on a cold container
+// (node deps not yet installed) cliMain's guard below waits out session-setup
+// before giving up, and fails loud rather than silently passing.
+// `let`, not `const`: the cold-start poll re-binds these once the package loads.
+let {
   LONG_RUN_RE,
   LONG_RUN_THRESHOLD,
   SCATTERED_THRESHOLD: TOTAL_INVISIBLE_THRESHOLD,
@@ -28,6 +40,44 @@ const {
 } = /** @type {typeof import("agent-sanitizer/invisible")} */ (
   await lazyImport("agent-sanitizer/invisible")
 );
+
+/**
+ * Re-attempt the sanitizer import, waiting out an in-flight session-setup before
+ * giving up. On a cold container the node deps this hook needs are still being
+ * installed when SessionStart fires; without this wait `stripInvisible` is
+ * undefined, the scan is skipped, and the instruction files load UNSCANNED for the
+ * whole session (fail open) — silently. Reuses the control-plane poll (marker +
+ * PID liveness) so the wait bound matches every other cold-start-aware gate.
+ * @returns {Promise<boolean>} whether the sanitizer is now bound
+ */
+async function ensureSanitizerLoaded() {
+  if (typeof stripInvisible === "function") return true;
+  /* c8 ignore start -- cold-start reload: only runs when the top-level
+     agent-sanitizer import above failed (node deps not yet installed), which
+     can't be simulated in-process or in the spawned-subprocess CLI run the tests
+     observe (the test env always has the deps, so the guard above early-returns).
+     The reload reuses awaitControlPlaneBindings / markerIsTrusted /
+     probeSetupAlive, each unit-tested directly. */
+  const marker = hookgateMarkerPath();
+  const reloaded = await awaitControlPlaneBindings({
+    tryImport: async () => {
+      const mod = await lazyImport("agent-sanitizer/invisible");
+      return typeof mod.stripInvisible === "function" ? mod : null;
+    },
+    markerPresent: () => markerIsTrusted(marker),
+    setupAlive: () => probeSetupAlive(marker),
+  });
+  if (!reloaded) return false;
+  ({
+    LONG_RUN_RE,
+    LONG_RUN_THRESHOLD,
+    SCATTERED_THRESHOLD: TOTAL_INVISIBLE_THRESHOLD,
+    STRIP,
+    stripInvisible,
+  } = /** @type {typeof import("agent-sanitizer/invisible")} */ (reloaded));
+  return true;
+  /* c8 ignore stop */
+}
 
 // Decoder
 
@@ -229,14 +279,15 @@ export async function cliMain() {
   /* c8 ignore start -- fail-closed module-load guard: only reachable when the
      agent-sanitizer import above failed, which can't be simulated in the
      spawned-subprocess CLI run the tests observe. */
-  if (typeof stripInvisible !== "function") {
+  if (!(await ensureSanitizerLoaded())) {
     // Emit the engagement event with a "skipped" outcome so the loss is LOUD on
     // the trace channel — a scan that never ran is otherwise invisible, and the
     // downstream PreToolUse sanitize gate then passes cleanly all session.
     trace(TraceEvent.SCAN_INVISIBLE_CHARS_RAN, { outcome: "skipped" });
     process.stderr.write(
-      "scan-invisible-chars: agent-sanitizer failed to load; instruction " +
-        "files were NOT scanned for hidden Unicode.\n",
+      "scan-invisible-chars: agent-sanitizer failed to load (node deps not " +
+        "installed and session-setup did not finish in time); instruction " +
+        "files were NOT scanned for hidden Unicode. Run `pnpm install`.\n",
     );
     process.exit(1);
   }

--- a/claude-hooks/scan-invisible-chars.mjs
+++ b/claude-hooks/scan-invisible-chars.mjs
@@ -8,9 +8,12 @@
 import { readFileSync, globSync, writeFileSync, unlinkSync } from "node:fs";
 import { join, relative } from "node:path";
 import {
+  awaitLazyDependency,
+  hookgateMarkerPath,
   isMain,
   lazyImport,
   markerIsTrusted,
+  probeSetupAlive,
   writeFileNoFollow,
 } from "./lib/hook-io.mjs";
 import {
@@ -18,11 +21,6 @@ import {
   ALERT_ACK_FILE,
   PROJECT_DIR,
 } from "./lib/invisible-alert.mjs";
-import {
-  awaitControlPlaneBindings,
-  hookgateMarkerPath,
-  probeSetupAlive,
-} from "./lib/control-plane.mjs";
 import { trace, TraceEvent } from "./lib/trace.mjs";
 
 // Layer-1 primitives, bound via lazyImport (see its doc for the fail-OPEN
@@ -56,10 +54,10 @@ async function ensureSanitizerLoaded() {
      agent-sanitizer import above failed (node deps not yet installed), which
      can't be simulated in-process or in the spawned-subprocess CLI run the tests
      observe (the test env always has the deps, so the guard above early-returns).
-     The reload reuses awaitControlPlaneBindings / markerIsTrusted /
+     The reload reuses awaitLazyDependency / markerIsTrusted /
      probeSetupAlive, each unit-tested directly. */
   const marker = hookgateMarkerPath();
-  const reloaded = await awaitControlPlaneBindings({
+  const reloaded = await awaitLazyDependency({
     tryImport: async () => {
       const mod = await lazyImport("agent-sanitizer/invisible");
       return typeof mod.stripInvisible === "function" ? mod : null;

--- a/package.json
+++ b/package.json
@@ -168,6 +168,34 @@
     "./claude-hooks/lib/control-plane": {
       "types": "./types/claude-hooks/lib/control-plane.d.mts",
       "default": "./claude-hooks/lib/control-plane.mjs"
+    },
+    "./claude-hooks/lib/invisible-alert": {
+      "types": "./types/claude-hooks/lib/invisible-alert.d.mts",
+      "default": "./claude-hooks/lib/invisible-alert.mjs"
+    },
+    "./claude-hooks/lib/authored-content": {
+      "types": "./types/claude-hooks/lib/authored-content.d.mts",
+      "default": "./claude-hooks/lib/authored-content.mjs"
+    },
+    "./claude-hooks/lib/env-config": {
+      "types": "./types/claude-hooks/lib/env-config.d.mts",
+      "default": "./claude-hooks/lib/env-config.mjs"
+    },
+    "./claude-hooks/lib/secret-annotate": {
+      "types": "./types/claude-hooks/lib/secret-annotate.d.mts",
+      "default": "./claude-hooks/lib/secret-annotate.mjs"
+    },
+    "./claude-hooks/lib/reveal": {
+      "types": "./types/claude-hooks/lib/reveal.d.mts",
+      "default": "./claude-hooks/lib/reveal.mjs"
+    },
+    "./claude-hooks/lib/redactor-client": {
+      "types": "./types/claude-hooks/lib/redactor-client.d.mts",
+      "default": "./claude-hooks/lib/redactor-client.mjs"
+    },
+    "./claude-hooks/lib/trace": {
+      "types": "./types/claude-hooks/lib/trace.d.mts",
+      "default": "./claude-hooks/lib/trace.mjs"
     }
   },
   "files": [

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -90,12 +90,46 @@ function registeredLazyModule(specifier) {
 }
 async function lazyImport(specifier) {
   const registered = registeredLazyModules[specifier];
-  if (registered) return registered;
+  if (registered) {
+    lazyImportErrors.delete(specifier);
+    return registered;
+  }
   try {
-    return await import(specifier);
-  } catch {
+    const loaded2 = await import(specifier);
+    lazyImportErrors.delete(specifier);
+    return loaded2;
+  } catch (err) {
+    lazyImportErrors.delete(specifier);
+    lazyImportErrors.set(specifier, err);
     return {};
   }
+}
+function lazyImportErrorFor(pkg) {
+  for (const [specifier, err] of [...lazyImportErrors].reverse())
+    if (specifier === pkg || specifier.startsWith(`${pkg}/`)) return err;
+  return void 0;
+}
+function failedLazyPackages() {
+  const pkgs = /* @__PURE__ */ new Set();
+  for (const specifier of [...lazyImportErrors.keys()].reverse()) {
+    if (!/^[\w@]/.test(specifier) || specifier.includes(":")) continue;
+    const parts2 = specifier.split("/");
+    pkgs.add(
+      specifier.startsWith("@") ? parts2.slice(0, 2).join("/") : parts2[0]
+    );
+  }
+  return [...pkgs];
+}
+function missingPackageMessage(pkg, err = lazyImportErrorFor(pkg), remedy = DEFAULT_MISSING_PACKAGE_REMEDY) {
+  const prefix = `${pkg} is unavailable: `;
+  const causeCap = 300 - prefix.length - remedy.length - 2 - 12;
+  const cause = err === void 0 ? "no load error recorded \u2014 the package likely loaded but lacks an expected export (version skew)" : safeErrMessage(err, causeCap);
+  return `${prefix}${cause}; ${remedy}`;
+}
+function missingPackageError(pkg, err = lazyImportErrorFor(pkg), remedy = DEFAULT_MISSING_PACKAGE_REMEDY) {
+  return Object.assign(new Error(missingPackageMessage(pkg, err, remedy)), {
+    code: "DEP_UNAVAILABLE"
+  });
 }
 function makeDeadline(budgetMs, now = Date.now) {
   const end = now() + budgetMs;
@@ -165,7 +199,7 @@ function writeFileNoFollow(path2, content3, mode = 384) {
     closeSync(fd);
   }
 }
-var cliEntryClaimed, HookEvent, PermissionDecision, LONE_SURROGATE_RE, MAX_STDIN_BYTES, registeredLazyModules, UNTRUSTED_TEXT_CAP;
+var cliEntryClaimed, HookEvent, PermissionDecision, LONE_SURROGATE_RE, MAX_STDIN_BYTES, registeredLazyModules, lazyImportErrors, DEFAULT_MISSING_PACKAGE_REMEDY, UNTRUSTED_TEXT_CAP;
 var init_hook_io = __esm({
   "claude-hooks/lib/hook-io.mjs"() {
     "use strict";
@@ -184,6 +218,8 @@ var init_hook_io = __esm({
     LONE_SURROGATE_RE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
     MAX_STDIN_BYTES = 64 * 1024 * 1024;
     registeredLazyModules = /* @__PURE__ */ Object.create(null);
+    lazyImportErrors = /* @__PURE__ */ new Map();
+    DEFAULT_MISSING_PACKAGE_REMEDY = "reinstall the hook dependencies (pnpm install) and retry.";
     UNTRUSTED_TEXT_CAP = 500;
   }
 });
@@ -35413,15 +35449,15 @@ function tokenizeAttention(effects, ok3) {
   const attentionMarkers2 = this.parser.constructs.attentionMarkers.null;
   const previous3 = this.previous;
   const before = classifyCharacter(previous3);
-  let marker;
+  let marker2;
   return start;
   function start(code4) {
-    marker = code4;
+    marker2 = code4;
     effects.enter("attentionSequence");
     return inside(code4);
   }
   function inside(code4) {
-    if (code4 === marker) {
+    if (code4 === marker2) {
       effects.consume(code4);
       return inside;
     }
@@ -35429,8 +35465,8 @@ function tokenizeAttention(effects, ok3) {
     const after = classifyCharacter(code4);
     const open = !after || after === 2 && before || attentionMarkers2.includes(code4);
     const close = !before || before === 2 && after || attentionMarkers2.includes(previous3);
-    token._open = Boolean(marker === 42 ? open : open && (before || !close));
-    token._close = Boolean(marker === 42 ? close : close && (after || !open));
+    token._open = Boolean(marker2 === 42 ? open : open && (before || !close));
+    token._close = Boolean(marker2 === 42 ? close : close && (after || !open));
     return ok3(code4);
   }
 }
@@ -35760,7 +35796,7 @@ function tokenizeCodeFenced(effects, ok3, nok) {
   };
   let initialPrefix = 0;
   let sizeOpen = 0;
-  let marker;
+  let marker2;
   return start;
   function start(code4) {
     return beforeSequenceOpen(code4);
@@ -35768,14 +35804,14 @@ function tokenizeCodeFenced(effects, ok3, nok) {
   function beforeSequenceOpen(code4) {
     const tail = self.events[self.events.length - 1];
     initialPrefix = tail && tail[1].type === "linePrefix" ? tail[2].sliceSerialize(tail[1], true).length : 0;
-    marker = code4;
+    marker2 = code4;
     effects.enter("codeFenced");
     effects.enter("codeFencedFence");
     effects.enter("codeFencedFenceSequence");
     return sequenceOpen(code4);
   }
   function sequenceOpen(code4) {
-    if (code4 === marker) {
+    if (code4 === marker2) {
       sizeOpen++;
       effects.consume(code4);
       return sequenceOpen;
@@ -35808,7 +35844,7 @@ function tokenizeCodeFenced(effects, ok3, nok) {
       effects.exit("codeFencedFenceInfo");
       return factorySpace(effects, metaBefore, "whitespace")(code4);
     }
-    if (code4 === 96 && code4 === marker) {
+    if (code4 === 96 && code4 === marker2) {
       return nok(code4);
     }
     effects.consume(code4);
@@ -35830,7 +35866,7 @@ function tokenizeCodeFenced(effects, ok3, nok) {
       effects.exit("codeFencedFenceMeta");
       return infoBefore(code4);
     }
-    if (code4 === 96 && code4 === marker) {
+    if (code4 === 96 && code4 === marker2) {
       return nok(code4);
     }
     effects.consume(code4);
@@ -35881,14 +35917,14 @@ function tokenizeCodeFenced(effects, ok3, nok) {
       return markdownSpace(code4) ? factorySpace(effects2, beforeSequenceClose, "linePrefix", self.parser.constructs.disable.null.includes("codeIndented") ? void 0 : 4)(code4) : beforeSequenceClose(code4);
     }
     function beforeSequenceClose(code4) {
-      if (code4 === marker) {
+      if (code4 === marker2) {
         effects2.enter("codeFencedFenceSequence");
         return sequenceClose(code4);
       }
       return nok2(code4);
     }
     function sequenceClose(code4) {
-      if (code4 === marker) {
+      if (code4 === marker2) {
         size++;
         effects2.consume(code4);
         return sequenceClose;
@@ -36734,7 +36770,7 @@ var init_micromark_factory_label = __esm({
 
 // node_modules/.pnpm/micromark-factory-title@2.0.1/node_modules/micromark-factory-title/index.js
 function factoryTitle(effects, ok3, nok, type, markerType, stringType) {
-  let marker;
+  let marker2;
   return start;
   function start(code4) {
     if (code4 === 34 || code4 === 39 || code4 === 40) {
@@ -36742,13 +36778,13 @@ function factoryTitle(effects, ok3, nok, type, markerType, stringType) {
       effects.enter(markerType);
       effects.consume(code4);
       effects.exit(markerType);
-      marker = code4 === 40 ? 41 : code4;
+      marker2 = code4 === 40 ? 41 : code4;
       return begin;
     }
     return nok(code4);
   }
   function begin(code4) {
-    if (code4 === marker) {
+    if (code4 === marker2) {
       effects.enter(markerType);
       effects.consume(code4);
       effects.exit(markerType);
@@ -36759,9 +36795,9 @@ function factoryTitle(effects, ok3, nok, type, markerType, stringType) {
     return atBreak(code4);
   }
   function atBreak(code4) {
-    if (code4 === marker) {
+    if (code4 === marker2) {
       effects.exit(stringType);
-      return begin(marker);
+      return begin(marker2);
     }
     if (code4 === null) {
       return nok(code4);
@@ -36778,7 +36814,7 @@ function factoryTitle(effects, ok3, nok, type, markerType, stringType) {
     return inside(code4);
   }
   function inside(code4) {
-    if (code4 === marker || code4 === null || markdownLineEnding(code4)) {
+    if (code4 === marker2 || code4 === null || markdownLineEnding(code4)) {
       effects.exit("chunkString");
       return atBreak(code4);
     }
@@ -36786,7 +36822,7 @@ function factoryTitle(effects, ok3, nok, type, markerType, stringType) {
     return code4 === 92 ? escape : inside;
   }
   function escape(code4) {
-    if (code4 === marker || code4 === 92) {
+    if (code4 === marker2 || code4 === 92) {
       effects.consume(code4);
       return inside;
     }
@@ -37138,7 +37174,7 @@ function resolveToHtmlFlow(events) {
 }
 function tokenizeHtmlFlow(effects, ok3, nok) {
   const self = this;
-  let marker;
+  let marker2;
   let closingTag;
   let buffer;
   let index2;
@@ -37165,7 +37201,7 @@ function tokenizeHtmlFlow(effects, ok3, nok) {
     }
     if (code4 === 63) {
       effects.consume(code4);
-      marker = 3;
+      marker2 = 3;
       return self.interrupt ? ok3 : continuationDeclarationInside;
     }
     if (asciiAlpha(code4)) {
@@ -37178,18 +37214,18 @@ function tokenizeHtmlFlow(effects, ok3, nok) {
   function declarationOpen(code4) {
     if (code4 === 45) {
       effects.consume(code4);
-      marker = 2;
+      marker2 = 2;
       return commentOpenInside;
     }
     if (code4 === 91) {
       effects.consume(code4);
-      marker = 5;
+      marker2 = 5;
       index2 = 0;
       return cdataOpenInside;
     }
     if (asciiAlpha(code4)) {
       effects.consume(code4);
-      marker = 4;
+      marker2 = 4;
       return self.interrupt ? ok3 : continuationDeclarationInside;
     }
     return nok(code4);
@@ -37225,18 +37261,18 @@ function tokenizeHtmlFlow(effects, ok3, nok) {
       const slash = code4 === 47;
       const name50 = buffer.toLowerCase();
       if (!slash && !closingTag && htmlRawNames.includes(name50)) {
-        marker = 1;
+        marker2 = 1;
         return self.interrupt ? ok3(code4) : continuation(code4);
       }
       if (htmlBlockNames.includes(buffer.toLowerCase())) {
-        marker = 6;
+        marker2 = 6;
         if (slash) {
           effects.consume(code4);
           return basicSelfClosing;
         }
         return self.interrupt ? ok3(code4) : continuation(code4);
       }
-      marker = 7;
+      marker2 = 7;
       return self.interrupt && !self.parser.lazy[self.now().line] ? nok(code4) : closingTag ? completeClosingTagAfter(code4) : completeAttributeNameBefore(code4);
     }
     if (code4 === 45 || asciiAlphanumeric(code4)) {
@@ -37351,27 +37387,27 @@ function tokenizeHtmlFlow(effects, ok3, nok) {
     return nok(code4);
   }
   function continuation(code4) {
-    if (code4 === 45 && marker === 2) {
+    if (code4 === 45 && marker2 === 2) {
       effects.consume(code4);
       return continuationCommentInside;
     }
-    if (code4 === 60 && marker === 1) {
+    if (code4 === 60 && marker2 === 1) {
       effects.consume(code4);
       return continuationRawTagOpen;
     }
-    if (code4 === 62 && marker === 4) {
+    if (code4 === 62 && marker2 === 4) {
       effects.consume(code4);
       return continuationClose;
     }
-    if (code4 === 63 && marker === 3) {
+    if (code4 === 63 && marker2 === 3) {
       effects.consume(code4);
       return continuationDeclarationInside;
     }
-    if (code4 === 93 && marker === 5) {
+    if (code4 === 93 && marker2 === 5) {
       effects.consume(code4);
       return continuationCdataInside;
     }
-    if (markdownLineEnding(code4) && (marker === 6 || marker === 7)) {
+    if (markdownLineEnding(code4) && (marker2 === 6 || marker2 === 7)) {
       effects.exit("htmlFlowData");
       return effects.check(blankLineBefore, continuationAfter, continuationStart)(code4);
     }
@@ -37441,7 +37477,7 @@ function tokenizeHtmlFlow(effects, ok3, nok) {
       effects.consume(code4);
       return continuationClose;
     }
-    if (code4 === 45 && marker === 2) {
+    if (code4 === 45 && marker2 === 2) {
       effects.consume(code4);
       return continuationDeclarationInside;
     }
@@ -37511,7 +37547,7 @@ var init_html_flow = __esm({
 // node_modules/.pnpm/micromark-core-commonmark@2.0.3/node_modules/micromark-core-commonmark/lib/html-text.js
 function tokenizeHtmlText(effects, ok3, nok) {
   const self = this;
-  let marker;
+  let marker2;
   let index2;
   let returnState;
   return start;
@@ -37739,7 +37775,7 @@ function tokenizeHtmlText(effects, ok3, nok) {
     }
     if (code4 === 34 || code4 === 39) {
       effects.consume(code4);
-      marker = code4;
+      marker2 = code4;
       return tagOpenAttributeValueQuoted;
     }
     if (markdownLineEnding(code4)) {
@@ -37754,9 +37790,9 @@ function tokenizeHtmlText(effects, ok3, nok) {
     return tagOpenAttributeValueUnquoted;
   }
   function tagOpenAttributeValueQuoted(code4) {
-    if (code4 === marker) {
+    if (code4 === marker2) {
       effects.consume(code4);
-      marker = void 0;
+      marker2 = void 0;
       return tagOpenAttributeValueQuotedAfter;
     }
     if (code4 === null) {
@@ -38149,18 +38185,18 @@ var init_line_ending = __esm({
 // node_modules/.pnpm/micromark-core-commonmark@2.0.3/node_modules/micromark-core-commonmark/lib/thematic-break.js
 function tokenizeThematicBreak(effects, ok3, nok) {
   let size = 0;
-  let marker;
+  let marker2;
   return start;
   function start(code4) {
     effects.enter("thematicBreak");
     return before(code4);
   }
   function before(code4) {
-    marker = code4;
+    marker2 = code4;
     return atBreak(code4);
   }
   function atBreak(code4) {
-    if (code4 === marker) {
+    if (code4 === marker2) {
       effects.enter("thematicBreakSequence");
       return sequence(code4);
     }
@@ -38171,7 +38207,7 @@ function tokenizeThematicBreak(effects, ok3, nok) {
     return nok(code4);
   }
   function sequence(code4) {
-    if (code4 === marker) {
+    if (code4 === marker2) {
       effects.consume(code4);
       size++;
       return sequence;
@@ -38379,7 +38415,7 @@ function resolveToSetextUnderline(events, context) {
 }
 function tokenizeSetextUnderline(effects, ok3, nok) {
   const self = this;
-  let marker;
+  let marker2;
   return start;
   function start(code4) {
     let index2 = self.events.length;
@@ -38392,7 +38428,7 @@ function tokenizeSetextUnderline(effects, ok3, nok) {
     }
     if (!self.parser.lazy[self.now().line] && (self.interrupt || paragraph2)) {
       effects.enter("setextHeadingLine");
-      marker = code4;
+      marker2 = code4;
       return before(code4);
     }
     return nok(code4);
@@ -38402,7 +38438,7 @@ function tokenizeSetextUnderline(effects, ok3, nok) {
     return inside(code4);
   }
   function inside(code4) {
-    if (code4 === marker) {
+    if (code4 === marker2) {
       effects.consume(code4);
       return inside;
     }
@@ -40948,13 +40984,13 @@ var init_format_code_as_indented = __esm({
 
 // node_modules/.pnpm/mdast-util-to-markdown@2.1.2/node_modules/mdast-util-to-markdown/lib/util/check-fence.js
 function checkFence(state) {
-  const marker = state.options.fence || "`";
-  if (marker !== "`" && marker !== "~") {
+  const marker2 = state.options.fence || "`";
+  if (marker2 !== "`" && marker2 !== "~") {
     throw new Error(
-      "Cannot serialize code with `" + marker + "` for `options.fence`, expected `` ` `` or `~`"
+      "Cannot serialize code with `" + marker2 + "` for `options.fence`, expected `` ` `` or `~`"
     );
   }
-  return marker;
+  return marker2;
 }
 var init_check_fence = __esm({
   "node_modules/.pnpm/mdast-util-to-markdown@2.1.2/node_modules/mdast-util-to-markdown/lib/util/check-fence.js"() {
@@ -40963,9 +40999,9 @@ var init_check_fence = __esm({
 
 // node_modules/.pnpm/mdast-util-to-markdown@2.1.2/node_modules/mdast-util-to-markdown/lib/handle/code.js
 function code2(node2, _, state, info) {
-  const marker = checkFence(state);
+  const marker2 = checkFence(state);
   const raw = node2.value || "";
-  const suffix = marker === "`" ? "GraveAccent" : "Tilde";
+  const suffix = marker2 === "`" ? "GraveAccent" : "Tilde";
   if (formatCodeAsIndented(node2, state)) {
     const exit4 = state.enter("codeIndented");
     const value2 = state.indentLines(raw, map2);
@@ -40973,7 +41009,7 @@ function code2(node2, _, state, info) {
     return value2;
   }
   const tracker = state.createTracker(info);
-  const sequence = marker.repeat(Math.max(longestStreak(raw, marker) + 1, 3));
+  const sequence = marker2.repeat(Math.max(longestStreak(raw, marker2) + 1, 3));
   const exit3 = state.enter("codeFenced");
   let value = tracker.move(sequence);
   if (node2.lang) {
@@ -41022,13 +41058,13 @@ var init_code = __esm({
 
 // node_modules/.pnpm/mdast-util-to-markdown@2.1.2/node_modules/mdast-util-to-markdown/lib/util/check-quote.js
 function checkQuote(state) {
-  const marker = state.options.quote || '"';
-  if (marker !== '"' && marker !== "'") {
+  const marker2 = state.options.quote || '"';
+  if (marker2 !== '"' && marker2 !== "'") {
     throw new Error(
-      "Cannot serialize title with `" + marker + "` for `options.quote`, expected `\"`, or `'`"
+      "Cannot serialize title with `" + marker2 + "` for `options.quote`, expected `\"`, or `'`"
     );
   }
-  return marker;
+  return marker2;
 }
 var init_check_quote = __esm({
   "node_modules/.pnpm/mdast-util-to-markdown@2.1.2/node_modules/mdast-util-to-markdown/lib/util/check-quote.js"() {
@@ -41098,13 +41134,13 @@ var init_definition2 = __esm({
 
 // node_modules/.pnpm/mdast-util-to-markdown@2.1.2/node_modules/mdast-util-to-markdown/lib/util/check-emphasis.js
 function checkEmphasis(state) {
-  const marker = state.options.emphasis || "*";
-  if (marker !== "*" && marker !== "_") {
+  const marker2 = state.options.emphasis || "*";
+  if (marker2 !== "*" && marker2 !== "_") {
     throw new Error(
-      "Cannot serialize emphasis with `" + marker + "` for `options.emphasis`, expected `*`, or `_`"
+      "Cannot serialize emphasis with `" + marker2 + "` for `options.emphasis`, expected `*`, or `_`"
     );
   }
-  return marker;
+  return marker2;
 }
 var init_check_emphasis = __esm({
   "node_modules/.pnpm/mdast-util-to-markdown@2.1.2/node_modules/mdast-util-to-markdown/lib/util/check-emphasis.js"() {
@@ -41121,7 +41157,7 @@ var init_encode_character_reference = __esm({
 });
 
 // node_modules/.pnpm/mdast-util-to-markdown@2.1.2/node_modules/mdast-util-to-markdown/lib/util/encode-info.js
-function encodeInfo(outside, inside, marker) {
+function encodeInfo(outside, inside, marker2) {
   const outsideKind = classifyCharacter(outside);
   const insideKind = classifyCharacter(inside);
   if (outsideKind === void 0) {
@@ -41129,7 +41165,7 @@ function encodeInfo(outside, inside, marker) {
       // Letter inside:
       // we have to encode *both* letters for `_` as it is looser.
       // it already forms for `*` (and GFMs `~`).
-      marker === "_" ? { inside: true, outside: true } : { inside: false, outside: false }
+      marker2 === "_" ? { inside: true, outside: true } : { inside: false, outside: false }
     ) : insideKind === 1 ? (
       // Whitespace inside: encode both (letter, whitespace).
       { inside: true, outside: true }
@@ -41169,13 +41205,13 @@ var init_encode_info = __esm({
 
 // node_modules/.pnpm/mdast-util-to-markdown@2.1.2/node_modules/mdast-util-to-markdown/lib/handle/emphasis.js
 function emphasis(node2, _, state, info) {
-  const marker = checkEmphasis(state);
+  const marker2 = checkEmphasis(state);
   const exit3 = state.enter("emphasis");
   const tracker = state.createTracker(info);
-  const before = tracker.move(marker);
+  const before = tracker.move(marker2);
   let between = tracker.move(
     state.containerPhrasing(node2, {
-      after: marker,
+      after: marker2,
       before,
       ...tracker.current()
     })
@@ -41184,17 +41220,17 @@ function emphasis(node2, _, state, info) {
   const open = encodeInfo(
     info.before.charCodeAt(info.before.length - 1),
     betweenHead,
-    marker
+    marker2
   );
   if (open.inside) {
     between = encodeCharacterReference(betweenHead) + between.slice(1);
   }
   const betweenTail = between.charCodeAt(between.length - 1);
-  const close = encodeInfo(info.after.charCodeAt(0), betweenTail, marker);
+  const close = encodeInfo(info.after.charCodeAt(0), betweenTail, marker2);
   if (close.inside) {
     between = between.slice(0, -1) + encodeCharacterReference(betweenTail);
   }
-  const after = tracker.move(marker);
+  const after = tracker.move(marker2);
   exit3();
   state.attentionEncodeSurroundingInfo = {
     after: close.outside,
@@ -41621,13 +41657,13 @@ var init_link_reference = __esm({
 
 // node_modules/.pnpm/mdast-util-to-markdown@2.1.2/node_modules/mdast-util-to-markdown/lib/util/check-bullet.js
 function checkBullet(state) {
-  const marker = state.options.bullet || "*";
-  if (marker !== "*" && marker !== "+" && marker !== "-") {
+  const marker2 = state.options.bullet || "*";
+  if (marker2 !== "*" && marker2 !== "+" && marker2 !== "-") {
     throw new Error(
-      "Cannot serialize items with `" + marker + "` for `options.bullet`, expected `*`, `+`, or `-`"
+      "Cannot serialize items with `" + marker2 + "` for `options.bullet`, expected `*`, `+`, or `-`"
     );
   }
-  return marker;
+  return marker2;
 }
 var init_check_bullet = __esm({
   "node_modules/.pnpm/mdast-util-to-markdown@2.1.2/node_modules/mdast-util-to-markdown/lib/util/check-bullet.js"() {
@@ -41661,13 +41697,13 @@ var init_check_bullet_other = __esm({
 
 // node_modules/.pnpm/mdast-util-to-markdown@2.1.2/node_modules/mdast-util-to-markdown/lib/util/check-bullet-ordered.js
 function checkBulletOrdered(state) {
-  const marker = state.options.bulletOrdered || ".";
-  if (marker !== "." && marker !== ")") {
+  const marker2 = state.options.bulletOrdered || ".";
+  if (marker2 !== "." && marker2 !== ")") {
     throw new Error(
-      "Cannot serialize items with `" + marker + "` for `options.bulletOrdered`, expected `.` or `)`"
+      "Cannot serialize items with `" + marker2 + "` for `options.bulletOrdered`, expected `.` or `)`"
     );
   }
-  return marker;
+  return marker2;
 }
 var init_check_bullet_ordered = __esm({
   "node_modules/.pnpm/mdast-util-to-markdown@2.1.2/node_modules/mdast-util-to-markdown/lib/util/check-bullet-ordered.js"() {
@@ -41676,13 +41712,13 @@ var init_check_bullet_ordered = __esm({
 
 // node_modules/.pnpm/mdast-util-to-markdown@2.1.2/node_modules/mdast-util-to-markdown/lib/util/check-rule.js
 function checkRule(state) {
-  const marker = state.options.rule || "*";
-  if (marker !== "*" && marker !== "-" && marker !== "_") {
+  const marker2 = state.options.rule || "*";
+  if (marker2 !== "*" && marker2 !== "-" && marker2 !== "_") {
     throw new Error(
-      "Cannot serialize rules with `" + marker + "` for `options.rule`, expected `*`, `-`, or `_`"
+      "Cannot serialize rules with `" + marker2 + "` for `options.rule`, expected `*`, `-`, or `_`"
     );
   }
-  return marker;
+  return marker2;
 }
 var init_check_rule = __esm({
   "node_modules/.pnpm/mdast-util-to-markdown@2.1.2/node_modules/mdast-util-to-markdown/lib/util/check-rule.js"() {
@@ -41856,13 +41892,13 @@ var init_root = __esm({
 
 // node_modules/.pnpm/mdast-util-to-markdown@2.1.2/node_modules/mdast-util-to-markdown/lib/util/check-strong.js
 function checkStrong(state) {
-  const marker = state.options.strong || "*";
-  if (marker !== "*" && marker !== "_") {
+  const marker2 = state.options.strong || "*";
+  if (marker2 !== "*" && marker2 !== "_") {
     throw new Error(
-      "Cannot serialize strong with `" + marker + "` for `options.strong`, expected `*`, or `_`"
+      "Cannot serialize strong with `" + marker2 + "` for `options.strong`, expected `*`, or `_`"
     );
   }
-  return marker;
+  return marker2;
 }
 var init_check_strong = __esm({
   "node_modules/.pnpm/mdast-util-to-markdown@2.1.2/node_modules/mdast-util-to-markdown/lib/util/check-strong.js"() {
@@ -41871,13 +41907,13 @@ var init_check_strong = __esm({
 
 // node_modules/.pnpm/mdast-util-to-markdown@2.1.2/node_modules/mdast-util-to-markdown/lib/handle/strong.js
 function strong(node2, _, state, info) {
-  const marker = checkStrong(state);
+  const marker2 = checkStrong(state);
   const exit3 = state.enter("strong");
   const tracker = state.createTracker(info);
-  const before = tracker.move(marker + marker);
+  const before = tracker.move(marker2 + marker2);
   let between = tracker.move(
     state.containerPhrasing(node2, {
-      after: marker,
+      after: marker2,
       before,
       ...tracker.current()
     })
@@ -41886,17 +41922,17 @@ function strong(node2, _, state, info) {
   const open = encodeInfo(
     info.before.charCodeAt(info.before.length - 1),
     betweenHead,
-    marker
+    marker2
   );
   if (open.inside) {
     between = encodeCharacterReference(betweenHead) + between.slice(1);
   }
   const betweenTail = between.charCodeAt(between.length - 1);
-  const close = encodeInfo(info.after.charCodeAt(0), betweenTail, marker);
+  const close = encodeInfo(info.after.charCodeAt(0), betweenTail, marker2);
   if (close.inside) {
     between = between.slice(0, -1) + encodeCharacterReference(betweenTail);
   }
-  const after = tracker.move(marker + marker);
+  const after = tracker.move(marker2 + marker2);
   exit3();
   state.attentionEncodeSurroundingInfo = {
     after: close.outside,
@@ -42729,17 +42765,17 @@ function resolveToPotentialGfmFootnoteCall(events, context) {
     start: Object.assign({}, events[index2 + 3][1].start),
     end: Object.assign({}, events[events.length - 1][1].end)
   };
-  const marker = {
+  const marker2 = {
     type: "gfmFootnoteCallMarker",
     start: Object.assign({}, events[index2 + 3][1].end),
     end: Object.assign({}, events[index2 + 3][1].end)
   };
-  marker.end.column++;
-  marker.end.offset++;
-  marker.end._bufferIndex++;
+  marker2.end.column++;
+  marker2.end.offset++;
+  marker2.end._bufferIndex++;
   const string3 = {
     type: "gfmFootnoteCallString",
-    start: Object.assign({}, marker.end),
+    start: Object.assign({}, marker2.end),
     end: Object.assign({}, events[events.length - 1][1].start)
   };
   const chunk = {
@@ -42757,8 +42793,8 @@ function resolveToPotentialGfmFootnoteCall(events, context) {
     events[index2 + 3],
     events[index2 + 4],
     // The `^`.
-    ["enter", marker, context],
-    ["exit", marker, context],
+    ["enter", marker2, context],
+    ["exit", marker2, context],
     // Everything in between.
     ["enter", string3, context],
     ["enter", chunk, context],
@@ -66544,10 +66580,74 @@ var init_dist2 = __esm({
 });
 
 // claude-hooks/lib/control-plane.mjs
+import { readFileSync } from "node:fs";
+function hookgateMarkerPath(projectDir = process.env.CLAUDE_PROJECT_DIR, runtimeDir = process.env.XDG_RUNTIME_DIR) {
+  if (!projectDir) return null;
+  const base2 = runtimeDir && runtimeDir.startsWith("/") ? runtimeDir : "/tmp";
+  return `${base2}/${HOOKGATE_MARKER_STEM}${projectDir.replace(/[^A-Za-z0-9]/g, "_")}`;
+}
+function probeSetupAlive(markerPath) {
+  if (markerPath === null) return true;
+  let pid;
+  try {
+    pid = parseInt(readFileSync(markerPath, "utf8"), 10);
+  } catch {
+    return true;
+  }
+  if (!Number.isInteger(pid) || pid <= 0) return true;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (
+      /** @type {NodeJS.ErrnoException} */
+      err.code === "EPERM"
+    );
+  }
+}
+async function awaitControlPlaneBindings({
+  tryImport,
+  markerPresent,
+  setupAlive,
+  now = () => Date.now(),
+  sleep: sleep2 = (ms) => new Promise((resolve2) => {
+    setTimeout(resolve2, ms);
+  }),
+  graceMs = 5e3,
+  settleMs = 1e3,
+  ceilingMs = 9e5,
+  intervalMs = 250
+}) {
+  const start = now();
+  let sawInstalling = false;
+  let enteredDone = false;
+  let doneAt = 0;
+  for (; ; ) {
+    const bindings = await tryImport();
+    if (bindings) return bindings;
+    const installing = markerPresent() && setupAlive();
+    let giveUp;
+    if (installing) {
+      sawInstalling = true;
+      enteredDone = false;
+      giveUp = now() - start > ceilingMs;
+    } else if (sawInstalling) {
+      if (!enteredDone) {
+        enteredDone = true;
+        doneAt = now();
+      }
+      giveUp = now() - doneAt > settleMs;
+    } else {
+      giveUp = now() - start > graceMs;
+    }
+    if (giveUp) return null;
+    await sleep2(intervalMs);
+  }
+}
 function controlPlane(overrides = {}) {
   const bindings = { claudeAdapter: claudeAdapter2, Decision: Decision2, EventKind: EventKind2, ...overrides };
   if (!bindings.claudeAdapter || !bindings.Decision || !bindings.EventKind)
-    throw new Error("agent-control-plane-core is unavailable");
+    throw missingPackageError("agent-control-plane-core");
   return (
     /** @type {ReturnType<typeof controlPlane>} */
     bindings
@@ -66585,35 +66685,49 @@ async function runJudgeCli(hookName, judge, {
     onError(err, input);
   }
 }
-var claudeAdapter2, Decision2, EventKind2;
+var claudeAdapter2, Decision2, EventKind2, HOOKGATE_MARKER_STEM, marker, loaded;
 var init_control_plane2 = __esm({
   async "claude-hooks/lib/control-plane.mjs"() {
     "use strict";
     init_hook_io();
-    {
-      const { claudeAdapter: adapter } = (
-        /** @type {Partial<typeof import("agent-control-plane-core/claude")>} */
-        await lazyImport("agent-control-plane-core/claude")
+    HOOKGATE_MARKER_STEM = "agent-sanitizer-hookgate-inflight-";
+    marker = hookgateMarkerPath();
+    loaded = await awaitControlPlaneBindings({
+      tryImport: async () => {
+        const { claudeAdapter: adapter } = (
+          /** @type {Partial<typeof import("agent-control-plane-core/claude")>} */
+          await lazyImport("agent-control-plane-core/claude")
+        );
+        const { Decision: decision, EventKind: eventKind } = (
+          /** @type {Partial<typeof import("agent-control-plane-core")>} */
+          await lazyImport("agent-control-plane-core")
+        );
+        if (!adapter || !decision || !eventKind) return null;
+        return { claudeAdapter: adapter, Decision: decision, EventKind: eventKind };
+      },
+      markerPresent: () => markerIsTrusted(marker),
+      setupAlive: () => probeSetupAlive(marker)
+    });
+    if (loaded) {
+      const bound = (
+        /** @type {{ claudeAdapter: typeof claudeAdapter, Decision: typeof Decision, EventKind: typeof EventKind }} */
+        loaded
       );
-      const { Decision: decision, EventKind: eventKind } = (
-        /** @type {Partial<typeof import("agent-control-plane-core")>} */
-        await lazyImport("agent-control-plane-core")
-      );
-      claudeAdapter2 = adapter;
-      Decision2 = decision;
-      EventKind2 = eventKind;
+      claudeAdapter2 = bound.claudeAdapter;
+      Decision2 = bound.Decision;
+      EventKind2 = bound.EventKind;
     }
   }
 });
 
 // claude-hooks/lib/invisible-alert.mjs
-import { readFileSync } from "node:fs";
+import { readFileSync as readFileSync2 } from "node:fs";
 import { createHash } from "node:crypto";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 function invisibleCharAlert() {
   if (!markerIsTrusted(ALERT_FILE)) return null;
-  const raw = readFileSync(ALERT_FILE, "utf-8").trim();
+  const raw = readFileSync2(ALERT_FILE, "utf-8").trim();
   return scrubUntrustedText(raw, applyLayer12);
 }
 function alertAcknowledged() {
@@ -67196,13 +67310,15 @@ var init_trace2 = __esm({
 // claude-hooks/pretooluse-sanitize.mjs
 var pretooluse_sanitize_exports = {};
 __export(pretooluse_sanitize_exports, {
+  PRE_TOOL_USE_MESSAGES: () => PRE_TOOL_USE_MESSAGES,
   buildPreToolUseResponse: () => buildPreToolUseResponse,
   cliMain: () => cliMain,
+  depLoadHint: () => depLoadHint,
   failClosedFields: () => failClosedFields,
   judgePreToolUseSanitize: () => judgePreToolUseSanitize
 });
 import { createRequire as createRequire4 } from "node:module";
-import { readFileSync as readFileSync2 } from "node:fs";
+import { readFileSync as readFileSync3 } from "node:fs";
 function emitTraced(toolName, fields) {
   let outcome = "modified";
   if (fields === null) outcome = "noop";
@@ -67277,17 +67393,21 @@ function assembleResponse({
   if (pendingGateAck) acknowledgeAlert();
   return fields;
 }
-async function judgePreToolUseSanitize(event, rehydrate) {
+async function judgePreToolUseSanitize(event, rehydrate, opts = {}) {
+  const { messages = PRE_TOOL_USE_MESSAGES, gates = [] } = opts;
   const { Decision: Decision3, EventKind: EventKind3 } = controlPlane();
   if (event.event === EventKind3.UNKNOWN)
-    return {
-      decision: Decision3.DENY,
-      reason: "PreToolUse sanitization blocked (fail-closed): unrecognized hook payload."
-    };
-  const fields = await buildPreToolUseResponse(
-    { tool_name: event.tool, tool_input: event.input },
-    rehydrate
-  );
+    return { decision: Decision3.DENY, reason: messages.unknownEvent };
+  const input = {
+    tool_name: event.tool,
+    tool_input: event.input,
+    session_id: event.meta?.session_id
+  };
+  for (const gate of gates) {
+    const denyReason = gate(input);
+    if (denyReason) return { decision: Decision3.DENY, reason: denyReason };
+  }
+  const fields = await buildPreToolUseResponse(input, rehydrate);
   if (fields === null) return { decision: Decision3.ALLOW };
   const verdict = {
     decision: fields.permissionDecision ?? Decision3.ALLOW
@@ -67303,26 +67423,45 @@ async function judgePreToolUseSanitize(event, rehydrate) {
     verdict
   );
 }
-function failClosedFields(parsedOk, err) {
+function depLoadHint(err, remedy = DEFAULT_MISSING_PACKAGE_REMEDY, failedPackages = failedLazyPackages, loadErrorFor = lazyImportErrorFor) {
+  if (
+    /** @type {{code?: unknown}} */
+    err?.code === "DEP_UNAVAILABLE"
+  )
+    return "";
+  const [pkg] = failedPackages();
+  return pkg === void 0 ? "" : ` ${missingPackageMessage(pkg, loadErrorFor(pkg), remedy)}`;
+}
+function failClosedFields(parsedOk, err, opts = {}) {
+  const { messages = PRE_TOOL_USE_MESSAGES, hint = depLoadHint(err) } = opts;
+  const cause = `${safeErrMessage(err)}${hint}`;
   return {
     permissionDecision: parsedOk ? PermissionDecision.ASK : PermissionDecision.DENY,
-    permissionDecisionReason: parsedOk ? `PreToolUse sanitization failed (fail-closed): ${safeErrMessage(err)}` : `PreToolUse input unparsable (fail-closed): ${safeErrMessage(err)}`
+    permissionDecisionReason: parsedOk ? messages.failed(cause) : messages.unparsable(cause)
   };
 }
-async function cliMain() {
-  await runJudgeCli("pretooluse-sanitize", judgePreToolUseSanitize, {
-    // Fail closed WITHOUT the package: unparsable INPUT (`input` undefined)
-    // hard-denies (adversary-inducible, no benefit to failing); any throw
-    // after a clean parse — a layer engine down or the control-plane package
-    // unavailable — asks to keep a human in the loop. emitHookResponse renders
-    // natively, so this posture holds even when the adapter never loaded.
-    onError: (err, input) => emitHookResponse(
-      HookEvent.PRE_TOOL_USE,
-      failClosedFields(input !== void 0, err)
-    )
-  });
+async function cliMain(opts = {}) {
+  const { messages = PRE_TOOL_USE_MESSAGES, gates = [], remedy } = opts;
+  await runJudgeCli(
+    HOOK_NAME,
+    (event) => judgePreToolUseSanitize(event, void 0, { messages, gates }),
+    {
+      // Fail closed WITHOUT the package: unparsable INPUT (`input` undefined)
+      // hard-denies (adversary-inducible, no benefit to failing); any throw
+      // after a clean parse — a layer engine down or the control-plane package
+      // unavailable — asks to keep a human in the loop. emitHookResponse renders
+      // natively, so this posture holds even when the adapter never loaded.
+      onError: (err, input) => emitHookResponse(
+        HookEvent.PRE_TOOL_USE,
+        failClosedFields(input !== void 0, err, {
+          messages,
+          hint: depLoadHint(err, remedy)
+        })
+      )
+    }
+  );
 }
-var HOOK_NAME, normalizeConfusables2, normalizeContext2, rehydrateRedacted2, require5, confusableScan, redactorIo, defaultRehydrate;
+var HOOK_NAME, PRE_TOOL_USE_MESSAGES, normalizeConfusables2, normalizeContext2, rehydrateRedacted2, require5, confusableScan, redactorIo, defaultRehydrate;
 var init_pretooluse_sanitize = __esm({
   async "claude-hooks/pretooluse-sanitize.mjs"() {
     "use strict";
@@ -67333,6 +67472,11 @@ var init_pretooluse_sanitize = __esm({
     init_redactor_client();
     init_trace2();
     HOOK_NAME = "pretooluse-sanitize";
+    PRE_TOOL_USE_MESSAGES = Object.freeze({
+      unknownEvent: "PreToolUse sanitization blocked (fail-closed): unrecognized hook payload.",
+      failed: (cause) => `PreToolUse sanitization failed (fail-closed): ${cause}`,
+      unparsable: (cause) => `PreToolUse input unparsable (fail-closed): ${cause}`
+    });
     ({ normalizeConfusables: normalizeConfusables2, normalizeContext: normalizeContext2 } = /** @type {typeof import("agent-sanitizer/confusables")} */
     await lazyImport("agent-sanitizer/confusables"));
     ({ rehydrateRedacted: rehydrateRedacted2 } = /** @type {typeof import("agent-sanitizer/rehydrate")} */
@@ -67342,7 +67486,7 @@ var init_pretooluse_sanitize = __esm({
       text5
     );
     redactorIo = {
-      readFile: (path2) => readFileSync2(path2, "utf8"),
+      readFile: (path2) => readFileSync3(path2, "utf8"),
       redactMap: async (text5) => (
         /** @type {any} */
         await redactViaDaemon(text5, { map: true })
@@ -67612,8 +67756,9 @@ function failClosedReplacement(input, message) {
 function sanitizerDepsLoaded() {
   return typeof sanitizeTextSeam === "function" && typeof suppressToolOutput2 === "function";
 }
-function failClosedContext(depsLoaded = sanitizerDepsLoaded) {
-  return depsLoaded() ? FAIL_CLOSED_CONTEXT : FAIL_CLOSED_CONTEXT + MISSING_DEPS_HINT;
+function failClosedContext(depsLoaded = sanitizerDepsLoaded, remedy = DEFAULT_MISSING_PACKAGE_REMEDY) {
+  if (depsLoaded()) return FAIL_CLOSED_CONTEXT;
+  return `${FAIL_CLOSED_CONTEXT} ${missingPackageMessage("agent-sanitizer", lazyImportErrorFor("agent-sanitizer"), remedy)}`;
 }
 function emitFailClosed(input, message, emit = (fields) => emitHookResponse(HookEvent.POST_TOOL_USE, fields)) {
   const additionalContext = failClosedContext();
@@ -67725,7 +67870,7 @@ async function cliMain2(ext = {}) {
     }
   );
 }
-var _sanitizer, HTML_TAG_PRESENT2, applyLayer13, matchesSecretHint2, SECRET_HINT2, SECRET_HINT_EXT2, _output, sanitizeTextSeam, composeContextSeam, describeRemoved3, describeWarned3, suppressToolOutput2, HOOK_NAME2, SANITIZE_BUDGET_MS, SGR_OUTPUT_NOTE, WEB_INGRESS_TOOLS, FAIL_CLOSED_CONTEXT, MISSING_DEPS_HINT;
+var _sanitizer, HTML_TAG_PRESENT2, applyLayer13, matchesSecretHint2, SECRET_HINT2, SECRET_HINT_EXT2, _output, sanitizeTextSeam, composeContextSeam, describeRemoved3, describeWarned3, suppressToolOutput2, HOOK_NAME2, SANITIZE_BUDGET_MS, SGR_OUTPUT_NOTE, WEB_INGRESS_TOOLS, FAIL_CLOSED_CONTEXT;
 var init_sanitize_output = __esm({
   async "claude-hooks/sanitize-output.mjs"() {
     "use strict";
@@ -67751,7 +67896,6 @@ var init_sanitize_output = __esm({
     SGR_OUTPUT_NOTE = "Display-only ANSI color stripped; pipe through cat -v to inspect raw escapes.";
     WEB_INGRESS_TOOLS = /* @__PURE__ */ new Set(["WebFetch", "WebSearch"]);
     FAIL_CLOSED_CONTEXT = "CRITICAL: sanitize-output hook failed; this tool's output was suppressed (replaced with a placeholder) to fail closed -- the unsanitized output was not shown. Investigate the hook error before relying on this tool.";
-    MISSING_DEPS_HINT = " The cause is a missing dependency (agent-sanitizer did not load), not a hook defect: reinstall the plugin, then retry the tool call.";
     if (isMain(import.meta.url)) {
       await cliMain2();
     }
@@ -67820,21 +67964,18 @@ var init_prompt = __esm({
 // claude-hooks/sanitize-user-prompt.mjs
 var sanitize_user_prompt_exports = {};
 __export(sanitize_user_prompt_exports, {
+  USER_PROMPT_MESSAGES: () => USER_PROMPT_MESSAGES,
   classifyPrompt: () => classifyPrompt2,
   judgeSanitizeUserPrompt: () => judgeSanitizeUserPrompt,
   main: () => main
 });
-function judgeSanitizeUserPrompt(event, strip = stripAnsiFully3) {
+function judgeSanitizeUserPrompt(event, strip = stripAnsiFully3, messages = USER_PROMPT_MESSAGES) {
   const { Decision: Decision3, EventKind: EventKind3 } = controlPlane();
   if (event.event === EventKind3.UNKNOWN)
-    return {
-      decision: Decision3.DENY,
-      reason: "User prompt blocked (fail-closed): unrecognized hook payload."
-    };
+    return { decision: Decision3.DENY, reason: messages.unknownEvent };
   if (event.event !== EventKind3.PROMPT_SUBMIT)
     return { decision: Decision3.ALLOW };
-  if (typeof strip !== "function")
-    throw new Error("agent-sanitizer is unavailable");
+  if (typeof strip !== "function") throw missingPackageError("agent-sanitizer");
   const prompt = (
     /** @type {string} */
     event.input.prompt
@@ -67843,18 +67984,18 @@ function judgeSanitizeUserPrompt(event, strip = stripAnsiFully3) {
   const verdict = classifyPrompt2(prompt, strip);
   if (verdict.action === "pass") return { decision: Decision3.ALLOW };
   if (verdict.action === "note")
-    return { decision: Decision3.ALLOW, additional_context: SGR_NOTE };
+    return { decision: Decision3.ALLOW, additional_context: messages.sgrNote };
   return {
     decision: Decision3.DENY,
     reason: verdict.reason,
-    additional_context: BLOCK_CONTEXT
+    additional_context: messages.blockContext
   };
 }
-async function main(read, write, strip = stripAnsiFully3) {
+async function main(read, write, strip = stripAnsiFully3, messages = USER_PROMPT_MESSAGES) {
   await runJudgeCli(
     "sanitize-user-prompt",
     (event) => {
-      const verdict = judgeSanitizeUserPrompt(event, strip);
+      const verdict = judgeSanitizeUserPrompt(event, strip, messages);
       trace(TraceEvent.HOOK_RAN, {
         hook: "sanitize-user-prompt",
         outcome: verdict.decision === controlPlane().Decision.DENY ? "deny" : verdict.additional_context ? "note" : "allow"
@@ -67867,21 +68008,25 @@ async function main(read, write, strip = stripAnsiFully3) {
       onError: (err) => write(
         JSON.stringify({
           decision: "block",
-          reason: `sanitize-user-prompt hook failed (fail-closed): ${safeErrMessage(err)}`
+          reason: messages.hookFailed(safeErrMessage(err))
         })
       )
     }
   );
 }
-var classifyPrompt2, stripAnsiFully3, BLOCK_CONTEXT, SGR_NOTE;
+var classifyPrompt2, stripAnsiFully3, USER_PROMPT_MESSAGES;
 var init_sanitize_user_prompt = __esm({
   async "claude-hooks/sanitize-user-prompt.mjs"() {
     "use strict";
     init_hook_io();
     await init_control_plane2();
     init_trace2();
-    BLOCK_CONTEXT = "User prompt blocked: payload-capable invisible/ANSI characters detected.";
-    SGR_NOTE = "The prompt contains ANSI SGR color codes (pasted terminal output). They are display-only formatting noise; read through them.";
+    USER_PROMPT_MESSAGES = Object.freeze({
+      unknownEvent: "User prompt blocked (fail-closed): unrecognized hook payload.",
+      blockContext: "User prompt blocked: payload-capable invisible/ANSI characters detected.",
+      sgrNote: "The prompt contains ANSI SGR color codes (pasted terminal output). They are display-only formatting noise; read through them.",
+      hookFailed: (cause) => `sanitize-user-prompt hook failed (fail-closed): ${cause}`
+    });
     try {
       ({ classifyPrompt: classifyPrompt2 } = await Promise.resolve().then(() => (init_prompt(), prompt_exports)));
       ({ stripAnsiFully: stripAnsiFully3 } = await Promise.resolve().then(() => (init_src2(), src_exports2)));
@@ -67908,8 +68053,30 @@ __export(scan_invisible_chars_exports, {
   formatReport: () => formatReport,
   scanFile: () => scanFile
 });
-import { readFileSync as readFileSync3, globSync, writeFileSync as writeFileSync2, unlinkSync as unlinkSync2 } from "node:fs";
+import { readFileSync as readFileSync4, globSync, writeFileSync as writeFileSync2, unlinkSync as unlinkSync2 } from "node:fs";
 import { join as join4, relative } from "node:path";
+async function ensureSanitizerLoaded() {
+  if (typeof stripInvisible3 === "function") return true;
+  const marker2 = hookgateMarkerPath();
+  const reloaded = await awaitControlPlaneBindings({
+    tryImport: async () => {
+      const mod = await lazyImport("agent-sanitizer/invisible");
+      return typeof mod.stripInvisible === "function" ? mod : null;
+    },
+    markerPresent: () => markerIsTrusted(marker2),
+    setupAlive: () => probeSetupAlive(marker2)
+  });
+  if (!reloaded) return false;
+  ({
+    LONG_RUN_RE: LONG_RUN_RE3,
+    LONG_RUN_THRESHOLD: LONG_RUN_THRESHOLD2,
+    SCATTERED_THRESHOLD: TOTAL_INVISIBLE_THRESHOLD,
+    STRIP: STRIP3,
+    stripInvisible: stripInvisible3
+  } = /** @type {typeof import("agent-sanitizer/invisible")} */
+  reloaded);
+  return true;
+}
 function decodeRun(run) {
   const cps = [...run].map((ch) => (
     /** @type {number} */
@@ -67949,7 +68116,7 @@ function findInstructionFiles(dir) {
   }).map((name50) => join4(dir, name50));
 }
 function scanFile(filePath) {
-  const content3 = readFileSync3(filePath, "utf-8");
+  const content3 = readFileSync4(filePath, "utf-8");
   const findings = [];
   LONG_RUN_RE3.lastIndex = 0;
   let match;
@@ -68019,10 +68186,10 @@ function scanProject() {
   return allFindings;
 }
 async function cliMain3() {
-  if (typeof stripInvisible3 !== "function") {
+  if (!await ensureSanitizerLoaded()) {
     trace(TraceEvent.SCAN_INVISIBLE_CHARS_RAN, { outcome: "skipped" });
     process.stderr.write(
-      "scan-invisible-chars: agent-sanitizer failed to load; instruction files were NOT scanned for hidden Unicode.\n"
+      "scan-invisible-chars: agent-sanitizer failed to load (node deps not installed and session-setup did not finish in time); instruction files were NOT scanned for hidden Unicode. Run `pnpm install`.\n"
     );
     process.exit(1);
   }
@@ -68045,7 +68212,7 @@ async function cliMain3() {
   for (const { file } of allFindings) {
     const absPath = join4(PROJECT_DIR, file);
     try {
-      const original = readFileSync3(absPath, "utf-8");
+      const original = readFileSync4(absPath, "utf-8");
       const stripped = stripInvisible3(original);
       if (stripped !== original) {
         writeFileSync2(absPath, stripped);
@@ -68072,6 +68239,7 @@ var init_scan_invisible_chars = __esm({
     "use strict";
     init_hook_io();
     await init_invisible_alert();
+    await init_control_plane2();
     init_trace2();
     ({
       LONG_RUN_RE: LONG_RUN_RE3,
@@ -68100,16 +68268,16 @@ var LAZY_LOADERS = {
   "namespace-guard": () => Promise.resolve().then(() => (init_dist2(), dist_exports))
 };
 async function registerAvailableModules() {
-  const loaded = {};
+  const loaded2 = {};
   await Promise.all(
     Object.entries(LAZY_LOADERS).map(async ([specifier, load]) => {
       try {
-        loaded[specifier] = await load();
+        loaded2[specifier] = await load();
       } catch {
       }
     })
   );
-  registerLazyModules(loaded);
+  registerLazyModules(loaded2);
 }
 async function main2() {
   claimCliEntry();

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -49,6 +49,7 @@ import {
   openSync,
   closeSync,
   lstatSync,
+  readFileSync,
   unlinkSync,
   writeFileSync
 } from "node:fs";
@@ -161,6 +162,69 @@ function emitHookResponse(hookEventName, fields) {
     JSON.stringify({ hookSpecificOutput: { hookEventName, ...fields } })
   );
 }
+function hookgateMarkerPath(projectDir = process.env.CLAUDE_PROJECT_DIR, runtimeDir = process.env.XDG_RUNTIME_DIR) {
+  if (!projectDir) return null;
+  const base2 = runtimeDir && runtimeDir.startsWith("/") ? runtimeDir : "/tmp";
+  return `${base2}/${HOOKGATE_MARKER_STEM}${projectDir.replace(/[^A-Za-z0-9]/g, "_")}`;
+}
+function probeSetupAlive(markerPath) {
+  if (markerPath === null) return true;
+  let pid;
+  try {
+    pid = parseInt(readFileSync(markerPath, "utf8"), 10);
+  } catch {
+    return true;
+  }
+  if (!Number.isInteger(pid) || pid <= 0) return true;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (
+      /** @type {NodeJS.ErrnoException} */
+      err.code === "EPERM"
+    );
+  }
+}
+async function awaitLazyDependency({
+  tryImport,
+  markerPresent,
+  setupAlive,
+  now = () => Date.now(),
+  sleep: sleep2 = (ms) => new Promise((resolve2) => {
+    setTimeout(resolve2, ms);
+  }),
+  graceMs = 5e3,
+  settleMs = 1e3,
+  ceilingMs = 9e5,
+  intervalMs = 250
+}) {
+  const start = now();
+  let sawInstalling = false;
+  let enteredDone = false;
+  let doneAt = 0;
+  for (; ; ) {
+    const bindings = await tryImport();
+    if (bindings) return bindings;
+    const installing = markerPresent() && setupAlive();
+    let giveUp;
+    if (installing) {
+      sawInstalling = true;
+      enteredDone = false;
+      giveUp = now() - start > ceilingMs;
+    } else if (sawInstalling) {
+      if (!enteredDone) {
+        enteredDone = true;
+        doneAt = now();
+      }
+      giveUp = now() - doneAt > settleMs;
+    } else {
+      giveUp = now() - start > graceMs;
+    }
+    if (giveUp) return null;
+    await sleep2(intervalMs);
+  }
+}
 function markerIsTrusted(path2) {
   if (path2 === null) return false;
   let st;
@@ -199,7 +263,7 @@ function writeFileNoFollow(path2, content3, mode = 384) {
     closeSync(fd);
   }
 }
-var cliEntryClaimed, HookEvent, PermissionDecision, LONE_SURROGATE_RE, MAX_STDIN_BYTES, registeredLazyModules, lazyImportErrors, DEFAULT_MISSING_PACKAGE_REMEDY, UNTRUSTED_TEXT_CAP;
+var cliEntryClaimed, HookEvent, PermissionDecision, LONE_SURROGATE_RE, MAX_STDIN_BYTES, registeredLazyModules, lazyImportErrors, DEFAULT_MISSING_PACKAGE_REMEDY, UNTRUSTED_TEXT_CAP, HOOKGATE_MARKER_STEM;
 var init_hook_io = __esm({
   "claude-hooks/lib/hook-io.mjs"() {
     "use strict";
@@ -221,6 +285,7 @@ var init_hook_io = __esm({
     lazyImportErrors = /* @__PURE__ */ new Map();
     DEFAULT_MISSING_PACKAGE_REMEDY = "reinstall the hook dependencies (pnpm install) and retry.";
     UNTRUSTED_TEXT_CAP = 500;
+    HOOKGATE_MARKER_STEM = "agent-sanitizer-hookgate-inflight-";
   }
 });
 
@@ -66580,70 +66645,6 @@ var init_dist2 = __esm({
 });
 
 // claude-hooks/lib/control-plane.mjs
-import { readFileSync } from "node:fs";
-function hookgateMarkerPath(projectDir = process.env.CLAUDE_PROJECT_DIR, runtimeDir = process.env.XDG_RUNTIME_DIR) {
-  if (!projectDir) return null;
-  const base2 = runtimeDir && runtimeDir.startsWith("/") ? runtimeDir : "/tmp";
-  return `${base2}/${HOOKGATE_MARKER_STEM}${projectDir.replace(/[^A-Za-z0-9]/g, "_")}`;
-}
-function probeSetupAlive(markerPath) {
-  if (markerPath === null) return true;
-  let pid;
-  try {
-    pid = parseInt(readFileSync(markerPath, "utf8"), 10);
-  } catch {
-    return true;
-  }
-  if (!Number.isInteger(pid) || pid <= 0) return true;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (err) {
-    return (
-      /** @type {NodeJS.ErrnoException} */
-      err.code === "EPERM"
-    );
-  }
-}
-async function awaitControlPlaneBindings({
-  tryImport,
-  markerPresent,
-  setupAlive,
-  now = () => Date.now(),
-  sleep: sleep2 = (ms) => new Promise((resolve2) => {
-    setTimeout(resolve2, ms);
-  }),
-  graceMs = 5e3,
-  settleMs = 1e3,
-  ceilingMs = 9e5,
-  intervalMs = 250
-}) {
-  const start = now();
-  let sawInstalling = false;
-  let enteredDone = false;
-  let doneAt = 0;
-  for (; ; ) {
-    const bindings = await tryImport();
-    if (bindings) return bindings;
-    const installing = markerPresent() && setupAlive();
-    let giveUp;
-    if (installing) {
-      sawInstalling = true;
-      enteredDone = false;
-      giveUp = now() - start > ceilingMs;
-    } else if (sawInstalling) {
-      if (!enteredDone) {
-        enteredDone = true;
-        doneAt = now();
-      }
-      giveUp = now() - doneAt > settleMs;
-    } else {
-      giveUp = now() - start > graceMs;
-    }
-    if (giveUp) return null;
-    await sleep2(intervalMs);
-  }
-}
 function controlPlane(overrides = {}) {
   const bindings = { claudeAdapter: claudeAdapter2, Decision: Decision2, EventKind: EventKind2, ...overrides };
   if (!bindings.claudeAdapter || !bindings.Decision || !bindings.EventKind)
@@ -66685,14 +66686,13 @@ async function runJudgeCli(hookName, judge, {
     onError(err, input);
   }
 }
-var claudeAdapter2, Decision2, EventKind2, HOOKGATE_MARKER_STEM, marker, loaded;
+var claudeAdapter2, Decision2, EventKind2, marker, loaded;
 var init_control_plane2 = __esm({
   async "claude-hooks/lib/control-plane.mjs"() {
     "use strict";
     init_hook_io();
-    HOOKGATE_MARKER_STEM = "agent-sanitizer-hookgate-inflight-";
     marker = hookgateMarkerPath();
-    loaded = await awaitControlPlaneBindings({
+    loaded = await awaitLazyDependency({
       tryImport: async () => {
         const { claudeAdapter: adapter } = (
           /** @type {Partial<typeof import("agent-control-plane-core/claude")>} */
@@ -68058,7 +68058,7 @@ import { join as join4, relative } from "node:path";
 async function ensureSanitizerLoaded() {
   if (typeof stripInvisible3 === "function") return true;
   const marker2 = hookgateMarkerPath();
-  const reloaded = await awaitControlPlaneBindings({
+  const reloaded = await awaitLazyDependency({
     tryImport: async () => {
       const mod = await lazyImport("agent-sanitizer/invisible");
       return typeof mod.stripInvisible === "function" ? mod : null;
@@ -68239,7 +68239,6 @@ var init_scan_invisible_chars = __esm({
     "use strict";
     init_hook_io();
     await init_invisible_alert();
-    await init_control_plane2();
     init_trace2();
     ({
       LONG_RUN_RE: LONG_RUN_RE3,

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -54,6 +54,7 @@ import {
   writeFileSync
 } from "node:fs";
 import { userInfo } from "node:os";
+import { createHash } from "node:crypto";
 import { pathToFileURL } from "node:url";
 function isMain(importMetaUrl) {
   if (cliEntryClaimed) return false;
@@ -123,7 +124,7 @@ function failedLazyPackages() {
 }
 function missingPackageMessage(pkg, err = lazyImportErrorFor(pkg), remedy = DEFAULT_MISSING_PACKAGE_REMEDY) {
   const prefix = `${pkg} is unavailable: `;
-  const causeCap = 300 - prefix.length - remedy.length - 2 - 12;
+  const causeCap = Math.max(0, 300 - prefix.length - remedy.length - 2 - 12);
   const cause = err === void 0 ? "no load error recorded \u2014 the package likely loaded but lacks an expected export (version skew)" : safeErrMessage(err, causeCap);
   return `${prefix}${cause}; ${remedy}`;
 }
@@ -165,7 +166,9 @@ function emitHookResponse(hookEventName, fields) {
 function hookgateMarkerPath(projectDir = process.env.CLAUDE_PROJECT_DIR, runtimeDir = process.env.XDG_RUNTIME_DIR) {
   if (!projectDir) return null;
   const base2 = runtimeDir && runtimeDir.startsWith("/") ? runtimeDir : "/tmp";
-  return `${base2}/${HOOKGATE_MARKER_STEM}${projectDir.replace(/[^A-Za-z0-9]/g, "_")}`;
+  const digest = createHash("sha256").update(projectDir).digest("hex").slice(0, 8);
+  const flattened = projectDir.replace(/[^A-Za-z0-9]/g, "_");
+  return `${base2}/${HOOKGATE_MARKER_STEM}${flattened}-${digest}`;
 }
 function probeSetupAlive(markerPath) {
   if (markerPath === null) return true;
@@ -66722,7 +66725,7 @@ var init_control_plane2 = __esm({
 
 // claude-hooks/lib/invisible-alert.mjs
 import { readFileSync as readFileSync2 } from "node:fs";
-import { createHash } from "node:crypto";
+import { createHash as createHash2 } from "node:crypto";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 function invisibleCharAlert() {
@@ -66750,7 +66753,7 @@ var init_invisible_alert = __esm({
     ({ applyLayer1: applyLayer12 } = /** @type {typeof import("agent-sanitizer")} */
     await lazyImport("agent-sanitizer"));
     PROJECT_DIR = process.env.CLAUDE_PROJECT_DIR || process.cwd();
-    PROJECT_HASH = createHash("sha256").update(PROJECT_DIR).digest("hex").slice(0, 8);
+    PROJECT_HASH = createHash2("sha256").update(PROJECT_DIR).digest("hex").slice(0, 8);
     ALERT_FILE = join(
       tmpdir(),
       `.claude-invisible-char-alert-${PROJECT_HASH}`
@@ -67394,7 +67397,8 @@ function assembleResponse({
   return fields;
 }
 async function judgePreToolUseSanitize(event, rehydrate, opts = {}) {
-  const { messages = PRE_TOOL_USE_MESSAGES, gates = [] } = opts;
+  const { gates = [] } = opts;
+  const messages = { ...PRE_TOOL_USE_MESSAGES, ...opts.messages };
   const { Decision: Decision3, EventKind: EventKind3 } = controlPlane();
   if (event.event === EventKind3.UNKNOWN)
     return { decision: Decision3.DENY, reason: messages.unknownEvent };
@@ -67429,11 +67433,13 @@ function depLoadHint(err, remedy = DEFAULT_MISSING_PACKAGE_REMEDY, failedPackage
     err?.code === "DEP_UNAVAILABLE"
   )
     return "";
+  if (!(err instanceof TypeError)) return "";
   const [pkg] = failedPackages();
   return pkg === void 0 ? "" : ` ${missingPackageMessage(pkg, loadErrorFor(pkg), remedy)}`;
 }
 function failClosedFields(parsedOk, err, opts = {}) {
-  const { messages = PRE_TOOL_USE_MESSAGES, hint = depLoadHint(err) } = opts;
+  const { hint = depLoadHint(err) } = opts;
+  const messages = { ...PRE_TOOL_USE_MESSAGES, ...opts.messages };
   const cause = `${safeErrMessage(err)}${hint}`;
   return {
     permissionDecision: parsedOk ? PermissionDecision.ASK : PermissionDecision.DENY,
@@ -67441,7 +67447,8 @@ function failClosedFields(parsedOk, err, opts = {}) {
   };
 }
 async function cliMain(opts = {}) {
-  const { messages = PRE_TOOL_USE_MESSAGES, gates = [], remedy } = opts;
+  const { gates = [], remedy } = opts;
+  const messages = { ...PRE_TOOL_USE_MESSAGES, ...opts.messages };
   await runJudgeCli(
     HOOK_NAME,
     (event) => judgePreToolUseSanitize(event, void 0, { messages, gates }),
@@ -67529,7 +67536,7 @@ var init_secret_annotate = __esm({
 });
 
 // claude-hooks/lib/reveal.mjs
-import { createHash as createHash2 } from "node:crypto";
+import { createHash as createHash3 } from "node:crypto";
 import { mkdirSync, lstatSync as lstatSync3 } from "node:fs";
 import { tmpdir as tmpdir3, userInfo as userInfo3 } from "node:os";
 import { join as join3, resolve, sep } from "node:path";
@@ -67537,7 +67544,7 @@ function revealDir() {
   return process.env._AGENT_SANITIZER_REVEAL_DIR || join3(tmpdir3(), "agent-sanitizer-layer2-reveal");
 }
 function revealPathFor(content3) {
-  const digest = createHash2("sha256").update(content3, "utf8").digest("hex");
+  const digest = createHash3("sha256").update(content3, "utf8").digest("hex");
   return join3(revealDir(), `${digest}.txt`);
 }
 function revealDirIsSafe(dir) {
@@ -67969,7 +67976,8 @@ __export(sanitize_user_prompt_exports, {
   judgeSanitizeUserPrompt: () => judgeSanitizeUserPrompt,
   main: () => main
 });
-function judgeSanitizeUserPrompt(event, strip = stripAnsiFully3, messages = USER_PROMPT_MESSAGES) {
+function judgeSanitizeUserPrompt(event, strip = stripAnsiFully3, overrides = USER_PROMPT_MESSAGES) {
+  const messages = { ...USER_PROMPT_MESSAGES, ...overrides };
   const { Decision: Decision3, EventKind: EventKind3 } = controlPlane();
   if (event.event === EventKind3.UNKNOWN)
     return { decision: Decision3.DENY, reason: messages.unknownEvent };
@@ -67991,7 +67999,8 @@ function judgeSanitizeUserPrompt(event, strip = stripAnsiFully3, messages = USER
     additional_context: messages.blockContext
   };
 }
-async function main(read, write, strip = stripAnsiFully3, messages = USER_PROMPT_MESSAGES) {
+async function main(read, write, strip = stripAnsiFully3, overrides = USER_PROMPT_MESSAGES) {
+  const messages = { ...USER_PROMPT_MESSAGES, ...overrides };
   await runJudgeCli(
     "sanitize-user-prompt",
     (event) => {

--- a/test/claude-hooks-host-seams.test.mjs
+++ b/test/claude-hooks-host-seams.test.mjs
@@ -1,0 +1,468 @@
+/**
+ * The host-injection seams on the claude-hooks gates: the reason tables, the
+ * PreToolUse host-gate list, the dependency-load diagnostics, and the cold-start
+ * poll the hooks wait on while an install is still in flight.
+ *
+ * These exist because the package cannot know where it is installed. A host that
+ * does — that can name the file wiring the adapter, or the command that
+ * reinstalls it — must be able to say so in a fail-closed reason without forking
+ * the module. So each seam is asserted on two properties:
+ *
+ *   - INERT BY DEFAULT. A seam left unsupplied must produce byte-identical
+ *     output to the same call made with no options bag at all. An extension
+ *     point that changes a shipped verdict when nobody uses it is a regression
+ *     wearing a feature's clothes.
+ *   - LOAD-BEARING WHEN SUPPLIED. The override must reach the emitted reason,
+ *     and a host gate's deny must SHORT-CIRCUIT the rewriting layers — a call
+ *     reported as both denied and sanitized is two verdicts for one event.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const { claudeAdapter } = await import("agent-control-plane-core/claude");
+const { Decision } = await import("agent-control-plane-core");
+const {
+  lazyImport,
+  lazyImportErrorFor,
+  failedLazyPackages,
+  missingPackageMessage,
+  missingPackageError,
+  safeErrMessage,
+  DEFAULT_MISSING_PACKAGE_REMEDY,
+} = await import("../claude-hooks/lib/hook-io.mjs");
+const { hookgateMarkerPath, probeSetupAlive, awaitControlPlaneBindings } =
+  await import("../claude-hooks/lib/control-plane.mjs");
+const { judgeSanitizeUserPrompt, USER_PROMPT_MESSAGES } =
+  await import("../claude-hooks/sanitize-user-prompt.mjs");
+const {
+  judgePreToolUseSanitize,
+  failClosedFields,
+  depLoadHint,
+  PRE_TOOL_USE_MESSAGES,
+} = await import("../claude-hooks/pretooluse-sanitize.mjs");
+const { failClosedContext } =
+  await import("../claude-hooks/sanitize-output.mjs");
+
+const HOST_REMEDY = "run ./setup.sh in the project root and retry.";
+
+/** @param {Record<string, unknown>} payload */
+const parse = (payload) => claudeAdapter.parse(payload);
+
+const unknownEvent = () => parse({ no_such_field: 1 });
+
+describe("dependency-load diagnostics", () => {
+  it("records why a package failed to load and names it as a failed package", async () => {
+    const ns = await lazyImport("no-such-package-ffc1a9");
+    // lazyImport swallows the failure into {} — that is the fail-closed
+    // contract; the recorded error is the only place the cause survives.
+    assert.deepEqual(ns, {});
+    const err = lazyImportErrorFor("no-such-package-ffc1a9");
+    assert.ok(err instanceof Error);
+    assert.ok(failedLazyPackages().includes("no-such-package-ffc1a9"));
+  });
+
+  it("matches a subpath specifier to its package", async () => {
+    await lazyImport("no-such-package-ffc1a9/sub/deep");
+    assert.ok(lazyImportErrorFor("no-such-package-ffc1a9") instanceof Error);
+    // Reported once under the bare package name, not once per subpath.
+    assert.equal(
+      failedLazyPackages().filter((p) => p === "no-such-package-ffc1a9").length,
+      1,
+    );
+  });
+
+  it("scopes a scoped package to its two segments", async () => {
+    await lazyImport("@scope-ffc1a9/pkg/sub");
+    assert.ok(failedLazyPackages().includes("@scope-ffc1a9/pkg"));
+    assert.ok(!failedLazyPackages().includes("@scope-ffc1a9"));
+  });
+
+  it("never reports a relative or URL specifier as a reinstallable package", async () => {
+    await lazyImport("./no-such-relative-ffc1a9.mjs");
+    await lazyImport("node:no-such-builtin-ffc1a9");
+    const failed = failedLazyPackages();
+    assert.ok(!failed.some((p) => p.startsWith(".")));
+    assert.ok(!failed.some((p) => p.includes(":")));
+  });
+
+  it("ranks a repeat failure as the newest, not by when it first failed", async () => {
+    await lazyImport("first-ffc1a9");
+    await lazyImport("second-ffc1a9");
+    await lazyImport("first-ffc1a9");
+    // A fail-closed reason names ONE package; it must be the one that just
+    // failed, so a stale first failure cannot outrank the current one.
+    assert.equal(failedLazyPackages()[0], "first-ffc1a9");
+  });
+
+  it("clears the record once the specifier loads", async () => {
+    await lazyImport("agent-sanitizer/invisible");
+    assert.equal(lazyImportErrorFor("agent-sanitizer"), undefined);
+    assert.ok(!failedLazyPackages().includes("agent-sanitizer"));
+  });
+
+  it("keeps the remedy inside the downstream 300-char re-scrub", () => {
+    // The reason is re-scrubbed by safeErrMessage before it reaches the user, so
+    // an unbounded cause would truncate the remedy off the end — losing the only
+    // actionable half of the message. The cap is computed for exactly this.
+    const huge = new Error("x".repeat(5000));
+    const message = missingPackageMessage("a-package", huge, HOST_REMEDY);
+    assert.ok(safeErrMessage(message).endsWith(HOST_REMEDY));
+  });
+
+  it("says so when nothing was recorded, rather than inventing a cause", () => {
+    const message = missingPackageMessage("a-package", undefined, HOST_REMEDY);
+    assert.match(message, /version skew/u);
+    assert.ok(message.endsWith(HOST_REMEDY));
+  });
+
+  it("defaults the remedy to the package's own wording", () => {
+    assert.ok(
+      missingPackageMessage("a-package", new Error("boom")).endsWith(
+        DEFAULT_MISSING_PACKAGE_REMEDY,
+      ),
+    );
+  });
+
+  it("tags the throwable so a reason-builder does not append a second copy", () => {
+    const err = missingPackageError("a-package", new Error("boom"));
+    assert.equal(/** @type {{code?: string}} */ (err).code, "DEP_UNAVAILABLE");
+    assert.equal(depLoadHint(err), "");
+  });
+
+  it("names the failed package and the host remedy on an untagged error", async () => {
+    await lazyImport("no-such-package-ffc1a9");
+    const hint = depLoadHint(new TypeError("x is not a function"), HOST_REMEDY);
+    assert.match(hint, /no-such-package-ffc1a9 is unavailable/u);
+    assert.ok(hint.endsWith(HOST_REMEDY));
+  });
+
+  it("adds no hint when nothing failed to load", () => {
+    assert.equal(
+      depLoadHint(new TypeError("unrelated"), HOST_REMEDY, () => []),
+      "",
+    );
+  });
+});
+
+describe("user-prompt gate reason table", () => {
+  it("is inert by default", () => {
+    const event = unknownEvent();
+    assert.deepEqual(
+      judgeSanitizeUserPrompt(event),
+      judgeSanitizeUserPrompt(event, undefined, USER_PROMPT_MESSAGES),
+    );
+    assert.equal(
+      judgeSanitizeUserPrompt(event).reason,
+      USER_PROMPT_MESSAGES.unknownEvent,
+    );
+  });
+
+  it("carries a host's deny-when-blind reason", () => {
+    const verdict = judgeSanitizeUserPrompt(unknownEvent(), undefined, {
+      ...USER_PROMPT_MESSAGES,
+      unknownEvent: "blocked: fix the adapter parse in hooks/prompt.mjs",
+    });
+    assert.equal(verdict.decision, Decision.DENY);
+    assert.equal(
+      verdict.reason,
+      "blocked: fix the adapter parse in hooks/prompt.mjs",
+    );
+  });
+
+  it("carries a host's block context on a real payload block", () => {
+    // U+E0041 (TAG LATIN A) is payload-capable and invisible: the classifier
+    // blocks it, which is the arm that emits blockContext.
+    const event = parse({
+      hook_event_name: "UserPromptSubmit",
+      prompt: `hello${"\u{E0041}".repeat(20)}`,
+    });
+    const verdict = judgeSanitizeUserPrompt(event, undefined, {
+      ...USER_PROMPT_MESSAGES,
+      blockContext: "host block note",
+    });
+    assert.equal(verdict.decision, Decision.DENY);
+    assert.equal(verdict.additional_context, "host block note");
+  });
+
+  it("reports a missing package as a tagged dependency failure", () => {
+    const event = parse({ hook_event_name: "UserPromptSubmit", prompt: "hi" });
+    assert.throws(() => judgeSanitizeUserPrompt(event, null), {
+      code: "DEP_UNAVAILABLE",
+    });
+  });
+});
+
+describe("PreToolUse host gates", () => {
+  /** A tool input the confusable layer WILL rewrite, so a skipped layer shows. */
+  const confusableWrite = () =>
+    parse({
+      hook_event_name: "PreToolUse",
+      tool_name: "Bash",
+      // Cyrillic es/a/er in place of Latin c/a/p.
+      tool_input: { command: "сар /tmp/x /tmp/y" },
+      session_id: "sess-1",
+    });
+
+  it("is inert with no gates supplied", async () => {
+    const event = confusableWrite();
+    const withBag = await judgePreToolUseSanitize(event, undefined, {});
+    const without = await judgePreToolUseSanitize(event);
+    assert.deepEqual(withBag, without);
+    // Non-vacuous: the layers really did run, so a short-circuit is observable.
+    assert.ok(without.mutated_input !== undefined);
+  });
+
+  it("denies on a gate reason and skips the rewriting layers", async () => {
+    const verdict = await judgePreToolUseSanitize(
+      confusableWrite(),
+      undefined,
+      { gates: [() => "denied: run /pr-creation first"] },
+    );
+    assert.equal(verdict.decision, Decision.DENY);
+    assert.equal(verdict.reason, "denied: run /pr-creation first");
+    // The whole point of running gates first: a denied call is not ALSO
+    // reported as a sanitized one.
+    assert.equal(verdict.mutated_input, undefined);
+    assert.equal(verdict.additional_context, undefined);
+  });
+
+  it("falls through a gate that abstains, and runs gates in order", async () => {
+    const seen = [];
+    const verdict = await judgePreToolUseSanitize(
+      confusableWrite(),
+      undefined,
+      {
+        gates: [
+          (input) => {
+            seen.push(input.session_id);
+            return null;
+          },
+          (input) => {
+            seen.push(input.tool_name);
+            return undefined;
+          },
+        ],
+      },
+    );
+    assert.deepEqual(seen, ["sess-1", "Bash"]);
+    assert.ok(verdict.mutated_input !== undefined);
+  });
+
+  it("hands the gate the session identity, which rides in meta not the input", async () => {
+    let got;
+    await judgePreToolUseSanitize(confusableWrite(), undefined, {
+      gates: [
+        (input) => {
+          got = input;
+          return null;
+        },
+      ],
+    });
+    // A once-per-session checkpoint cannot tell two sessions apart without it.
+    assert.equal(got.session_id, "sess-1");
+    assert.equal(got.tool_name, "Bash");
+  });
+
+  it("lets a broken gate throw rather than swallowing it", async () => {
+    // The throw reaches the CLI's fail-closed catch, which ASKS. Swallowing it
+    // would silently downgrade a broken host gate into a pass.
+    await assert.rejects(
+      judgePreToolUseSanitize(confusableWrite(), undefined, {
+        gates: [
+          () => {
+            throw new Error("gate is broken");
+          },
+        ],
+      }),
+      /gate is broken/u,
+    );
+  });
+
+  it("carries a host's deny-when-blind reason", async () => {
+    const verdict = await judgePreToolUseSanitize(unknownEvent(), undefined, {
+      messages: { ...PRE_TOOL_USE_MESSAGES, unknownEvent: "host blind deny" },
+    });
+    assert.equal(verdict.decision, Decision.DENY);
+    assert.equal(verdict.reason, "host blind deny");
+  });
+});
+
+describe("PreToolUse fail-closed fields", () => {
+  it("is inert by default", () => {
+    const err = new Error("boom");
+    assert.deepEqual(
+      failClosedFields(true, err),
+      failClosedFields(true, err, {}),
+    );
+  });
+
+  it("asks after a clean parse and denies on unparsable input", () => {
+    const err = new Error("boom");
+    assert.equal(failClosedFields(true, err).permissionDecision, "ask");
+    assert.equal(failClosedFields(false, err).permissionDecision, "deny");
+  });
+
+  it("routes both reasons through the host's table and hint", () => {
+    const opts = {
+      messages: {
+        ...PRE_TOOL_USE_MESSAGES,
+        failed: (cause) => `HOST-FAILED ${cause}`,
+        unparsable: (cause) => `HOST-UNPARSABLE ${cause}`,
+      },
+      hint: " HOST-HINT",
+    };
+    assert.equal(
+      failClosedFields(true, new Error("boom"), opts).permissionDecisionReason,
+      "HOST-FAILED boom HOST-HINT",
+    );
+    assert.equal(
+      failClosedFields(false, new Error("boom"), opts).permissionDecisionReason,
+      "HOST-UNPARSABLE boom HOST-HINT",
+    );
+  });
+});
+
+describe("sanitize-output fail-closed context", () => {
+  it("says only that the output was suppressed when the deps did load", () => {
+    const context = failClosedContext(() => true, HOST_REMEDY);
+    assert.match(context, /output was suppressed/u);
+    assert.ok(!context.includes(HOST_REMEDY));
+  });
+
+  it("names the missing dependency and the host remedy when they did not", () => {
+    const context = failClosedContext(() => false, HOST_REMEDY);
+    assert.match(context, /agent-sanitizer is unavailable/u);
+    assert.ok(context.endsWith(HOST_REMEDY));
+  });
+});
+
+describe("cold-start marker", () => {
+  it("has no path when no project dir is set — nothing installed it", () => {
+    assert.equal(hookgateMarkerPath(undefined, "/run/user/1000"), null);
+  });
+
+  it("prefers an absolute runtime dir over world-writable /tmp", () => {
+    assert.ok(
+      hookgateMarkerPath("/w/p", "/run/user/1000").startsWith(
+        "/run/user/1000/",
+      ),
+    );
+    assert.ok(hookgateMarkerPath("/w/p", "relative/dir").startsWith("/tmp/"));
+    assert.ok(hookgateMarkerPath("/w/p", undefined).startsWith("/tmp/"));
+  });
+
+  it("flattens the project dir so the path is one filename", () => {
+    const path = hookgateMarkerPath("/work/my proj", undefined);
+    assert.equal(path.slice("/tmp/".length).includes("/"), false);
+    // Two projects must not collide onto one marker.
+    assert.notEqual(path, hookgateMarkerPath("/work/other", undefined));
+  });
+});
+
+describe("setup-liveness probe", () => {
+  it("reads a null path as alive so the caller's own bound governs", () => {
+    assert.equal(probeSetupAlive(null), true);
+  });
+
+  it("reads an unreadable marker as alive, favouring a brief wait", () => {
+    assert.equal(probeSetupAlive("/no/such/marker-ffc1a9"), true);
+  });
+
+  it("reads our own live pid as alive", async () => {
+    const { writeFileSync, mkdtempSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const marker = join(mkdtempSync(join(tmpdir(), "seam-")), "m");
+    writeFileSync(marker, String(process.pid));
+    assert.equal(probeSetupAlive(marker), true);
+    // A pid that cannot exist reads as dead — that is the arm that stops the
+    // wait when setup was killed and left its marker behind.
+    writeFileSync(marker, "2147483646");
+    assert.equal(probeSetupAlive(marker), false);
+    // Garbage contents are a write race, not a death: keep waiting.
+    writeFileSync(marker, "not-a-pid");
+    assert.equal(probeSetupAlive(marker), true);
+  });
+});
+
+describe("cold-start wait", () => {
+  const never = () => false;
+  /** A clock that advances by `step` on every read. */
+  const ticking = (step) => {
+    let t = 0;
+    return () => (t += step);
+  };
+
+  it("returns immediately on a warm session, with no sleep at all", async () => {
+    let slept = 0;
+    const bindings = await awaitControlPlaneBindings({
+      tryImport: async () => ({ ok: true }),
+      markerPresent: never,
+      setupAlive: never,
+      sleep: async () => {
+        slept += 1;
+      },
+    });
+    assert.deepEqual(bindings, { ok: true });
+    assert.equal(slept, 0);
+  });
+
+  it("gives up after the grace window when no setup was ever seen", async () => {
+    const bindings = await awaitControlPlaneBindings({
+      tryImport: async () => null,
+      markerPresent: never,
+      setupAlive: never,
+      now: ticking(2000),
+      sleep: async () => {},
+      graceMs: 5000,
+    });
+    // A genuinely-absent dependency must fail closed fast, not after a long
+    // block — the wait exists for a live install, not for an absent one.
+    assert.equal(bindings, null);
+  });
+
+  it("waits out a live install past the grace window, then settles", async () => {
+    let attempts = 0;
+    let installing = true;
+    const bindings = await awaitControlPlaneBindings({
+      tryImport: async () => {
+        attempts += 1;
+        // Setup finishes without ever providing the dep.
+        if (attempts === 40) installing = false;
+        return null;
+      },
+      markerPresent: () => installing,
+      setupAlive: () => installing,
+      now: ticking(500),
+      sleep: async () => {},
+      graceMs: 5000,
+      settleMs: 1000,
+      ceilingMs: 900000,
+    });
+    assert.equal(bindings, null);
+    // Past the 5s grace by a wide margin: the marker, not the clock, held it.
+    assert.ok(
+      attempts > 30,
+      `only ${attempts} attempts — the wait was cut off`,
+    );
+  });
+
+  it("stops at the ceiling when setup is alive but hung", async () => {
+    let attempts = 0;
+    const bindings = await awaitControlPlaneBindings({
+      tryImport: async () => {
+        attempts += 1;
+        return null;
+      },
+      markerPresent: () => true,
+      setupAlive: () => true,
+      now: ticking(100000),
+      sleep: async () => {},
+      ceilingMs: 900000,
+    });
+    assert.equal(bindings, null);
+    // The ceiling is a backstop, not the normal exit: it must exist, because a
+    // hook killed for running over its harness timeout is a fail-OPEN.
+    assert.ok(attempts > 1);
+  });
+});

--- a/test/claude-hooks-host-seams.test.mjs
+++ b/test/claude-hooks-host-seams.test.mjs
@@ -110,6 +110,28 @@ describe("dependency-load diagnostics", () => {
     assert.ok(safeErrMessage(message).endsWith(HOST_REMEDY));
   });
 
+  it("spends the whole budget on the remedy when the REMEDY is what is long", () => {
+    // The symmetric case to the one above, and the one the host knob opened: a
+    // remedy long enough to drive the cause budget negative. safeErrMessage does
+    // not clamp a negative cap — `slice(0, -n)` trims from the END — so without
+    // the clamp the cause survives nearly whole and pushes the message far past
+    // the budget. Clamped, the cause collapses to the truncation marker and the
+    // overflow is only what the remedy itself costs.
+    const longRemedy = `${"reinstall the dependencies ".repeat(11)}and retry.`;
+    assert.ok(longRemedy.length > 260, "remedy must overrun the budget");
+    const cause = "a".repeat(400);
+    const message = missingPackageMessage(
+      "a-package",
+      new Error(cause),
+      longRemedy,
+    );
+    assert.ok(message.endsWith(longRemedy));
+    assert.ok(
+      !message.includes("aaaaaaaaaa"),
+      "the cause must not survive when the remedy has spent the budget",
+    );
+  });
+
   it("says so when nothing was recorded, rather than inventing a cause", () => {
     const message = missingPackageMessage("a-package", undefined, HOST_REMEDY);
     assert.match(message, /version skew/u);
@@ -143,6 +165,24 @@ describe("dependency-load diagnostics", () => {
       "",
     );
   });
+
+  it("names a package only for the error shape an unloaded binding produces", async () => {
+    await lazyImport("no-such-package-ffc1a9");
+    // The recorded-failure set is process-wide and carries no link to the error
+    // being reported, so naming a package from it is only sound for the failure
+    // this hint explains: calling an undefined binding, which raises a TypeError.
+    // A layer engine reporting its own problem must not be answered with a
+    // reinstall that fixes nothing.
+    assert.equal(
+      depLoadHint(new Error("redactor daemon refused"), HOST_REMEDY),
+      "",
+    );
+    assert.equal(
+      depLoadHint(new RangeError("depth exceeded"), HOST_REMEDY),
+      "",
+    );
+    assert.notEqual(depLoadHint(new TypeError("x is not a function")), "");
+  });
 });
 
 describe("user-prompt gate reason table", () => {
@@ -167,6 +207,26 @@ describe("user-prompt gate reason table", () => {
     assert.equal(
       verdict.reason,
       "blocked: fix the adapter parse in hooks/prompt.mjs",
+    );
+  });
+
+  it("fills the unset fields of a PARTIAL reason table", () => {
+    // Same fail-open shape as the PreToolUse gate: main() threads this object
+    // into its onError. A partial table would also silently drop sgrNote and
+    // blockContext from the verdict rather than erroring.
+    const verdict = judgeSanitizeUserPrompt(unknownEvent(), undefined, {
+      unknownEvent: "host blind deny",
+    });
+    assert.equal(verdict.reason, "host blind deny");
+    const blocked = parse({
+      hook_event_name: "UserPromptSubmit",
+      prompt: `hello${"\u{E0041}".repeat(20)}`,
+    });
+    assert.equal(
+      judgeSanitizeUserPrompt(blocked, undefined, {
+        unknownEvent: "host blind deny",
+      }).additional_context,
+      USER_PROMPT_MESSAGES.blockContext,
     );
   });
 
@@ -264,6 +324,25 @@ describe("PreToolUse host gates", () => {
     assert.equal(got.tool_name, "Bash");
   });
 
+  it("fills the unset fields of a PARTIAL reason table", async () => {
+    // Every other seam case spreads the whole default table, which is exactly the
+    // shape that cannot expose a wholesale substitution. A bare one-field object
+    // is what a host actually writes — and the field it did NOT set is consumed
+    // inside runJudgeCli's catch, where an undefined reason-builder throws out of
+    // the handler and the hook emits nothing at all: a fail-OPEN pass.
+    const verdict = await judgePreToolUseSanitize(unknownEvent(), undefined, {
+      messages: { unknownEvent: "host blind deny" },
+    });
+    assert.equal(verdict.reason, "host blind deny");
+    const fields = failClosedFields(true, new Error("boom"), {
+      messages: { unknownEvent: "host blind deny" },
+    });
+    assert.equal(
+      fields.permissionDecisionReason,
+      PRE_TOOL_USE_MESSAGES.failed("boom"),
+    );
+  });
+
   it("lets a broken gate throw rather than swallowing it", async () => {
     // The throw reaches the CLI's fail-closed catch, which ASKS. Swallowing it
     // would silently downgrade a broken host gate into a pass.
@@ -342,6 +421,9 @@ describe("cold-start marker", () => {
     assert.equal(hookgateMarkerPath(undefined, "/run/user/1000"), null);
   });
 
+  // Both arguments are passed explicitly throughout: omitting one falls back to
+  // its process.env default, and a CI runner (which sets XDG_RUNTIME_DIR) then
+  // takes a different branch than a developer shell (which usually does not).
   it("prefers an absolute runtime dir over world-writable /tmp", () => {
     assert.ok(
       hookgateMarkerPath("/w/p", "/run/user/1000").startsWith(
@@ -349,14 +431,40 @@ describe("cold-start marker", () => {
       ),
     );
     assert.ok(hookgateMarkerPath("/w/p", "relative/dir").startsWith("/tmp/"));
-    assert.ok(hookgateMarkerPath("/w/p", undefined).startsWith("/tmp/"));
+    assert.ok(hookgateMarkerPath("/w/p", "").startsWith("/tmp/"));
+  });
+
+  it("reads both defaults from the environment", () => {
+    const saved = { ...process.env };
+    try {
+      process.env.CLAUDE_PROJECT_DIR = "/env/project";
+      process.env.XDG_RUNTIME_DIR = "/run/user/4242";
+      // Compared against the explicit-argument call rather than a literal path,
+      // so this pins where the defaults come FROM without restating the stem.
+      assert.equal(
+        hookgateMarkerPath(),
+        hookgateMarkerPath("/env/project", "/run/user/4242"),
+      );
+      delete process.env.CLAUDE_PROJECT_DIR;
+      assert.equal(hookgateMarkerPath(), null);
+    } finally {
+      process.env = saved;
+    }
   });
 
   it("flattens the project dir so the path is one filename", () => {
-    const path = hookgateMarkerPath("/work/my proj", undefined);
+    const path = hookgateMarkerPath("/work/my proj", "");
     assert.equal(path.slice("/tmp/".length).includes("/"), false);
-    // Two projects must not collide onto one marker.
-    assert.notEqual(path, hookgateMarkerPath("/work/other", undefined));
+  });
+
+  it("keeps dirs that flatten alike on separate markers", () => {
+    // The flattening is lossy, so it cannot be the identity: these three differ
+    // only in characters it replaces. Sharing a marker would make each project's
+    // hook wait on the others' installs, silently, in both directions.
+    const paths = ["/work/a-b", "/work/a_b", "/work/a b"].map((dir) =>
+      hookgateMarkerPath(dir, ""),
+    );
+    assert.equal(new Set(paths).size, 3);
   });
 });
 

--- a/test/claude-hooks-host-seams.test.mjs
+++ b/test/claude-hooks-host-seams.test.mjs
@@ -29,9 +29,10 @@ const {
   missingPackageError,
   safeErrMessage,
   DEFAULT_MISSING_PACKAGE_REMEDY,
+  hookgateMarkerPath,
+  probeSetupAlive,
+  awaitLazyDependency,
 } = await import("../claude-hooks/lib/hook-io.mjs");
-const { hookgateMarkerPath, probeSetupAlive, awaitControlPlaneBindings } =
-  await import("../claude-hooks/lib/control-plane.mjs");
 const { judgeSanitizeUserPrompt, USER_PROMPT_MESSAGES } =
   await import("../claude-hooks/sanitize-user-prompt.mjs");
 const {
@@ -395,7 +396,7 @@ describe("cold-start wait", () => {
 
   it("returns immediately on a warm session, with no sleep at all", async () => {
     let slept = 0;
-    const bindings = await awaitControlPlaneBindings({
+    const bindings = await awaitLazyDependency({
       tryImport: async () => ({ ok: true }),
       markerPresent: never,
       setupAlive: never,
@@ -408,7 +409,7 @@ describe("cold-start wait", () => {
   });
 
   it("gives up after the grace window when no setup was ever seen", async () => {
-    const bindings = await awaitControlPlaneBindings({
+    const bindings = await awaitLazyDependency({
       tryImport: async () => null,
       markerPresent: never,
       setupAlive: never,
@@ -424,7 +425,7 @@ describe("cold-start wait", () => {
   it("waits out a live install past the grace window, then settles", async () => {
     let attempts = 0;
     let installing = true;
-    const bindings = await awaitControlPlaneBindings({
+    const bindings = await awaitLazyDependency({
       tryImport: async () => {
         attempts += 1;
         // Setup finishes without ever providing the dep.
@@ -449,7 +450,7 @@ describe("cold-start wait", () => {
 
   it("stops at the ceiling when setup is alive but hung", async () => {
     let attempts = 0;
-    const bindings = await awaitControlPlaneBindings({
+    const bindings = await awaitLazyDependency({
       tryImport: async () => {
         attempts += 1;
         return null;

--- a/test/claude-hooks-host-seams.test.mjs
+++ b/test/claude-hooks-host-seams.test.mjs
@@ -418,7 +418,7 @@ describe("sanitize-output fail-closed context", () => {
 
 describe("cold-start marker", () => {
   it("has no path when no project dir is set — nothing installed it", () => {
-    assert.equal(hookgateMarkerPath(undefined, "/run/user/1000"), null);
+    assert.equal(hookgateMarkerPath("", "/run/user/1000"), null);
   });
 
   // Both arguments are passed explicitly throughout: omitting one falls back to

--- a/test/downstream-parity.test.mjs
+++ b/test/downstream-parity.test.mjs
@@ -1,0 +1,122 @@
+/**
+ * The seams are only worth shipping if a host can retire its FORK with them, so
+ * this composes all three at once — reason table, deny gate, host remedy —
+ * against the shapes a real downstream (agent-glovebox) forks these modules to
+ * get today, where the unit cases each exercise one seam in isolation.
+ *
+ * The strings are transcribed from that fork rather than invented, because what
+ * they demonstrate is the thing the package cannot do for itself: they cite the
+ * host's own paths (`.claude/hooks/…`, `session-setup.sh`). Each assertion
+ * compares the emitted verdict against the text this test HANDED IN, never
+ * against the downstream's file — so this cannot rot when that wording changes,
+ * and it is not a second copy of anything. What it fails on is a refactor that
+ * drops a table field, stops threading `session_id`, or lets a gate deny fall
+ * through into the rewriting layers — each of which makes the fork unretirable
+ * again, and none of which the per-seam cases would show as one broken workflow.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const { claudeAdapter } = await import("agent-control-plane-core/claude");
+const { Decision } = await import("agent-control-plane-core");
+const { missingPackageMessage, safeErrMessage } =
+  await import("../claude-hooks/lib/hook-io.mjs");
+const { judgeSanitizeUserPrompt } =
+  await import("../claude-hooks/sanitize-user-prompt.mjs");
+const { judgePreToolUseSanitize, failClosedFields } =
+  await import("../claude-hooks/pretooluse-sanitize.mjs");
+
+// Verbatim from the downstream fork.
+const HOST_REMEDY =
+  "re-run .claude/hooks/session-setup.sh (or pnpm install) and retry.";
+
+const HOST_PROMPT_MESSAGES = {
+  unknownEvent:
+    "User prompt blocked (fail-closed): unrecognized hook payload — the " +
+    "harness's hook-input shape no longer parses as a UserPromptSubmit " +
+    "event. Fix the adapter parse (agent-control-plane-core's claude " +
+    "adapter, wired by .claude/hooks/sanitize-user-prompt.mjs); " +
+    "resubmitting the prompt cannot clear this.",
+};
+
+const HOST_PRE_TOOL_USE_MESSAGES = {
+  unknownEvent:
+    "PreToolUse sanitization blocked (fail-closed): unrecognized hook " +
+    "payload — the harness's hook-input shape no longer parses as a " +
+    "PreToolUse event. Fix the adapter parse (agent-control-plane-core's " +
+    "claude adapter, wired by .claude/hooks/pretooluse-sanitize.mjs); " +
+    "retrying the call cannot clear this.",
+};
+
+/** @param {Record<string, unknown>} payload */
+const parse = (payload) => claudeAdapter.parse(payload);
+
+const unknownEvent = () => parse({ no_such_field: 1 });
+
+describe("a host can retire its fork through the seams", () => {
+  it("emits the host's deny-when-blind reason on both gates", async () => {
+    assert.equal(
+      judgeSanitizeUserPrompt(unknownEvent(), undefined, HOST_PROMPT_MESSAGES)
+        .reason,
+      HOST_PROMPT_MESSAGES.unknownEvent,
+    );
+    const verdict = await judgePreToolUseSanitize(unknownEvent(), undefined, {
+      messages: HOST_PRE_TOOL_USE_MESSAGES,
+    });
+    assert.equal(verdict.decision, Decision.DENY);
+    assert.equal(verdict.reason, HOST_PRE_TOOL_USE_MESSAGES.unknownEvent);
+  });
+
+  it("carries the host's remedy into a fail-closed reason", () => {
+    // The fork's whole reason for existing in this module: a reader is told
+    // which command to run, and the package cannot know that command.
+    const hint = ` ${missingPackageMessage("agent-sanitizer", new Error("Cannot find package"), HOST_REMEDY)}`;
+    const fields = failClosedFields(
+      true,
+      new TypeError("x is not a function"),
+      {
+        hint,
+      },
+    );
+    assert.equal(fields.permissionDecision, "ask");
+    assert.ok(
+      /** @type {string} */ (fields.permissionDecisionReason).endsWith(
+        HOST_REMEDY,
+      ),
+    );
+    // And it survives the re-scrub the harness applies on the way out.
+    assert.ok(
+      safeErrMessage(
+        /** @type {string} */ (fields.permissionDecisionReason),
+      ).endsWith(HOST_REMEDY),
+    );
+  });
+
+  it("runs the host's own deny gate, keyed on the session it is given", async () => {
+    // Stands in for the fork's PR-skill gate: a once-per-session checkpoint,
+    // which needs the session identity and must deny before any rewriting layer.
+    const seen = [];
+    /** @param {{session_id?: string}} input */
+    const hostGate = (input) => {
+      seen.push(input.session_id);
+      return "Run the /pr-creation skill before opening a PR.";
+    };
+    const verdict = await judgePreToolUseSanitize(
+      parse({
+        hook_event_name: "PreToolUse",
+        tool_name: "Bash",
+        tool_input: { command: "gh pr create --title x" },
+        session_id: "sess-abc",
+      }),
+      undefined,
+      { gates: [hostGate], messages: HOST_PRE_TOOL_USE_MESSAGES },
+    );
+    assert.deepEqual(seen, ["sess-abc"]);
+    assert.equal(verdict.decision, Decision.DENY);
+    assert.equal(
+      verdict.reason,
+      "Run the /pr-creation skill before opening a PR.",
+    );
+    assert.equal(verdict.mutated_input, undefined);
+  });
+});


### PR DESCRIPTION
## Summary

Give a host three ways to say what the package cannot: its own fail-closed reason text, its own deny gates, and its own reinstall command. A downstream (glovebox) currently forks four of these hook modules, and the whole substance of the fork is reason strings that name the host's files — the package has no idea where it is installed, so it cannot write them.

The forks are the problem this solves. A forked gate stops receiving upstream fixes silently, which is a bad property for a module whose job is to fail closed.

## Changes

- **Reason tables.** `PRE_TOOL_USE_MESSAGES` and `USER_PROMPT_MESSAGES` are frozen defaults, and a host's table is **merged over** them, never substituted for them — so an override is only ever additive and a partial table is a supported case. Unsupplied, they produce byte-identical output to the previous hardcoded strings.
- **Host deny gates.** `judgePreToolUseSanitize(event, rehydrate, { gates })` runs host predicates before any rewriting layer, so a denied call is not also reported as a sanitized one. The PreToolUse input now carries `session_id` (it rides in `event.meta`, not beside the tool input), which a once-per-session host checkpoint needs to tell two sessions apart.
- **Dependency-load diagnostics** in `lib/hook-io`: `lazyImport` records why each specifier failed; `missingPackageMessage`/`missingPackageError` turn a bare `X is not a function` into a named package plus a remedy the host supplies. `depLoadHint` appends it to the PreToolUse reason — for a TypeError only, the shape an unloaded binding actually produces, so a layer engine reporting its own problem is not answered with a reinstall that fixes nothing. `sanitize-output`'s `failClosedContext` now routes through the same builder instead of its own hardcoded "reinstall the plugin" sentence.
- **A cold-start wait** (`hookgateMarkerPath`, `probeSetupAlive`, `awaitLazyDependency`) in `lib/hook-io`, used by `scan-invisible-chars`. This one is a **bug fix, not a seam**: on a container whose deps are still installing when SessionStart fires, the scan previously skipped silently and every instruction file loaded UNSCANNED for the rest of the session. It now waits while the setup process is demonstrably alive (PID liveness on a uid-checked marker) and fails loud when it is not. The marker's identity is a digest of the raw project dir; the flattened form in the filename is for a human reading `ls /tmp`, and is too lossy to be the key.
- **Seven `claude-hooks/lib` subpaths exported** — invisible-alert, authored-content, env-config, secret-annotate, reveal, redactor-client, trace. `test/claude-hooks-exports.test.mjs` derives both halves of its contract from the map, so it moved them from its de-exported arm with no edit.
- **`lazyImport` deletes before re-recording** a specifier's error: a `Map` keeps a re-set key at its original position, so a stale first failure could outrank the one that just happened in the two recency-ordered readers.

## Review focus

Read `judgePreToolUseSanitize` in `claude-hooks/pretooluse-sanitize.mjs` first. Two invariants live there and neither is visible from the call site:

1. The gate loop must stay **above** `buildPreToolUseResponse` and must `return`, not `break` — a gate deny that fell through would emit a verdict carrying both a deny reason and a `mutated_input`, which is two verdicts for one event.
2. The reason table must be **merged**, not substituted. This is the fail-open the first review round caught: `failClosedFields` runs inside `runJudgeCli`'s catch, so a missing reason-builder throws out of the handler, the hook emits nothing, and the harness reads that as non-blocking.

The part I am least sure of is the **marker path** (`agent-sanitizer-hookgate-inflight-<flattened>-<sha256[0:8]>`). It is a wire contract with a host's setup script, which must write the byte-identical path; the package owns the format now, so a host whose script builds a different one gets no wait at all and silently degrades to the old fail-fast behavior. There is no way for the package to detect that.

## Tests / verification

- `pnpm test` → 2103 pass / 0 fail, run under all four combinations of `CLAUDE_PROJECT_DIR` and `XDG_RUNTIME_DIR` being set or unset. `pnpm lint`, `pnpm check` → clean.
- `test/claude-hooks-host-seams.test.mjs` (43 cases) drives each seam in isolation, asserted on both halves: **inert by default** (`deepEqual` against the same call with no options bag) and **load-bearing when supplied**. Non-vacuity is explicit — the inert-by-default case also asserts `mutated_input !== undefined`, so a short-circuit is observably different from a no-op pipeline.
- `test/downstream-parity.test.mjs` composes all three seams at once against the shapes the downstream forks these modules to get, which is the claim the PR is actually making and which no per-seam case covers. Every assertion compares the verdict against text the test handed in, never against the other repo's file, so it is one source rather than a copy and cannot rot when that wording changes.
- Each second-round fix carries the test whose absence hid it: a bare one-field table (every first-round case spread the whole default, the one shape that cannot expose a wholesale substitution), a long remedy against a long cause, two dirs differing only in the characters the flattening replaces, and a non-TypeError error.
- The recency fix is pinned by a test that was **red before it**: `failedLazyPackages()[0]` returned the stale first failure, which is how the bug was found.
- The `awaitLazyDependency` arms run on an injected clock, so the grace/settle/ceiling exits are asserted without wall-clock waits. The "waits out a live install" case asserts `attempts > 30` — i.e. that the marker, not the 5s grace, held it.
- A broken host gate is asserted to **throw**, not be swallowed: the throw reaches the CLI catch, which asks. Swallowing would downgrade a broken gate into a pass.
- Two CI rounds were red on marker-path cases that passed locally, both the same defect: an argument left `undefined` selects that parameter's `process.env` default, so a job that sets the variable takes a different branch than a developer shell. `XDG_RUNTIME_DIR` (set by the runner) reddened the general suite; `CLAUDE_PROJECT_DIR` (exported by `run-hook-lifecycle.sh` before it runs the tests) reddened only that leg. Every argument is explicit now, and one case controls the environment directly so the defaults are covered on purpose rather than by accident.

## Decisions made

- **The remedy is a per-call parameter, not a module-level setting.** A settable global would be mutable state on a security path, and the call sites that need it are few. Under the alternative a host would configure it once at startup; the cost is that a reason's wording would depend on load order.
- **`depLoadHint` is gated on `instanceof TypeError`** rather than on a per-hook list of expected packages. The recorded-failure set is process-wide and carries no link to the error being reported, so naming a package from it is an inference — sound for the failure the hint explains (an undefined binding called), unsound otherwise. The alternative, threading each hook's own dependency list in, reintroduces the hardcoded package list the loader-derived set exists to avoid.
- **`depLoadHint` stays in `pretooluse-sanitize.mjs`** rather than moving to `lib/hook-io` beside the records it reads. Its only consumer is that hook's fail-closed reason. Under the alternative it becomes a shared primitive for hosts building their own hooks' reasons.
- **`awaitControlPlaneBindings` is renamed `awaitLazyDependency` and moved to `lib/hook-io`.** It waits on any lazily-loaded package — `scan-invisible-chars` uses it for `agent-sanitizer` — and leaving it in `lib/control-plane` made the SessionStart scanner import a module whose body awaits `agent-control-plane-core`, a package that hook never touches.
- **The cold-start wait ships here rather than as its own PR**, though it is a behaviour change rather than a seam, as the review notes. It is the last thing keeping the downstream's `scan-invisible-chars` and `lib-control-plane` forks alive, so splitting it would leave this PR unable to retire what it is for. Under the alternative it lands separately and the fork retirement waits on two releases.
- **The marker format is package-owned** rather than injectable. The module-level bootstrap calls `hookgateMarkerPath()` with no arguments, so a parameter would not reach it; an env var would be a second configuration channel for one string. A host adopting the wait changes its setup script's marker to match.

## Checklist

- [x] Commits follow Conventional Commits; each subject reads as a user-facing release note.
- [x] `pnpm test`, `pnpm lint`, and `pnpm check` pass locally.
- [x] New seams have inert-by-default tests (byte-identical output when unsupplied) and pin their invariants.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version are left untouched.
