### PR TITLE
test(secrets): pin the credential-name matcher across both languages

### DIFF
--- a/test/credential-matcher-parity.test.mjs
+++ b/test/credential-matcher-parity.test.mjs
@@ -1,0 +1,386 @@
+/**
+ * The Python and JavaScript name matchers must answer every name identically.
+ *
+ * `credential_name_matcher` and `credentialNameMatcher` are two implementations
+ * of one rule over one vocabulary file, and a consumer binds BOTH on the same
+ * tool call: agent-glovebox binds the Python one to its redactor daemon and the
+ * JavaScript one to the tool-output gate that runs in front of it, under the same
+ * policy. A name the two answer differently is therefore a credential one path
+ * redacts and the other forwards to the transcript.
+ *
+ * Nothing pinned that agreement before this file. Each language's suite tested
+ * its own copy against cases a human had transcribed into both — which is how the
+ * copies drifted the last time: Python's `$` also matches just before a trailing
+ * newline and JavaScript's does not, so `MY_TOKEN\n` was credential-bearing to one
+ * side and not the other. Transcribed cases cannot catch that, because whoever
+ * writes them writes the same case twice.
+ *
+ * So the assertions here are DIFFERENTIAL: they compare the two implementations
+ * against each other over names derived from the vocabulary, rather than either
+ * against a hand-written expectation. The vocabulary is read at run time, so a
+ * noun added to the JSON is covered with no edit to this file.
+ *
+ * `python-credential-matcher.mjs` drives the real Python matcher over one
+ * long-lived worker; see its header for the protocol.
+ *
+ * # covers: src/credential-names.mjs
+ * # covers: python/agent_sanitizer/secrets/credential_names.py
+ */
+import { after, describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  credentialNameMatcher,
+  credentialNames,
+} from "../src/credential-names.mjs";
+import {
+  pythonHoldsCredential,
+  pythonNounAlphabetFolding,
+  pythonParseRejection,
+  stopPythonCredentialMatcher,
+} from "./python-credential-matcher.mjs";
+
+after(stopPythonCredentialMatcher);
+
+// The two policies agent-glovebox actually binds, and they want opposite trades.
+// Both are asserted, because a divergence that showed up under only one would be
+// a live leak on the other consumer.
+const POLICIES = [
+  // The redactor daemon's environment, and the tool-output gate in front of it.
+  { label: "redactor", scope: "trailing", declineNonSecret: true },
+  // The env scrub, which prefers over-stripping to forwarding a secret.
+  { label: "scrub", scope: "any-segment", declineNonSecret: false },
+];
+
+const { segments, nonSecretSegments } = credentialNames();
+const MAX_RUN = Math.max(...segments.map((noun) => noun.split("_").length));
+
+/** Assert the two implementations agree on every name, naming the first that splits.
+ *
+ * Returns the JavaScript verdicts so a caller can add a DIRECTIONAL assertion on
+ * top: agreement alone is satisfied by two implementations that both answer
+ * "false" to everything, so every use of this is paired with a check that the
+ * corpus is one the matcher genuinely discriminates.
+ *
+ * @param {typeof POLICIES[number]} policy @param {string[]} names
+ * @returns {Promise<boolean[]>} */
+async function assertAgreement(policy, names) {
+  const js = names.map(credentialNameMatcher(policy));
+  const py = await pythonHoldsCredential(policy, names);
+  const split = names.findIndex((_, i) => js[i] !== py[i]);
+  if (split !== -1)
+    assert.fail(
+      `${policy.label}: ${JSON.stringify(names[split])} — js=${js[split]} python=${py[split]}`,
+    );
+  return js;
+}
+
+describe("the vocabulary is enumerable and non-empty", () => {
+  // Non-vacuity for every enumeration below: an empty vocabulary would make each
+  // per-member test a loop over nothing, which reports as a passing suite.
+  it("renders segments and non-secret markers to enumerate", () => {
+    assert.ok(segments.length > 0);
+    assert.ok(nonSecretSegments.length > 0);
+  });
+
+  // `maxRun` is derived from the NOUNS alone, so it bounds how far back either
+  // matcher looks for a non-secret marker too. A marker longer than the longest
+  // noun would sit outside every trailing run and never decline anything — in
+  // both languages at once, so the differential tests below could not see it.
+  for (const marker of nonSecretSegments)
+    it(`${marker} is short enough for the trailing-run walk to reach it`, () => {
+      assert.ok(
+        marker.split("_").length <= MAX_RUN,
+        `${marker} is ${marker.split("_").length} words but the walk stops at ${MAX_RUN}`,
+      );
+    });
+});
+
+describe("every env-name segment, in both languages", () => {
+  for (const segment of segments)
+    for (const policy of POLICIES)
+      it(`${segment} under ${policy.label}`, async () => {
+        // The spellings a real environment produces, plus the trailing newline
+        // that split the two implementations before.
+        const names = [
+          segment,
+          `DEPLOY_${segment}`,
+          `deploy_${segment.toLowerCase()}`,
+          `${segment}\n`,
+          `DEPLOY_${segment}\n`,
+          `${segment}_ORG`,
+          `PREFIX_${segment}_FALLBACK_4`,
+        ];
+        const js = await assertAgreement(policy, names);
+        // Directional, so agreement on "false everywhere" cannot pass this.
+        assert.equal(js[1], true, `DEPLOY_${segment} must hold a credential`);
+      });
+});
+
+describe("every non-secret marker, in both languages", () => {
+  // Built from the vocabulary rather than named, so a new noun or marker needs no
+  // edit here. The first env-name segment supplies a real credential noun to put
+  // in front of the marker.
+  const noun = segments[0];
+  for (const marker of nonSecretSegments)
+    it(`${marker} declines under the redactor and not under the scrub`, async () => {
+      const name = `${noun}_${marker}`;
+      const names = [name, name.toLowerCase(), `${name}\n`];
+      const [redactor, scrub] = POLICIES;
+      const jsRedactor = await assertAgreement(redactor, names);
+      const jsScrub = await assertAgreement(scrub, names);
+      // The two policies must actually split on this name, or `declineNonSecret`
+      // is decorative: the redactor declines an identifier, the scrub keeps it.
+      assert.equal(
+        jsRedactor[0],
+        false,
+        `${name} must be declined as non-secret`,
+      );
+      assert.equal(
+        jsScrub[0],
+        true,
+        `${name} must survive a scrub that over-strips`,
+      );
+    });
+});
+
+describe("a generated corpus agrees across the language boundary", () => {
+  // Every token the vocabulary renders, crossed with the shapes a real
+  // environment produces. The tails are the point: a trailing newline is what
+  // Python's `$` accepts and JavaScript's rejects, so it is the one character
+  // that separates a correctly anchored implementation from a plausible one.
+  const PREFIXES = ["", "DEPLOY_", "npm_config_", "A_B_"];
+  const SUFFIXES = ["", "_ID", "_ORG", "_V2", "_FALLBACK_4"];
+  const CASINGS = [
+    (s) => s,
+    (s) => s.toLowerCase(),
+    (s) => `${s.slice(0, 1)}${s.slice(1).toLowerCase()}`,
+  ];
+  const TAILS = ["", "\n", "\r\n", " ", "_"];
+
+  const corpus = [
+    ...new Set(
+      [...segments, ...nonSecretSegments].flatMap((token) =>
+        PREFIXES.flatMap((prefix) =>
+          SUFFIXES.flatMap((suffix) =>
+            CASINGS.flatMap((casing) =>
+              TAILS.map((tail) => casing(`${prefix}${token}${suffix}`) + tail),
+            ),
+          ),
+        ),
+      ),
+    ),
+  ];
+
+  it("is large enough to be worth comparing", () => {
+    assert.ok(corpus.length > 1000, `${corpus.length} names is too few`);
+    // The case the bug hid in must actually be present.
+    assert.ok(corpus.some((name) => name.endsWith("\n")));
+  });
+
+  for (const policy of POLICIES)
+    it(`${policy.label}: same verdict for all ${corpus.length} names`, async () => {
+      const js = await assertAgreement(policy, corpus);
+      // Agreement on an all-false corpus would be worthless. Both directions must
+      // occur, so the comparison is over a set the matcher genuinely discriminates.
+      assert.ok(js.some(Boolean) && js.some((v) => !v));
+    });
+});
+
+describe("hostile names agree too", () => {
+  // A scrub does not choose these — it is handed whatever the surrounding process
+  // exported, so a name can carry anything a process environment can carry.
+  const HOSTILE = [
+    "",
+    "_",
+    "__",
+    "TOKEN ",
+    " TOKEN",
+    "TOKEN.*",
+    "(?:TOKEN)",
+    "TOKEN$",
+    "^TOKEN",
+    "TOKEN[",
+    "TOKEN\\",
+    // Written as escapes, never as raw bytes: a literal NUL makes the source
+    // read as binary to grep and the diff tools, and a raw U+2028 is a line
+    // terminator to some JavaScript parsers.
+    "TOKEN\0",
+    "TOKEN\t",
+    "TOKEN\u00A0",
+    "TOKEN\u2028",
+    "TOKEN\u2029",
+    "TOKEN\r",
+    "TOKEN\u{1F600}",
+    // Lone surrogates: legal in both languages' string types, illegal as UTF-8.
+    "TOKEN\uD800",
+    "\uDFFFTOKEN",
+    // Case-folding shapes where one character upper-cases into several.
+    "TOKENß",
+    "ıTOKEN",
+    "TOKENﬁ",
+    "ſECRET_KEY",
+    // Normalization: the same name in NFC and NFD must not split the two.
+    "TÖKEN_KEY".normalize("NFC"),
+    "TÖKEN_KEY".normalize("NFD"),
+    // Long enough that a quadratic walk would be visible, on both sides.
+    "A".repeat(20_000),
+    `${"A_".repeat(10_000)}TOKEN`,
+    `${"_".repeat(5_000)}KEY`,
+  ];
+
+  for (const policy of POLICIES)
+    it(`${policy.label}: same verdict for every hostile name`, async () => {
+      const js = await assertAgreement(policy, HOSTILE);
+      // Both directions, so this cannot pass on two implementations that agree
+      // only because a hostile name makes them both give up. `ſECRET_KEY` is the
+      // one that matters: the long s upper-cases to S in both languages, so the
+      // name really does hold a credential and really must be matched.
+      assert.equal(js[HOSTILE.indexOf("ſECRET_KEY")], true);
+      assert.ok(js.some((v) => !v));
+    });
+});
+
+describe("the case-folding step is portable", () => {
+  // This is WHY the corpus above agrees, and it generalizes past any corpus.
+  // Upper-casing is the matcher's only text transform, and the vocabulary is pure
+  // [A-Z0-9_]; so the two languages answer every name alike exactly when they
+  // agree on which code points fold INTO that alphabet, and on the images.
+  //
+  // The assertion is deliberately not "str.upper() and toUpperCase() agree
+  // everywhere" — they do not. 55 code points differ between the runtimes here,
+  // all of them Unicode-version skew between Node's ICU and CPython's tables, and
+  // that count moves whenever either is upgraded. None of them reaches the noun
+  // alphabet, which is the property that actually matters and the one that holds
+  // across versions.
+  it("both languages fold the same code points into the noun alphabet", async () => {
+    const NOUN_ALPHABET = /^[A-Z0-9_]+$/;
+    /** @type {Map<number, string>} */
+    const js = new Map();
+    for (let cp = 0; cp <= 0x10ffff; cp++) {
+      if (cp >= 0xd800 && cp <= 0xdfff) continue;
+      const upper = String.fromCodePoint(cp).toUpperCase();
+      if (NOUN_ALPHABET.test(upper)) js.set(cp, upper);
+    }
+    const python = new Map(await pythonNounAlphabetFolding());
+
+    assert.ok(js.size > 0, "the sweep found nothing — it is not running");
+    // Non-vacuity of the interesting half: the set must include characters that
+    // are not already ASCII, or it proves only that A-Z maps to itself.
+    assert.ok(
+      [...js].some(([cp]) => cp > 0x7f),
+      "no non-ASCII code point folds in — the sweep missed the hard cases",
+    );
+    assert.deepEqual(
+      [...python].sort(([a], [b]) => a - b),
+      [...js].sort(([a], [b]) => a - b),
+    );
+  });
+});
+
+describe("both languages refuse the same unusable vocabularies", () => {
+  // Fail-closed parity. An empty rendering is the dangerous one: it compiles to a
+  // matcher that answers "not a credential" for every name, so a consumer that
+  // got it would forward every credential silently, with no error anywhere. One
+  // language raising while the other builds it is that leak on one of the two
+  // paths.
+  const GOOD_NOUN = { parts: ["token"], uses: ["env-name", "field-value"] };
+  const UNUSABLE = [
+    ["no spec at all", {}],
+    ["empty noun list", { nouns: [], nonSecretSuffixes: [["key", "id"]] }],
+    ["no non-secret suffixes", { nouns: [GOOD_NOUN], nonSecretSuffixes: [] }],
+    [
+      "empty parts",
+      {
+        nouns: [{ parts: [], uses: ["env-name"] }],
+        nonSecretSuffixes: [["key", "id"]],
+      },
+    ],
+    [
+      "empty non-secret suffix",
+      { nouns: [GOOD_NOUN], nonSecretSuffixes: [[]] },
+    ],
+    [
+      "a regex metacharacter in a part",
+      {
+        nouns: [{ parts: [".*"], uses: ["env-name", "field-value"] }],
+        nonSecretSuffixes: [["key", "id"]],
+      },
+    ],
+    [
+      "an anchor in a part",
+      {
+        nouns: [{ parts: ["^token$"], uses: ["env-name", "field-value"] }],
+        nonSecretSuffixes: [["key", "id"]],
+      },
+    ],
+    // The two anchoring cases, as DATA. Python's `$` matches before a trailing
+    // newline and JavaScript's does not, so a validator anchored `^…$` on the
+    // Python side accepts these and its JavaScript twin rejects them — the exact
+    // split that let a token smuggle a newline past one of the two.
+    [
+      "a trailing newline in a part",
+      {
+        nouns: [{ parts: ["token\n"], uses: ["env-name", "field-value"] }],
+        nonSecretSuffixes: [["key", "id"]],
+      },
+    ],
+    [
+      "a trailing newline in a non-secret suffix",
+      { nouns: [GOOD_NOUN], nonSecretSuffixes: [["key", "id\n"]] },
+    ],
+    [
+      "a leading newline in a part",
+      {
+        nouns: [{ parts: ["\ntoken"], uses: ["env-name", "field-value"] }],
+        nonSecretSuffixes: [["key", "id"]],
+      },
+    ],
+    [
+      "no noun marked env-name",
+      {
+        nouns: [{ parts: ["token"], uses: ["field-value"] }],
+        nonSecretSuffixes: [["key", "id"]],
+      },
+    ],
+    [
+      "no noun marked field-value",
+      {
+        nouns: [{ parts: ["token"], uses: ["env-name"] }],
+        nonSecretSuffixes: [["key", "id"]],
+      },
+    ],
+    [
+      "an unknown use",
+      {
+        nouns: [{ parts: ["token"], uses: ["env-nam"] }],
+        nonSecretSuffixes: [["key", "id"]],
+      },
+    ],
+  ];
+
+  for (const [label, spec] of UNUSABLE)
+    it(`${label}: both raise`, async () => {
+      assert.throws(
+        () => credentialNameMatcher({ spec }),
+        `javascript accepted an unusable vocabulary: ${label}`,
+      );
+      assert.notEqual(
+        await pythonParseRejection(spec),
+        null,
+        `python accepted an unusable vocabulary: ${label}`,
+      );
+    });
+
+  it("and both accept the good one, so the refusals mean something", async () => {
+    const spec = {
+      nouns: [GOOD_NOUN],
+      nonSecretSuffixes: [["key", "id"]],
+    };
+    assert.equal(
+      credentialNameMatcher({ spec, scope: "trailing" })("DEPLOY_TOKEN"),
+      true,
+    );
+    assert.equal(await pythonParseRejection(spec), null);
+  });
+});

--- a/test/credential-matcher-parity.test.mjs
+++ b/test/credential-matcher-parity.test.mjs
@@ -20,6 +20,30 @@
  * against a hand-written expectation. The vocabulary is read at run time, so a
  * noun added to the JSON is covered with no edit to this file.
  *
+ * WHY TWO IMPLEMENTATIONS AT ALL — this file guards a duplication, so it owes an
+ * account of why the duplication cannot simply be removed. A test that polices
+ * two copies is usually a sign the copies should be one; here they cannot be:
+ *
+ * * `credential-names.mjs` is a published standalone export
+ *   (`agent-sanitizer/credential-names-matcher`). Consumers import it with no
+ *   Python present, so it cannot delegate to the Python side.
+ * * The JavaScript matcher gates tool output IN FRONT OF the Python redactor
+ *   daemon and must fail closed when that daemon is down. Asking the daemon for
+ *   the verdict would make the gate depend on the thing it protects.
+ * * The rule is control flow, not data, so it cannot move into the shared JSON
+ *   the way the VOCABULARY already has.
+ *
+ * The renderings alone could be generated once into a committed artifact with a
+ * `committed == regenerate(source)` freshness check. That was rejected: both
+ * languages publish their validator, and `spec=` validates a CALLER's runtime
+ * vocabulary, so neither validator could be deleted. Generating would add an
+ * artifact on top of the duplication rather than removing it, and then need code
+ * to keep the two in step — more copies, not fewer.
+ *
+ * The duplication is therefore load-bearing, and this suite is the instrument
+ * that keeps it honest. If either bullet above stops being true, delete the
+ * redundant implementation instead of extending this file.
+ *
  * `python-credential-matcher.mjs` drives the real Python matcher over one
  * long-lived worker; see its header for the protocol.
  *

--- a/test/credential-name-matcher.test.mjs
+++ b/test/credential-name-matcher.test.mjs
@@ -15,12 +15,23 @@
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import {
   credentialNameMatcher,
   credentialNames,
   parseCredentialNames,
 } from "../src/credential-names.mjs";
+
+const MODULE_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "src",
+  "credential-names.mjs",
+);
 
 const SPEC = {
   nouns: [
@@ -200,6 +211,34 @@ describe("an unusable vocabulary throws rather than matching nothing", () => {
       assert.throws(() => credentialNameMatcher({ spec }), message);
     });
   }
+
+  it("an unreadable data file throws instead of rendering an empty vocabulary", async () => {
+    // The reader's own failure, which no `spec` case reaches: every branch above
+    // drives the pure validator, and a missing FILE never gets that far. It is
+    // worth pinning because the tempting repair — catching the read and returning
+    // an empty vocabulary so start-up survives — turns the matcher into one that
+    // answers "not a credential" for every name, with no error anywhere.
+    //
+    // Driven by importing a COPY of the module from a directory where its data
+    // file's relative path resolves to nothing. `DATA_FILE` is a module constant
+    // derived from `import.meta.url`, so there is no in-process seam to redirect;
+    // this costs no coverage, because the fail-closed branches this file's other
+    // cases exercise all live in `parseCredentialNames`, which is already driven
+    // directly.
+    const directory = mkdtempSync(join(tmpdir(), "credential-names-"));
+    const copy = join(directory, "credential-names.mjs");
+    writeFileSync(copy, readFileSync(MODULE_PATH));
+    try {
+      const { credentialNames: orphaned, parseCredentialNames: validator } =
+        await import(pathToFileURL(copy).href);
+      // The validator still works from the copy, so the throw below is the
+      // missing file and not a broken import.
+      assert.ok(validator(SPEC).segments.length > 0);
+      assert.throws(() => orphaned(), /ENOENT|no such file/);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
 
   it("no spec at all means the packaged vocabulary, not an empty one", () => {
     // The one absent-spec case that must NOT throw: omitting `spec` is how every

--- a/test/python-credential-matcher.mjs
+++ b/test/python-credential-matcher.mjs
@@ -1,0 +1,189 @@
+/**
+ * Test bridge to the PYTHON credential-name matcher.
+ *
+ * `credential_name_matcher` (Python) and `credentialNameMatcher` (JS) are two
+ * implementations of one rule over one vocabulary file. A consumer binds both on
+ * the same tool call — agent-glovebox binds the Python one to its redactor daemon
+ * and the JS one to the tool-output gate in front of it — so a name the two
+ * answer differently is a value one path redacts and the other forwards. That
+ * disagreement is the whole reason the rule was extracted into this package, and
+ * nothing pins it from inside a single language: each suite tests its own copy
+ * against cases a human transcribed into both, which is exactly how the copies
+ * drifted before.
+ *
+ * So this drives the REAL Python matcher rather than restating its answers, the
+ * same way `real-redactor.mjs` drives the real redaction engine: one long-lived
+ * `uv run` worker, newline-delimited JSON in and out, so a 10,000-name corpus
+ * costs one process spawn instead of ten thousand.
+ *
+ * Request  line: {"op": "match"|"parse"|"folding", ...}
+ * Response line: {"ok": <result>} or {"error": "<message>"}
+ *
+ * Every response is plain ASCII JSON: the corpus carries lone surrogates and a
+ * `match` reply that echoed a name back would be unencodable on the Python side.
+ * Replies therefore carry booleans and code point NUMBERS, never the names or
+ * characters they are about.
+ */
+import { spawn } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, "..");
+const pythonDir = join(repoRoot, "python");
+
+// Reached exactly as the pytest suite reaches it (tests/secrets/conftest.py): run
+// from the repo root's virtual project so `uv run --extra dev` resolves the
+// package's deps from the root lock, with `python/` on sys.path so the import
+// comes from the working tree rather than an installed copy.
+//
+// `agent_sanitizer.secrets` is the package's PUBLIC surface, which is what a
+// consumer imports; importing the private module instead would leave a broken
+// re-export invisible here.
+const DRIVER = `
+import sys, json, re
+sys.path.insert(0, ${JSON.stringify(pythonDir)})
+from agent_sanitizer.secrets import credential_name_matcher, parse_credential_names
+
+NOUN_ALPHABET = re.compile(r"[A-Z0-9_]+")
+
+def folding():
+    """Every code point whose upper-casing lands inside the noun alphabet.
+
+    The matcher's ONLY text transform is str.upper(); the vocabulary is pure
+    [A-Z0-9_]. So the two languages agree on every name exactly when they agree
+    on this set and its images.
+    """
+    return [
+        [cp, chr(cp).upper()]
+        for cp in range(0x110000)
+        if not 0xD800 <= cp <= 0xDFFF
+        and NOUN_ALPHABET.fullmatch(chr(cp).upper())
+    ]
+
+def handle(req):
+    op = req["op"]
+    if op == "folding":
+        return folding()
+    if op == "parse":
+        parse_credential_names(req["spec"])
+        return True
+    holds = credential_name_matcher(
+        scope=req["scope"],
+        decline_non_secret=req["declineNonSecret"],
+        **({"spec": req["spec"]} if req.get("spec") is not None else {}),
+    )
+    return [holds(name) for name in req["names"]]
+
+for line in sys.stdin:
+    line = line.rstrip("\\n")
+    if not line:
+        continue
+    try:
+        reply = {"ok": handle(json.loads(line))}
+    except Exception as exc:
+        reply = {"error": f"{type(exc).__name__}: {exc}"}
+    sys.stdout.write(json.dumps(reply) + "\\n")
+    sys.stdout.flush()
+`;
+
+let worker = null;
+let buffer = "";
+/** @type {{resolve: (v: unknown) => void, reject: (e: Error) => void}[]} */
+const pending = [];
+
+function fail(err) {
+  while (pending.length) pending.shift().reject(err);
+}
+
+function ensureWorker() {
+  if (worker) return;
+  worker = spawn(
+    "uv",
+    ["run", "--extra", "dev", "--frozen", "python", "-c", DRIVER],
+    { cwd: repoRoot },
+  );
+  worker.on("error", (err) =>
+    fail(
+      new Error(`python credential matcher failed to start: ${err.message}`),
+    ),
+  );
+  // Startup failures (a syntax error in DRIVER, a missing dependency) surface
+  // only here: the worker dies before answering, and without this the test would
+  // hang on a promise nobody settles rather than name what went wrong.
+  let stderr = "";
+  worker.stderr.setEncoding("utf8");
+  worker.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+  worker.on("exit", (code) => {
+    if (pending.length)
+      fail(
+        new Error(
+          `python credential matcher exited (code ${code}) mid-request: ${stderr.slice(-2000)}`,
+        ),
+      );
+  });
+  worker.stdout.setEncoding("utf8");
+  worker.stdout.on("data", (chunk) => {
+    buffer += chunk;
+    let nl;
+    while ((nl = buffer.indexOf("\n")) >= 0) {
+      const line = buffer.slice(0, nl);
+      buffer = buffer.slice(nl + 1);
+      const entry = pending.shift();
+      if (entry) entry.resolve(JSON.parse(line));
+    }
+  });
+}
+
+/** @param {Record<string, unknown>} request @returns {Promise<{ok?: unknown, error?: string}>} */
+function ask(request) {
+  ensureWorker();
+  return new Promise((resolve, reject) => {
+    pending.push({ resolve, reject });
+    worker.stdin.write(`${JSON.stringify(request)}\n`);
+  });
+}
+
+/** The Python matcher's verdict for each of `names`, under one policy.
+ *
+ * @param {{scope: "trailing" | "any-segment", declineNonSecret: boolean, spec?: Record<string, unknown>}} policy
+ * @param {string[]} names
+ * @returns {Promise<boolean[]>} */
+export async function pythonHoldsCredential(policy, names) {
+  const reply = await ask({
+    op: "match",
+    scope: policy.scope,
+    declineNonSecret: policy.declineNonSecret,
+    spec: policy.spec ?? null,
+    names,
+  });
+  if (reply.error)
+    throw new Error(`python matcher refused the corpus: ${reply.error}`);
+  return reply.ok;
+}
+
+/** The Python validator's refusal message for `spec`, or null when it accepts.
+ * @param {unknown} spec @returns {Promise<string | null>} */
+export async function pythonParseRejection(spec) {
+  const reply = await ask({ op: "parse", spec });
+  return reply.error ?? null;
+}
+
+/** Every code point whose `str.upper()` lands in `[A-Z0-9_]`, as `[cp, image]`.
+ * @returns {Promise<[number, string][]>} */
+export async function pythonNounAlphabetFolding() {
+  const reply = await ask({ op: "folding" });
+  if (reply.error)
+    throw new Error(`python folding sweep failed: ${reply.error}`);
+  return reply.ok;
+}
+
+/** Shut the worker down so the test process can exit promptly. */
+export function stopPythonCredentialMatcher() {
+  if (!worker) return;
+  worker.stdin.end();
+  worker.kill();
+  worker = null;
+}

--- a/tests/secrets/test_credential_names.py
+++ b/tests/secrets/test_credential_names.py
@@ -241,6 +241,15 @@ _BAD_SPECS = [
         "nonSecretSuffixes[0]",
     ),
     (
+        # The same anchoring case as ``part_trailing_newline``, on the other path
+        # through the validator. ``re.fullmatch`` rejects it; a ``^…$`` pattern
+        # would accept it here and be rejected by the JavaScript twin reading the
+        # same file, which is the split that has to stay closed on BOTH paths.
+        "suffix_trailing_newline",
+        {**_GOOD, "nonSecretSuffixes": [["key", "id\n"]]},
+        "nonSecretSuffixes[0]",
+    ),
+    (
         "no_env_name_noun",
         {**_GOOD, "nouns": [{"parts": ["token"], "uses": [FIELD_VALUE_USE]}]},
         "env-name",
@@ -393,3 +402,74 @@ def test_a_hostile_variable_name_cannot_stall_the_matcher(
     # over the true bound while still an order of magnitude under the quadratic
     # walk's ~2e8 for this input.
     assert len(counted) <= 4 * segments
+
+
+@pytest.mark.parametrize("segment", credential_name_segments())
+def test_every_rendered_segment_drives_the_real_matcher(segment: str) -> None:
+    """Member by member, from the vocabulary: a name ending in each rendered
+    segment holds a credential, in every spelling an environment produces.
+
+    The per-noun tests above assert that a segment is RENDERED. This asserts the
+    matcher then acts on it, which is a different failure: a noun can reach the
+    segment list and still be unreachable by the walk that consumes it.
+
+    The trailing-newline case is asserted NEGATIVE, and that is the point of it.
+    ``KEY\\n`` is not the noun ``KEY``, so the name does not hold a credential —
+    but Python's ``$`` also matches just before a trailing newline, so a matcher
+    rebuilt around ``re.search(r"KEY$", name)`` would answer True here while its
+    JavaScript twin answered False, and a value would reach the transcript through
+    whichever path ran second. ``test/credential-matcher-parity.test.mjs`` checks
+    the two implementations against each other; this pins the Python side alone,
+    so the suite still fails if the JavaScript side is renamed away.
+    """
+    holds = credential_name_matcher()
+    assert holds(f"DEPLOY_{segment}")
+    assert holds(f"deploy_{segment.lower()}")
+    assert not holds(f"DEPLOY_{segment}\n")
+
+
+@pytest.mark.parametrize("marker", non_secret_name_segments())
+def test_every_non_secret_marker_declines_a_credential_name(marker: str) -> None:
+    """Member by member: each marker turns a name that otherwise holds a
+    credential into one the redactor declines, and ``decline_non_secret=False``
+    turns it back on for a scrub that prefers over-stripping.
+
+    Built from the vocabulary rather than named, so a marker added to the JSON is
+    covered with no edit here. Asserting both directions is what stops this from
+    passing on a matcher that simply never matched the name at all.
+    """
+    name = f"{credential_name_segments()[0]}_{marker}"
+    assert not credential_name_matcher()(name)
+    assert credential_name_matcher(scope="any-segment", decline_non_secret=False)(name)
+
+
+def test_a_missing_data_file_raises_rather_than_rendering_nothing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """The reader's own failure, which no ``spec`` case reaches: every bad-spec
+    case above drives the pure validator, and a missing FILE never gets that far.
+
+    It is worth pinning because the tempting repair — catching the read so
+    start-up survives a packaging mistake — yields an empty vocabulary, and a
+    matcher over an empty noun set answers "not a credential" for every name it is
+    asked about. That forwards every credential with no error anywhere.
+    """
+    monkeypatch.setattr(
+        credential_names, "CREDENTIAL_NAMES_FILE", tmp_path / "absent.json"
+    )
+    # The renderings are memoized, so the patched path is only read if the cache
+    # is cleared first — and restored afterwards so no later test sees the gap.
+    credential_names._rendered.cache_clear()
+    try:
+        with pytest.raises(FileNotFoundError):
+            credential_name_matcher()
+    finally:
+        # Undo before the cache clear, not after: the accessor re-reads on the
+        # next call, and monkeypatch's own teardown would otherwise run second and
+        # leave the cache holding the failure for every later test in the session.
+        monkeypatch.undo()
+        credential_names._rendered.cache_clear()
+    # Non-vacuity: the accessor works again with the real file back, so the raise
+    # above was the missing file rather than a cache left poisoned by an earlier
+    # test — which would make this pass without exercising anything.
+    assert credential_name_segments()


### PR DESCRIPTION
## Summary

The rule that decides whether an environment-variable NAME holds a credential ships twice in this package: once in Python as `credential_name_matcher`, once in JavaScript as `credentialNameMatcher`. Both read the same vocabulary file. A consumer binds **both at once**: agent-glovebox binds the Python one to its redactor daemon and the JavaScript one to the gate that inspects tool output before the daemon sees it, under the same policy. If the two disagree about a name, one path removes the secret and the other passes it through, so the secret reaches the transcript anyway.

Nothing checked that the two agree. Each language had its own test file, and each tested its own copy against examples a person had typed into both files. That cannot find a disagreement, because the person writes the same example twice. This is how the two copies drifted apart before the rule was moved into this package: Python's `$` also matches just before a newline at the end of a string, and JavaScript's does not, so the name `MY_TOKEN` followed by a newline looked like a credential to one and not to the other.

I checked all four properties the move had to preserve. **All four already hold** — no source file changed. What was missing was anything keeping them true. This PR adds that.

The new suite compares the two implementations **against each other**, rather than against expectations someone wrote down. It runs the real Python matcher in a background process and asks it the same names the JavaScript matcher was asked, then compares answer to answer. The names are built from the vocabulary file at run time, so adding a word to that file extends the test automatically.

## Changes

- **`test/credential-matcher-parity.test.mjs`** (new) — the cross-language suite. Compares both implementations over a 2,000-name generated corpus, every vocabulary member one by one, hostile names, and the specs both must reject. Runs under both policies glovebox binds.
- **`test/python-credential-matcher.mjs`** (new) — the bridge to the real Python matcher. One long-lived `uv run` worker speaking newline-delimited JSON, so a 2,000-name corpus costs one process start rather than 2,000. Same pattern as the existing `test/real-redactor.mjs`.
- **`test/credential-name-matcher.test.mjs`** — a missing data file must throw, not yield an empty vocabulary.
- **`tests/secrets/test_credential_names.py`** — the Python twin of that missing-file case; per-member tests that drive the real matcher; and the trailing-newline rejection on the non-secret-suffix path, which the noun path already had.

## Decisions made

- **The case-folding check asserts a property, not an absence of difference.** Python's `str.upper()` and JavaScript's `toUpperCase()` genuinely disagree on 55 code points, all of it version skew between Node's Unicode tables and CPython's. That count moves whenever either is upgraded, so asserting "no differences" would break on an unrelated version bump. The test instead asserts what actually matters and stays true across versions: the two agree exactly on which code points upper-case **into** `[A-Z0-9_]`, the alphabet the vocabulary uses. Under the alternative the suite would be a version tripwire rather than a correctness check.
- **No source file changed.** All four invariants held on inspection and under test. The alternative — changing code to match the described defects — would have been a regression.
- **The missing-file case is driven differently in each language.** Python can redirect the path in process. JavaScript computes it from `import.meta.url` with no seam, so that test imports a copy of the module from a directory where the relative path resolves to nothing. This costs no coverage: the module is at 100% branch coverage before and after, because the fail-closed branches all live in the pure validator, which is driven directly.

## Tests / verification

Full suite green: `pnpm test` → 2231 pass, 0 fail, 82s. `pnpm lint`, `pnpm typecheck`, `uv run ruff check` all clean. `uv run pytest tests/secrets/test_credential_names.py` → 131 pass, 5 skipped.

Every new test was checked for vacuity by putting the defect back and watching it fail. Details below.

<details><summary>Verification residue</summary>

**Invariant status before this PR — all four already held.**

| # | Property | Holds | Read at |
|---|---|---|---|
| A | Matcher anchoring | yes | `credential_names.py:236-247`, `credential-names.mjs:212-225` — neither matches with a regex. Both do set membership over `name.upper().split("_")`, so there is no `$` to diverge on. |
| B | Token validator anchoring | yes | `credential_names.py:49` `re.compile(r"[a-z0-9]+")` used with `.fullmatch` (`:86`), equivalent to `\A…\Z`; `credential-names.mjs:61` `/^[a-z0-9]+$/`, where JS `$` without `m` already means end-of-input. Note `\A`/`\Z` are *not* the fix on the JS side — they compile as the literals `A`/`Z` (`test/secret-detectors-portability.test.mjs:20-24`). |
| C | Fail closed on a bad vocabulary | yes | Empty list `credential_names.py:107-112` / `credential-names.mjs:121,138`; metacharacter `:86` / `:84`; missing file propagates from `:157` / `:168`. The empty case raises rather than compiling — confirmed by probe, not just by reading. |
| D | Validator drivable in process | yes | `parse_credential_names` (`:115`) and `parseCredentialNames` (`:119`) are pure, public, and take a spec. `src/credential-names.mjs` is at **100% branch coverage** with no ignore pragma — `npx c8 --include 'src/credential-names.mjs' --reporter text node --test test/credential-*.test.mjs`. |

**Observed, not inferred.** Before writing tests I ran a 10,530-name corpus through both implementations: **0 disagreements** under both policies. I then swept all 1,114,112 code points: `str.upper()` and `toUpperCase()` differ on 55, and **0** of those reach `[A-Z0-9_]`. Both runtimes fold exactly 73 code points into that alphabet, with identical images and no set difference. That sweep is now the test at `credential-matcher-parity.test.mjs`.

**Non-vacuity — defect re-introduced, observed red, restored, observed green.** Predicted before each run; all four matched.

1. Python validator `re.fullmatch` → `^…$` with `.match()`. Red, and only where expected: `test_the_validator_rejects_a_bad_spec[part_trailing_newline]`, `[suffix_trailing_newline]`, plus parity subtests 8 and 9 (`a trailing newline in a part`, `…in a non-secret suffix`). 83 pass / 2 fail.
2. Python matcher made newline-tolerant (`.rstrip("\n")` before splitting), simulating what `$` would do. The corpus went red naming the exact split: `redactor: "API_KEY\n" — js=false python=true`. 28 Python tests red.
3. Empty vocabulary made to compile instead of raise. The fail-open is real and was confirmed directly — an empty spec built a matcher and `credential_name_matcher(...)("GITHUB_TOKEN")` returned `False`. Red: 8 Python tests, 5 parity subtests.
4. JS reader made to swallow a missing file and return an empty vocabulary. Red: `an unreadable data file throws instead of rendering an empty vocabulary`.

Falsifying commands: `node --test test/credential-matcher-parity.test.mjs` (85 pass); `uv run pytest tests/secrets/test_credential_names.py -q` (131 pass); `pnpm test` (2231 pass).

**The second policy is covered.** `credentialRule("any-segment", false)` is JS-only in glovebox, but this package exports it in both languages (`python/agent_sanitizer/secrets/__init__.py:33,62`), so a Python consumer can bind it. Every parity test runs under both policies.

**One thing found and pinned, not a defect today.** `maxRun` is derived from the nouns alone, but it also bounds how far back both matchers look for a non-secret marker. A `nonSecretSuffixes` entry longer than the longest noun would sit outside every trailing run and never decline anything — in **both** languages at once, so the differential tests could not see it. The packaged data is fine today (longest noun 3 words). There is now a per-marker assertion that each marker is short enough for the walk to reach it, so adding a 4-word marker fails loudly instead of silently doing nothing.

**Not done.** No new lint, hook, or required check, per the constraint. See below.

</details>

## Proposed guards

Not shipped — a proposal only.

**Class:** a cross-language pair drifting because each side is only tested against transcribed cases.

**Shape:** a check that every `export`ed name in `src/credential-names.mjs` has a counterpart in `python/agent_sanitizer/secrets/credential_names.py` and is exercised by a differential test. A registry-free version is plausible here in a way it would not be in a consumer repo, because both implementations sit in this tree: the check can enumerate the two modules' exports directly rather than consult a hand-maintained list.

**Arithmetic — this is why I am not proposing it be built.** The class has fired **once**, over the whole life of these two files, and that instance was found and fixed before the extraction. One escape is expensive (a credential in a transcript), but the guard catches only the subset of drift that shows up as an export-name mismatch — and the actual bug was a regex anchor with identical export names on both sides, which this guard would **not** have caught. The differential suite in this PR does catch it, and catches the shape the guard cannot. Cost would be a check on every push forever, plus maintenance whenever either module's export list moves. Benefit ≈ 0 defects caught per year × the guard's fractional coverage of a class the new tests already cover. **It fails the arithmetic; the tests are the right instrument here, not a lint.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01D22EpMaQxPACDK9wV2HbGr)_