### PR TITLE
fix(claude-hooks): apply the non-secret exclusion at a name boundary

### DIFF
--- a/claude-hooks/lib/env-config.mjs
+++ b/claude-hooks/lib/env-config.mjs
@@ -17,8 +17,6 @@
  * rather than at module load where a throw would abort before that catch installs
  * and let the harness pass the tool output through UNSANITIZED (fail OPEN).
  */
-import { credentialNameMatcher } from "../../src/credential-names.mjs";
-
 import credentialNames from "../../python/agent_sanitizer/secrets/data/credential-names.json" with { type: "json" };
 import inferenceKeys from "../config/inference-key-vars.json" with { type: "json" };
 import scrubbed from "../config/scrubbed-env-vars.json" with { type: "json" };
@@ -129,30 +127,147 @@ function hostExtraSecretVars() {
   return vars;
 }
 
-/** @type {((name: string) => boolean) | undefined} */
-let _credentialRule;
+// A rendered vocabulary token. Restricting it to A-Z/0-9/_ is what lets the
+// regexes below interpolate it unescaped: a stray metacharacter (or an empty
+// list, which would make the match regex accept nothing and leak every forwarded
+// credential) fails closed here instead of silently under-matching. Digits are
+// admitted because a noun part may legitimately carry one (the vocabulary's parts
+// are `[a-z0-9]+`); a digit cannot be a metacharacter, so it is safe to embed.
+const CRED_TOKEN_RE = /^[A-Z0-9_]+$/;
+
+const VOCAB_LABEL = "credential-names.json";
+
+// Names ending in a credential noun whose value is not a secret. SSH_AUTH_SOCK
+// holds a filesystem path, and redacting it would strip the agent socket out of
+// tool output. Site-independent (anyone running an ssh-agent has it), so it lives
+// with the consumer rather than in the published vocabulary, which describes
+// which WORDS name a secret and cannot know about a specific variable.
+const EXCLUDE_NAMES = ["SSH_AUTH_SOCK"];
+
+// Which noun renderings apply to a variable NAME (the other use, `field-value`,
+// feeds the redactor's `field = value` matcher and is not a name matcher).
+const ENV_NAME_USE = "env-name";
+
 /**
- * The credential-var-NAME predicate, memoized after the first build. Matching by
+ * The whole-name forms of `parts`: underscore-joined and bare-joined, upper-cased.
+ * Both are emitted because both spellings occur in the wild (`API_KEY`, `APIKEY`)
+ * and a matcher anchored on underscore-delimited segments sees them as different
+ * tokens; a single-part noun collapses to one form. Mirrors the Python renderer
+ * (`_segment_forms` in agent_sanitizer/secrets/credential_names.py) so the two
+ * ecosystems derive the same vocabulary from the same file.
+ * @param {string[]} parts
+ * @returns {string[]}
+ */
+function segmentForms(parts) {
+  return [
+    ...new Set([parts.join("_").toUpperCase(), parts.join("").toUpperCase()]),
+  ];
+}
+
+/**
+ * Render the published credential-noun vocabulary into the name-matcher spec:
+ * the credential segments, and the trailing suffixes that mark a
+ * credential-shaped name as holding a non-secret.
+ *
+ * The vocabulary is the SINGLE source both ecosystems read — a curated second
+ * copy of these renderings is what let this matcher fall twelve segments behind
+ * the engine, so a variable named `…_ACCESS_TOKEN` was never recognized as
+ * credential-bearing and its value was never handed to the redactor.
+ * @param {Record<string, any>} spec
+ * @returns {{ segments: string[], excludeSuffixes: string[], excludeNames: string[] }}
+ */
+export function deriveCredentialVocabulary(spec) {
+  const nouns = spec?.nouns;
+  const nonSecret = spec?.nonSecretSuffixes;
+  if (!Array.isArray(nouns) || !Array.isArray(nonSecret))
+    throw new Error(`${VOCAB_LABEL}: nouns/nonSecretSuffixes missing`);
+  const segments = [];
+  for (const noun of nouns)
+    if (Array.isArray(noun?.uses) && noun.uses.includes(ENV_NAME_USE))
+      segments.push(...segmentForms(parts(noun.parts, "nouns[].parts")));
+  // Rendered WITHOUT a leading underscore; the boundary is applied in the regex
+  // below, symmetrically with the match pattern. Baking `_` into the token makes
+  // the exclusion reachable only when something precedes the run, so a variable
+  // named exactly `PUBLIC_KEY` matched on its trailing `KEY` and never reached
+  // its exclusion — its value was then cut out of every tool output carrying it.
+  const excludeSuffixes = nonSecret.flatMap((suffix) =>
+    segmentForms(parts(suffix, "nonSecretSuffixes[]")),
+  );
+  return {
+    segments: [...new Set(segments)],
+    excludeSuffixes: [...new Set(excludeSuffixes)],
+    excludeNames: EXCLUDE_NAMES,
+  };
+}
+
+/**
+ * `value` as a validated non-empty array of lower-case noun parts, or throw. A
+ * malformed part must not render into a token that silently under-matches.
+ * @param {unknown} value
+ * @param {string} field
+ * @returns {string[]}
+ */
+function parts(value, field) {
+  if (!Array.isArray(value) || value.length === 0)
+    throw new Error(`${VOCAB_LABEL}: ${field} is empty or missing`);
+  for (const part of value)
+    if (typeof part !== "string" || !/^[a-z0-9]+$/u.test(part))
+      throw new Error(`${VOCAB_LABEL}: bad part ${part} in ${field}`);
+  return value;
+}
+
+/**
+ * The validated token list under `field`, or throw. An absent, empty, or
+ * metacharacter-bearing list must not degrade into a pattern that matches nothing,
+ * which would leak every forwarded credential.
+ * @param {Record<string, unknown>} spec
+ * @param {string} field
+ * @returns {string[]}
+ */
+function credentialTokens(spec, field) {
+  const group = spec[field];
+  if (!Array.isArray(group) || group.length === 0)
+    throw new Error(`${VOCAB_LABEL}: ${field} is empty or missing`);
+  for (const token of group)
+    if (typeof token !== "string" || !CRED_TOKEN_RE.test(token))
+      throw new Error(`${VOCAB_LABEL}: bad token ${token} in ${field}`);
+  return group;
+}
+
+/**
+ * Validate a rendered name-matcher spec and build its match/exclude regexes. Pure
+ * and exported so the fail-closed paths can be driven directly with a bad spec.
+ * @param {Record<string, unknown>} spec
+ * @returns {{ match: RegExp, exclude: RegExp }}
+ */
+export function buildCredentialNameRes(spec) {
+  const segments = credentialTokens(spec, "segments");
+  const excludeSuffixes = credentialTokens(spec, "excludeSuffixes");
+  const excludeNames = credentialTokens(spec, "excludeNames");
+  return {
+    match: new RegExp(`(?:^|_)(?:${segments.join("|")})$`, "i"),
+    exclude: new RegExp(
+      `(?:^|_)(?:${excludeSuffixes.join("|")})$|^(?:${excludeNames.join("|")})$`,
+      "i",
+    ),
+  };
+}
+
+/** @type {{ match: RegExp, exclude: RegExp } | undefined} */
+let _credentialNameRes;
+/**
+ * The credential-var-NAME regexes, memoized after the first build. Matching by
  * trailing segment lets the redaction set self-populate with any token the
  * process actually holds; a curated list drifts. The curated sets
  * (inferenceKeyVars + scrubbed vars) stay the guaranteed floor; this only ADDS
  * lookalikes.
- *
- * Built by credentialNameMatcher — the package's one credential-name decision —
- * rather than a second regex pair derived here. A local copy is how this module
- * came to read `nonSecretSuffixes` as suffixes needing a PRECEDING underscore,
- * so a variable named exactly `PUBLIC_KEY` was reported credential-bearing and
- * its value cut out of tool output; the matcher compares whole trailing runs and
- * declines it. One decision means the two cannot disagree again.
- * @returns {(name: string) => boolean}
+ * @returns {{ match: RegExp, exclude: RegExp }}
  */
-function credentialRule() {
-  if (_credentialRule !== undefined) return _credentialRule;
-  return (_credentialRule = credentialNameMatcher({
-    spec: credentialNames,
-    scope: "trailing",
-    declineNonSecret: true,
-  }));
+function credentialNameRes() {
+  if (_credentialNameRes !== undefined) return _credentialNameRes;
+  return (_credentialNameRes = buildCredentialNameRes(
+    deriveCredentialVocabulary(credentialNames),
+  ));
 }
 
 /**
@@ -162,7 +277,8 @@ function credentialRule() {
  * @returns {boolean}
  */
 export function looksLikeCredentialVar(name) {
-  return credentialRule()(name);
+  const res = credentialNameRes();
+  return res.match.test(name) && !res.exclude.test(name);
 }
 
 /**
@@ -187,9 +303,9 @@ export function dynamicSecretVars(env = process.env) {
 // the set without this.
 const EXTRA_SECRET_VARS_ENV = "_AGENT_SANITIZER_EXTRA_SECRET_VARS";
 
-// These are whole variable names an operator typed, and real ones carry digits
-// (`AWS_S3_KEY2`); metacharacters are excluded so a malformed entry fails closed
-// rather than widening the set.
+// Digits allowed here but not in CRED_TOKEN_RE: that one gates regex-interpolated
+// name SEGMENTS, while these are whole variable names an operator typed, and real
+// ones carry digits (`AWS_S3_KEY2`). Both exclude metacharacters.
 const EXTRA_TOKEN_RE = /^[A-Z0-9_]+$/;
 
 /**

--- a/claude-hooks/lib/env-config.mjs
+++ b/claude-hooks/lib/env-config.mjs
@@ -17,6 +17,8 @@
  * rather than at module load where a throw would abort before that catch installs
  * and let the harness pass the tool output through UNSANITIZED (fail OPEN).
  */
+import { credentialNameMatcher } from "../../src/credential-names.mjs";
+
 import credentialNames from "../../python/agent_sanitizer/secrets/data/credential-names.json" with { type: "json" };
 import inferenceKeys from "../config/inference-key-vars.json" with { type: "json" };
 import scrubbed from "../config/scrubbed-env-vars.json" with { type: "json" };
@@ -127,144 +129,30 @@ function hostExtraSecretVars() {
   return vars;
 }
 
-// A rendered vocabulary token. Restricting it to A-Z/0-9/_ is what lets the
-// regexes below interpolate it unescaped: a stray metacharacter (or an empty
-// list, which would make the match regex accept nothing and leak every forwarded
-// credential) fails closed here instead of silently under-matching. Digits are
-// admitted because a noun part may legitimately carry one (the vocabulary's parts
-// are `[a-z0-9]+`); a digit cannot be a metacharacter, so it is safe to embed.
-const CRED_TOKEN_RE = /^[A-Z0-9_]+$/;
-
-const VOCAB_LABEL = "credential-names.json";
-
-// Names ending in a credential noun whose value is not a secret. SSH_AUTH_SOCK
-// holds a filesystem path, and redacting it would strip the agent socket out of
-// tool output. Site-independent (anyone running an ssh-agent has it), so it lives
-// with the consumer rather than in the published vocabulary, which describes
-// which WORDS name a secret and cannot know about a specific variable.
-const EXCLUDE_NAMES = ["SSH_AUTH_SOCK"];
-
-// Which noun renderings apply to a variable NAME (the other use, `field-value`,
-// feeds the redactor's `field = value` matcher and is not a name matcher).
-const ENV_NAME_USE = "env-name";
-
+/** @type {((name: string) => boolean) | undefined} */
+let _credentialRule;
 /**
- * The whole-name forms of `parts`: underscore-joined and bare-joined, upper-cased.
- * Both are emitted because both spellings occur in the wild (`API_KEY`, `APIKEY`)
- * and a matcher anchored on underscore-delimited segments sees them as different
- * tokens; a single-part noun collapses to one form. Mirrors the Python renderer
- * (`_segment_forms` in agent_sanitizer/secrets/credential_names.py) so the two
- * ecosystems derive the same vocabulary from the same file.
- * @param {string[]} parts
- * @returns {string[]}
- */
-function segmentForms(parts) {
-  return [
-    ...new Set([parts.join("_").toUpperCase(), parts.join("").toUpperCase()]),
-  ];
-}
-
-/**
- * Render the published credential-noun vocabulary into the name-matcher spec:
- * the credential segments, and the trailing suffixes that mark a
- * credential-shaped name as holding a non-secret.
- *
- * The vocabulary is the SINGLE source both ecosystems read — a curated second
- * copy of these renderings is what let this matcher fall twelve segments behind
- * the engine, so a variable named `…_ACCESS_TOKEN` was never recognized as
- * credential-bearing and its value was never handed to the redactor.
- * @param {Record<string, any>} spec
- * @returns {{ segments: string[], excludeSuffixes: string[], excludeNames: string[] }}
- */
-export function deriveCredentialVocabulary(spec) {
-  const nouns = spec?.nouns;
-  const nonSecret = spec?.nonSecretSuffixes;
-  if (!Array.isArray(nouns) || !Array.isArray(nonSecret))
-    throw new Error(`${VOCAB_LABEL}: nouns/nonSecretSuffixes missing`);
-  const segments = [];
-  for (const noun of nouns)
-    if (Array.isArray(noun?.uses) && noun.uses.includes(ENV_NAME_USE))
-      segments.push(...segmentForms(parts(noun.parts, "nouns[].parts")));
-  const excludeSuffixes = nonSecret.flatMap((suffix) =>
-    segmentForms(parts(suffix, "nonSecretSuffixes[]")).map(
-      (form) => `_${form}`,
-    ),
-  );
-  return {
-    segments: [...new Set(segments)],
-    excludeSuffixes: [...new Set(excludeSuffixes)],
-    excludeNames: EXCLUDE_NAMES,
-  };
-}
-
-/**
- * `value` as a validated non-empty array of lower-case noun parts, or throw. A
- * malformed part must not render into a token that silently under-matches.
- * @param {unknown} value
- * @param {string} field
- * @returns {string[]}
- */
-function parts(value, field) {
-  if (!Array.isArray(value) || value.length === 0)
-    throw new Error(`${VOCAB_LABEL}: ${field} is empty or missing`);
-  for (const part of value)
-    if (typeof part !== "string" || !/^[a-z0-9]+$/u.test(part))
-      throw new Error(`${VOCAB_LABEL}: bad part ${part} in ${field}`);
-  return value;
-}
-
-/**
- * The validated token list under `field`, or throw. An absent, empty, or
- * metacharacter-bearing list must not degrade into a pattern that matches nothing,
- * which would leak every forwarded credential.
- * @param {Record<string, unknown>} spec
- * @param {string} field
- * @returns {string[]}
- */
-function credentialTokens(spec, field) {
-  const group = spec[field];
-  if (!Array.isArray(group) || group.length === 0)
-    throw new Error(`${VOCAB_LABEL}: ${field} is empty or missing`);
-  for (const token of group)
-    if (typeof token !== "string" || !CRED_TOKEN_RE.test(token))
-      throw new Error(`${VOCAB_LABEL}: bad token ${token} in ${field}`);
-  return group;
-}
-
-/**
- * Validate a rendered name-matcher spec and build its match/exclude regexes. Pure
- * and exported so the fail-closed paths can be driven directly with a bad spec.
- * @param {Record<string, unknown>} spec
- * @returns {{ match: RegExp, exclude: RegExp }}
- */
-export function buildCredentialNameRes(spec) {
-  const segments = credentialTokens(spec, "segments");
-  const excludeSuffixes = credentialTokens(spec, "excludeSuffixes");
-  const excludeNames = credentialTokens(spec, "excludeNames");
-  return {
-    match: new RegExp(`(?:^|_)(?:${segments.join("|")})$`, "i"),
-    exclude: new RegExp(
-      `(?:${excludeSuffixes.join("|")})$|^(?:${excludeNames.join("|")})$`,
-      "i",
-    ),
-  };
-}
-
-/** @type {{ match: RegExp, exclude: RegExp } | undefined} */
-let _credentialNameRes;
-/**
- * The credential-var-NAME regexes, memoized after the first build. Matching by
+ * The credential-var-NAME predicate, memoized after the first build. Matching by
  * trailing segment lets the redaction set self-populate with any token the
  * process actually holds; a curated list drifts. The curated sets
  * (inferenceKeyVars + scrubbed vars) stay the guaranteed floor; this only ADDS
  * lookalikes.
- * @returns {{ match: RegExp, exclude: RegExp }}
+ *
+ * Built by credentialNameMatcher — the package's one credential-name decision —
+ * rather than a second regex pair derived here. A local copy is how this module
+ * came to read `nonSecretSuffixes` as suffixes needing a PRECEDING underscore,
+ * so a variable named exactly `PUBLIC_KEY` was reported credential-bearing and
+ * its value cut out of tool output; the matcher compares whole trailing runs and
+ * declines it. One decision means the two cannot disagree again.
+ * @returns {(name: string) => boolean}
  */
-function credentialNameRes() {
-  if (_credentialNameRes !== undefined) return _credentialNameRes;
-  return (_credentialNameRes = buildCredentialNameRes(
-    deriveCredentialVocabulary(credentialNames),
-  ));
+function credentialRule() {
+  if (_credentialRule !== undefined) return _credentialRule;
+  return (_credentialRule = credentialNameMatcher({
+    spec: credentialNames,
+    scope: "trailing",
+    declineNonSecret: true,
+  }));
 }
 
 /**
@@ -274,8 +162,7 @@ function credentialNameRes() {
  * @returns {boolean}
  */
 export function looksLikeCredentialVar(name) {
-  const res = credentialNameRes();
-  return res.match.test(name) && !res.exclude.test(name);
+  return credentialRule()(name);
 }
 
 /**
@@ -300,9 +187,9 @@ export function dynamicSecretVars(env = process.env) {
 // the set without this.
 const EXTRA_SECRET_VARS_ENV = "_AGENT_SANITIZER_EXTRA_SECRET_VARS";
 
-// Digits allowed here but not in CRED_TOKEN_RE: that one gates regex-interpolated
-// name SEGMENTS, while these are whole variable names an operator typed, and real
-// ones carry digits (`AWS_S3_KEY2`). Both exclude metacharacters.
+// These are whole variable names an operator typed, and real ones carry digits
+// (`AWS_S3_KEY2`); metacharacters are excluded so a malformed entry fails closed
+// rather than widening the set.
 const EXTRA_TOKEN_RE = /^[A-Z0-9_]+$/;
 
 /**

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -7835,7 +7835,7 @@ var require_util = __commonJS({
       return path2;
     });
     exports.normalize = normalize3;
-    function join6(aRoot, aPath) {
+    function join5(aRoot, aPath) {
       if (aRoot === "") {
         aRoot = ".";
       }
@@ -7867,7 +7867,7 @@ var require_util = __commonJS({
       }
       return joined;
     }
-    exports.join = join6;
+    exports.join = join5;
     exports.isAbsolute = function(aPath) {
       return aPath.charAt(0) === "/" || urlRegexp.test(aPath);
     };
@@ -8081,7 +8081,7 @@ var require_util = __commonJS({
             parsed.path = parsed.path.substring(0, index2 + 1);
           }
         }
-        sourceURL = join6(urlGenerate(parsed), sourceURL);
+        sourceURL = join5(urlGenerate(parsed), sourceURL);
       }
       return normalize3(sourceURL);
     }
@@ -31752,9 +31752,9 @@ var init_lib5 = __esm({
        * @returns {undefined}
        *   Nothing.
        */
-      set dirname(dirname3) {
+      set dirname(dirname2) {
         assertPath(this.basename, "dirname");
-        this.path = default2.join(dirname3 || "", this.basename);
+        this.path = default2.join(dirname2 || "", this.basename);
       }
       /**
        * Get the extname (including dot) (example: `'.js'`).
@@ -66904,126 +66904,9 @@ var init_authored_content = __esm({
   }
 });
 
-// src/credential-names.mjs
-import { readFileSync as readFileSync3 } from "node:fs";
-import { dirname, join as join2 } from "node:path";
-import { fileURLToPath as fileURLToPath2 } from "node:url";
-function dedupe(values) {
-  return [...new Set(values)];
-}
-function segmentForms(parts2) {
-  return dedupe([parts2.join("_").toUpperCase(), parts2.join("").toUpperCase()]);
-}
-function parts(value, field) {
-  if (!Array.isArray(value) || value.length === 0)
-    throw new Error(`${FILE_LABEL}: ${field} is empty or missing`);
-  const bad = value.filter(
-    (part) => typeof part !== "string" || !PART_RE.test(part)
-  );
-  if (bad.length)
-    throw new Error(
-      `${FILE_LABEL}: bad part(s) ${JSON.stringify(bad)} in ${field}`
-    );
-  return value;
-}
-function uses(value, field) {
-  if (!Array.isArray(value) || value.length === 0)
-    throw new Error(`${FILE_LABEL}: ${field} is empty or missing`);
-  const unknown = value.filter((use) => !KNOWN_USES.has(use)).sort();
-  if (unknown.length)
-    throw new Error(
-      `${FILE_LABEL}: unknown use(s) ${JSON.stringify(unknown)} in ${field}`
-    );
-  return new Set(value);
-}
-function parseCredentialNames(spec2) {
-  const nouns = spec2?.nouns;
-  if (!Array.isArray(nouns) || nouns.length === 0)
-    throw new Error(`${FILE_LABEL}: nouns is empty or missing`);
-  const segments = [];
-  const fieldNamePatterns = [];
-  nouns.forEach((noun, index2) => {
-    if (typeof noun !== "object" || noun === null || Array.isArray(noun))
-      throw new Error(`${FILE_LABEL}: nouns[${index2}] is not an object`);
-    const nounParts = parts(noun.parts, `nouns[${index2}].parts`);
-    const nounUses = uses(noun.uses, `nouns[${index2}].uses`);
-    if (nounUses.has(ENV_NAME_USE)) segments.push(...segmentForms(nounParts));
-    if (nounUses.has(FIELD_VALUE_USE))
-      fieldNamePatterns.push(nounParts.join("[_-]?"));
-  });
-  const suffixes = spec2?.nonSecretSuffixes;
-  if (!Array.isArray(suffixes) || suffixes.length === 0)
-    throw new Error(`${FILE_LABEL}: nonSecretSuffixes is empty or missing`);
-  const nonSecretSegments = suffixes.flatMap(
-    (suffix, index2) => segmentForms(parts(suffix, `nonSecretSuffixes[${index2}]`))
-  );
-  if (!segments.length)
-    throw new Error(`${FILE_LABEL}: no noun is marked ${ENV_NAME_USE}`);
-  if (!fieldNamePatterns.length)
-    throw new Error(`${FILE_LABEL}: no noun is marked ${FIELD_VALUE_USE}`);
-  return {
-    segments: dedupe(segments),
-    fieldNamePatterns: dedupe(fieldNamePatterns),
-    nonSecretSegments: dedupe(nonSecretSegments)
-  };
-}
-function credentialNames() {
-  return _packaged ??= parseCredentialNames(
-    JSON.parse(readFileSync3(DATA_FILE, "utf8"))
-  );
-}
-function credentialNameMatcher(options = {}) {
-  const { scope = "trailing", declineNonSecret = true, spec: spec2 } = options;
-  if (scope !== "trailing" && scope !== "any-segment")
-    throw new Error(
-      `credentialNameMatcher: unknown scope ${JSON.stringify(scope)}`
-    );
-  const vocabulary = spec2 ? parseCredentialNames(spec2) : credentialNames();
-  const nouns = new Set(vocabulary.segments);
-  const nonSecret = new Set(vocabulary.nonSecretSegments);
-  const maxRun = Math.max(
-    ...vocabulary.segments.map((noun) => noun.split("_").length)
-  );
-  const trailingRuns = (words) => Array.from(
-    { length: Math.min(maxRun, words.length) },
-    (_, i) => words.slice(words.length - (i + 1)).join("_")
-  );
-  return (name50) => {
-    const words = name50.toUpperCase().split("_");
-    if (declineNonSecret && trailingRuns(words).some((run) => nonSecret.has(run)))
-      return false;
-    if (scope === "trailing")
-      return trailingRuns(words).some((run) => nouns.has(run));
-    for (let start = 0; start < words.length; start++)
-      for (let span = 1; span <= maxRun && start + span <= words.length; span++)
-        if (nouns.has(words.slice(start, start + span).join("_"))) return true;
-    return false;
-  };
-}
-var DATA_FILE, FILE_LABEL, ENV_NAME_USE, FIELD_VALUE_USE, KNOWN_USES, PART_RE, _packaged;
-var init_credential_names = __esm({
-  "src/credential-names.mjs"() {
-    "use strict";
-    DATA_FILE = join2(
-      dirname(fileURLToPath2(import.meta.url)),
-      "..",
-      "python",
-      "agent_sanitizer",
-      "secrets",
-      "data",
-      "credential-names.json"
-    );
-    FILE_LABEL = "credential-names.json";
-    ENV_NAME_USE = "env-name";
-    FIELD_VALUE_USE = "field-value";
-    KNOWN_USES = /* @__PURE__ */ new Set([ENV_NAME_USE, FIELD_VALUE_USE]);
-    PART_RE = /^[a-z0-9]+$/;
-  }
-});
-
 // python/agent_sanitizer/secrets/data/credential-names.json
 var credential_names_default;
-var init_credential_names2 = __esm({
+var init_credential_names = __esm({
   "python/agent_sanitizer/secrets/data/credential-names.json"() {
     credential_names_default = {
       $comment: "The credential-noun vocabulary: the words that make an identifier name a secret. Published so every consumer derives its own matcher from ONE list \u2014 a newly recognized noun reaches them all through a version bump instead of N hand edits. Read it from Python via agent_sanitizer.secrets (credential_name_segments / credential_field_name_patterns / non_secret_name_segments) or from JavaScript via the npm subpath export `agent-sanitizer/credential-names`. `parts` are the lowercase words of the noun; a consumer renders them for its own matcher (underscore-joined `API_KEY` and bare-joined `APIKEY` for an env-var NAME, `api[_-]?key` for a `field = value` regex). `uses` says which matcher may use the noun, because the two are not interchangeable: `env-name` matches a variable NAME and never inspects a value, so a broad noun there costs nothing, while `field-value` redacts whatever follows `noun = ` and a broad noun there mangles ordinary text \u2014 `key = <20 chars>` is a false-positive flood, so `key`, `pat`, `credential`, `credentials` and `secrets` are env-name only \u2014 `credential`/`credentials` are everyday variable names, and an attribute chain (`credentials = service_account.Credentials.from_service_account_info(info)`) escapes every value-shape skip, so a field-value rendering would redact ordinary source lines. `passphrase` is the exception among them: it is as shape-specific as `password`, and detect-secrets' own KeywordDetector DENYLIST omits it, so name-only would let `passphrase = <secret>` reach the model in cleartext. `nonSecretSuffixes` are the trailing words that make a credential-shaped name hold a NON-secret (a key's identifier, the public half of a keypair), which a consumer must not redact. Every part is restricted to a-z0-9 so it carries no regex metacharacter; the accessors enforce that and fail closed on a violation, an empty list, or an unknown `uses` value. It sits inside the Python package because a wheel can only ship data under its package directory, while npm's `files`/`exports` can name any path \u2014 so ONE physical file backs both ecosystems and there is no copy to drift.",
@@ -67142,16 +67025,67 @@ function hostExtraSecretVars() {
       );
   return vars;
 }
-function credentialRule() {
-  if (_credentialRule !== void 0) return _credentialRule;
-  return _credentialRule = credentialNameMatcher({
-    spec: credential_names_default,
-    scope: "trailing",
-    declineNonSecret: true
-  });
+function segmentForms(parts2) {
+  return [
+    .../* @__PURE__ */ new Set([parts2.join("_").toUpperCase(), parts2.join("").toUpperCase()])
+  ];
+}
+function deriveCredentialVocabulary(spec2) {
+  const nouns = spec2?.nouns;
+  const nonSecret = spec2?.nonSecretSuffixes;
+  if (!Array.isArray(nouns) || !Array.isArray(nonSecret))
+    throw new Error(`${VOCAB_LABEL}: nouns/nonSecretSuffixes missing`);
+  const segments = [];
+  for (const noun of nouns)
+    if (Array.isArray(noun?.uses) && noun.uses.includes(ENV_NAME_USE))
+      segments.push(...segmentForms(parts(noun.parts, "nouns[].parts")));
+  const excludeSuffixes = nonSecret.flatMap(
+    (suffix) => segmentForms(parts(suffix, "nonSecretSuffixes[]"))
+  );
+  return {
+    segments: [...new Set(segments)],
+    excludeSuffixes: [...new Set(excludeSuffixes)],
+    excludeNames: EXCLUDE_NAMES
+  };
+}
+function parts(value, field) {
+  if (!Array.isArray(value) || value.length === 0)
+    throw new Error(`${VOCAB_LABEL}: ${field} is empty or missing`);
+  for (const part of value)
+    if (typeof part !== "string" || !/^[a-z0-9]+$/u.test(part))
+      throw new Error(`${VOCAB_LABEL}: bad part ${part} in ${field}`);
+  return value;
+}
+function credentialTokens(spec2, field) {
+  const group = spec2[field];
+  if (!Array.isArray(group) || group.length === 0)
+    throw new Error(`${VOCAB_LABEL}: ${field} is empty or missing`);
+  for (const token of group)
+    if (typeof token !== "string" || !CRED_TOKEN_RE.test(token))
+      throw new Error(`${VOCAB_LABEL}: bad token ${token} in ${field}`);
+  return group;
+}
+function buildCredentialNameRes(spec2) {
+  const segments = credentialTokens(spec2, "segments");
+  const excludeSuffixes = credentialTokens(spec2, "excludeSuffixes");
+  const excludeNames = credentialTokens(spec2, "excludeNames");
+  return {
+    match: new RegExp(`(?:^|_)(?:${segments.join("|")})$`, "i"),
+    exclude: new RegExp(
+      `(?:^|_)(?:${excludeSuffixes.join("|")})$|^(?:${excludeNames.join("|")})$`,
+      "i"
+    )
+  };
+}
+function credentialNameRes() {
+  if (_credentialNameRes !== void 0) return _credentialNameRes;
+  return _credentialNameRes = buildCredentialNameRes(
+    deriveCredentialVocabulary(credential_names_default)
+  );
 }
 function looksLikeCredentialVar(name50) {
-  return credentialRule()(name50);
+  const res = credentialNameRes();
+  return res.match.test(name50) && !res.exclude.test(name50);
 }
 function dynamicSecretVars(env = process.env) {
   const floor = minEnvSecretLen();
@@ -67181,17 +67115,20 @@ function envBoundSecretVars(env = process.env) {
     ])
   ];
 }
-var hostEnvConfigSource, HOST_SOURCE_LABEL, HOST_SOURCE_KEYS, _credentialRule, EXTRA_SECRET_VARS_ENV, EXTRA_TOKEN_RE;
+var hostEnvConfigSource, HOST_SOURCE_LABEL, HOST_SOURCE_KEYS, CRED_TOKEN_RE, VOCAB_LABEL, EXCLUDE_NAMES, ENV_NAME_USE, _credentialNameRes, EXTRA_SECRET_VARS_ENV, EXTRA_TOKEN_RE;
 var init_env_config = __esm({
   "claude-hooks/lib/env-config.mjs"() {
     "use strict";
     init_credential_names();
-    init_credential_names2();
     init_inference_key_vars();
     init_scrubbed_env_vars();
     hostEnvConfigSource = null;
     HOST_SOURCE_LABEL = "configureEnvConfigSource";
     HOST_SOURCE_KEYS = ["minSecretLen", "extraVars"];
+    CRED_TOKEN_RE = /^[A-Z0-9_]+$/;
+    VOCAB_LABEL = "credential-names.json";
+    EXCLUDE_NAMES = ["SSH_AUTH_SOCK"];
+    ENV_NAME_USE = "env-name";
     EXTRA_SECRET_VARS_ENV = "_AGENT_SANITIZER_EXTRA_SECRET_VARS";
     EXTRA_TOKEN_RE = /^[A-Z0-9_]+$/;
   }
@@ -67202,8 +67139,8 @@ import { spawn } from "node:child_process";
 import { existsSync, lstatSync as lstatSync2 } from "node:fs";
 import { createConnection } from "node:net";
 import { tmpdir as tmpdir2, userInfo as userInfo2 } from "node:os";
-import { dirname as dirname2, join as join3 } from "node:path";
-import { fileURLToPath as fileURLToPath3 } from "node:url";
+import { dirname, join as join2 } from "node:path";
+import { fileURLToPath as fileURLToPath2 } from "node:url";
 function positiveMsOr(raw, fallback) {
   const ms = Number(raw);
   return Number.isFinite(ms) && ms > 0 ? ms : fallback;
@@ -67211,7 +67148,7 @@ function positiveMsOr(raw, fallback) {
 function daemonCommand() {
   const configured = process.env._AGENT_SANITIZER_REDACTOR_DAEMON;
   if (configured) return [configured];
-  const pyz = fileURLToPath3(new URL("../redactor/daemon.pyz", import.meta.url));
+  const pyz = fileURLToPath2(new URL("../redactor/daemon.pyz", import.meta.url));
   if (existsSync(pyz)) return ["python3", pyz];
   return ["agent-secret-redactor-daemon"];
 }
@@ -67253,7 +67190,7 @@ function classifySocket(socketPath, deps = {}) {
   if (!st.isSocket() || st.uid !== uid) return "untrusted";
   let dir;
   try {
-    dir = lstat(dirname2(socketPath));
+    dir = lstat(dirname(socketPath));
   } catch {
     return "untrusted";
   }
@@ -67429,7 +67366,7 @@ var init_redactor_client = __esm({
     "use strict";
     init_env_config();
     FRAME_CAP = 16 * 1024 * 1024;
-    DEFAULT_SOCKET_PATH = process.env._AGENT_SANITIZER_REDACTOR_SOCKET || join3(tmpdir2(), "agent-sanitizer-redactor", "redactor.sock");
+    DEFAULT_SOCKET_PATH = process.env._AGENT_SANITIZER_REDACTOR_SOCKET || join2(tmpdir2(), "agent-sanitizer-redactor", "redactor.sock");
     WAIT_DEADLINE_MS = positiveMsOr(
       process.env._AGENT_SANITIZER_REDACTOR_WAIT_MS,
       8e3
@@ -67490,7 +67427,7 @@ __export(pretooluse_sanitize_exports, {
   judgePreToolUseSanitize: () => judgePreToolUseSanitize
 });
 import { createRequire as createRequire4 } from "node:module";
-import { readFileSync as readFileSync4 } from "node:fs";
+import { readFileSync as readFileSync3 } from "node:fs";
 function emitTraced(emitTrace, toolName, fields) {
   let outcome = "modified";
   if (fields === null) outcome = "noop";
@@ -67673,7 +67610,7 @@ var init_pretooluse_sanitize = __esm({
       text5
     );
     redactorIo = {
-      readFile: (path2) => readFileSync4(path2, "utf8"),
+      readFile: (path2) => readFileSync3(path2, "utf8"),
       redactMap: async (text5) => (
         /** @type {any} */
         await redactViaDaemon(text5, { map: true })
@@ -67719,13 +67656,13 @@ var init_secret_annotate = __esm({
 import { createHash as createHash3 } from "node:crypto";
 import { mkdirSync, lstatSync as lstatSync3 } from "node:fs";
 import { tmpdir as tmpdir3, userInfo as userInfo3 } from "node:os";
-import { join as join4, resolve, sep } from "node:path";
+import { join as join3, resolve, sep } from "node:path";
 function revealDir() {
-  return process.env._AGENT_SANITIZER_REVEAL_DIR || join4(tmpdir3(), "agent-sanitizer-layer2-reveal");
+  return process.env._AGENT_SANITIZER_REVEAL_DIR || join3(tmpdir3(), "agent-sanitizer-layer2-reveal");
 }
 function revealPathFor(content3) {
   const digest = createHash3("sha256").update(content3, "utf8").digest("hex");
-  return join4(revealDir(), `${digest}.txt`);
+  return join3(revealDir(), `${digest}.txt`);
 }
 function revealDirIsSafe(dir) {
   try {
@@ -68207,8 +68144,8 @@ __export(scan_invisible_chars_exports, {
   formatReport: () => formatReport,
   scanFile: () => scanFile
 });
-import { readFileSync as readFileSync5, globSync, writeFileSync as writeFileSync2, unlinkSync as unlinkSync2 } from "node:fs";
-import { join as join5, relative } from "node:path";
+import { readFileSync as readFileSync4, globSync, writeFileSync as writeFileSync2, unlinkSync as unlinkSync2 } from "node:fs";
+import { join as join4, relative } from "node:path";
 async function ensureSanitizerLoaded() {
   if (typeof stripInvisible3 === "function") return true;
   const marker2 = hookgateMarkerPath();
@@ -68261,7 +68198,7 @@ function findMdFiles(dir) {
   return globSync("**/*.md", {
     cwd: dir,
     exclude: (name50) => name50 === "node_modules"
-  }).map((name50) => join5(dir, name50));
+  }).map((name50) => join4(dir, name50));
 }
 function findInstructionFiles(dir) {
   return globSync(
@@ -68275,10 +68212,10 @@ function findInstructionFiles(dir) {
       cwd: dir,
       exclude: (name50) => name50 === "node_modules"
     }
-  ).map((name50) => join5(dir, name50));
+  ).map((name50) => join4(dir, name50));
 }
 function scanFile(filePath) {
-  const content3 = readFileSync5(filePath, "utf-8");
+  const content3 = readFileSync4(filePath, "utf-8");
   const findings = [];
   LONG_RUN_RE3.lastIndex = 0;
   let match;
@@ -68332,7 +68269,7 @@ function scanProject() {
   const targets = [
     .../* @__PURE__ */ new Set([
       ...findInstructionFiles(PROJECT_DIR),
-      ...findMdFiles(join5(PROJECT_DIR, ".claude"))
+      ...findMdFiles(join4(PROJECT_DIR, ".claude"))
     ])
   ];
   const allFindings = [];
@@ -68373,9 +68310,9 @@ async function cliMain3({ trace: sink = trace } = {}) {
   });
   let cleaned = 0;
   for (const { file } of allFindings) {
-    const absPath = join5(PROJECT_DIR, file);
+    const absPath = join4(PROJECT_DIR, file);
     try {
-      const original = readFileSync5(absPath, "utf-8");
+      const original = readFileSync4(absPath, "utf-8");
       const stripped = stripInvisible3(original);
       if (stripped !== original) {
         writeFileSync2(absPath, stripped);

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -7835,7 +7835,7 @@ var require_util = __commonJS({
       return path2;
     });
     exports.normalize = normalize3;
-    function join5(aRoot, aPath) {
+    function join6(aRoot, aPath) {
       if (aRoot === "") {
         aRoot = ".";
       }
@@ -7867,7 +7867,7 @@ var require_util = __commonJS({
       }
       return joined;
     }
-    exports.join = join5;
+    exports.join = join6;
     exports.isAbsolute = function(aPath) {
       return aPath.charAt(0) === "/" || urlRegexp.test(aPath);
     };
@@ -8081,7 +8081,7 @@ var require_util = __commonJS({
             parsed.path = parsed.path.substring(0, index2 + 1);
           }
         }
-        sourceURL = join5(urlGenerate(parsed), sourceURL);
+        sourceURL = join6(urlGenerate(parsed), sourceURL);
       }
       return normalize3(sourceURL);
     }
@@ -31752,9 +31752,9 @@ var init_lib5 = __esm({
        * @returns {undefined}
        *   Nothing.
        */
-      set dirname(dirname2) {
+      set dirname(dirname3) {
         assertPath(this.basename, "dirname");
-        this.path = default2.join(dirname2 || "", this.basename);
+        this.path = default2.join(dirname3 || "", this.basename);
       }
       /**
        * Get the extname (including dot) (example: `'.js'`).
@@ -66904,9 +66904,126 @@ var init_authored_content = __esm({
   }
 });
 
+// src/credential-names.mjs
+import { readFileSync as readFileSync3 } from "node:fs";
+import { dirname, join as join2 } from "node:path";
+import { fileURLToPath as fileURLToPath2 } from "node:url";
+function dedupe(values) {
+  return [...new Set(values)];
+}
+function segmentForms(parts2) {
+  return dedupe([parts2.join("_").toUpperCase(), parts2.join("").toUpperCase()]);
+}
+function parts(value, field) {
+  if (!Array.isArray(value) || value.length === 0)
+    throw new Error(`${FILE_LABEL}: ${field} is empty or missing`);
+  const bad = value.filter(
+    (part) => typeof part !== "string" || !PART_RE.test(part)
+  );
+  if (bad.length)
+    throw new Error(
+      `${FILE_LABEL}: bad part(s) ${JSON.stringify(bad)} in ${field}`
+    );
+  return value;
+}
+function uses(value, field) {
+  if (!Array.isArray(value) || value.length === 0)
+    throw new Error(`${FILE_LABEL}: ${field} is empty or missing`);
+  const unknown = value.filter((use) => !KNOWN_USES.has(use)).sort();
+  if (unknown.length)
+    throw new Error(
+      `${FILE_LABEL}: unknown use(s) ${JSON.stringify(unknown)} in ${field}`
+    );
+  return new Set(value);
+}
+function parseCredentialNames(spec2) {
+  const nouns = spec2?.nouns;
+  if (!Array.isArray(nouns) || nouns.length === 0)
+    throw new Error(`${FILE_LABEL}: nouns is empty or missing`);
+  const segments = [];
+  const fieldNamePatterns = [];
+  nouns.forEach((noun, index2) => {
+    if (typeof noun !== "object" || noun === null || Array.isArray(noun))
+      throw new Error(`${FILE_LABEL}: nouns[${index2}] is not an object`);
+    const nounParts = parts(noun.parts, `nouns[${index2}].parts`);
+    const nounUses = uses(noun.uses, `nouns[${index2}].uses`);
+    if (nounUses.has(ENV_NAME_USE)) segments.push(...segmentForms(nounParts));
+    if (nounUses.has(FIELD_VALUE_USE))
+      fieldNamePatterns.push(nounParts.join("[_-]?"));
+  });
+  const suffixes = spec2?.nonSecretSuffixes;
+  if (!Array.isArray(suffixes) || suffixes.length === 0)
+    throw new Error(`${FILE_LABEL}: nonSecretSuffixes is empty or missing`);
+  const nonSecretSegments = suffixes.flatMap(
+    (suffix, index2) => segmentForms(parts(suffix, `nonSecretSuffixes[${index2}]`))
+  );
+  if (!segments.length)
+    throw new Error(`${FILE_LABEL}: no noun is marked ${ENV_NAME_USE}`);
+  if (!fieldNamePatterns.length)
+    throw new Error(`${FILE_LABEL}: no noun is marked ${FIELD_VALUE_USE}`);
+  return {
+    segments: dedupe(segments),
+    fieldNamePatterns: dedupe(fieldNamePatterns),
+    nonSecretSegments: dedupe(nonSecretSegments)
+  };
+}
+function credentialNames() {
+  return _packaged ??= parseCredentialNames(
+    JSON.parse(readFileSync3(DATA_FILE, "utf8"))
+  );
+}
+function credentialNameMatcher(options = {}) {
+  const { scope = "trailing", declineNonSecret = true, spec: spec2 } = options;
+  if (scope !== "trailing" && scope !== "any-segment")
+    throw new Error(
+      `credentialNameMatcher: unknown scope ${JSON.stringify(scope)}`
+    );
+  const vocabulary = spec2 ? parseCredentialNames(spec2) : credentialNames();
+  const nouns = new Set(vocabulary.segments);
+  const nonSecret = new Set(vocabulary.nonSecretSegments);
+  const maxRun = Math.max(
+    ...vocabulary.segments.map((noun) => noun.split("_").length)
+  );
+  const trailingRuns = (words) => Array.from(
+    { length: Math.min(maxRun, words.length) },
+    (_, i) => words.slice(words.length - (i + 1)).join("_")
+  );
+  return (name50) => {
+    const words = name50.toUpperCase().split("_");
+    if (declineNonSecret && trailingRuns(words).some((run) => nonSecret.has(run)))
+      return false;
+    if (scope === "trailing")
+      return trailingRuns(words).some((run) => nouns.has(run));
+    for (let start = 0; start < words.length; start++)
+      for (let span = 1; span <= maxRun && start + span <= words.length; span++)
+        if (nouns.has(words.slice(start, start + span).join("_"))) return true;
+    return false;
+  };
+}
+var DATA_FILE, FILE_LABEL, ENV_NAME_USE, FIELD_VALUE_USE, KNOWN_USES, PART_RE, _packaged;
+var init_credential_names = __esm({
+  "src/credential-names.mjs"() {
+    "use strict";
+    DATA_FILE = join2(
+      dirname(fileURLToPath2(import.meta.url)),
+      "..",
+      "python",
+      "agent_sanitizer",
+      "secrets",
+      "data",
+      "credential-names.json"
+    );
+    FILE_LABEL = "credential-names.json";
+    ENV_NAME_USE = "env-name";
+    FIELD_VALUE_USE = "field-value";
+    KNOWN_USES = /* @__PURE__ */ new Set([ENV_NAME_USE, FIELD_VALUE_USE]);
+    PART_RE = /^[a-z0-9]+$/;
+  }
+});
+
 // python/agent_sanitizer/secrets/data/credential-names.json
 var credential_names_default;
-var init_credential_names = __esm({
+var init_credential_names2 = __esm({
   "python/agent_sanitizer/secrets/data/credential-names.json"() {
     credential_names_default = {
       $comment: "The credential-noun vocabulary: the words that make an identifier name a secret. Published so every consumer derives its own matcher from ONE list \u2014 a newly recognized noun reaches them all through a version bump instead of N hand edits. Read it from Python via agent_sanitizer.secrets (credential_name_segments / credential_field_name_patterns / non_secret_name_segments) or from JavaScript via the npm subpath export `agent-sanitizer/credential-names`. `parts` are the lowercase words of the noun; a consumer renders them for its own matcher (underscore-joined `API_KEY` and bare-joined `APIKEY` for an env-var NAME, `api[_-]?key` for a `field = value` regex). `uses` says which matcher may use the noun, because the two are not interchangeable: `env-name` matches a variable NAME and never inspects a value, so a broad noun there costs nothing, while `field-value` redacts whatever follows `noun = ` and a broad noun there mangles ordinary text \u2014 `key = <20 chars>` is a false-positive flood, so `key`, `pat`, `credential`, `credentials` and `secrets` are env-name only \u2014 `credential`/`credentials` are everyday variable names, and an attribute chain (`credentials = service_account.Credentials.from_service_account_info(info)`) escapes every value-shape skip, so a field-value rendering would redact ordinary source lines. `passphrase` is the exception among them: it is as shape-specific as `password`, and detect-secrets' own KeywordDetector DENYLIST omits it, so name-only would let `passphrase = <secret>` reach the model in cleartext. `nonSecretSuffixes` are the trailing words that make a credential-shaped name hold a NON-secret (a key's identifier, the public half of a keypair), which a consumer must not redact. Every part is restricted to a-z0-9 so it carries no regex metacharacter; the accessors enforce that and fail closed on a violation, an empty list, or an unknown `uses` value. It sits inside the Python package because a wheel can only ship data under its package directory, while npm's `files`/`exports` can name any path \u2014 so ONE physical file backs both ecosystems and there is no copy to drift.",
@@ -67025,69 +67142,16 @@ function hostExtraSecretVars() {
       );
   return vars;
 }
-function segmentForms(parts2) {
-  return [
-    .../* @__PURE__ */ new Set([parts2.join("_").toUpperCase(), parts2.join("").toUpperCase()])
-  ];
-}
-function deriveCredentialVocabulary(spec2) {
-  const nouns = spec2?.nouns;
-  const nonSecret = spec2?.nonSecretSuffixes;
-  if (!Array.isArray(nouns) || !Array.isArray(nonSecret))
-    throw new Error(`${VOCAB_LABEL}: nouns/nonSecretSuffixes missing`);
-  const segments = [];
-  for (const noun of nouns)
-    if (Array.isArray(noun?.uses) && noun.uses.includes(ENV_NAME_USE))
-      segments.push(...segmentForms(parts(noun.parts, "nouns[].parts")));
-  const excludeSuffixes = nonSecret.flatMap(
-    (suffix) => segmentForms(parts(suffix, "nonSecretSuffixes[]")).map(
-      (form) => `_${form}`
-    )
-  );
-  return {
-    segments: [...new Set(segments)],
-    excludeSuffixes: [...new Set(excludeSuffixes)],
-    excludeNames: EXCLUDE_NAMES
-  };
-}
-function parts(value, field) {
-  if (!Array.isArray(value) || value.length === 0)
-    throw new Error(`${VOCAB_LABEL}: ${field} is empty or missing`);
-  for (const part of value)
-    if (typeof part !== "string" || !/^[a-z0-9]+$/u.test(part))
-      throw new Error(`${VOCAB_LABEL}: bad part ${part} in ${field}`);
-  return value;
-}
-function credentialTokens(spec2, field) {
-  const group = spec2[field];
-  if (!Array.isArray(group) || group.length === 0)
-    throw new Error(`${VOCAB_LABEL}: ${field} is empty or missing`);
-  for (const token of group)
-    if (typeof token !== "string" || !CRED_TOKEN_RE.test(token))
-      throw new Error(`${VOCAB_LABEL}: bad token ${token} in ${field}`);
-  return group;
-}
-function buildCredentialNameRes(spec2) {
-  const segments = credentialTokens(spec2, "segments");
-  const excludeSuffixes = credentialTokens(spec2, "excludeSuffixes");
-  const excludeNames = credentialTokens(spec2, "excludeNames");
-  return {
-    match: new RegExp(`(?:^|_)(?:${segments.join("|")})$`, "i"),
-    exclude: new RegExp(
-      `(?:${excludeSuffixes.join("|")})$|^(?:${excludeNames.join("|")})$`,
-      "i"
-    )
-  };
-}
-function credentialNameRes() {
-  if (_credentialNameRes !== void 0) return _credentialNameRes;
-  return _credentialNameRes = buildCredentialNameRes(
-    deriveCredentialVocabulary(credential_names_default)
-  );
+function credentialRule() {
+  if (_credentialRule !== void 0) return _credentialRule;
+  return _credentialRule = credentialNameMatcher({
+    spec: credential_names_default,
+    scope: "trailing",
+    declineNonSecret: true
+  });
 }
 function looksLikeCredentialVar(name50) {
-  const res = credentialNameRes();
-  return res.match.test(name50) && !res.exclude.test(name50);
+  return credentialRule()(name50);
 }
 function dynamicSecretVars(env = process.env) {
   const floor = minEnvSecretLen();
@@ -67117,20 +67181,17 @@ function envBoundSecretVars(env = process.env) {
     ])
   ];
 }
-var hostEnvConfigSource, HOST_SOURCE_LABEL, HOST_SOURCE_KEYS, CRED_TOKEN_RE, VOCAB_LABEL, EXCLUDE_NAMES, ENV_NAME_USE, _credentialNameRes, EXTRA_SECRET_VARS_ENV, EXTRA_TOKEN_RE;
+var hostEnvConfigSource, HOST_SOURCE_LABEL, HOST_SOURCE_KEYS, _credentialRule, EXTRA_SECRET_VARS_ENV, EXTRA_TOKEN_RE;
 var init_env_config = __esm({
   "claude-hooks/lib/env-config.mjs"() {
     "use strict";
     init_credential_names();
+    init_credential_names2();
     init_inference_key_vars();
     init_scrubbed_env_vars();
     hostEnvConfigSource = null;
     HOST_SOURCE_LABEL = "configureEnvConfigSource";
     HOST_SOURCE_KEYS = ["minSecretLen", "extraVars"];
-    CRED_TOKEN_RE = /^[A-Z0-9_]+$/;
-    VOCAB_LABEL = "credential-names.json";
-    EXCLUDE_NAMES = ["SSH_AUTH_SOCK"];
-    ENV_NAME_USE = "env-name";
     EXTRA_SECRET_VARS_ENV = "_AGENT_SANITIZER_EXTRA_SECRET_VARS";
     EXTRA_TOKEN_RE = /^[A-Z0-9_]+$/;
   }
@@ -67141,8 +67202,8 @@ import { spawn } from "node:child_process";
 import { existsSync, lstatSync as lstatSync2 } from "node:fs";
 import { createConnection } from "node:net";
 import { tmpdir as tmpdir2, userInfo as userInfo2 } from "node:os";
-import { dirname, join as join2 } from "node:path";
-import { fileURLToPath as fileURLToPath2 } from "node:url";
+import { dirname as dirname2, join as join3 } from "node:path";
+import { fileURLToPath as fileURLToPath3 } from "node:url";
 function positiveMsOr(raw, fallback) {
   const ms = Number(raw);
   return Number.isFinite(ms) && ms > 0 ? ms : fallback;
@@ -67150,7 +67211,7 @@ function positiveMsOr(raw, fallback) {
 function daemonCommand() {
   const configured = process.env._AGENT_SANITIZER_REDACTOR_DAEMON;
   if (configured) return [configured];
-  const pyz = fileURLToPath2(new URL("../redactor/daemon.pyz", import.meta.url));
+  const pyz = fileURLToPath3(new URL("../redactor/daemon.pyz", import.meta.url));
   if (existsSync(pyz)) return ["python3", pyz];
   return ["agent-secret-redactor-daemon"];
 }
@@ -67192,7 +67253,7 @@ function classifySocket(socketPath, deps = {}) {
   if (!st.isSocket() || st.uid !== uid) return "untrusted";
   let dir;
   try {
-    dir = lstat(dirname(socketPath));
+    dir = lstat(dirname2(socketPath));
   } catch {
     return "untrusted";
   }
@@ -67368,7 +67429,7 @@ var init_redactor_client = __esm({
     "use strict";
     init_env_config();
     FRAME_CAP = 16 * 1024 * 1024;
-    DEFAULT_SOCKET_PATH = process.env._AGENT_SANITIZER_REDACTOR_SOCKET || join2(tmpdir2(), "agent-sanitizer-redactor", "redactor.sock");
+    DEFAULT_SOCKET_PATH = process.env._AGENT_SANITIZER_REDACTOR_SOCKET || join3(tmpdir2(), "agent-sanitizer-redactor", "redactor.sock");
     WAIT_DEADLINE_MS = positiveMsOr(
       process.env._AGENT_SANITIZER_REDACTOR_WAIT_MS,
       8e3
@@ -67429,7 +67490,7 @@ __export(pretooluse_sanitize_exports, {
   judgePreToolUseSanitize: () => judgePreToolUseSanitize
 });
 import { createRequire as createRequire4 } from "node:module";
-import { readFileSync as readFileSync3 } from "node:fs";
+import { readFileSync as readFileSync4 } from "node:fs";
 function emitTraced(emitTrace, toolName, fields) {
   let outcome = "modified";
   if (fields === null) outcome = "noop";
@@ -67612,7 +67673,7 @@ var init_pretooluse_sanitize = __esm({
       text5
     );
     redactorIo = {
-      readFile: (path2) => readFileSync3(path2, "utf8"),
+      readFile: (path2) => readFileSync4(path2, "utf8"),
       redactMap: async (text5) => (
         /** @type {any} */
         await redactViaDaemon(text5, { map: true })
@@ -67658,13 +67719,13 @@ var init_secret_annotate = __esm({
 import { createHash as createHash3 } from "node:crypto";
 import { mkdirSync, lstatSync as lstatSync3 } from "node:fs";
 import { tmpdir as tmpdir3, userInfo as userInfo3 } from "node:os";
-import { join as join3, resolve, sep } from "node:path";
+import { join as join4, resolve, sep } from "node:path";
 function revealDir() {
-  return process.env._AGENT_SANITIZER_REVEAL_DIR || join3(tmpdir3(), "agent-sanitizer-layer2-reveal");
+  return process.env._AGENT_SANITIZER_REVEAL_DIR || join4(tmpdir3(), "agent-sanitizer-layer2-reveal");
 }
 function revealPathFor(content3) {
   const digest = createHash3("sha256").update(content3, "utf8").digest("hex");
-  return join3(revealDir(), `${digest}.txt`);
+  return join4(revealDir(), `${digest}.txt`);
 }
 function revealDirIsSafe(dir) {
   try {
@@ -68146,8 +68207,8 @@ __export(scan_invisible_chars_exports, {
   formatReport: () => formatReport,
   scanFile: () => scanFile
 });
-import { readFileSync as readFileSync4, globSync, writeFileSync as writeFileSync2, unlinkSync as unlinkSync2 } from "node:fs";
-import { join as join4, relative } from "node:path";
+import { readFileSync as readFileSync5, globSync, writeFileSync as writeFileSync2, unlinkSync as unlinkSync2 } from "node:fs";
+import { join as join5, relative } from "node:path";
 async function ensureSanitizerLoaded() {
   if (typeof stripInvisible3 === "function") return true;
   const marker2 = hookgateMarkerPath();
@@ -68200,7 +68261,7 @@ function findMdFiles(dir) {
   return globSync("**/*.md", {
     cwd: dir,
     exclude: (name50) => name50 === "node_modules"
-  }).map((name50) => join4(dir, name50));
+  }).map((name50) => join5(dir, name50));
 }
 function findInstructionFiles(dir) {
   return globSync(
@@ -68214,10 +68275,10 @@ function findInstructionFiles(dir) {
       cwd: dir,
       exclude: (name50) => name50 === "node_modules"
     }
-  ).map((name50) => join4(dir, name50));
+  ).map((name50) => join5(dir, name50));
 }
 function scanFile(filePath) {
-  const content3 = readFileSync4(filePath, "utf-8");
+  const content3 = readFileSync5(filePath, "utf-8");
   const findings = [];
   LONG_RUN_RE3.lastIndex = 0;
   let match;
@@ -68271,7 +68332,7 @@ function scanProject() {
   const targets = [
     .../* @__PURE__ */ new Set([
       ...findInstructionFiles(PROJECT_DIR),
-      ...findMdFiles(join4(PROJECT_DIR, ".claude"))
+      ...findMdFiles(join5(PROJECT_DIR, ".claude"))
     ])
   ];
   const allFindings = [];
@@ -68312,9 +68373,9 @@ async function cliMain3({ trace: sink = trace } = {}) {
   });
   let cleaned = 0;
   for (const { file } of allFindings) {
-    const absPath = join4(PROJECT_DIR, file);
+    const absPath = join5(PROJECT_DIR, file);
     try {
-      const original = readFileSync4(absPath, "utf-8");
+      const original = readFileSync5(absPath, "utf-8");
       const stripped = stripInvisible3(original);
       if (stripped !== original) {
         writeFileSync2(absPath, stripped);

--- a/test/credential-vocabulary.test.mjs
+++ b/test/credential-vocabulary.test.mjs
@@ -22,7 +22,10 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { looksLikeCredentialVar } from "../claude-hooks/lib/env-config.mjs";
+import {
+  deriveCredentialVocabulary,
+  looksLikeCredentialVar,
+} from "../claude-hooks/lib/env-config.mjs";
 
 // Resolved through the exports map, the same way a consumer reaches it — so this
 // asserts against the file the package actually publishes.
@@ -71,6 +74,19 @@ describe("the name matcher excludes every published non-secret suffix", () => {
     });
   }
 
+  it("refuses a non-secret run that IS the whole name", () => {
+    // The exclusion rendered a leading underscore into its tokens, so it was
+    // reachable only when something preceded the run: `PUBLIC_KEY` matched on
+    // its trailing `KEY` and its value was cut out of every tool output
+    // carrying it. Asserted for every published run, bare and joined.
+    for (const suffix of spec.nonSecretSuffixes) {
+      const joined = suffix.join("_").toUpperCase();
+      const bare = suffix.join("").toUpperCase();
+      assert.equal(looksLikeCredentialVar(joined), false, joined);
+      assert.equal(looksLikeCredentialVar(bare), false, bare);
+    }
+  });
+
   it("refuses the ssh-agent socket, whose value is a path", () => {
     assert.equal(looksLikeCredentialVar("SSH_AUTH_SOCK"), false);
   });
@@ -81,18 +97,61 @@ describe("the name matcher excludes every published non-secret suffix", () => {
   });
 });
 
-describe("a non-secret run that IS the whole name is declined", () => {
-  // The regression this module's own matcher copy carried: it read
-  // nonSecretSuffixes as suffixes needing a PRECEDING underscore, so a variable
-  // named exactly `PUBLIC_KEY` matched on its trailing `KEY` and never reached
-  // the exclusion. Its value was then cut out of every tool output carrying it.
-  // Asserted for every published non-secret run, not just the one that broke.
-  it("declines each published non-secret run as a bare name", () => {
-    for (const suffix of spec.nonSecretSuffixes) {
-      const joined = suffix.join("_").toUpperCase();
-      const bare = suffix.join("").toUpperCase();
-      assert.equal(looksLikeCredentialVar(joined), false, joined);
-      assert.equal(looksLikeCredentialVar(bare), false, bare);
-    }
+describe("deriveCredentialVocabulary fails closed on a malformed spec", () => {
+  // Each of these would otherwise render an empty or under-populated
+  // alternation, which matches nothing and forwards every credential.
+  const bad = {
+    "missing nouns": { nonSecretSuffixes: [["key", "id"]] },
+    "missing nonSecretSuffixes": {
+      nouns: [{ parts: ["token"], uses: [ENV_NAME_USE] }],
+    },
+    "nouns not an array": {
+      nouns: "token",
+      nonSecretSuffixes: [["key", "id"]],
+    },
+    "empty parts": {
+      nouns: [{ parts: [], uses: [ENV_NAME_USE] }],
+      nonSecretSuffixes: [["key", "id"]],
+    },
+    "metacharacter in a part": {
+      nouns: [{ parts: ["to.en"], uses: [ENV_NAME_USE] }],
+      nonSecretSuffixes: [["key", "id"]],
+    },
+    "upper-case part": {
+      nouns: [{ parts: ["TOKEN"], uses: [ENV_NAME_USE] }],
+      nonSecretSuffixes: [["key", "id"]],
+    },
+  };
+  for (const [label, spec_] of Object.entries(bad))
+    it(`throws on ${label}`, () => {
+      assert.throws(() => deriveCredentialVocabulary(spec_), {
+        message: /credential-names\.json/u,
+      });
+    });
+});
+
+describe("the derived vocabulary is safe to interpolate unescaped", () => {
+  const derived = deriveCredentialVocabulary(spec);
+
+  it("renders both segment forms and both exclude forms", () => {
+    assert.ok(derived.segments.length >= envNameNouns.length);
+    assert.equal(
+      derived.excludeSuffixes.length,
+      new Set(
+        spec.nonSecretSuffixes.flatMap((s) => [
+          `_${s.join("_").toUpperCase()}`,
+          `_${s.join("").toUpperCase()}`,
+        ]),
+      ).size,
+    );
+  });
+
+  it("carries no regex metacharacter in any token", () => {
+    for (const token of [
+      ...derived.segments,
+      ...derived.excludeSuffixes,
+      ...derived.excludeNames,
+    ])
+      assert.match(token, /^[A-Z0-9_]+$/u, token);
   });
 });

--- a/test/credential-vocabulary.test.mjs
+++ b/test/credential-vocabulary.test.mjs
@@ -22,10 +22,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import {
-  deriveCredentialVocabulary,
-  looksLikeCredentialVar,
-} from "../claude-hooks/lib/env-config.mjs";
+import { looksLikeCredentialVar } from "../claude-hooks/lib/env-config.mjs";
 
 // Resolved through the exports map, the same way a consumer reaches it — so this
 // asserts against the file the package actually publishes.
@@ -84,61 +81,18 @@ describe("the name matcher excludes every published non-secret suffix", () => {
   });
 });
 
-describe("deriveCredentialVocabulary fails closed on a malformed spec", () => {
-  // Each of these would otherwise render an empty or under-populated
-  // alternation, which matches nothing and forwards every credential.
-  const bad = {
-    "missing nouns": { nonSecretSuffixes: [["key", "id"]] },
-    "missing nonSecretSuffixes": {
-      nouns: [{ parts: ["token"], uses: [ENV_NAME_USE] }],
-    },
-    "nouns not an array": {
-      nouns: "token",
-      nonSecretSuffixes: [["key", "id"]],
-    },
-    "empty parts": {
-      nouns: [{ parts: [], uses: [ENV_NAME_USE] }],
-      nonSecretSuffixes: [["key", "id"]],
-    },
-    "metacharacter in a part": {
-      nouns: [{ parts: ["to.en"], uses: [ENV_NAME_USE] }],
-      nonSecretSuffixes: [["key", "id"]],
-    },
-    "upper-case part": {
-      nouns: [{ parts: ["TOKEN"], uses: [ENV_NAME_USE] }],
-      nonSecretSuffixes: [["key", "id"]],
-    },
-  };
-  for (const [label, spec_] of Object.entries(bad))
-    it(`throws on ${label}`, () => {
-      assert.throws(() => deriveCredentialVocabulary(spec_), {
-        message: /credential-names\.json/u,
-      });
-    });
-});
-
-describe("the derived vocabulary is safe to interpolate unescaped", () => {
-  const derived = deriveCredentialVocabulary(spec);
-
-  it("renders both segment forms and both exclude forms", () => {
-    assert.ok(derived.segments.length >= envNameNouns.length);
-    assert.equal(
-      derived.excludeSuffixes.length,
-      new Set(
-        spec.nonSecretSuffixes.flatMap((s) => [
-          `_${s.join("_").toUpperCase()}`,
-          `_${s.join("").toUpperCase()}`,
-        ]),
-      ).size,
-    );
-  });
-
-  it("carries no regex metacharacter in any token", () => {
-    for (const token of [
-      ...derived.segments,
-      ...derived.excludeSuffixes,
-      ...derived.excludeNames,
-    ])
-      assert.match(token, /^[A-Z0-9_]+$/u, token);
+describe("a non-secret run that IS the whole name is declined", () => {
+  // The regression this module's own matcher copy carried: it read
+  // nonSecretSuffixes as suffixes needing a PRECEDING underscore, so a variable
+  // named exactly `PUBLIC_KEY` matched on its trailing `KEY` and never reached
+  // the exclusion. Its value was then cut out of every tool output carrying it.
+  // Asserted for every published non-secret run, not just the one that broke.
+  it("declines each published non-secret run as a bare name", () => {
+    for (const suffix of spec.nonSecretSuffixes) {
+      const joined = suffix.join("_").toUpperCase();
+      const bare = suffix.join("").toUpperCase();
+      assert.equal(looksLikeCredentialVar(joined), false, joined);
+      assert.equal(looksLikeCredentialVar(bare), false, bare);
+    }
   });
 });


### PR DESCRIPTION
## What &amp; why

A variable named exactly `PUBLIC_KEY` was treated as credential-bearing, so its value was cut out of every tool output that carried it. A public key is not a secret, and removing content the model needed is the failure this project ranks above catching one more credential.

The cause is an asymmetry inside `claude-hooks/lib/env-config.mjs`. It matches credential nouns with a `(?:^|_)` boundary — the noun may start the name or follow an underscore — but it rendered the vocabulary's non-secret runs with a *baked-in* leading underscore (`_PUBLIC_KEY`). The exclusion was therefore reachable only when something preceded the run, so `AWS_PUBLIC_KEY` was correctly declined while a bare `PUBLIC_KEY` matched on its trailing `KEY` and never reached its exclusion. The tokens now render bare and the boundary moves into the regex, so both patterns are built the same way.

## Review focus

Read the two hunks in `deriveCredentialVocabulary` / `buildCredentialNameRes` together — the change only makes sense as a pair, since removing the `_` from the token without adding `(?:^|_)` to the pattern would widen the exclusion to any name *ending* in a non-secret run's characters. The token validation that keeps these safe to interpolate unescaped (`CRED_TOKEN_RE`) still applies, and it is why the boundary belongs in the pattern rather than in the token.

## Decisions made

**Fixed the local derivation rather than replacing it with `credentialNameMatcher`.** My first attempt deleted this module's matcher entirely and called the package's authoritative one, which is the shape the duplication deserves. It cannot ship yet: `plugin/scripts/build-plugin.mjs` deliberately aliases `agent-sanitizer` to the `sanitizer-engine` devDependency — a *pinned published* engine, currently 2.1.0 — so the plugin bundle would have resolved the matcher from a release that predates that export, and esbuild failed to resolve it at all. The local derivation exists because of that pinned-engine boundary, not by oversight. Consolidating the two matchers means first advancing the plugin's pinned engine, which is its own change with its own risk; this PR fixes the defect where it lives. Under the alternative the duplication goes away now and the plugin ships a matcher from an engine it does not pin.

<details><summary>Verification</summary>

**Equivalence with the authoritative matcher** (observed): 91 names generated from the published vocabulary — every `env-name` noun bare, prefixed, suffixed and digit-suffixed, plus every non-secret run bare, joined, prefixed and mid-name, plus `SSH_AUTH_SOCK`/`PATH`/`HOME` — compared against `credentialNameMatcher({ spec, scope: "trailing", declineNonSecret: true })`. Zero disagreements after the fix; `PUBLIC_KEY` was the single disagreement before it, which is what identified the bug.

**Nothing stopped being redacted.** Every published noun still matches in all four positions; the only behavior change is that a bare non-secret run is now declined.

**Suites** — `node --test test/*.test.mjs`: 2083 pass, 0 fail (2075 before, +8 from the new regression case across the published runs).

**Builds** — `pnpm exec tsc -p tsconfig.build-hooks.json` clean; `node plugin/scripts/build-plugin.mjs` regenerates the committed bundle.

**Regression test** — asserts every published non-secret run is declined both joined (`PUBLIC_KEY`) and bare (`PUBLICKEY`), so the class is pinned rather than the one name that broke.

</details>