### PR TITLE
feat(claude-hooks): host-configurable missing-package remedy and env-secret source

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,16 @@ explicit per-call remedy (including a per-gate `MESSAGES.remedy`) still wins,
 and `null` restores the packaged wording. Keep it to a sentence: past ~260
 characters it overruns the 300-char message budget.
 
+**A host's own secret registry can drive the env-bound redaction set.**
+`configureEnvConfigSource({ minSecretLen, extraVars })` (from `lib/env-config`)
+replaces the placeholder floor and unions extra `[A-Z0-9_]` variable names into
+`envBoundSecretVars()`, so a host that already declares its forwarded
+credentials (and their length floor) in a registry of its own feeds the packaged
+helpers from it instead of forking the module. Unset fields keep the package
+derivation; `null` restores it entirely. A malformed source throws on first use,
+inside the consuming hook's fail-closed catch, and an unread key is reported on
+stderr.
+
 Hook internals are tuned by `_AGENT_SANITIZER_*` variables (redactor daemon
 path/socket/timeouts, sanitize budget, trace channel, Layer-2 reveal dir). The
 leading underscore marks them unstable — the supported surface is the `--hook=`

--- a/README.md
+++ b/README.md
@@ -218,9 +218,9 @@ replaces the placeholder floor and unions extra `[A-Z0-9_]` variable names into
 `envBoundSecretVars()`, so a host that already declares its forwarded
 credentials (and their length floor) in a registry of its own feeds the packaged
 helpers from it instead of forking the module. Unset fields keep the package
-derivation; `null` restores it entirely. A malformed source throws on first use,
-inside the consuming hook's fail-closed catch, and an unread key is reported on
-stderr.
+derivation; `null` restores it entirely. A malformed source — a non-object, a
+key the seam does not read, a bad field — throws on first use, inside the
+consuming hook's fail-closed catch, never at configure time.
 
 Hook internals are tuned by `_AGENT_SANITIZER_*` variables (redactor daemon
 path/socket/timeouts, sanitize budget, trace channel, Layer-2 reveal dir). The

--- a/README.md
+++ b/README.md
@@ -202,6 +202,16 @@ hook module, and every consumer waits on that path instead. `lib/control-plane`
 resolves the marker at module scope, so a call that lands after that import
 warns on stderr — it cannot steer the wait that already started.
 
+**A host's own remedy can replace the packaged one in every fail-closed
+reason.** Deep call sites (`lib/control-plane`'s missing-package throw) take no
+remedy argument, so by default they can only say `pnpm install`. A host whose
+install has one entry point calls `configureMissingPackageRemedy(text)` (from
+`lib/hook-io`) — typically at its bundle entry — and every remedy-less
+`missingPackageMessage`/`missingPackageError` states that text instead. An
+explicit per-call remedy (including a per-gate `MESSAGES.remedy`) still wins,
+and `null` restores the packaged wording. Keep it to a sentence: past ~260
+characters it overruns the 300-char message budget.
+
 Hook internals are tuned by `_AGENT_SANITIZER_*` variables (redactor daemon
 path/socket/timeouts, sanitize budget, trace channel, Layer-2 reveal dir). The
 leading underscore marks them unstable — the supported surface is the `--hook=`

--- a/claude-hooks/lib/env-config.mjs
+++ b/claude-hooks/lib/env-config.mjs
@@ -31,12 +31,86 @@ export function inferenceKeyVars() {
 }
 
 /**
+ * Host-supplied secret-vocabulary source, consulted before the package configs.
+ * Null (the default) keeps the package derivation.
+ * @type {{ minSecretLen?: number, extraVars?: string[] } | null}
+ */
+let hostEnvConfigSource = null;
+
+const HOST_SOURCE_LABEL = "configureEnvConfigSource";
+
+/**
+ * Adopt a host's own secret config in place of the package's: `minSecretLen`
+ * replaces the placeholder floor, and `extraVars` are unioned into the
+ * env-bound redaction set. This seam is what lets a host whose credential
+ * registry already names its forwarded secrets (and their length floor) drive
+ * the packaged helpers from that registry instead of forking this module —
+ * a fork is the drift channel that lets the two redaction sets silently
+ * disagree. Unset fields keep their package derivation. Like the missing-package
+ * remedy seam there is no too-late window: the source is consulted at each
+ * helper call, never resolved at module scope, so a later call steers every
+ * later answer. VALIDATION stays lazy, matching this module's load posture: a
+ * malformed source throws on first use inside the consuming hook's fail-closed
+ * catch, not at configure time, where a top-level throw in a bundle entry would
+ * kill the hook before its catch installs (fail OPEN).
+ * A key this seam does not read is reported on stderr, not thrown: a misspelled
+ * `extraVars` would otherwise leave the seam silently inert — the host believes
+ * a forwarded credential is masked while its value flows to the model — and a
+ * throw at a bundle entry's top level would kill the hook before its fail-closed
+ * catch installs (fail OPEN, same posture as configureHookgateMarker's late-call
+ * report).
+ * @param {{ minSecretLen?: number, extraVars?: string[] } | null} source
+ *   host config, or null to restore the package derivation
+ * @returns {void}
+ */
+export function configureEnvConfigSource(source) {
+  if (source !== null)
+    for (const key of Object.keys(source))
+      if (key !== "minSecretLen" && key !== "extraVars")
+        process.stderr.write(
+          `agent-sanitizer: ${HOST_SOURCE_LABEL} ignoring unknown key ` +
+            `${JSON.stringify(key)}; it reads minSecretLen and extraVars.\n`,
+        );
+  hostEnvConfigSource = source;
+}
+
+/**
  * The placeholder floor: a candidate value shorter than this is too short to be a
- * real secret and is skipped by the env-bound redaction pre-gate.
+ * real secret and is skipped by the env-bound redaction pre-gate. A malformed
+ * host floor throws rather than degrading to the package's — a host that set 32
+ * must not silently run at a laxer floor, and a non-positive one would admit
+ * empty placeholders as secrets.
  * @returns {number}
  */
 export function minEnvSecretLen() {
-  return inferenceKeys.min_secret_len;
+  const hostLen = hostEnvConfigSource?.minSecretLen;
+  if (hostLen === undefined) return inferenceKeys.min_secret_len;
+  if (!Number.isInteger(hostLen) || hostLen <= 0)
+    throw new Error(
+      `${HOST_SOURCE_LABEL}: minSecretLen must be a positive integer, got ${JSON.stringify(hostLen)}`,
+    );
+  return hostLen;
+}
+
+/**
+ * The host's declared extra secret variable names, or throw. A malformed entry
+ * fails CLOSED, same contract as {@link extraSecretVars}: dropping it silently
+ * would leave the host believing a forwarded credential is masked while its
+ * value flows to the model verbatim.
+ * @returns {string[]}
+ */
+function hostExtraSecretVars() {
+  const vars = hostEnvConfigSource?.extraVars;
+  if (vars === undefined) return [];
+  if (!Array.isArray(vars))
+    throw new Error(`${HOST_SOURCE_LABEL}: extraVars must be an array`);
+  for (const name of vars)
+    if (typeof name !== "string" || !EXTRA_TOKEN_RE.test(name))
+      throw new Error(
+        `${HOST_SOURCE_LABEL}: ${JSON.stringify(name)} is not a variable name ` +
+          "(expected [A-Z0-9_] names)",
+      );
+  return vars;
 }
 
 // A rendered vocabulary token. Restricting it to A-Z/0-9/_ is what lets the
@@ -239,10 +313,11 @@ export function extraSecretVars(env = process.env) {
 
 /**
  * The env-bound redaction set: the UNION of the inference keys, the curated host
- * credentials, any credential-shaped var present in the environment, and the
- * operator's declared extras. The redactor binds the same union; every consumer
- * (the sanitize-output pre-gate, the redactor client's per-request env snapshot)
- * must mirror it exactly, else a credential value would never trip the daemon.
+ * credentials, any credential-shaped var present in the environment, the
+ * operator's declared extras, and the host's configured extras. The redactor
+ * binds the same union; every consumer (the sanitize-output pre-gate, the
+ * redactor client's per-request env snapshot) must mirror it exactly, else a
+ * credential value would never trip the daemon.
  * @param {Record<string, string | undefined>} [env]
  * @returns {string[]}
  */
@@ -253,6 +328,7 @@ export function envBoundSecretVars(env = process.env) {
       ...scrubbed.vars,
       ...dynamicSecretVars(env),
       ...extraSecretVars(env),
+      ...hostExtraSecretVars(),
     ]),
   ];
 }

--- a/claude-hooks/lib/env-config.mjs
+++ b/claude-hooks/lib/env-config.mjs
@@ -39,6 +39,8 @@ let hostEnvConfigSource = null;
 
 const HOST_SOURCE_LABEL = "configureEnvConfigSource";
 
+const HOST_SOURCE_KEYS = ["minSecretLen", "extraVars"];
+
 /**
  * Adopt a host's own secret config in place of the package's: `minSecretLen`
  * replaces the placeholder floor, and `extraVars` are unioned into the
@@ -46,32 +48,44 @@ const HOST_SOURCE_LABEL = "configureEnvConfigSource";
  * registry already names its forwarded secrets (and their length floor) drive
  * the packaged helpers from that registry instead of forking this module —
  * a fork is the drift channel that lets the two redaction sets silently
- * disagree. Unset fields keep their package derivation. Like the missing-package
- * remedy seam there is no too-late window: the source is consulted at each
- * helper call, never resolved at module scope, so a later call steers every
- * later answer. VALIDATION stays lazy, matching this module's load posture: a
- * malformed source throws on first use inside the consuming hook's fail-closed
- * catch, not at configure time, where a top-level throw in a bundle entry would
- * kill the hook before its catch installs (fail OPEN).
- * A key this seam does not read is reported on stderr, not thrown: a misspelled
- * `extraVars` would otherwise leave the seam silently inert — the host believes
- * a forwarded credential is masked while its value flows to the model — and a
- * throw at a bundle entry's top level would kill the hook before its fail-closed
- * catch installs (fail OPEN, same posture as configureHookgateMarker's late-call
- * report).
+ * disagree. Unset fields keep their package derivation; `undefined` and `null`
+ * both restore it entirely. Like the missing-package remedy seam there is no
+ * too-late window: the source is consulted at each helper call, never resolved
+ * at module scope, so a later call steers every later answer. A malformed
+ * source — a non-object, a key this seam does not read, a bad field — throws
+ * on first use, not here (see {@link hostSource}).
  * @param {{ minSecretLen?: number, extraVars?: string[] } | null} source
  *   host config, or null to restore the package derivation
  * @returns {void}
  */
 export function configureEnvConfigSource(source) {
-  if (source !== null)
-    for (const key of Object.keys(source))
-      if (key !== "minSecretLen" && key !== "extraVars")
-        process.stderr.write(
-          `agent-sanitizer: ${HOST_SOURCE_LABEL} ignoring unknown key ` +
-            `${JSON.stringify(key)}; it reads minSecretLen and extraVars.\n`,
-        );
-  hostEnvConfigSource = source;
+  hostEnvConfigSource = source ?? null;
+}
+
+/**
+ * The stored host source with its shape validated, or null when unconfigured.
+ * Shape errors — a non-object source, a key this seam does not read — throw
+ * HERE, on first use inside the consuming hook's fail-closed catch, never at
+ * configure time: a top-level throw in a bundle entry would kill the hook
+ * before that catch installs (fail OPEN), and silently ignoring the problem
+ * is worse — a typo'd `minSecretLength: 32` must not leave the helpers
+ * running at the package floor while the host believes it configured 32.
+ * @returns {{ minSecretLen?: number, extraVars?: string[] } | null}
+ */
+function hostSource() {
+  const source = hostEnvConfigSource;
+  if (source === null) return null;
+  if (typeof source !== "object")
+    throw new Error(
+      `${HOST_SOURCE_LABEL}: source must be an object, got ${typeof source}`,
+    );
+  for (const key of Object.keys(source))
+    if (!HOST_SOURCE_KEYS.includes(key))
+      throw new Error(
+        `${HOST_SOURCE_LABEL}: unknown key ${JSON.stringify(key)}; it reads ` +
+          `${HOST_SOURCE_KEYS.join(" and ")}`,
+      );
+  return source;
 }
 
 /**
@@ -83,7 +97,7 @@ export function configureEnvConfigSource(source) {
  * @returns {number}
  */
 export function minEnvSecretLen() {
-  const hostLen = hostEnvConfigSource?.minSecretLen;
+  const hostLen = hostSource()?.minSecretLen;
   if (hostLen === undefined) return inferenceKeys.min_secret_len;
   if (!Number.isInteger(hostLen) || hostLen <= 0)
     throw new Error(
@@ -100,7 +114,7 @@ export function minEnvSecretLen() {
  * @returns {string[]}
  */
 function hostExtraSecretVars() {
-  const vars = hostEnvConfigSource?.extraVars;
+  const vars = hostSource()?.extraVars;
   if (vars === undefined) return [];
   if (!Array.isArray(vars))
     throw new Error(`${HOST_SOURCE_LABEL}: extraVars must be an array`);

--- a/claude-hooks/lib/hook-io.mjs
+++ b/claude-hooks/lib/hook-io.mjs
@@ -242,6 +242,33 @@ export const DEFAULT_MISSING_PACKAGE_REMEDY =
   "reinstall the hook dependencies (pnpm install) and retry.";
 
 /**
+ * Host-supplied default remedy, replacing DEFAULT_MISSING_PACKAGE_REMEDY. Null
+ * (the default) keeps the package's wording.
+ * @type {string | null}
+ */
+let missingPackageRemedyOverride = null;
+
+/**
+ * Adopt a host's own remedy as the default {@link missingPackageMessage} and
+ * {@link missingPackageError} state when their caller passes none. This refusal
+ * to hard-code the wording is what prevents a fail-closed reason whose remedy
+ * names a command the host doesn't have: deep call sites (controlPlane's
+ * missing-package throw) never take a remedy argument, so without this seam
+ * they can only ever tell a reader to run `pnpm install` — wrong advice in a
+ * host whose one install entry point is its own setup script. An explicit
+ * per-call remedy still wins over the configured one. Unlike the hookgate
+ * marker there is no too-late window: the remedy is consulted at each throw,
+ * never resolved at module scope, so a later call steers every later message.
+ * Keep it to a sentence — a remedy beyond ~260 characters overruns the 300-char
+ * message budget (see missingPackageMessage).
+ * @param {string | null} remedy  host remedy text, or null to restore the package default
+ * @returns {void}
+ */
+export function configureMissingPackageRemedy(remedy) {
+  missingPackageRemedyOverride = remedy;
+}
+
+/**
  * The fail-closed reason for a package a hook could not load: the recorded
  * loader error plus the remedy. The cause is scrubbed (it is spliced into
  * reasons shown to user and model) and its cap is COMPUTED so that
@@ -257,7 +284,7 @@ export const DEFAULT_MISSING_PACKAGE_REMEDY =
 export function missingPackageMessage(
   pkg,
   err = lazyImportErrorFor(pkg),
-  remedy = DEFAULT_MISSING_PACKAGE_REMEDY,
+  remedy = missingPackageRemedyOverride ?? DEFAULT_MISSING_PACKAGE_REMEDY,
 ) {
   const prefix = `${pkg} is unavailable: `;
   // 2 for the "; " joiner; 12 for safeErrMessage's own "…[truncated]" marker,
@@ -287,7 +314,7 @@ export function missingPackageMessage(
 export function missingPackageError(
   pkg,
   err = lazyImportErrorFor(pkg),
-  remedy = DEFAULT_MISSING_PACKAGE_REMEDY,
+  remedy = missingPackageRemedyOverride ?? DEFAULT_MISSING_PACKAGE_REMEDY,
 ) {
   return Object.assign(new Error(missingPackageMessage(pkg, err, remedy)), {
     code: "DEP_UNAVAILABLE",

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -122,13 +122,13 @@ function failedLazyPackages() {
   }
   return [...pkgs];
 }
-function missingPackageMessage(pkg, err = lazyImportErrorFor(pkg), remedy = DEFAULT_MISSING_PACKAGE_REMEDY) {
+function missingPackageMessage(pkg, err = lazyImportErrorFor(pkg), remedy = missingPackageRemedyOverride ?? DEFAULT_MISSING_PACKAGE_REMEDY) {
   const prefix = `${pkg} is unavailable: `;
   const causeCap = Math.max(0, 300 - prefix.length - remedy.length - 2 - 12);
   const cause = err === void 0 ? "no load error recorded \u2014 the package likely loaded but lacks an expected export (version skew)" : safeErrMessage(err, causeCap);
   return `${prefix}${cause}; ${remedy}`;
 }
-function missingPackageError(pkg, err = lazyImportErrorFor(pkg), remedy = DEFAULT_MISSING_PACKAGE_REMEDY) {
+function missingPackageError(pkg, err = lazyImportErrorFor(pkg), remedy = missingPackageRemedyOverride ?? DEFAULT_MISSING_PACKAGE_REMEDY) {
   return Object.assign(new Error(missingPackageMessage(pkg, err, remedy)), {
     code: "DEP_UNAVAILABLE"
   });
@@ -268,7 +268,7 @@ function writeFileNoFollow(path2, content3, mode = 384) {
     closeSync(fd);
   }
 }
-var cliEntryClaimed, HookEvent, PermissionDecision, LONE_SURROGATE_RE, MAX_STDIN_BYTES, registeredLazyModules, lazyImportErrors, DEFAULT_MISSING_PACKAGE_REMEDY, UNTRUSTED_TEXT_CAP, HOOKGATE_MARKER_STEM, hookgateMarkerOverride, hookgateMarkerResolved;
+var cliEntryClaimed, HookEvent, PermissionDecision, LONE_SURROGATE_RE, MAX_STDIN_BYTES, registeredLazyModules, lazyImportErrors, DEFAULT_MISSING_PACKAGE_REMEDY, missingPackageRemedyOverride, UNTRUSTED_TEXT_CAP, HOOKGATE_MARKER_STEM, hookgateMarkerOverride, hookgateMarkerResolved;
 var init_hook_io = __esm({
   "claude-hooks/lib/hook-io.mjs"() {
     "use strict";
@@ -289,6 +289,7 @@ var init_hook_io = __esm({
     registeredLazyModules = /* @__PURE__ */ Object.create(null);
     lazyImportErrors = /* @__PURE__ */ new Map();
     DEFAULT_MISSING_PACKAGE_REMEDY = "reinstall the hook dependencies (pnpm install) and retry.";
+    missingPackageRemedyOverride = null;
     UNTRUSTED_TEXT_CAP = 500;
     HOOKGATE_MARKER_STEM = "agent-sanitizer-hookgate-inflight-";
     hookgateMarkerOverride = null;
@@ -66990,7 +66991,25 @@ function inferenceKeyVars() {
   return inference_key_vars_default.vars;
 }
 function minEnvSecretLen() {
-  return inference_key_vars_default.min_secret_len;
+  const hostLen = hostEnvConfigSource?.minSecretLen;
+  if (hostLen === void 0) return inference_key_vars_default.min_secret_len;
+  if (!Number.isInteger(hostLen) || hostLen <= 0)
+    throw new Error(
+      `${HOST_SOURCE_LABEL}: minSecretLen must be a positive integer, got ${JSON.stringify(hostLen)}`
+    );
+  return hostLen;
+}
+function hostExtraSecretVars() {
+  const vars = hostEnvConfigSource?.extraVars;
+  if (vars === void 0) return [];
+  if (!Array.isArray(vars))
+    throw new Error(`${HOST_SOURCE_LABEL}: extraVars must be an array`);
+  for (const name50 of vars)
+    if (typeof name50 !== "string" || !EXTRA_TOKEN_RE.test(name50))
+      throw new Error(
+        `${HOST_SOURCE_LABEL}: ${JSON.stringify(name50)} is not a variable name (expected [A-Z0-9_] names)`
+      );
+  return vars;
 }
 function segmentForms(parts2) {
   return [
@@ -67079,17 +67098,20 @@ function envBoundSecretVars(env = process.env) {
       ...inferenceKeyVars(),
       ...scrubbed_env_vars_default.vars,
       ...dynamicSecretVars(env),
-      ...extraSecretVars(env)
+      ...extraSecretVars(env),
+      ...hostExtraSecretVars()
     ])
   ];
 }
-var CRED_TOKEN_RE, VOCAB_LABEL, EXCLUDE_NAMES, ENV_NAME_USE, _credentialNameRes, EXTRA_SECRET_VARS_ENV, EXTRA_TOKEN_RE;
+var hostEnvConfigSource, HOST_SOURCE_LABEL, CRED_TOKEN_RE, VOCAB_LABEL, EXCLUDE_NAMES, ENV_NAME_USE, _credentialNameRes, EXTRA_SECRET_VARS_ENV, EXTRA_TOKEN_RE;
 var init_env_config = __esm({
   "claude-hooks/lib/env-config.mjs"() {
     "use strict";
     init_credential_names();
     init_inference_key_vars();
     init_scrubbed_env_vars();
+    hostEnvConfigSource = null;
+    HOST_SOURCE_LABEL = "configureEnvConfigSource";
     CRED_TOKEN_RE = /^[A-Z0-9_]+$/;
     VOCAB_LABEL = "credential-names.json";
     EXCLUDE_NAMES = ["SSH_AUTH_SOCK"];

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -66990,8 +66990,22 @@ var init_scrubbed_env_vars = __esm({
 function inferenceKeyVars() {
   return inference_key_vars_default.vars;
 }
+function hostSource() {
+  const source = hostEnvConfigSource;
+  if (source === null) return null;
+  if (typeof source !== "object")
+    throw new Error(
+      `${HOST_SOURCE_LABEL}: source must be an object, got ${typeof source}`
+    );
+  for (const key of Object.keys(source))
+    if (!HOST_SOURCE_KEYS.includes(key))
+      throw new Error(
+        `${HOST_SOURCE_LABEL}: unknown key ${JSON.stringify(key)}; it reads ${HOST_SOURCE_KEYS.join(" and ")}`
+      );
+  return source;
+}
 function minEnvSecretLen() {
-  const hostLen = hostEnvConfigSource?.minSecretLen;
+  const hostLen = hostSource()?.minSecretLen;
   if (hostLen === void 0) return inference_key_vars_default.min_secret_len;
   if (!Number.isInteger(hostLen) || hostLen <= 0)
     throw new Error(
@@ -67000,7 +67014,7 @@ function minEnvSecretLen() {
   return hostLen;
 }
 function hostExtraSecretVars() {
-  const vars = hostEnvConfigSource?.extraVars;
+  const vars = hostSource()?.extraVars;
   if (vars === void 0) return [];
   if (!Array.isArray(vars))
     throw new Error(`${HOST_SOURCE_LABEL}: extraVars must be an array`);
@@ -67103,7 +67117,7 @@ function envBoundSecretVars(env = process.env) {
     ])
   ];
 }
-var hostEnvConfigSource, HOST_SOURCE_LABEL, CRED_TOKEN_RE, VOCAB_LABEL, EXCLUDE_NAMES, ENV_NAME_USE, _credentialNameRes, EXTRA_SECRET_VARS_ENV, EXTRA_TOKEN_RE;
+var hostEnvConfigSource, HOST_SOURCE_LABEL, HOST_SOURCE_KEYS, CRED_TOKEN_RE, VOCAB_LABEL, EXCLUDE_NAMES, ENV_NAME_USE, _credentialNameRes, EXTRA_SECRET_VARS_ENV, EXTRA_TOKEN_RE;
 var init_env_config = __esm({
   "claude-hooks/lib/env-config.mjs"() {
     "use strict";
@@ -67112,6 +67126,7 @@ var init_env_config = __esm({
     init_scrubbed_env_vars();
     hostEnvConfigSource = null;
     HOST_SOURCE_LABEL = "configureEnvConfigSource";
+    HOST_SOURCE_KEYS = ["minSecretLen", "extraVars"];
     CRED_TOKEN_RE = /^[A-Z0-9_]+$/;
     VOCAB_LABEL = "credential-names.json";
     EXCLUDE_NAMES = ["SSH_AUTH_SOCK"];

--- a/test/claude-hooks-host-seams.test.mjs
+++ b/test/claude-hooks-host-seams.test.mjs
@@ -368,25 +368,47 @@ describe("env-config host source seam", () => {
     }
   });
 
-  it("reports an unread key on stderr instead of leaving the seam silently inert", () => {
-    // A misspelled field must not be swallowed — the host would believe a
-    // forwarded credential is masked while nothing changed — but it must not
-    // throw either (bundle-entry top level: a throw there is a fail-OPEN hook).
-    const written = [];
-    const original = process.stderr.write;
-    // @ts-expect-error -- narrower than the overloaded write signature; the
-    // caller here only ever passes a string chunk.
-    process.stderr.write = (chunk) => {
-      written.push(String(chunk));
-      return true;
-    };
+  it("treats an undefined source as unconfigured, not as a configure-time crash", () => {
+    // The shape a host actually produces: configureEnvConfigSource(
+    // hostConfig.envSource) with the field absent. A throw here would land at
+    // the bundle entry's top level — a fail-OPEN hook — for a host that simply
+    // has nothing to configure.
+    const packageFloor = minEnvSecretLen();
+    configureEnvConfigSource(/** @type {any} */ (undefined));
     try {
-      configureEnvConfigSource(/** @type {any} */ ({ extra_vars: ["OOPS"] }));
+      assert.equal(minEnvSecretLen(), packageFloor);
+      assert.ok(envBoundSecretVars(env).includes("MY_API_KEY"));
     } finally {
-      process.stderr.write = original;
       configureEnvConfigSource(null);
     }
-    assert.match(written.join(""), /unknown key "extra_vars"/u);
+  });
+
+  it("throws at USE on a non-object source, never running silently inert", () => {
+    const nonObject = /** @type {any} */ ("X");
+    configureEnvConfigSource(nonObject);
+    try {
+      assert.throws(() => minEnvSecretLen(), /must be an object/u);
+      assert.throws(() => envBoundSecretVars({}), /must be an object/u);
+    } finally {
+      configureEnvConfigSource(null);
+    }
+  });
+
+  it("throws at USE on a key the seam does not read", () => {
+    // A typo'd field name must not leave the helpers on the package derivation
+    // while the host believes it configured them — same fail-closed contract as
+    // a malformed field value, and same USE-time timing (a configure-time throw
+    // lands at the bundle entry's top level, a fail-OPEN hook).
+    configureEnvConfigSource(/** @type {any} */ ({ minSecretLength: 32 }));
+    try {
+      assert.throws(() => minEnvSecretLen(), /unknown key "minSecretLength"/u);
+      assert.throws(
+        () => envBoundSecretVars({}),
+        /unknown key "minSecretLength"/u,
+      );
+    } finally {
+      configureEnvConfigSource(null);
+    }
   });
 });
 

--- a/test/claude-hooks-host-seams.test.mjs
+++ b/test/claude-hooks-host-seams.test.mjs
@@ -35,6 +35,12 @@ const {
   awaitLazyDependency,
 } = await import("../claude-hooks/lib/hook-io.mjs");
 const { controlPlane } = await import("../claude-hooks/lib/control-plane.mjs");
+const {
+  configureEnvConfigSource,
+  minEnvSecretLen,
+  envBoundSecretVars,
+  dynamicSecretVars,
+} = await import("../claude-hooks/lib/env-config.mjs");
 const { judgeSanitizeUserPrompt, USER_PROMPT_MESSAGES } =
   await import("../claude-hooks/sanitize-user-prompt.mjs");
 const {
@@ -277,6 +283,110 @@ describe("missing-package remedy seam", () => {
     } finally {
       configureMissingPackageRemedy(null);
     }
+  });
+});
+
+describe("env-config host source seam", () => {
+  // A value long enough for the package floor (16) but short of the host's.
+  const env = { MY_API_KEY: "x".repeat(20), PATH: "/usr/bin" };
+
+  it("is inert by default: unconfigured answers are identical after a round trip", () => {
+    const floorBefore = minEnvSecretLen();
+    const setBefore = envBoundSecretVars(env);
+    // Non-vacuous baseline: the shape-inferred path really ran.
+    assert.ok(setBefore.includes("MY_API_KEY"));
+    configureEnvConfigSource({
+      minSecretLen: 99,
+      extraVars: ["HOST_SEAM_VAR"],
+    });
+    configureEnvConfigSource(null);
+    assert.equal(minEnvSecretLen(), floorBefore);
+    assert.deepEqual(envBoundSecretVars(env), setBefore);
+  });
+
+  it("applies a configured floor to the helpers that consult it", () => {
+    configureEnvConfigSource({ minSecretLen: 99 });
+    try {
+      assert.equal(minEnvSecretLen(), 99);
+      // 20 chars is below the host floor: no longer secret-shaped enough.
+      assert.ok(!dynamicSecretVars(env).includes("MY_API_KEY"));
+      assert.ok(!envBoundSecretVars(env).includes("MY_API_KEY"));
+      // A value clearing the host floor still qualifies — it is a floor, not a block.
+      assert.ok(
+        dynamicSecretVars({ MY_API_KEY: "x".repeat(120) }).includes(
+          "MY_API_KEY",
+        ),
+      );
+    } finally {
+      configureEnvConfigSource(null);
+    }
+  });
+
+  it("unions configured extraVars into the redaction set, keeping the package floor", () => {
+    const floorBefore = minEnvSecretLen();
+    configureEnvConfigSource({ extraVars: ["GLOVEBOX_PROVIDER_SEED"] });
+    try {
+      assert.ok(envBoundSecretVars({}).includes("GLOVEBOX_PROVIDER_SEED"));
+      // A partial source keeps the unset field on its package derivation.
+      assert.equal(minEnvSecretLen(), floorBefore);
+    } finally {
+      configureEnvConfigSource(null);
+    }
+  });
+
+  it("fails closed on a malformed source at USE, not at configure", () => {
+    // Configure itself must not throw: it runs at a bundle entry's top level,
+    // where a throw kills the hook before its fail-closed catch installs.
+    for (const bad of [0, "16"]) {
+      configureEnvConfigSource({
+        minSecretLen: /** @type {number} */ (bad),
+      });
+      try {
+        assert.throws(() => minEnvSecretLen(), /minSecretLen/u);
+        assert.throws(() => dynamicSecretVars(env), /minSecretLen/u);
+      } finally {
+        configureEnvConfigSource(null);
+      }
+    }
+    for (const bad of ["bad-name", 7]) {
+      configureEnvConfigSource({
+        extraVars: /** @type {string[]} */ ([bad]),
+      });
+      try {
+        assert.throws(() => envBoundSecretVars({}), /not a variable name/u);
+      } finally {
+        configureEnvConfigSource(null);
+      }
+    }
+    configureEnvConfigSource({
+      extraVars: /** @type {string[]} */ (/** @type {unknown} */ ("X")),
+    });
+    try {
+      assert.throws(() => envBoundSecretVars({}), /must be an array/u);
+    } finally {
+      configureEnvConfigSource(null);
+    }
+  });
+
+  it("reports an unread key on stderr instead of leaving the seam silently inert", () => {
+    // A misspelled field must not be swallowed — the host would believe a
+    // forwarded credential is masked while nothing changed — but it must not
+    // throw either (bundle-entry top level: a throw there is a fail-OPEN hook).
+    const written = [];
+    const original = process.stderr.write;
+    // @ts-expect-error -- narrower than the overloaded write signature; the
+    // caller here only ever passes a string chunk.
+    process.stderr.write = (chunk) => {
+      written.push(String(chunk));
+      return true;
+    };
+    try {
+      configureEnvConfigSource(/** @type {any} */ ({ extra_vars: ["OOPS"] }));
+    } finally {
+      process.stderr.write = original;
+      configureEnvConfigSource(null);
+    }
+    assert.match(written.join(""), /unknown key "extra_vars"/u);
   });
 });
 

--- a/test/claude-hooks-host-seams.test.mjs
+++ b/test/claude-hooks-host-seams.test.mjs
@@ -29,10 +29,12 @@ const {
   missingPackageError,
   safeErrMessage,
   DEFAULT_MISSING_PACKAGE_REMEDY,
+  configureMissingPackageRemedy,
   hookgateMarkerPath,
   probeSetupAlive,
   awaitLazyDependency,
 } = await import("../claude-hooks/lib/hook-io.mjs");
+const { controlPlane } = await import("../claude-hooks/lib/control-plane.mjs");
 const { judgeSanitizeUserPrompt, USER_PROMPT_MESSAGES } =
   await import("../claude-hooks/sanitize-user-prompt.mjs");
 const {
@@ -182,6 +184,99 @@ describe("dependency-load diagnostics", () => {
       "",
     );
     assert.notEqual(depLoadHint(new TypeError("x is not a function")), "");
+  });
+});
+
+describe("missing-package remedy seam", () => {
+  it("is inert by default: unconfigured output is byte-identical after a round trip", () => {
+    const before = missingPackageMessage("a-package", new Error("boom"));
+    configureMissingPackageRemedy(HOST_REMEDY);
+    configureMissingPackageRemedy(null);
+    assert.equal(missingPackageMessage("a-package", new Error("boom")), before);
+    assert.equal(
+      before,
+      `a-package is unavailable: boom; ${DEFAULT_MISSING_PACKAGE_REMEDY}`,
+    );
+  });
+
+  it("reaches controlPlane's missing-package throw end-to-end", () => {
+    // The consumer that motivated the seam: controlPlane() throws with no
+    // remedy argument, so before the seam it could only ever say pnpm install.
+    configureMissingPackageRemedy(HOST_REMEDY);
+    try {
+      assert.throws(
+        () => controlPlane({ claudeAdapter: undefined }),
+        (err) => {
+          assert.equal(
+            /** @type {{code?: string}} */ (err).code,
+            "DEP_UNAVAILABLE",
+          );
+          const message = /** @type {Error} */ (err).message;
+          assert.match(message, /agent-control-plane-core is unavailable/u);
+          assert.ok(message.endsWith(HOST_REMEDY));
+          return true;
+        },
+      );
+    } finally {
+      configureMissingPackageRemedy(null);
+    }
+  });
+
+  it("still lets an explicit per-call remedy win", () => {
+    configureMissingPackageRemedy(HOST_REMEDY);
+    try {
+      const message = missingPackageMessage(
+        "a-package",
+        new Error("boom"),
+        "explicit remedy.",
+      );
+      assert.ok(message.endsWith("explicit remedy."));
+      assert.ok(!message.includes(HOST_REMEDY));
+      assert.ok(
+        missingPackageError(
+          "a-package",
+          new Error("boom"),
+          "explicit remedy.",
+        ).message.endsWith("explicit remedy."),
+      );
+    } finally {
+      configureMissingPackageRemedy(null);
+    }
+  });
+
+  it("is re-steerable, not latched: the last configure wins", () => {
+    configureMissingPackageRemedy("first remedy.");
+    configureMissingPackageRemedy(HOST_REMEDY);
+    try {
+      assert.ok(
+        missingPackageMessage("a-package", new Error("boom")).endsWith(
+          HOST_REMEDY,
+        ),
+      );
+    } finally {
+      configureMissingPackageRemedy(null);
+    }
+  });
+
+  it("keeps a long configured remedy whole through the 300-char budget", () => {
+    // Same clamp the explicit-remedy test above exercises, but through the
+    // configured default — the path a host actually takes.
+    const longRemedy = `${"run the host installer ".repeat(12)}and retry.`;
+    assert.ok(longRemedy.length > 260, "remedy must overrun the budget");
+    configureMissingPackageRemedy(longRemedy);
+    try {
+      const message = missingPackageMessage(
+        "a-package",
+        new Error("a".repeat(400)),
+      );
+      assert.ok(message.endsWith(longRemedy));
+      assert.ok(
+        !message.includes("aaaaaaaaaa"),
+        "the cause must not survive when the remedy has spent the budget",
+      );
+    } finally {
+      configureMissingPackageRemedy(null);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

`agent-glovebox` still forks two `claude-hooks` modules whose bodies match this package's, only because they close over host-specific things the package hard-codes: the `pnpm install` remedy in the deep missing-package throws, and the package-internal secret config in `lib/env-config`. This PR adds the two configure-once host seams that make those forks deletable — same shape as the existing `configureHookgateMarker`, injectable trace sink, and per-gate `MESSAGES.remedy` seams — so glovebox can drop its `lib-control-plane.mjs` transport fork and its `lib-env-config.mjs` divergences and consume the packaged modules directly.

## Changes

- `configureMissingPackageRemedy(text)` (`lib/hook-io`): the default remedy `missingPackageMessage`/`missingPackageError` state when the caller passes none, so remedy-less deep call sites (`controlPlane()`/`runJudgeCli()` in `lib/control-plane`) name the host's install entry point instead of `pnpm install`. An explicit per-call remedy (including per-gate `MESSAGES.remedy`) keeps precedence; `null` restores the packaged wording.
- `configureEnvConfigSource({ minSecretLen, extraVars })` (`lib/env-config`): replaces the placeholder floor and unions host-declared `[A-Z0-9_]` variable names into `envBoundSecretVars()`, so a host whose credential registry already names its forwarded secrets drives the packaged helpers from it. Unset fields keep the package derivation; `undefined`/`null` restore it entirely. Validation is lazy and complete: a malformed source — a non-object, a key the seam does not read, a bad field value — throws on first use, inside the consuming hook's fail-closed catch, never at configure time and never silently.
- README: one paragraph per seam, beside the marker-seam docs; regenerated `plugin/dist` bundle (build artifact of the changed sources).

## Decisions made

- **Latching: both seams are re-steerable (last configure wins), not latched.** The hookgate marker warns on a late call only because `lib/control-plane` resolves it at module scope; both new seams are consulted at each call, so there is no too-late window to warn about. Under a latch, a host bundle that configures twice would silently keep the first value.
- **The remedy seam does not steer the shallow per-gate defaults** (`USER_PROMPT_MESSAGES.remedy`, `PRE_TOOL_USE_MESSAGES.remedy`, `failClosedContext`): those already take host overrides, and routing the seam under them would stack a second precedence layer on the same field. Under the alternative, configuring only the seam would also cover the shallow paths, at the cost of making "explicit wins" ambiguous for the default tables.
- **No vocabulary-spec override in the env-config seam.** The motivating downstream shares the published credential-noun vocabulary and supplies only a floor plus variable names, so `looksLikeCredentialVar`'s derivation stays package-only; `extraVars` reach the redaction set through the same union as `_AGENT_SANITIZER_EXTRA_SECRET_VARS`.
- **Every malformed-source class throws at first USE, none at configure time and none silently.** A configure-time throw lands at a bundle entry's top level, killing the hook before its fail-closed catch installs (fail open); a silent degrade — an unknown key, a non-object source — would leave the helpers on the package derivation while the host believes it configured them (a typo'd `minSecretLength: 32` running at floor 16). So `undefined` reads as unconfigured, and the readers validate shape and fields through one accessor whose throw lands inside the consuming hook's catch.

## Tests / verification

- `node --test test/claude-hooks-host-seams.test.mjs` — 55 pass; the 11 new tests fail without the source change (verified twice via `git stash push -- claude-hooks…`: the original 9 red on the unmodified base, the 3 lazy-validation cases red on the pre-rework module), including the end-to-end case that a configured remedy reaches `controlPlane()`'s `DEP_UNAVAILABLE` throw.
- The long-remedy case pins that a configured remedy past ~260 chars still survives the 300-char message budget whole.
- `pnpm test` (full suite — its bundle round-trip test is what caught the stale `plugin/dist`), `pnpm lint`, and `pnpm check` pass locally.

Review focus: `claude-hooks/lib/env-config.mjs` — the seam sits beside the guaranteed-floor union every redaction consumer must mirror; `hostSource()` is the one accessor all host reads must go through, or a new field would dodge the shape validation.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/); each subject reads as a user-facing release note.
- [x] `pnpm test`, `pnpm lint`, and `pnpm check` pass locally.
- [x] New or changed detectors have negative tests (zero findings on legitimate input) and pin their invariants with property/fuzz tests.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version are left untouched (the release workflow owns them).