### PR TITLE
feat(claude-hooks): let a host supply the trace sink and the hookgate marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,12 @@ surface is the `--hook=` CLI, so these move between minor versions.
 `cliMain`, so a composer that wraps `cliMain` gets the hook's exact fail-closed
 CLI wiring plus its own policy:
 
-| Field        | Runs                                                     | Does                                                                     |
-| ------------ | -------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `postText`   | once per string **value** leaf, after Layers 1–4         | returns `{cleaned?, warning?}`; `cleaned` replaces the model-facing text |
-| `redactNote` | on the pre-redaction text of a leaf that tripped Layer 4 | returns a note appended to that leaf's redaction warning                 |
-| `audit`      | once per judged event carrying a tool response           | is handed the output the model will actually see                         |
+| Field        | Runs                                                     | Does                                                                                 |
+| ------------ | -------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `postText`   | once per string **value** leaf, after Layers 1–4         | returns `{cleaned?, warning?}`; `cleaned` replaces the model-facing text             |
+| `redactNote` | on the pre-redaction text of a leaf that tripped Layer 4 | returns a note appended to that leaf's redaction warning                             |
+| `audit`      | once per judged event carrying a tool response           | is handed the output the model will actually see, and the `session_id` it belongs to |
+| `trace`      | on every exit, in place of the package's trace channel   | receives the engagement announcement (see the trace sink below)                      |
 
 Omit the bag and every seam is inert — the verdicts are byte-identical to this
 module alone. A callback that throws is **not** caught: it lands in the CLI's
@@ -171,6 +172,33 @@ secret-shaped output is suppressed, not shown unvetted. Layers 1–3 still run.
 **Layer 5 (second-model injection filtering) is not included.** These hooks
 never supply the `/output` seam's `filterInjection` callback, so nothing here
 calls a model or leaves the machine.
+
+**Every hook's trace sink is injectable.** Each one announces that it engaged —
+that is what makes a layer that stopped running loud rather than silent — and by
+default that announcement goes to `_AGENT_SANITIZER_TRACE` /
+`_AGENT_SANITIZER_TRACE_FILE`. A host that already runs a trace channel under
+its own variables passes its own sink instead, so the announcement lands where
+its detector actually reads:
+
+```js
+import { cliMain } from "agent-sanitizer/claude-hooks/scan-invisible-chars";
+await cliMain({ trace: (event, fields) => myChannel.emit(event, fields) });
+```
+
+The sink is the last argument of each hook's entry point — `cliMain({trace})` on
+`scan-invisible-chars` and `pretooluse-sanitize`, the extension bag's `trace` on
+`sanitize-output`, and a trailing parameter on `sanitize-user-prompt`'s `main`.
+It receives the same `TraceEvent` names the default emits, and it **replaces**
+the default rather than running alongside it — the package channel goes silent,
+so there is one announcement to detect, not two.
+
+**A host's own cold-start marker can replace the derived one.** The hooks wait
+out an in-flight dependency install by polling a marker file whose path they
+derive from `CLAUDE_PROJECT_DIR`; a host whose setup script already writes one
+calls `configureHookgateMarker(path)` (from `lib/hook-io`) before importing any
+hook module, and every consumer waits on that path instead. `lib/control-plane`
+resolves the marker at module scope, so a call that lands after that import
+warns on stderr — it cannot steer the wait that already started.
 
 Hook internals are tuned by `_AGENT_SANITIZER_*` variables (redactor daemon
 path/socket/timeouts, sanitize budget, trace channel, Layer-2 reveal dir). The

--- a/README.md
+++ b/README.md
@@ -185,12 +185,14 @@ import { cliMain } from "agent-sanitizer/claude-hooks/scan-invisible-chars";
 await cliMain({ trace: (event, fields) => myChannel.emit(event, fields) });
 ```
 
-The sink is the last argument of each hook's entry point — `cliMain({trace})` on
+The sink rides each hook's options bag — `cliMain({trace})` on
 `scan-invisible-chars` and `pretooluse-sanitize`, the extension bag's `trace` on
-`sanitize-output`, and a trailing parameter on `sanitize-user-prompt`'s `main`.
-It receives the same `TraceEvent` names the default emits, and it **replaces**
-the default rather than running alongside it — the package channel goes silent,
-so there is one announcement to detect, not two.
+`sanitize-output`, `main(read, write, {trace})` on `sanitize-user-prompt`. It
+receives the same `TraceEvent` names the default emits, and it **replaces** the
+default rather than running alongside it — the package channel goes silent, so
+there is one announcement to detect, not two. It may throw freely: each hook
+binds the sink it is given through `bestEffortTrace`, so an announcement can
+never be the thing that breaks a hook.
 
 **A host's own cold-start marker can replace the derived one.** The hooks wait
 out an in-flight dependency install by polling a marker file whose path they

--- a/claude-hooks/lib/hook-io.mjs
+++ b/claude-hooks/lib/hook-io.mjs
@@ -395,6 +395,43 @@ export function emitHookResponse(hookEventName, fields) {
 const HOOKGATE_MARKER_STEM = "agent-sanitizer-hookgate-inflight-";
 
 /**
+ * Host-supplied marker path, replacing the derived one. Null (the default) keeps
+ * the derivation below.
+ * @type {string | null}
+ */
+let hookgateMarkerOverride = null;
+
+/** Whether {@link hookgateMarkerPath} has already handed a path to a caller. */
+let hookgateMarkerResolved = false;
+
+/**
+ * Adopt a host's own cold-start marker path in place of the derived one, so a
+ * host whose setup script already writes a marker under its own convention can
+ * use these hooks without running a second, disagreeing wait loop against a path
+ * nothing writes.
+ *
+ * ORDERING, same rule as {@link registerLazyModules}: call this before importing
+ * any hook module. `lib/control-plane.mjs` resolves the marker at MODULE scope,
+ * so a call that lands after that import cannot reach the wait it was meant to
+ * steer. A late call is reported on stderr rather than thrown: a throw at a
+ * bundle entry's top level kills the hook process before it writes a response,
+ * and a hook that emits nothing is read as non-blocking — the fail-OPEN this
+ * whole file is built to avoid. The late call still takes effect for every
+ * later resolution.
+ * @param {string | null} path  absolute marker path, or null to restore the derivation
+ * @returns {void}
+ */
+export function configureHookgateMarker(path) {
+  if (hookgateMarkerResolved)
+    process.stderr.write(
+      "agent-sanitizer: configureHookgateMarker called after a marker path was " +
+        "already resolved; whatever resolved it is using the previous path and " +
+        "cannot be re-steered. Call it before importing any hook module.\n",
+    );
+  hookgateMarkerOverride = path;
+}
+
+/**
  * Path of the cold-start in-flight marker a host's setup script writes
  * SYNCHRONOUSLY before it starts installing deps (its own PID as the contents)
  * and removes once the hook dependencies are provisioned. A hook that fires
@@ -405,7 +442,8 @@ const HOOKGATE_MARKER_STEM = "agent-sanitizer-hookgate-inflight-";
  * the raw CLAUDE_PROJECT_DIR the harness sets for both processes (no
  * canonicalization — the two must produce byte-identical paths), so no env has
  * to propagate from setup to the hook. Null when CLAUDE_PROJECT_DIR is unset (no
- * setup ran → nothing to wait on).
+ * setup ran → nothing to wait on), or whatever a host set via
+ * {@link configureHookgateMarker}.
  * @param {string | undefined} [projectDir]
  * @param {string | undefined} [runtimeDir]
  * @returns {string | null}
@@ -414,6 +452,8 @@ export function hookgateMarkerPath(
   projectDir = process.env.CLAUDE_PROJECT_DIR,
   runtimeDir = process.env.XDG_RUNTIME_DIR,
 ) {
+  hookgateMarkerResolved = true;
+  if (hookgateMarkerOverride !== null) return hookgateMarkerOverride;
   if (!projectDir) return null;
   // Prefer the per-user, mode-0700 runtime dir when the harness gives an
   // absolute one; else the world-writable /tmp, where markerIsTrusted() — not

--- a/claude-hooks/lib/trace.mjs
+++ b/claude-hooks/lib/trace.mjs
@@ -9,9 +9,23 @@
  *
  * METADATA ONLY — never pass a tool_input body or secret material as a field; the
  * channel is not redaction-aware.
+ *
+ * The sink is INJECTABLE. A host that already runs a trace channel under its own
+ * environment variables — and a detector that reds when a defense layer stops
+ * announcing itself — passes its own {@link TraceFn} to each hook's entry point
+ * (`cliMain`, or `main` for the prompt gate) instead of forking this module. Left
+ * unsupplied, every hook uses {@link trace} below, so the shipped behavior is
+ * unchanged.
  */
 
 import { appendFileSync } from "node:fs";
+
+/**
+ * The sink shape a hook emits through: the event name, its metadata fields, and
+ * the level. A host implementation receives the same {@link TraceEvent} names the
+ * default emits, so it can remap them onto its own channel's vocabulary.
+ * @typedef {(event: string, fields?: Record<string, unknown>, level?: "info"|"debug") => void} TraceFn
+ */
 
 /** Trace-channel event names. */
 export const TraceEvent = Object.freeze({

--- a/claude-hooks/lib/trace.mjs
+++ b/claude-hooks/lib/trace.mjs
@@ -24,6 +24,10 @@ import { appendFileSync } from "node:fs";
  * The sink shape a hook emits through: the event name, its metadata fields, and
  * the level. A host implementation receives the same {@link TraceEvent} names the
  * default emits, so it can remap them onto its own channel's vocabulary.
+ *
+ * A sink is NOT required to be total — throw freely. Every hook binds the one it
+ * was given through {@link bestEffortTrace}, which is what upholds the channel's
+ * never-breaks-a-hook posture on host code that cannot promise it.
  * @typedef {(event: string, fields?: Record<string, unknown>, level?: "info"|"debug") => void} TraceFn
  */
 
@@ -71,4 +75,32 @@ export function trace(event, fields = {}, level = "info") {
   } catch {
     // best-effort: a trace we can't write must never break a hook.
   }
+}
+
+/**
+ * `sink` with {@link trace}'s best-effort posture forced onto it: a throw is
+ * swallowed, so an announcement can never break the hook making it.
+ *
+ * This is what makes the sink safely injectable. The announcement call sites were
+ * placed under the guarantee that emitting cannot fail, and one of them relies on
+ * it outright: scan-invisible-chars announces BEFORE it auto-cleans the
+ * contaminated instruction files and arms the PreToolUse gate, with no catch
+ * above it, so a throwing sink there would abort the scan — leaving the payload on
+ * disk, the gate un-armed, and NO announcement on any channel. The loss the
+ * announcement exists to make loud would itself be silent.
+ *
+ * Swallowing is right here and is not licence to swallow elsewhere in this tree:
+ * a dropped announcement is already loud in the host's own detector — that is what
+ * a trace channel is — whereas a killed hook is loud nowhere.
+ * @param {TraceFn} sink
+ * @returns {TraceFn}
+ */
+export function bestEffortTrace(sink) {
+  return (event, fields, level) => {
+    try {
+      sink(event, fields, level);
+    } catch {
+      // See above: an announcement must never be the thing that breaks a hook.
+    }
+  };
 }

--- a/claude-hooks/pretooluse-sanitize.mjs
+++ b/claude-hooks/pretooluse-sanitize.mjs
@@ -50,7 +50,7 @@ import {
   authoredContext,
 } from "./lib/authored-content.mjs";
 import { redactViaDaemon } from "./lib/redactor-client.mjs";
-import { trace, TraceEvent } from "./lib/trace.mjs";
+import { bestEffortTrace, trace, TraceEvent } from "./lib/trace.mjs";
 
 const HOOK_NAME = "pretooluse-sanitize";
 
@@ -174,15 +174,18 @@ function emitTraced(emitTrace, toolName, fields) {
  * @param {(tool: string, toolInput: any) => ReturnType<typeof rehydrateRedacted>} [rehydrate]
  * injectable for tests; the default binds the real redactor-daemon io (the
  * layer reads the target file and maps secrets through the daemon)
- * @param {import("./lib/trace.mjs").TraceFn} [emitTrace]  where engagement is
+ * @param {import("./lib/trace.mjs").TraceFn} [sink]  where engagement is
  * announced; a host with its own trace channel passes its sink (see lib/trace.mjs)
  * @returns {Promise<Record<string, unknown> | null>}
  */
 export async function buildPreToolUseResponse(
   input,
   rehydrate = defaultRehydrate,
-  emitTrace = trace,
+  sink = trace,
 ) {
+  // Every path into the announcement runs through here, so this is the one place
+  // a host sink has to be made best-effort (see bestEffortTrace).
+  const emitTrace = bestEffortTrace(sink);
   const asks = [];
   const contexts = [];
 

--- a/claude-hooks/pretooluse-sanitize.mjs
+++ b/claude-hooks/pretooluse-sanitize.mjs
@@ -150,18 +150,19 @@ const defaultRehydrate = (tool, toolInput) =>
  * it unchanged. The trace lives on this in-process, mutation-tested path, not in
  * the CLI block, so engagement is announced (hook_ran — metadata only: hook
  * name, tool, outcome) for every exit.
+ * @param {import("./lib/trace.mjs").TraceFn} emitTrace
  * @param {string} toolName
  * @param {Record<string, unknown> | null} fields
  * @returns {Record<string, unknown> | null}
  */
-function emitTraced(toolName, fields) {
+function emitTraced(emitTrace, toolName, fields) {
   let outcome = "modified";
   if (fields === null) outcome = "noop";
   else if (fields.permissionDecision === PermissionDecision.DENY)
     outcome = "deny";
   else if (fields.permissionDecision === PermissionDecision.ASK)
     outcome = "ask";
-  trace(TraceEvent.HOOK_RAN, { hook: HOOK_NAME, tool: toolName, outcome });
+  emitTrace(TraceEvent.HOOK_RAN, { hook: HOOK_NAME, tool: toolName, outcome });
   return fields;
 }
 
@@ -173,11 +174,14 @@ function emitTraced(toolName, fields) {
  * @param {(tool: string, toolInput: any) => ReturnType<typeof rehydrateRedacted>} [rehydrate]
  * injectable for tests; the default binds the real redactor-daemon io (the
  * layer reads the target file and maps secrets through the daemon)
+ * @param {import("./lib/trace.mjs").TraceFn} [emitTrace]  where engagement is
+ * announced; a host with its own trace channel passes its sink (see lib/trace.mjs)
  * @returns {Promise<Record<string, unknown> | null>}
  */
 export async function buildPreToolUseResponse(
   input,
   rehydrate = defaultRehydrate,
+  emitTrace = trace,
 ) {
   const asks = [];
   const contexts = [];
@@ -227,7 +231,7 @@ export async function buildPreToolUseResponse(
   // above, so it returns immediately.
   const rehydrated = await rehydrate(tool, current);
   if (rehydrated && "deny" in rehydrated)
-    return emitTraced(input.tool_name, {
+    return emitTraced(emitTrace, input.tool_name, {
       permissionDecision: PermissionDecision.DENY,
       permissionDecisionReason: rehydrated.deny,
     });
@@ -238,6 +242,7 @@ export async function buildPreToolUseResponse(
   }
 
   return emitTraced(
+    emitTrace,
     input.tool_name,
     assembleResponse({ changed, current, asks, contexts, pendingGateAck }),
   );
@@ -290,12 +295,16 @@ function assembleResponse({
  * fail-closed posture holds even when the adapter never loaded.
  * @param {import("agent-control-plane-core").ToolCallEvent} event
  * @param {(tool: string, toolInput: any) => ReturnType<typeof rehydrateRedacted>} [rehydrate]
- * @param {{ messages?: Partial<typeof PRE_TOOL_USE_MESSAGES>, gates?: HostGate[] }} [opts]
+ * @param {{
+ *   messages?: Partial<typeof PRE_TOOL_USE_MESSAGES>,
+ *   gates?: HostGate[],
+ *   trace?: import("./lib/trace.mjs").TraceFn,
+ * }} [opts]
  *   messages are merged over the defaults, so a partial table is supported
  * @returns {Promise<import("agent-control-plane-core").Verdict>}
  */
 export async function judgePreToolUseSanitize(event, rehydrate, opts = {}) {
-  const { gates = [] } = opts;
+  const { gates = [], trace: emitTrace = trace } = opts;
   // MERGED over the defaults, never substituted for them. A host that overrides
   // one field would otherwise leave the rest undefined, and the miss lands in
   // the fail-closed path: failClosedFields runs inside runJudgeCli's catch, so a
@@ -327,7 +336,7 @@ export async function judgePreToolUseSanitize(event, rehydrate, opts = {}) {
     const denyReason = gate(input);
     if (denyReason) return { decision: Decision.DENY, reason: denyReason };
   }
-  const fields = await buildPreToolUseResponse(input, rehydrate);
+  const fields = await buildPreToolUseResponse(input, rehydrate, emitTrace);
   if (fields === null) return { decision: Decision.ALLOW };
   /** @type {Record<string, unknown>} */
   const verdict = {
@@ -419,15 +428,21 @@ export function failClosedFields(parsedOk, err, opts = {}) {
  * @param {{
  *   messages?: Partial<typeof PRE_TOOL_USE_MESSAGES>,
  *   gates?: HostGate[],
+ *   trace?: import("./lib/trace.mjs").TraceFn,
  * }} [opts]
  * @returns {Promise<void>}
  */
 export async function cliMain(opts = {}) {
-  const { gates = [] } = opts;
+  const { gates = [], trace: emitTrace = trace } = opts;
   const messages = { ...PRE_TOOL_USE_MESSAGES, ...opts.messages };
   await runJudgeCli(
     HOOK_NAME,
-    (event) => judgePreToolUseSanitize(event, undefined, { messages, gates }),
+    (event) =>
+      judgePreToolUseSanitize(event, undefined, {
+        messages,
+        gates,
+        trace: emitTrace,
+      }),
     {
       // Fail closed WITHOUT the package: unparsable INPUT (`input` undefined)
       // hard-denies (adversary-inducible, no benefit to failing); any throw

--- a/claude-hooks/sanitize-output.mjs
+++ b/claude-hooks/sanitize-output.mjs
@@ -192,9 +192,17 @@ async function redactSecrets(text, webIngress = false, deadline) {
  * @property {(raw: string) => string | undefined} [redactNote]
  *   Given the pre-redaction text of a leaf that tripped Layer 4, returns a note
  *   appended to that leaf's "API keys/secrets redacted: …" warning.
- * @property {(record: { tool: string | null, modified: boolean, output: unknown, context?: string }) => Promise<void> | void} [audit]
+ * @property {(record: { tool: string | null, session_id?: string, modified: boolean, output: unknown, context?: string }) => Promise<void> | void} [audit]
  *   Awaited once per judged event that carried a tool response, with the output
- *   the model will actually see.
+ *   the model will actually see. `session_id` is the harness's session identity,
+ *   lifted from the event's `meta` — an audit trail that cannot say WHICH session
+ *   produced a record cannot be read back per-session, and the tool fields alone
+ *   do not carry it. Absent when the payload omitted it.
+ * @property {import("./lib/trace.mjs").TraceFn} [trace]
+ *   Where this hook announces engagement. A host that already runs a trace
+ *   channel under its own environment variables passes its sink here, so the
+ *   announcement lands where its detector reads instead of on this package's
+ *   channel. Defaults to lib/trace.mjs's `trace`.
  * @property {string} [remedy]
  *   What a reader should run when the sanitizer's own bindings are what is
  *   missing. This hook's host channel is `ext`, where the other two gates use a
@@ -578,7 +586,7 @@ export async function evaluateToolOutput(input, ext = {}) {
    * @returns {{ mutated_output?: unknown, additional_context?: string } | null}
    */
   const emit = (outcome, fields) => {
-    trace(TraceEvent.HOOK_RAN, {
+    (ext.trace ?? trace)(TraceEvent.HOOK_RAN, {
       hook: HOOK_NAME,
       tool: input.tool_name,
       outcome,
@@ -716,6 +724,10 @@ export async function judgeSanitizeOutput(event, ext = {}) {
     const modified = fields !== null && Object.hasOwn(fields, "mutated_output");
     await ext.audit({
       tool: event.tool,
+      // The session identity travels in `meta`, not alongside the tool fields, so
+      // a recorder filing one trail per session cannot reach it unless it is
+      // lifted here.
+      session_id: event.meta?.session_id,
       modified,
       output: modified ? fields?.mutated_output : event.response,
       context: fields?.additional_context,

--- a/claude-hooks/sanitize-output.mjs
+++ b/claude-hooks/sanitize-output.mjs
@@ -34,7 +34,7 @@ import {
   HookEvent,
 } from "./lib/hook-io.mjs";
 import { controlPlane, runJudgeCli } from "./lib/control-plane.mjs";
-import { trace, TraceEvent } from "./lib/trace.mjs";
+import { bestEffortTrace, trace, TraceEvent } from "./lib/trace.mjs";
 import { hasEnvBoundSecret } from "./lib/secret-annotate.mjs";
 import {
   persistReveal,
@@ -580,13 +580,16 @@ export function emitFailClosed(
  * @returns {Promise<{ mutated_output?: unknown, additional_context?: string } | null>}
  */
 export async function evaluateToolOutput(input, ext = {}) {
+  // Best-effort, like the default sink: a host callback that throws must not be
+  // the thing that suppresses a tool output (see bestEffortTrace).
+  const emitTrace = bestEffortTrace(ext.trace ?? trace);
   /**
    * @param {string} outcome  noop | clean | flagged | modified
    * @param {{ mutated_output?: unknown, additional_context?: string } | null} fields
    * @returns {{ mutated_output?: unknown, additional_context?: string } | null}
    */
   const emit = (outcome, fields) => {
-    (ext.trace ?? trace)(TraceEvent.HOOK_RAN, {
+    emitTrace(TraceEvent.HOOK_RAN, {
       hook: HOOK_NAME,
       tool: input.tool_name,
       outcome,

--- a/claude-hooks/sanitize-user-prompt.mjs
+++ b/claude-hooks/sanitize-user-prompt.mjs
@@ -165,6 +165,8 @@ export function judgeSanitizeUserPrompt(
  *   to the package's stripAnsiFully; injectable so the fail-closed path is testable)
  * @param {Partial<typeof USER_PROMPT_MESSAGES>} [overrides]  reason overrides,
  *   merged over the defaults so a partial table can never leave a field unset
+ * @param {import("./lib/trace.mjs").TraceFn} [emitTrace]  where engagement is
+ *   announced; a host with its own trace channel passes its sink (see lib/trace.mjs)
  * @returns {Promise<void>}
  */
 export async function main(
@@ -172,6 +174,7 @@ export async function main(
   write,
   strip = stripAnsiFully,
   overrides = USER_PROMPT_MESSAGES,
+  emitTrace = trace,
 ) {
   // Merged, not substituted — see judgeSanitizeUserPrompt. onError below is the
   // call site where a missing field would throw out of the catch and fail OPEN.
@@ -189,7 +192,7 @@ export async function main(
       const verdict = judgeSanitizeUserPrompt(event, strip, messages);
       // Announce engagement on the trace channel like the other stdin hooks —
       // a prompt gate that silently stopped running is otherwise invisible.
-      trace(TraceEvent.HOOK_RAN, {
+      emitTrace(TraceEvent.HOOK_RAN, {
         hook: "sanitize-user-prompt",
         outcome:
           verdict.decision === controlPlane().Decision.DENY

--- a/claude-hooks/sanitize-user-prompt.mjs
+++ b/claude-hooks/sanitize-user-prompt.mjs
@@ -27,7 +27,7 @@ import {
   DEFAULT_MISSING_PACKAGE_REMEDY,
 } from "./lib/hook-io.mjs";
 import { controlPlane, runJudgeCli } from "./lib/control-plane.mjs";
-import { trace, TraceEvent } from "./lib/trace.mjs";
+import { bestEffortTrace, trace, TraceEvent } from "./lib/trace.mjs";
 // classifyPrompt (the user-prompt verdict) and stripAnsiFully (its ANSI stripper)
 // come from the agent-sanitizer package. They are bound by a *caught* dynamic
 // import, never a bare top-level `import … from "…"`: a static npm import
@@ -159,23 +159,30 @@ export function judgeSanitizeUserPrompt(
 }
 
 /**
+ * `read` and `write` stay positional — every caller supplies both — while the
+ * injectable seams ride in one bag, so a host supplying only the last of them does
+ * not have to pass `undefined` for the others.
  * @param {() => Promise<any> | any} read
  * @param {(chunk: string) => void} write
- * @param {((s: string) => string) | null} [strip]  the ANSI stripper (defaults
- *   to the package's stripAnsiFully; injectable so the fail-closed path is testable)
- * @param {Partial<typeof USER_PROMPT_MESSAGES>} [overrides]  reason overrides,
- *   merged over the defaults so a partial table can never leave a field unset
- * @param {import("./lib/trace.mjs").TraceFn} [emitTrace]  where engagement is
- *   announced; a host with its own trace channel passes its sink (see lib/trace.mjs)
+ * @param {{
+ *   strip?: ((s: string) => string) | null,
+ *   overrides?: Partial<typeof USER_PROMPT_MESSAGES>,
+ *   trace?: import("./lib/trace.mjs").TraceFn,
+ * }} [opts]
+ *   `strip` is the ANSI stripper (defaults to the package's stripAnsiFully;
+ *   injectable so the fail-closed path is testable); `overrides` are reason
+ *   overrides, merged over the defaults so a partial table can never leave a field
+ *   unset; `trace` is where engagement is announced, for a host with its own trace
+ *   channel (see lib/trace.mjs).
  * @returns {Promise<void>}
  */
-export async function main(
-  read,
-  write,
-  strip = stripAnsiFully,
-  overrides = USER_PROMPT_MESSAGES,
-  emitTrace = trace,
-) {
+export async function main(read, write, opts = {}) {
+  const {
+    strip = stripAnsiFully,
+    overrides = USER_PROMPT_MESSAGES,
+    trace: sink = trace,
+  } = opts;
+  const emitTrace = bestEffortTrace(sink);
   // Merged, not substituted — see judgeSanitizeUserPrompt. onError below is the
   // call site where a missing field would throw out of the catch and fail OPEN.
   const messages = { ...USER_PROMPT_MESSAGES, ...overrides };

--- a/claude-hooks/scan-invisible-chars.mjs
+++ b/claude-hooks/scan-invisible-chars.mjs
@@ -271,9 +271,12 @@ function scanProject() {
  * the alert for the PreToolUse gate otherwise. Exported so a bundle entry
  * (which must claim the CLI slot before this module loads) can run the exact
  * same scan instead of duplicating it.
+ * @param {{ trace?: import("./lib/trace.mjs").TraceFn }} [opts]  `trace` is where
+ *   this scan announces engagement; a host with its own trace channel passes its
+ *   sink so the announcement lands where its detector reads (see lib/trace.mjs).
  * @returns {Promise<void>}
  */
-export async function cliMain() {
+export async function cliMain({ trace: emitTrace = trace } = {}) {
   /* c8 ignore start -- fail-closed module-load guard: only reachable when the
      agent-sanitizer import above failed, which can't be simulated in the
      spawned-subprocess CLI run the tests observe. */
@@ -281,7 +284,7 @@ export async function cliMain() {
     // Emit the engagement event with a "skipped" outcome so the loss is LOUD on
     // the trace channel — a scan that never ran is otherwise invisible, and the
     // downstream PreToolUse sanitize gate then passes cleanly all session.
-    trace(TraceEvent.SCAN_INVISIBLE_CHARS_RAN, { outcome: "skipped" });
+    emitTrace(TraceEvent.SCAN_INVISIBLE_CHARS_RAN, { outcome: "skipped" });
     process.stderr.write(
       "scan-invisible-chars: agent-sanitizer failed to load (node deps not " +
         "installed and session-setup did not finish in time); instruction " +
@@ -304,10 +307,10 @@ export async function cliMain() {
   const allFindings = scanProject();
 
   if (allFindings.length === 0) {
-    trace(TraceEvent.SCAN_INVISIBLE_CHARS_RAN, { outcome: "clean" });
+    emitTrace(TraceEvent.SCAN_INVISIBLE_CHARS_RAN, { outcome: "clean" });
     return;
   }
-  trace(TraceEvent.SCAN_INVISIBLE_CHARS_RAN, {
+  emitTrace(TraceEvent.SCAN_INVISIBLE_CHARS_RAN, {
     outcome: "found",
     files: allFindings.length,
   });

--- a/claude-hooks/scan-invisible-chars.mjs
+++ b/claude-hooks/scan-invisible-chars.mjs
@@ -21,7 +21,7 @@ import {
   ALERT_ACK_FILE,
   PROJECT_DIR,
 } from "./lib/invisible-alert.mjs";
-import { trace, TraceEvent } from "./lib/trace.mjs";
+import { bestEffortTrace, trace, TraceEvent } from "./lib/trace.mjs";
 
 // Layer-1 primitives, bound via lazyImport (see its doc for the fail-OPEN
 // hazard of a bare static npm import — here the instruction files would load
@@ -276,7 +276,11 @@ function scanProject() {
  *   sink so the announcement lands where its detector reads (see lib/trace.mjs).
  * @returns {Promise<void>}
  */
-export async function cliMain({ trace: emitTrace = trace } = {}) {
+export async function cliMain({ trace: sink = trace } = {}) {
+  // Bound best-effort: the announcements below run BEFORE the auto-clean and
+  // the alert write, with no catch above them, so a throwing host sink would
+  // abort the scan silently (see bestEffortTrace).
+  const emitTrace = bestEffortTrace(sink);
   /* c8 ignore start -- fail-closed module-load guard: only reachable when the
      agent-sanitizer import above failed, which can't be simulated in the
      spawned-subprocess CLI run the tests observe. */

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -67361,6 +67361,14 @@ function trace(event, fields = {}, level = "info") {
   } catch {
   }
 }
+function bestEffortTrace(sink) {
+  return (event, fields, level) => {
+    try {
+      sink(event, fields, level);
+    } catch {
+    }
+  };
+}
 var TraceEvent, LEVELS;
 var init_trace2 = __esm({
   "claude-hooks/lib/trace.mjs"() {
@@ -67395,7 +67403,8 @@ function emitTraced(emitTrace, toolName, fields) {
   emitTrace(TraceEvent.HOOK_RAN, { hook: HOOK_NAME, tool: toolName, outcome });
   return fields;
 }
-async function buildPreToolUseResponse(input, rehydrate = defaultRehydrate, emitTrace = trace) {
+async function buildPreToolUseResponse(input, rehydrate = defaultRehydrate, sink = trace) {
+  const emitTrace = bestEffortTrace(sink);
   const asks = [];
   const contexts = [];
   const findings = invisibleCharAlert();
@@ -67852,8 +67861,9 @@ function emitFailClosed(input, message, emit = (fields) => emitHookResponse(Hook
   }
 }
 async function evaluateToolOutput(input, ext = {}) {
+  const emitTrace = bestEffortTrace(ext.trace ?? trace);
   const emit = (outcome, fields2) => {
-    (ext.trace ?? trace)(TraceEvent.HOOK_RAN, {
+    emitTrace(TraceEvent.HOOK_RAN, {
       hook: HOOK_NAME2,
       tool: input.tool_name,
       outcome
@@ -68026,7 +68036,13 @@ function judgeSanitizeUserPrompt(event, strip = stripAnsiFully3, overrides = USE
     additional_context: messages.blockContext
   };
 }
-async function main(read, write, strip = stripAnsiFully3, overrides = USER_PROMPT_MESSAGES, emitTrace = trace) {
+async function main(read, write, opts = {}) {
+  const {
+    strip = stripAnsiFully3,
+    overrides = USER_PROMPT_MESSAGES,
+    trace: sink = trace
+  } = opts;
+  const emitTrace = bestEffortTrace(sink);
   const messages = { ...USER_PROMPT_MESSAGES, ...overrides };
   await runJudgeCli(
     "sanitize-user-prompt",
@@ -68225,7 +68241,8 @@ function scanProject() {
   }
   return allFindings;
 }
-async function cliMain3({ trace: emitTrace = trace } = {}) {
+async function cliMain3({ trace: sink = trace } = {}) {
+  const emitTrace = bestEffortTrace(sink);
   if (!await ensureSanitizerLoaded()) {
     emitTrace(TraceEvent.SCAN_INVISIBLE_CHARS_RAN, { outcome: "skipped" });
     process.stderr.write(

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -164,6 +164,8 @@ function emitHookResponse(hookEventName, fields) {
   );
 }
 function hookgateMarkerPath(projectDir = process.env.CLAUDE_PROJECT_DIR, runtimeDir = process.env.XDG_RUNTIME_DIR) {
+  hookgateMarkerResolved = true;
+  if (hookgateMarkerOverride !== null) return hookgateMarkerOverride;
   if (!projectDir) return null;
   const base2 = runtimeDir && runtimeDir.startsWith("/") ? runtimeDir : "/tmp";
   const digest = createHash("sha256").update(projectDir).digest("hex").slice(0, 8);
@@ -266,7 +268,7 @@ function writeFileNoFollow(path2, content3, mode = 384) {
     closeSync(fd);
   }
 }
-var cliEntryClaimed, HookEvent, PermissionDecision, LONE_SURROGATE_RE, MAX_STDIN_BYTES, registeredLazyModules, lazyImportErrors, DEFAULT_MISSING_PACKAGE_REMEDY, UNTRUSTED_TEXT_CAP, HOOKGATE_MARKER_STEM;
+var cliEntryClaimed, HookEvent, PermissionDecision, LONE_SURROGATE_RE, MAX_STDIN_BYTES, registeredLazyModules, lazyImportErrors, DEFAULT_MISSING_PACKAGE_REMEDY, UNTRUSTED_TEXT_CAP, HOOKGATE_MARKER_STEM, hookgateMarkerOverride, hookgateMarkerResolved;
 var init_hook_io = __esm({
   "claude-hooks/lib/hook-io.mjs"() {
     "use strict";
@@ -289,6 +291,8 @@ var init_hook_io = __esm({
     DEFAULT_MISSING_PACKAGE_REMEDY = "reinstall the hook dependencies (pnpm install) and retry.";
     UNTRUSTED_TEXT_CAP = 500;
     HOOKGATE_MARKER_STEM = "agent-sanitizer-hookgate-inflight-";
+    hookgateMarkerOverride = null;
+    hookgateMarkerResolved = false;
   }
 });
 
@@ -67381,17 +67385,17 @@ __export(pretooluse_sanitize_exports, {
 });
 import { createRequire as createRequire4 } from "node:module";
 import { readFileSync as readFileSync3 } from "node:fs";
-function emitTraced(toolName, fields) {
+function emitTraced(emitTrace, toolName, fields) {
   let outcome = "modified";
   if (fields === null) outcome = "noop";
   else if (fields.permissionDecision === PermissionDecision.DENY)
     outcome = "deny";
   else if (fields.permissionDecision === PermissionDecision.ASK)
     outcome = "ask";
-  trace(TraceEvent.HOOK_RAN, { hook: HOOK_NAME, tool: toolName, outcome });
+  emitTrace(TraceEvent.HOOK_RAN, { hook: HOOK_NAME, tool: toolName, outcome });
   return fields;
 }
-async function buildPreToolUseResponse(input, rehydrate = defaultRehydrate) {
+async function buildPreToolUseResponse(input, rehydrate = defaultRehydrate, emitTrace = trace) {
   const asks = [];
   const contexts = [];
   const findings = invisibleCharAlert();
@@ -67423,7 +67427,7 @@ async function buildPreToolUseResponse(input, rehydrate = defaultRehydrate) {
   }
   const rehydrated = await rehydrate(tool, current);
   if (rehydrated && "deny" in rehydrated)
-    return emitTraced(input.tool_name, {
+    return emitTraced(emitTrace, input.tool_name, {
       permissionDecision: PermissionDecision.DENY,
       permissionDecisionReason: rehydrated.deny
     });
@@ -67433,6 +67437,7 @@ async function buildPreToolUseResponse(input, rehydrate = defaultRehydrate) {
     contexts.push(rehydrated.context);
   }
   return emitTraced(
+    emitTrace,
     input.tool_name,
     assembleResponse({ changed, current, asks, contexts, pendingGateAck })
   );
@@ -67456,7 +67461,7 @@ function assembleResponse({
   return fields;
 }
 async function judgePreToolUseSanitize(event, rehydrate, opts = {}) {
-  const { gates = [] } = opts;
+  const { gates = [], trace: emitTrace = trace } = opts;
   const messages = { ...PRE_TOOL_USE_MESSAGES, ...opts.messages };
   const { Decision: Decision3, EventKind: EventKind3 } = controlPlane();
   if (event.event === EventKind3.UNKNOWN)
@@ -67470,7 +67475,7 @@ async function judgePreToolUseSanitize(event, rehydrate, opts = {}) {
     const denyReason = gate(input);
     if (denyReason) return { decision: Decision3.DENY, reason: denyReason };
   }
-  const fields = await buildPreToolUseResponse(input, rehydrate);
+  const fields = await buildPreToolUseResponse(input, rehydrate, emitTrace);
   if (fields === null) return { decision: Decision3.ALLOW };
   const verdict = {
     decision: fields.permissionDecision ?? Decision3.ALLOW
@@ -67506,11 +67511,15 @@ function failClosedFields(parsedOk, err, opts = {}) {
   };
 }
 async function cliMain(opts = {}) {
-  const { gates = [] } = opts;
+  const { gates = [], trace: emitTrace = trace } = opts;
   const messages = { ...PRE_TOOL_USE_MESSAGES, ...opts.messages };
   await runJudgeCli(
     HOOK_NAME,
-    (event) => judgePreToolUseSanitize(event, void 0, { messages, gates }),
+    (event) => judgePreToolUseSanitize(event, void 0, {
+      messages,
+      gates,
+      trace: emitTrace
+    }),
     {
       // Fail closed WITHOUT the package: unparsable INPUT (`input` undefined)
       // hard-denies (adversary-inducible, no benefit to failing); any throw
@@ -67844,7 +67853,7 @@ function emitFailClosed(input, message, emit = (fields) => emitHookResponse(Hook
 }
 async function evaluateToolOutput(input, ext = {}) {
   const emit = (outcome, fields2) => {
-    trace(TraceEvent.HOOK_RAN, {
+    (ext.trace ?? trace)(TraceEvent.HOOK_RAN, {
       hook: HOOK_NAME2,
       tool: input.tool_name,
       outcome
@@ -67907,6 +67916,10 @@ async function judgeSanitizeOutput(event, ext = {}) {
     const modified = fields !== null && Object.hasOwn(fields, "mutated_output");
     await ext.audit({
       tool: event.tool,
+      // The session identity travels in `meta`, not alongside the tool fields, so
+      // a recorder filing one trail per session cannot reach it unless it is
+      // lifted here.
+      session_id: event.meta?.session_id,
       modified,
       output: modified ? fields?.mutated_output : event.response,
       context: fields?.additional_context
@@ -68013,13 +68026,13 @@ function judgeSanitizeUserPrompt(event, strip = stripAnsiFully3, overrides = USE
     additional_context: messages.blockContext
   };
 }
-async function main(read, write, strip = stripAnsiFully3, overrides = USER_PROMPT_MESSAGES) {
+async function main(read, write, strip = stripAnsiFully3, overrides = USER_PROMPT_MESSAGES, emitTrace = trace) {
   const messages = { ...USER_PROMPT_MESSAGES, ...overrides };
   await runJudgeCli(
     "sanitize-user-prompt",
     (event) => {
       const verdict = judgeSanitizeUserPrompt(event, strip, messages);
-      trace(TraceEvent.HOOK_RAN, {
+      emitTrace(TraceEvent.HOOK_RAN, {
         hook: "sanitize-user-prompt",
         outcome: verdict.decision === controlPlane().Decision.DENY ? "deny" : verdict.additional_context ? "note" : "allow"
       });
@@ -68212,9 +68225,9 @@ function scanProject() {
   }
   return allFindings;
 }
-async function cliMain3() {
+async function cliMain3({ trace: emitTrace = trace } = {}) {
   if (!await ensureSanitizerLoaded()) {
-    trace(TraceEvent.SCAN_INVISIBLE_CHARS_RAN, { outcome: "skipped" });
+    emitTrace(TraceEvent.SCAN_INVISIBLE_CHARS_RAN, { outcome: "skipped" });
     process.stderr.write(
       "scan-invisible-chars: agent-sanitizer failed to load (node deps not installed and session-setup did not finish in time); instruction files were NOT scanned for hidden Unicode. Run `pnpm install`.\n"
     );
@@ -68228,10 +68241,10 @@ async function cliMain3() {
   }
   const allFindings = scanProject();
   if (allFindings.length === 0) {
-    trace(TraceEvent.SCAN_INVISIBLE_CHARS_RAN, { outcome: "clean" });
+    emitTrace(TraceEvent.SCAN_INVISIBLE_CHARS_RAN, { outcome: "clean" });
     return;
   }
-  trace(TraceEvent.SCAN_INVISIBLE_CHARS_RAN, {
+  emitTrace(TraceEvent.SCAN_INVISIBLE_CHARS_RAN, {
     outcome: "found",
     files: allFindings.length
   });

--- a/test/claude-hooks-extensions.test.mjs
+++ b/test/claude-hooks-extensions.test.mjs
@@ -251,10 +251,10 @@ describe("redactNote", () => {
 });
 
 describe("audit", () => {
-  /** @param {any} response @param {any} ext */
-  const judge = (response, ext) =>
+  /** @param {any} response @param {any} ext @param {any} [meta] */
+  const judge = (response, ext, meta) =>
     judgeSanitizeOutput(
-      { event: "PostToolUse", tool: "Bash", input: {}, response },
+      { event: "PostToolUse", tool: "Bash", input: {}, response, meta },
       ext,
     );
 
@@ -265,10 +265,24 @@ describe("audit", () => {
     assert.equal(records.length, 1);
     assert.deepEqual(records[0], {
       tool: "Bash",
+      session_id: undefined,
       modified: false,
       output: "plain output",
       context: undefined,
     });
+  });
+
+  it("is handed the session the record belongs to", async () => {
+    /** @type {any[]} */
+    const records = [];
+    await judge(
+      "plain output",
+      { audit: (r) => records.push(r) },
+      { session_id: "sess-42" },
+    );
+    // The identity travels in `meta`, never alongside the tool fields, so a
+    // recorder that files one trail per session has no other way to reach it.
+    assert.equal(records[0].session_id, "sess-42");
   });
 
   it("is handed the mutated output the model will actually see", async () => {

--- a/test/claude-hooks-hookgate-marker.test.mjs
+++ b/test/claude-hooks-hookgate-marker.test.mjs
@@ -1,0 +1,96 @@
+/**
+ * The host override for the cold-start hookgate marker.
+ *
+ * The hooks wait out an in-flight `session-setup` by polling a marker file whose
+ * path they DERIVE from `CLAUDE_PROJECT_DIR`. A host whose own setup script
+ * already writes a marker — under its own naming convention — otherwise has two
+ * choices, both bad: adopt this package's stem and digest verbatim (pinning
+ * itself to our path forever), or run a second wait loop against a path nothing
+ * writes. `configureHookgateMarker` is the third option, and this file pins its
+ * two properties:
+ *
+ *   - LOAD-BEARING WHEN SUPPLIED. Every consumer that resolves through
+ *     `hookgateMarkerPath()` — the module-scope wait in lib/control-plane.mjs,
+ *     the lazy reload in scan-invisible-chars — sees the host's path, and the
+ *     trust check that guards the wait accepts a real file there.
+ *   - LOUD, NOT FATAL, WHEN LATE. control-plane.mjs resolves the marker at module
+ *     scope, so a configure call that lands after that import cannot steer the
+ *     wait it was meant to steer. That is reported on stderr and not thrown: a
+ *     throw at a bundle entry's top level kills the hook before it writes a
+ *     response, and a hook that emits nothing is read as non-blocking — a
+ *     fail-OPEN, which is a far worse outcome than a mis-timed override.
+ *
+ * hook-io is imported ALONE here, and nothing resolves a marker before the first
+ * test: importing a hook module would run control-plane's module-scope
+ * resolution first, and the before-anything-resolved case could then never be
+ * observed at all.
+ */
+import { describe, it, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { configureHookgateMarker, hookgateMarkerPath, markerIsTrusted } =
+  await import("../claude-hooks/lib/hook-io.mjs");
+
+const dir = mkdtempSync(join(tmpdir(), "sanitizer-marker-"));
+const HOST_MARKER = join(dir, "host-hookgate-inflight");
+
+/** Run `fn` with stderr captured, returning what it wrote. */
+function captureStderr(fn) {
+  /** @type {string[]} */
+  const written = [];
+  const original = process.stderr.write;
+  // @ts-expect-error -- narrower than the overloaded write signature; the
+  // callers here only ever pass a string chunk.
+  process.stderr.write = (chunk) => {
+    written.push(String(chunk));
+    return true;
+  };
+  try {
+    fn();
+  } finally {
+    process.stderr.write = original;
+  }
+  return written.join("");
+}
+
+describe("configureHookgateMarker", () => {
+  it("replaces the derived path for every consumer", () => {
+    const warning = captureStderr(() => configureHookgateMarker(HOST_MARKER));
+    // Nothing has resolved a marker yet, so this call is in time and silent.
+    assert.equal(warning, "");
+    assert.equal(hookgateMarkerPath(), HOST_MARKER);
+    // Explicit arguments lose to the override too: a host that named its marker
+    // is naming it for every consumer, not just the env-derived ones.
+    assert.equal(
+      hookgateMarkerPath("/work/proj", "/run/user/1000"),
+      HOST_MARKER,
+    );
+  });
+
+  it("hands the wait a marker the trust check accepts", () => {
+    writeFileSync(HOST_MARKER, `${process.pid}\n`);
+    // markerIsTrusted is what gates the cold-start poll; resolving to a path it
+    // rejects would leave the wait permanently unarmed.
+    assert.equal(markerIsTrusted(hookgateMarkerPath()), true);
+  });
+
+  it("restores the derivation when passed null", () => {
+    captureStderr(() => configureHookgateMarker(null));
+    const derived = hookgateMarkerPath("/work/proj", "");
+    assert.ok(derived?.startsWith("/tmp/agent-sanitizer-hookgate-inflight-"));
+    assert.equal(hookgateMarkerPath("", ""), null);
+  });
+
+  it("warns rather than throws when it lands after a resolution", () => {
+    const warning = captureStderr(() => configureHookgateMarker(HOST_MARKER));
+    assert.match(warning, /configureHookgateMarker called after/u);
+    // The late call still governs every LATER resolution — the warning names
+    // what it could not reach, it does not discard the override.
+    assert.equal(hookgateMarkerPath(), HOST_MARKER);
+  });
+});
+
+after(() => rmSync(dir, { recursive: true, force: true }));

--- a/test/claude-hooks-trace-sink.test.mjs
+++ b/test/claude-hooks-trace-sink.test.mjs
@@ -1,0 +1,186 @@
+/**
+ * The injectable trace sink on all four hooks.
+ *
+ * Every hook announces that it ENGAGED on the trace channel, so a missing
+ * announcement is loud — that is the point of the channel. But the default sink
+ * is keyed to `_AGENT_SANITIZER_TRACE` / `_AGENT_SANITIZER_TRACE_FILE`, and a
+ * host that already runs a trace channel under ITS OWN variables, with a
+ * detector that reds when a defense layer stops announcing itself, would be
+ * adopting a hook whose announcement lands on a channel nothing reads: the layer
+ * looks disengaged while working fine. So each hook's entry point takes a sink.
+ *
+ * Two properties per hook, and the second is the load-bearing one:
+ *
+ *   - INERT BY DEFAULT. No sink supplied → the announcement still lands on the
+ *     package's own channel, byte-identically to before the seam existed.
+ *   - IT MOVES, IT DOES NOT COPY. A supplied sink receives the announcement and
+ *     the package channel receives NOTHING. A seam that merely forked the event
+ *     onto a second channel would leave the host's detector satisfied while the
+ *     package kept writing to a file the host never configured.
+ *
+ * Both are asserted for all four hooks member-by-member rather than for a
+ * representative one: the threading is hand-written per hook (an options bag
+ * here, an extension bag there, a positional parameter in the prompt gate), so a
+ * hook that drops the sink is exactly the regression this file exists to catch.
+ */
+import { describe, it, after } from "node:test";
+import assert from "node:assert/strict";
+import { Readable } from "node:stream";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// An empty project dir: the SessionStart scanner walks CLAUDE_PROJECT_DIR and
+// REWRITES contaminated instruction files, so pointing it at this repo would let
+// the test edit the tree. Set before the hook imports — invisible-alert.mjs
+// resolves the project dir at module load.
+const projectDir = mkdtempSync(join(tmpdir(), "sanitizer-trace-proj-"));
+process.env.CLAUDE_PROJECT_DIR = projectDir;
+process.env._AGENT_SANITIZER_TRACE = "info";
+
+const { TraceEvent } = await import("../claude-hooks/lib/trace.mjs");
+const preToolUse = await import("../claude-hooks/pretooluse-sanitize.mjs");
+const sanitizeOutput = await import("../claude-hooks/sanitize-output.mjs");
+const userPrompt = await import("../claude-hooks/sanitize-user-prompt.mjs");
+const scanInvisible = await import("../claude-hooks/scan-invisible-chars.mjs");
+
+const traceDir = mkdtempSync(join(tmpdir(), "sanitizer-trace-"));
+let traceFileSeq = 0;
+
+/**
+ * Point the package's default sink at a fresh file and return its path, so each
+ * case reads only its own run's lines.
+ */
+function freshTraceFile() {
+  traceFileSeq += 1;
+  const path = join(traceDir, `trace-${traceFileSeq}.jsonl`);
+  process.env._AGENT_SANITIZER_TRACE_FILE = path;
+  return path;
+}
+
+/** The JSON lines the package's default sink wrote to `path`. */
+function packageChannel(path) {
+  if (!existsSync(path)) return [];
+  return readFileSync(path, "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+/**
+ * Run `fn` with `payload` as the process's stdin and stdout swallowed — the
+ * stdin hooks read the real streams, and their rendered response would otherwise
+ * be interleaved into this runner's TAP output.
+ * @param {unknown} payload
+ * @param {() => Promise<void>} fn
+ */
+async function withStdio(payload, fn) {
+  const stdin = Object.getOwnPropertyDescriptor(process, "stdin");
+  const stdout = process.stdout.write;
+  Object.defineProperty(process, "stdin", {
+    value: Readable.from([Buffer.from(JSON.stringify(payload))]),
+    configurable: true,
+  });
+  // @ts-expect-error -- narrower than the overloaded write signature.
+  process.stdout.write = () => true;
+  try {
+    await fn();
+  } finally {
+    process.stdout.write = stdout;
+    if (stdin) Object.defineProperty(process, "stdin", stdin);
+  }
+}
+
+/**
+ * One entry per hook: how to run it with and without a host sink, and what its
+ * announcement looks like.
+ * @type {Array<{
+ *   name: string,
+ *   event: string,
+ *   run: (sink?: import("../claude-hooks/lib/trace.mjs").TraceFn) => Promise<void>,
+ * }>}
+ */
+const HOOKS = [
+  {
+    name: "pretooluse-sanitize",
+    event: TraceEvent.HOOK_RAN,
+    run: (sink) =>
+      withStdio(
+        {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_input: { command: "echo hi" },
+        },
+        () =>
+          sink ? preToolUse.cliMain({ trace: sink }) : preToolUse.cliMain(),
+      ),
+  },
+  {
+    name: "sanitize-output",
+    event: TraceEvent.HOOK_RAN,
+    run: (sink) =>
+      withStdio(
+        {
+          hook_event_name: "PostToolUse",
+          tool_name: "Bash",
+          tool_input: {},
+          tool_response: "plain output",
+        },
+        () =>
+          sink
+            ? sanitizeOutput.cliMain({ trace: sink })
+            : sanitizeOutput.cliMain(),
+      ),
+  },
+  {
+    name: "sanitize-user-prompt",
+    event: TraceEvent.HOOK_RAN,
+    run: (sink) => {
+      const read = () => ({
+        hook_event_name: "UserPromptSubmit",
+        prompt: "hello",
+      });
+      const write = () => {};
+      return sink
+        ? userPrompt.main(read, write, undefined, undefined, sink)
+        : userPrompt.main(read, write);
+    },
+  },
+  {
+    name: "scan-invisible-chars",
+    event: TraceEvent.SCAN_INVISIBLE_CHARS_RAN,
+    run: (sink) =>
+      sink ? scanInvisible.cliMain({ trace: sink }) : scanInvisible.cliMain(),
+  },
+];
+
+for (const hook of HOOKS) {
+  describe(hook.name, () => {
+    it("announces on the package channel when no sink is supplied", async () => {
+      const file = freshTraceFile();
+      await hook.run();
+      const events = packageChannel(file);
+      assert.equal(events.length, 1);
+      assert.equal(events[0].event, hook.event);
+    });
+
+    it("announces on an injected sink and NOT on the package channel", async () => {
+      const file = freshTraceFile();
+      /** @type {Array<[string, Record<string, unknown> | undefined]>} */
+      const host = [];
+      await hook.run((event, fields) => host.push([event, fields]));
+      // The host sees the same event name the default emits, so a detector can
+      // key on TraceEvent rather than on this package's file format.
+      assert.deepEqual(
+        host.map(([event]) => event),
+        [hook.event],
+      );
+      assert.deepEqual(packageChannel(file), []);
+    });
+  });
+}
+
+after(() => {
+  for (const dir of [traceDir, projectDir])
+    rmSync(dir, { recursive: true, force: true });
+});

--- a/test/claude-hooks-trace-sink.test.mjs
+++ b/test/claude-hooks-trace-sink.test.mjs
@@ -20,13 +20,21 @@
  *
  * Both are asserted for all four hooks member-by-member rather than for a
  * representative one: the threading is hand-written per hook (an options bag
- * here, an extension bag there, a positional parameter in the prompt gate), so a
- * hook that drops the sink is exactly the regression this file exists to catch.
+ * here, an extension bag there), so a hook that drops the sink is exactly the
+ * regression this file exists to catch. A third case per hook covers the sink
+ * THROWING, which host code is free to do and the announcement sites were written
+ * assuming it never would.
  */
 import { describe, it, after } from "node:test";
 import assert from "node:assert/strict";
 import { Readable } from "node:stream";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -142,7 +150,7 @@ const HOOKS = [
       });
       const write = () => {};
       return sink
-        ? userPrompt.main(read, write, undefined, undefined, sink)
+        ? userPrompt.main(read, write, { trace: sink })
         : userPrompt.main(read, write);
     },
   },
@@ -177,8 +185,53 @@ for (const hook of HOOKS) {
       );
       assert.deepEqual(packageChannel(file), []);
     });
+
+    it("survives a host sink that throws", async () => {
+      freshTraceFile();
+      // Host code carries no never-throws contract, and the announcement sites
+      // were placed under one — see bestEffortTrace, which is what makes this
+      // hold. scan-invisible-chars gets the assertion with teeth below.
+      await assert.doesNotReject(() =>
+        hook.run(() => {
+          throw new Error("host channel down");
+        }),
+      );
+    });
   });
 }
+
+// The one hook where a throwing sink costs more than an announcement: its
+// announcement runs BEFORE the auto-clean and the alert write, with no catch
+// above it, so an abort here leaves the payload on disk and the PreToolUse gate
+// un-armed — and says so on no channel at all. Asserted on the work, not on the
+// absence of a throw. Runs last: it contaminates the shared project dir the
+// cases above rely on being clean.
+describe("scan-invisible-chars with a throwing sink", () => {
+  it("still cleans the contaminated instruction file", async () => {
+    // Tag characters (U+E0041…) — a long enough run to clear the finding
+    // threshold, and the file is auto-cleanable, so the scan reaches the write.
+    const payload = Array.from({ length: 40 }, (_, i) =>
+      String.fromCodePoint(0xe0041 + (i % 26)),
+    ).join("");
+    const file = join(projectDir, "CLAUDE.md");
+    writeFileSync(file, `# Project\n\nhello${payload}world\n`);
+
+    const stderr = process.stderr.write;
+    // @ts-expect-error -- narrower than the overloaded write signature.
+    process.stderr.write = () => true;
+    try {
+      await scanInvisible.cliMain({
+        trace: () => {
+          throw new Error("host channel down");
+        },
+      });
+    } finally {
+      process.stderr.write = stderr;
+    }
+
+    assert.equal(readFileSync(file, "utf8").includes(payload), false);
+  });
+});
 
 after(() => {
   for (const dir of [traceDir, projectDir])


### PR DESCRIPTION
## Summary

Every hook announces that it engaged, so a layer that quietly stopped running is loud rather than silent. But the sink for that announcement was hard-coded to `_AGENT_SANITIZER_TRACE` / `_AGENT_SANITIZER_TRACE_FILE`, so a host that already runs its own trace channel — with a detector that alarms when a defense layer stops announcing itself — could not adopt any of the four hooks: the announcement lands on a channel the host reads nothing from, and a perfectly healthy layer reads as disengaged. Forking `lib/trace.mjs` was the only way out, which trades one fork for another.

Each hook's entry point now takes the sink as an argument. It **replaces** the default rather than running beside it, so a host that supplies one has exactly one announcement to detect, not two; supply nothing and behavior is unchanged. A host sink may throw — each hook binds the one it is given through `bestEffortTrace`, so an announcement can never be the thing that breaks a hook.

Two smaller adoption blockers in the same area ride along. The cold-start marker file the hooks poll while dependencies install had a path they derived themselves, so a host whose setup script already writes a marker had to adopt this package's filename verbatim or run a second, disagreeing wait loop — `configureHookgateMarker(path)` now points every consumer at the host's own. And `sanitize-output`'s audit callback was handed the tool, the output and the context but not the session, which lives on a different part of the event; a recorder filing one trail per session had no way to tell two sessions apart.

## Changes

- **Injectable trace sink, all four hooks.** `cliMain({trace})` on `scan-invisible-chars` and `pretooluse-sanitize`; the existing extension bag's `trace` on `sanitize-output`; `main(read, write, {trace})` on `sanitize-user-prompt`. The sink type ships as `TraceFn` from `lib/trace`, and receives the same `TraceEvent` names the default emits, so a host detector keys on the event rather than on this package's file format.
- **`bestEffortTrace`** binds each injected sink to the channel's never-breaks-a-hook posture, at the innermost point each hook's announcements share.
- **`configureHookgateMarker(path)`** in `lib/hook-io`, replacing the `CLAUDE_PROJECT_DIR`-derived marker path for every consumer; `null` restores the derivation.
- **`session_id` on the `ext.audit` record**, lifted from the event's `meta`.
- **`sanitize-user-prompt`'s `main` takes its injectable seams in one bag** — `{strip, overrides, trace}` — instead of growing to five positional parameters.
- README documents the seams under the existing host-composition section.
- The committed plugin bundle is regenerated (`node plugin/scripts/build-plugin.mjs`).

The other three extension points the adoption report asked for — `ext.postText`, `ext.redactNote`, `ext.remedy` — already exist on `main` and are unchanged here.

## Tests / verification

`pnpm test` (2131 tests), `pnpm lint`, `pnpm check`, `prettier --check .` — all green. Two new files:

- `test/claude-hooks-trace-sink.test.mjs` — three properties for all four hooks member-by-member: the announcement still lands on the package channel when no sink is supplied; lands **only** on an injected sink when one is; and a sink that throws does not break the hook. The second is load-bearing because a seam that merely forked the event onto a second channel would satisfy a host's detector while the package kept writing to a file the host never configured. The third gets an assertion with teeth on `scan-invisible-chars`: with a throwing sink, a contaminated `CLAUDE.md` is still cleaned — the work, not the absence of a throw.
- `test/claude-hooks-hookgate-marker.test.mjs` — the override reaches `markerIsTrusted`, the check that actually gates the cold-start poll, so it is asserted in terms of what the wait does rather than string equality alone.

Non-vacuity: every new and changed assertion was run against the code it is meant to catch. Against unmodified `origin/main` in a scratch worktree, 10 failed and 0 passed spuriously; with `bestEffortTrace` removed from `scan-invisible-chars`, both of that hook's throwing-sink cases go red. The inertness halves pass on both, which is what they are for.

## Review focus

`claude-hooks/lib/hook-io.mjs`. It is the one piece with module-level mutable state and an ordering requirement (`lib/control-plane.mjs` resolves the marker at module scope, so the configure call has to precede that import — the same rule `registerLazyModules` already carries). The part I am least sure of is the posture on a late call: it warns on stderr rather than throwing, because a throw at a bundle entry's top level kills the hook before it writes a response and a hook that emits nothing is read as non-blocking — a fail-open. A mis-ordered override, by contrast, only shortens the cold-start wait, which fails closed. If you would rather have the throw, that is a one-line change.

## Decisions made

- **Injected parameter over a configurable env-var name.** The alternative was `configureTrace({levelVar, fileVar})` on the module. The parameter composes with the existing extension-bag shape and needs no module-level state. Under the alternative a host would keep this package's file format and only rename the variables.
- **The sink replaces the default; it does not tee.** Emitting to both would leave the package writing to an unconfigured file forever, and give a host two announcements per engagement to reconcile. A host that wants both can call the exported `trace` from inside its own sink.
- **A throwing sink is swallowed, against this repo's general fail-loud rule.** A dropped announcement is already loud in the host's own detector — that is what a trace channel is for — whereas a hook killed mid-scan is loud nowhere. The swallow is confined to `bestEffortTrace` and documented there as not generalizing.
- **`sanitize-user-prompt`'s `main` signature changed rather than gaining a fifth positional.** `strip` and `overrides` move into the bag with `trace`. This is a breaking change to an exported subpath, taken now because the alternative is a five-positional signature that ships and then cannot be fixed cheaply; the README already scopes these composition exports as moving between minor versions, and per the repo's no-shims rule no alias is left behind. The only in-tree caller passed two arguments and is unaffected.
- **`sanitize-user-prompt` got the trace seam too**, though only the other three hooks were reported. Leaving one of four unable to redirect its trace means a host adopting all four still forks `lib/trace.mjs`, which is the thing this change exists to avoid.
- **The marker override uses module-level state**, unlike the trace sink. Its consumer resolves the path at module scope, so there is no parameter to thread — a settable configuration is the only shape that reaches it.
- **`session_id`, not `sessionId`.** It matches the `meta.session_id` field it is lifted from and the `session_id` the PreToolUse host-gate input already carries.

## Checklist

- [x] Commits follow Conventional Commits; each subject reads as a user-facing release note.
- [x] `pnpm test`, `pnpm lint`, and `pnpm check` pass locally.
- [x] No new detectors — this is a composition surface, not a detection change; the seams are asserted inert when unsupplied.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version left untouched.
