### PR TITLE
feat(claude-hooks): let a host share one lazy-module registry across hook-io instances

### DIFF
--- a/claude-hooks/lib/hook-io.mjs
+++ b/claude-hooks/lib/hook-io.mjs
@@ -13,23 +13,40 @@ import { createHash } from "node:crypto";
 import { pathToFileURL } from "node:url";
 
 /**
- * The process-wide state these helpers keep: the pre-registered module
- * namespaces {@link lazyImport} answers from, and the CLI-entry latch
- * {@link isMain} reads.
+ * EVERY process-wide slot these helpers keep — the four a host can observe or
+ * steer, so a second instance that adopts this object is steered in all four at
+ * once. A slot left off this object is one a host must configure per instance,
+ * and forgetting the second call fails silently; that is the whole failure class
+ * {@link adoptHookIoSharedState} exists to remove, so the object is complete
+ * rather than covering only the registry.
  *
- * `lazyModules` is empty when the hooks run from source; a build-time BUNDLE
- * (which ships with no node_modules for the runtime `import()` to resolve)
- * statically imports its packages and registers them here before importing the
- * hooks that lazy-load them, so the same hook source runs unchanged in both
- * worlds.
- *
- * Both fields live on ONE object so a second instance of this module can adopt
- * it — see {@link adoptHookIoSharedState}.
- * @typedef {{lazyModules: Record<string, Record<string, any>>, cliEntryClaimed: boolean}} HookIoSharedState
+ * - `lazyModules` — the namespaces {@link lazyImport} answers from. Empty when
+ *   the hooks run from source; a build-time BUNDLE (which ships with no
+ *   node_modules for the runtime `import()` to resolve) statically imports its
+ *   packages and registers them here before importing the hooks that lazy-load
+ *   them, so the same hook source runs unchanged in both worlds.
+ * - `cliEntryClaimed` — the CLI-entry latch {@link isMain} reads.
+ * - `missingPackageRemedy` — the host remedy {@link configureMissingPackageRemedy}
+ *   sets; null keeps {@link DEFAULT_MISSING_PACKAGE_REMEDY}.
+ * - `hookgateMarker` — the marker path {@link configureHookgateMarker} sets, and
+ *   `hookgateMarkerResolved`, the latch that makes a too-late call say so.
+ * @typedef {{
+ *   lazyModules: Record<string, Record<string, any>>,
+ *   cliEntryClaimed: boolean,
+ *   missingPackageRemedy: string | null,
+ *   hookgateMarker: string | null,
+ *   hookgateMarkerResolved: boolean,
+ * }} HookIoSharedState
  */
 
 /** @type {HookIoSharedState} */
-let shared = { lazyModules: Object.create(null), cliEntryClaimed: false };
+let shared = {
+  lazyModules: Object.create(null),
+  cliEntryClaimed: false,
+  missingPackageRemedy: null,
+  hookgateMarker: null,
+  hookgateMarkerResolved: false,
+};
 
 /**
  * This instance's state object, for a host to hand to another instance.
@@ -40,24 +57,42 @@ export function hookIoSharedState() {
 }
 
 /**
- * Route this instance's registry and CLI-entry latch through `state`.
+ * Route every slot of {@link HookIoSharedState} on this instance through `state`.
  *
- * A host that bundles its own copy of these helpers beside the packaged hooks
- * ends up with TWO instances of this module in one process, each with its own
- * registry object and its own latch. Without this seam the host must register
- * every specifier twice — once per instance — and claim the CLI slot twice, and
- * a specifier it registers on only one instance is invisible to the binders on
- * the other: those binders then resolve it at RUNTIME, inside a bundle that has
- * no node_modules, and the gate fails closed on every call. Adopting one state
- * object is what removes that failure mode rather than policing it.
+ * A host that ships its OWN hook-io module beside the packaged hooks ends up
+ * with two instances of this file's state in one process, each with its own
+ * registry and its own latches. Without this seam the host configures each slot
+ * twice, and a slot it sets on only one instance is invisible to the readers on
+ * the other. For the registry that means those readers resolve a specifier at
+ * RUNTIME, inside a bundle with no node_modules, and the gate fails closed on
+ * every call. Adopting one state object removes that failure mode rather than
+ * policing it.
  *
- * Call it before importing any module that lazy-loads a specifier, for the same
- * reason {@link registerLazyModules} carries that rule: a binder reads the
- * registry at its own module scope.
+ * WHY AN API AND NOT A BUNDLER ALIAS: collapsing the two module records at build
+ * time (an esbuild `alias` from the host's module to this one) is the cheaper
+ * fix and needs no API — but it works only when the host's module is a COPY of
+ * this one. The motivating host's is not: it exports names this module does not
+ * have and lacks names this one exports, so an alias breaks every call site of
+ * the difference. `test/claude-hooks-exports.test.mjs` still states the rule for
+ * a true copy — share this module, never duplicate it. This seam serves the
+ * other case, a host with its own module that must agree with ours on state.
  *
- * Registrations and a claim already made on this instance carry over, so a call
- * that lands after them keeps them rather than dropping them; an entry already
- * present in `state` wins, since it is the host's own choice for that specifier.
+ * Call it before importing any module that reads a slot, for the same reason
+ * {@link registerLazyModules} carries that rule: a reader binds at its own
+ * module scope.
+ *
+ * Slots already set on EITHER side survive: this instance's registrations and
+ * latches carry over, and a value already present in `state` wins, since it is
+ * the adopted root's own choice. Adopting the state this instance already holds
+ * is a no-op.
+ *
+ * CONSTRAINT: every instance must adopt the same root object, and none may adopt
+ * a second, different one. `shared` is reassigned, so a later `B.adopt(C)` would
+ * leave an earlier `A.adopt(B)` pointing at an abandoned object whose readers
+ * nothing reaches. This is not enforced with a throw: callers are bundle entry
+ * points, and a throw at their top level kills the hook before it writes a
+ * response — a hook that emits nothing reads as non-blocking, which is the
+ * fail-OPEN this whole module is built to avoid.
  * @param {HookIoSharedState} state
  * @returns {void}
  */
@@ -67,6 +102,14 @@ export function adoptHookIoSharedState(state) {
     if (state.lazyModules[specifier] === undefined)
       state.lazyModules[specifier] = namespace;
   if (shared.cliEntryClaimed) state.cliEntryClaimed = true;
+  if (
+    shared.missingPackageRemedy !== null &&
+    state.missingPackageRemedy === null
+  )
+    state.missingPackageRemedy = shared.missingPackageRemedy;
+  if (shared.hookgateMarker !== null && state.hookgateMarker === null)
+    state.hookgateMarker = shared.hookgateMarker;
+  if (shared.hookgateMarkerResolved) state.hookgateMarkerResolved = true;
   shared = state;
 }
 
@@ -287,13 +330,6 @@ export const DEFAULT_MISSING_PACKAGE_REMEDY =
   "reinstall the hook dependencies (pnpm install) and retry.";
 
 /**
- * Host-supplied default remedy, replacing DEFAULT_MISSING_PACKAGE_REMEDY. Null
- * (the default) keeps the package's wording.
- * @type {string | null}
- */
-let missingPackageRemedyOverride = null;
-
-/**
  * Adopt a host's own remedy as the default {@link missingPackageMessage} and
  * {@link missingPackageError} state when their caller passes none. This refusal
  * to hard-code the wording is what prevents a fail-closed reason whose remedy
@@ -310,7 +346,7 @@ let missingPackageRemedyOverride = null;
  * @returns {void}
  */
 export function configureMissingPackageRemedy(remedy) {
-  missingPackageRemedyOverride = remedy;
+  shared.missingPackageRemedy = remedy;
 }
 
 /**
@@ -329,7 +365,7 @@ export function configureMissingPackageRemedy(remedy) {
 export function missingPackageMessage(
   pkg,
   err = lazyImportErrorFor(pkg),
-  remedy = missingPackageRemedyOverride ?? DEFAULT_MISSING_PACKAGE_REMEDY,
+  remedy = shared.missingPackageRemedy ?? DEFAULT_MISSING_PACKAGE_REMEDY,
 ) {
   const prefix = `${pkg} is unavailable: `;
   // 2 for the "; " joiner; 12 for safeErrMessage's own "…[truncated]" marker,
@@ -359,7 +395,7 @@ export function missingPackageMessage(
 export function missingPackageError(
   pkg,
   err = lazyImportErrorFor(pkg),
-  remedy = missingPackageRemedyOverride ?? DEFAULT_MISSING_PACKAGE_REMEDY,
+  remedy = shared.missingPackageRemedy ?? DEFAULT_MISSING_PACKAGE_REMEDY,
 ) {
   return Object.assign(new Error(missingPackageMessage(pkg, err, remedy)), {
     code: "DEP_UNAVAILABLE",
@@ -467,16 +503,6 @@ export function emitHookResponse(hookEventName, fields) {
 const HOOKGATE_MARKER_STEM = "agent-sanitizer-hookgate-inflight-";
 
 /**
- * Host-supplied marker path, replacing the derived one. Null (the default) keeps
- * the derivation below.
- * @type {string | null}
- */
-let hookgateMarkerOverride = null;
-
-/** Whether {@link hookgateMarkerPath} has already handed a path to a caller. */
-let hookgateMarkerResolved = false;
-
-/**
  * Adopt a host's own cold-start marker path in place of the derived one, so a
  * host whose setup script already writes a marker under its own convention can
  * use these hooks without running a second, disagreeing wait loop against a path
@@ -494,13 +520,13 @@ let hookgateMarkerResolved = false;
  * @returns {void}
  */
 export function configureHookgateMarker(path) {
-  if (hookgateMarkerResolved)
+  if (shared.hookgateMarkerResolved)
     process.stderr.write(
       "agent-sanitizer: configureHookgateMarker called after a marker path was " +
         "already resolved; whatever resolved it is using the previous path and " +
         "cannot be re-steered. Call it before importing any hook module.\n",
     );
-  hookgateMarkerOverride = path;
+  shared.hookgateMarker = path;
 }
 
 /**
@@ -524,8 +550,8 @@ export function hookgateMarkerPath(
   projectDir = process.env.CLAUDE_PROJECT_DIR,
   runtimeDir = process.env.XDG_RUNTIME_DIR,
 ) {
-  hookgateMarkerResolved = true;
-  if (hookgateMarkerOverride !== null) return hookgateMarkerOverride;
+  shared.hookgateMarkerResolved = true;
+  if (shared.hookgateMarker !== null) return shared.hookgateMarker;
   if (!projectDir) return null;
   // Prefer the per-user, mode-0700 runtime dir when the harness gives an
   // absolute one; else the world-writable /tmp, where markerIsTrusted() — not

--- a/claude-hooks/lib/hook-io.mjs
+++ b/claude-hooks/lib/hook-io.mjs
@@ -12,7 +12,63 @@ import { userInfo } from "node:os";
 import { createHash } from "node:crypto";
 import { pathToFileURL } from "node:url";
 
-let cliEntryClaimed = false;
+/**
+ * The process-wide state these helpers keep: the pre-registered module
+ * namespaces {@link lazyImport} answers from, and the CLI-entry latch
+ * {@link isMain} reads.
+ *
+ * `lazyModules` is empty when the hooks run from source; a build-time BUNDLE
+ * (which ships with no node_modules for the runtime `import()` to resolve)
+ * statically imports its packages and registers them here before importing the
+ * hooks that lazy-load them, so the same hook source runs unchanged in both
+ * worlds.
+ *
+ * Both fields live on ONE object so a second instance of this module can adopt
+ * it — see {@link adoptHookIoSharedState}.
+ * @typedef {{lazyModules: Record<string, Record<string, any>>, cliEntryClaimed: boolean}} HookIoSharedState
+ */
+
+/** @type {HookIoSharedState} */
+let shared = { lazyModules: Object.create(null), cliEntryClaimed: false };
+
+/**
+ * This instance's state object, for a host to hand to another instance.
+ * @returns {HookIoSharedState}
+ */
+export function hookIoSharedState() {
+  return shared;
+}
+
+/**
+ * Route this instance's registry and CLI-entry latch through `state`.
+ *
+ * A host that bundles its own copy of these helpers beside the packaged hooks
+ * ends up with TWO instances of this module in one process, each with its own
+ * registry object and its own latch. Without this seam the host must register
+ * every specifier twice — once per instance — and claim the CLI slot twice, and
+ * a specifier it registers on only one instance is invisible to the binders on
+ * the other: those binders then resolve it at RUNTIME, inside a bundle that has
+ * no node_modules, and the gate fails closed on every call. Adopting one state
+ * object is what removes that failure mode rather than policing it.
+ *
+ * Call it before importing any module that lazy-loads a specifier, for the same
+ * reason {@link registerLazyModules} carries that rule: a binder reads the
+ * registry at its own module scope.
+ *
+ * Registrations and a claim already made on this instance carry over, so a call
+ * that lands after them keeps them rather than dropping them; an entry already
+ * present in `state` wins, since it is the host's own choice for that specifier.
+ * @param {HookIoSharedState} state
+ * @returns {void}
+ */
+export function adoptHookIoSharedState(state) {
+  if (state === shared) return;
+  for (const [specifier, namespace] of Object.entries(shared.lazyModules))
+    if (state.lazyModules[specifier] === undefined)
+      state.lazyModules[specifier] = namespace;
+  if (shared.cliEntryClaimed) state.cliEntryClaimed = true;
+  shared = state;
+}
 
 /**
  * True when this module is the process entry point (run directly as a CLI, not
@@ -29,7 +85,7 @@ export function isMain(importMetaUrl) {
   // alongside the real entry's and consume its stdin. An entry that claimed the
   // CLI slot (claimCliEntry) therefore makes every later isMain call answer
   // false — module bodies run in dependency order, so the claim lands first.
-  if (cliEntryClaimed) return false;
+  if (shared.cliEntryClaimed) return false;
   return (
     Boolean(process.argv[1]) &&
     importMetaUrl === pathToFileURL(process.argv[1]).href
@@ -43,7 +99,7 @@ export function isMain(importMetaUrl) {
  * @returns {void}
  */
 export function claimCliEntry() {
-  cliEntryClaimed = true;
+  shared.cliEntryClaimed = true;
 }
 
 /**
@@ -122,17 +178,6 @@ export async function readStdinJson(maxBytes = MAX_STDIN_BYTES) {
 }
 
 /**
- * Pre-registered module namespaces consulted by {@link lazyImport} before it
- * dials the loader. Empty when the hooks run from source; a build-time BUNDLE
- * (which ships with no node_modules for the runtime `import()` to resolve)
- * statically imports its packages and registers them here before importing the
- * hooks that lazy-load them, so the same hook source runs unchanged in both
- * worlds.
- * @type {Record<string, Record<string, any>>}
- */
-const registeredLazyModules = Object.create(null);
-
-/**
  * Register already-loaded module namespaces for {@link lazyImport} to return in
  * place of a runtime dynamic import. Call before importing any module that
  * lazy-loads the given specifiers.
@@ -140,7 +185,7 @@ const registeredLazyModules = Object.create(null);
  * @returns {void}
  */
 export function registerLazyModules(modules) {
-  Object.assign(registeredLazyModules, modules);
+  Object.assign(shared.lazyModules, modules);
 }
 
 /**
@@ -153,7 +198,7 @@ export function registerLazyModules(modules) {
  * @returns {Record<string, any> | undefined}
  */
 export function registeredLazyModule(specifier) {
-  return registeredLazyModules[specifier];
+  return shared.lazyModules[specifier];
 }
 
 /**
@@ -178,7 +223,7 @@ const lazyImportErrors = new Map();
  * @returns {Promise<Record<string, any>>}
  */
 export async function lazyImport(specifier) {
-  const registered = registeredLazyModules[specifier];
+  const registered = shared.lazyModules[specifier];
   if (registered) {
     lazyImportErrors.delete(specifier);
     return registered;

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -57,11 +57,11 @@ import { userInfo } from "node:os";
 import { createHash } from "node:crypto";
 import { pathToFileURL } from "node:url";
 function isMain(importMetaUrl) {
-  if (cliEntryClaimed) return false;
+  if (shared.cliEntryClaimed) return false;
   return Boolean(process.argv[1]) && importMetaUrl === pathToFileURL(process.argv[1]).href;
 }
 function claimCliEntry() {
-  cliEntryClaimed = true;
+  shared.cliEntryClaimed = true;
 }
 function readFlag(argv, name50) {
   const prefix = `--${name50}=`;
@@ -85,13 +85,13 @@ async function readStdinJson(maxBytes = MAX_STDIN_BYTES) {
   return JSON.parse((await readAllBounded(process.stdin, maxBytes)).toString());
 }
 function registerLazyModules(modules) {
-  Object.assign(registeredLazyModules, modules);
+  Object.assign(shared.lazyModules, modules);
 }
 function registeredLazyModule(specifier) {
-  return registeredLazyModules[specifier];
+  return shared.lazyModules[specifier];
 }
 async function lazyImport(specifier) {
-  const registered = registeredLazyModules[specifier];
+  const registered = shared.lazyModules[specifier];
   if (registered) {
     lazyImportErrors.delete(specifier);
     return registered;
@@ -268,11 +268,11 @@ function writeFileNoFollow(path2, content3, mode = 384) {
     closeSync(fd);
   }
 }
-var cliEntryClaimed, HookEvent, PermissionDecision, LONE_SURROGATE_RE, MAX_STDIN_BYTES, registeredLazyModules, lazyImportErrors, DEFAULT_MISSING_PACKAGE_REMEDY, missingPackageRemedyOverride, UNTRUSTED_TEXT_CAP, HOOKGATE_MARKER_STEM, hookgateMarkerOverride, hookgateMarkerResolved;
+var shared, HookEvent, PermissionDecision, LONE_SURROGATE_RE, MAX_STDIN_BYTES, lazyImportErrors, DEFAULT_MISSING_PACKAGE_REMEDY, missingPackageRemedyOverride, UNTRUSTED_TEXT_CAP, HOOKGATE_MARKER_STEM, hookgateMarkerOverride, hookgateMarkerResolved;
 var init_hook_io = __esm({
   "claude-hooks/lib/hook-io.mjs"() {
     "use strict";
-    cliEntryClaimed = false;
+    shared = { lazyModules: /* @__PURE__ */ Object.create(null), cliEntryClaimed: false };
     HookEvent = Object.freeze({
       PRE_TOOL_USE: "PreToolUse",
       POST_TOOL_USE: "PostToolUse",
@@ -286,7 +286,6 @@ var init_hook_io = __esm({
     });
     LONE_SURROGATE_RE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
     MAX_STDIN_BYTES = 64 * 1024 * 1024;
-    registeredLazyModules = /* @__PURE__ */ Object.create(null);
     lazyImportErrors = /* @__PURE__ */ new Map();
     DEFAULT_MISSING_PACKAGE_REMEDY = "reinstall the hook dependencies (pnpm install) and retry.";
     missingPackageRemedyOverride = null;

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -122,13 +122,13 @@ function failedLazyPackages() {
   }
   return [...pkgs];
 }
-function missingPackageMessage(pkg, err = lazyImportErrorFor(pkg), remedy = missingPackageRemedyOverride ?? DEFAULT_MISSING_PACKAGE_REMEDY) {
+function missingPackageMessage(pkg, err = lazyImportErrorFor(pkg), remedy = shared.missingPackageRemedy ?? DEFAULT_MISSING_PACKAGE_REMEDY) {
   const prefix = `${pkg} is unavailable: `;
   const causeCap = Math.max(0, 300 - prefix.length - remedy.length - 2 - 12);
   const cause = err === void 0 ? "no load error recorded \u2014 the package likely loaded but lacks an expected export (version skew)" : safeErrMessage(err, causeCap);
   return `${prefix}${cause}; ${remedy}`;
 }
-function missingPackageError(pkg, err = lazyImportErrorFor(pkg), remedy = missingPackageRemedyOverride ?? DEFAULT_MISSING_PACKAGE_REMEDY) {
+function missingPackageError(pkg, err = lazyImportErrorFor(pkg), remedy = shared.missingPackageRemedy ?? DEFAULT_MISSING_PACKAGE_REMEDY) {
   return Object.assign(new Error(missingPackageMessage(pkg, err, remedy)), {
     code: "DEP_UNAVAILABLE"
   });
@@ -164,8 +164,8 @@ function emitHookResponse(hookEventName, fields) {
   );
 }
 function hookgateMarkerPath(projectDir = process.env.CLAUDE_PROJECT_DIR, runtimeDir = process.env.XDG_RUNTIME_DIR) {
-  hookgateMarkerResolved = true;
-  if (hookgateMarkerOverride !== null) return hookgateMarkerOverride;
+  shared.hookgateMarkerResolved = true;
+  if (shared.hookgateMarker !== null) return shared.hookgateMarker;
   if (!projectDir) return null;
   const base2 = runtimeDir && runtimeDir.startsWith("/") ? runtimeDir : "/tmp";
   const digest = createHash("sha256").update(projectDir).digest("hex").slice(0, 8);
@@ -268,11 +268,17 @@ function writeFileNoFollow(path2, content3, mode = 384) {
     closeSync(fd);
   }
 }
-var shared, HookEvent, PermissionDecision, LONE_SURROGATE_RE, MAX_STDIN_BYTES, lazyImportErrors, DEFAULT_MISSING_PACKAGE_REMEDY, missingPackageRemedyOverride, UNTRUSTED_TEXT_CAP, HOOKGATE_MARKER_STEM, hookgateMarkerOverride, hookgateMarkerResolved;
+var shared, HookEvent, PermissionDecision, LONE_SURROGATE_RE, MAX_STDIN_BYTES, lazyImportErrors, DEFAULT_MISSING_PACKAGE_REMEDY, UNTRUSTED_TEXT_CAP, HOOKGATE_MARKER_STEM;
 var init_hook_io = __esm({
   "claude-hooks/lib/hook-io.mjs"() {
     "use strict";
-    shared = { lazyModules: /* @__PURE__ */ Object.create(null), cliEntryClaimed: false };
+    shared = {
+      lazyModules: /* @__PURE__ */ Object.create(null),
+      cliEntryClaimed: false,
+      missingPackageRemedy: null,
+      hookgateMarker: null,
+      hookgateMarkerResolved: false
+    };
     HookEvent = Object.freeze({
       PRE_TOOL_USE: "PreToolUse",
       POST_TOOL_USE: "PostToolUse",
@@ -288,11 +294,8 @@ var init_hook_io = __esm({
     MAX_STDIN_BYTES = 64 * 1024 * 1024;
     lazyImportErrors = /* @__PURE__ */ new Map();
     DEFAULT_MISSING_PACKAGE_REMEDY = "reinstall the hook dependencies (pnpm install) and retry.";
-    missingPackageRemedyOverride = null;
     UNTRUSTED_TEXT_CAP = 500;
     HOOKGATE_MARKER_STEM = "agent-sanitizer-hookgate-inflight-";
-    hookgateMarkerOverride = null;
-    hookgateMarkerResolved = false;
   }
 });
 

--- a/test/claude-hooks-exports.test.mjs
+++ b/test/claude-hooks-exports.test.mjs
@@ -12,7 +12,10 @@
  * modules plus lib/hook-io and lib/control-plane are what a consumer needs to
  * compose the hooks; hook-io in particular MUST be shared rather than copied,
  * because it owns the lazy-module registry and the CLI-slot singleton — two
- * inlined copies would double-fire the inlined CLIs.
+ * inlined copies would double-fire the inlined CLIs. A host that cannot share it
+ * because its own hook-io module is not a copy — it exports names this one does
+ * not have — reconciles the two through `adoptHookIoSharedState` instead, which
+ * puts both instances on one state object.
  *
  * These drive Node's real exports resolution via `import.meta.resolve` against
  * the package's own name — the same resolution a consumer's bare import

--- a/test/claude-hooks-shared-state.test.mjs
+++ b/test/claude-hooks-shared-state.test.mjs
@@ -1,0 +1,100 @@
+/**
+ * The cross-instance seam on hook-io: `hookIoSharedState` / `adoptHookIoSharedState`.
+ *
+ * A host that bundles its own copy of these helpers beside the packaged hooks
+ * runs TWO instances of this module in one process. Each keeps its own lazy
+ * registry and its own CLI-entry latch, so a specifier registered on one is
+ * invisible to the binders on the other — inside a bundle those binders then
+ * dial a loader with no node_modules and the gate fails closed on every call.
+ * The seam lets the second instance adopt the first's state object instead.
+ *
+ * Two module instances are produced here the same way a bundler produces them:
+ * by importing the module under two distinct specifiers, which gives two
+ * separate module records. The first test asserts they really are separate —
+ * without it every assertion below could pass on one shared instance and prove
+ * nothing.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { pathToFileURL } from "node:url";
+
+const MODULE = "../claude-hooks/lib/hook-io.mjs";
+
+let instances = 0;
+
+/**
+ * A pair of independent hook-io module instances, as a bundler's duplication
+ * produces them.
+ * @returns {Promise<[any, any]>}
+ */
+async function twoInstances() {
+  const tag = ++instances;
+  return Promise.all([
+    import(`${MODULE}?instance=${tag}a`),
+    import(`${MODULE}?instance=${tag}b`),
+  ]);
+}
+
+const ALPHA = { alpha: 1 };
+const BETA = { beta: 2 };
+
+/** The argv[1] URL isMain compares against, so a claim is what flips it. */
+const entryUrl = pathToFileURL(process.argv[1]).href;
+
+describe("hook-io instances are separate without the seam", () => {
+  it("neither registrations nor a CLI claim cross instances", async () => {
+    const [host, packaged] = await twoInstances();
+    host.registerLazyModules({ "pkg/one": ALPHA });
+    host.claimCliEntry();
+    assert.equal(packaged.registeredLazyModule("pkg/one"), undefined);
+    assert.deepEqual(await packaged.lazyImport("pkg/one"), {});
+    assert.equal(packaged.isMain(entryUrl), true);
+  });
+});
+
+describe("adoptHookIoSharedState", () => {
+  it("gives one registerLazyModules call reach over both instances", async () => {
+    const [host, packaged] = await twoInstances();
+    packaged.adoptHookIoSharedState(host.hookIoSharedState());
+    host.registerLazyModules({ "pkg/one": ALPHA });
+    assert.equal(packaged.registeredLazyModule("pkg/one"), ALPHA);
+    assert.equal(await packaged.lazyImport("pkg/one"), ALPHA);
+    // And back the other way: after the adopt there is one registry, not a copy
+    // taken at adopt time, so a packaged registration reaches the host binders.
+    packaged.registerLazyModules({ "pkg/two": BETA });
+    assert.equal(host.registeredLazyModule("pkg/two"), BETA);
+  });
+
+  it("gives one claimCliEntry call reach over both instances", async () => {
+    const [host, packaged] = await twoInstances();
+    packaged.adoptHookIoSharedState(host.hookIoSharedState());
+    assert.equal(packaged.isMain(entryUrl), true);
+    host.claimCliEntry();
+    assert.equal(packaged.isMain(entryUrl), false);
+    assert.equal(host.isMain(entryUrl), false);
+  });
+
+  it("carries the adopting instance's own registrations and claim over", async () => {
+    const [host, packaged] = await twoInstances();
+    packaged.registerLazyModules({ "pkg/two": BETA });
+    packaged.claimCliEntry();
+    packaged.adoptHookIoSharedState(host.hookIoSharedState());
+    assert.equal(host.registeredLazyModule("pkg/two"), BETA);
+    assert.equal(host.isMain(entryUrl), false);
+  });
+
+  it("keeps the adopted state's own entry for a specifier both hold", async () => {
+    const [host, packaged] = await twoInstances();
+    host.registerLazyModules({ "pkg/one": ALPHA });
+    packaged.registerLazyModules({ "pkg/one": BETA });
+    packaged.adoptHookIoSharedState(host.hookIoSharedState());
+    assert.equal(packaged.registeredLazyModule("pkg/one"), ALPHA);
+  });
+
+  it("is a no-op on the instance's own state", async () => {
+    const [host] = await twoInstances();
+    host.registerLazyModules({ "pkg/one": ALPHA });
+    host.adoptHookIoSharedState(host.hookIoSharedState());
+    assert.equal(host.registeredLazyModule("pkg/one"), ALPHA);
+  });
+});

--- a/test/claude-hooks-shared-state.test.mjs
+++ b/test/claude-hooks-shared-state.test.mjs
@@ -1,12 +1,16 @@
 /**
  * The cross-instance seam on hook-io: `hookIoSharedState` / `adoptHookIoSharedState`.
  *
- * A host that bundles its own copy of these helpers beside the packaged hooks
- * runs TWO instances of this module in one process. Each keeps its own lazy
- * registry and its own CLI-entry latch, so a specifier registered on one is
- * invisible to the binders on the other — inside a bundle those binders then
- * dial a loader with no node_modules and the gate fails closed on every call.
- * The seam lets the second instance adopt the first's state object instead.
+ * A host that ships its own hook-io module beside the packaged hooks runs TWO
+ * instances of this file's state in one process. Each keeps its own copy of all
+ * four host-visible slots — the lazy registry, the CLI-entry latch, the
+ * missing-package remedy and the hookgate marker path — so a slot set on one is
+ * invisible to the readers on the other. Every one of those splits fails
+ * SILENTLY, which is why each has a test here: an unregistered specifier makes
+ * the gate fail closed on every call, a lost claim makes an inlined CLI eat the
+ * entry's stdin, a lost remedy names a command the host does not have, and a
+ * lost marker path makes the cold-start wait poll a file nobody writes. The seam
+ * lets the second instance adopt the first's state object instead.
  *
  * Two module instances are produced here the same way a bundler produces them:
  * by importing the module under two distinct specifiers, which gives two
@@ -40,6 +44,9 @@ const BETA = { beta: 2 };
 
 /** The argv[1] URL isMain compares against, so a claim is what flips it. */
 const entryUrl = pathToFileURL(process.argv[1]).href;
+
+const HOST_REMEDY = "run ./setup.sh in the project root and retry.";
+const HOST_MARKER = "/run/host-hookgate-inflight";
 
 describe("hook-io instances are separate without the seam", () => {
   it("neither registrations nor a CLI claim cross instances", async () => {
@@ -81,6 +88,62 @@ describe("adoptHookIoSharedState", () => {
     packaged.adoptHookIoSharedState(host.hookIoSharedState());
     assert.equal(host.registeredLazyModule("pkg/two"), BETA);
     assert.equal(host.isMain(entryUrl), false);
+  });
+
+  it("keeps a claim already made on the adopted state", async () => {
+    // The mirror of the case above, and the one that pins `if (claimed) set true`
+    // against a plain `state.x = shared.x`: the plain form erases a claim the
+    // adopted root already holds. An entry that claims and then adopts would
+    // silently lose the claim, and per isMain's own note the inlined hook's CLI
+    // then fires alongside the entry's and eats its stdin — a fail-open.
+    const [host, packaged] = await twoInstances();
+    host.claimCliEntry();
+    packaged.adoptHookIoSharedState(host.hookIoSharedState());
+    assert.equal(host.isMain(entryUrl), false);
+    assert.equal(packaged.isMain(entryUrl), false);
+  });
+
+  it("carries the host remedy and marker path to the other instance", async () => {
+    // The two slots beyond the registry and the latch. Split, they fail the same
+    // silent way: the packaged control-plane waits on a marker path nobody
+    // writes, and a fail-closed reason names `pnpm install` in a host whose one
+    // install entry point is its own setup script.
+    const [host, packaged] = await twoInstances();
+    packaged.adoptHookIoSharedState(host.hookIoSharedState());
+    host.configureMissingPackageRemedy(HOST_REMEDY);
+    host.configureHookgateMarker(HOST_MARKER);
+    assert.match(
+      packaged.missingPackageMessage("pkg"),
+      new RegExp(HOST_REMEDY),
+    );
+    assert.equal(packaged.hookgateMarkerPath("/proj"), HOST_MARKER);
+  });
+
+  it("keeps a remedy and a marker set before the adopt", async () => {
+    const [host, packaged] = await twoInstances();
+    packaged.configureMissingPackageRemedy(HOST_REMEDY);
+    packaged.configureHookgateMarker(HOST_MARKER);
+    packaged.adoptHookIoSharedState(host.hookIoSharedState());
+    assert.match(host.missingPackageMessage("pkg"), new RegExp(HOST_REMEDY));
+    assert.equal(host.hookgateMarkerPath("/proj"), HOST_MARKER);
+  });
+
+  it("keeps the adopted state's own remedy and marker when both hold one", async () => {
+    // The adopted root is the host's choice, so its value wins over whatever the
+    // adopting instance had. Without that arm the carry-over above overwrites the
+    // root and the host's own configuration is silently replaced by the packaged
+    // instance's.
+    const [host, packaged] = await twoInstances();
+    host.configureMissingPackageRemedy(HOST_REMEDY);
+    host.configureHookgateMarker(HOST_MARKER);
+    packaged.configureMissingPackageRemedy("some other remedy.");
+    packaged.configureHookgateMarker("/run/other-marker");
+    packaged.adoptHookIoSharedState(host.hookIoSharedState());
+    assert.match(
+      packaged.missingPackageMessage("pkg"),
+      new RegExp(HOST_REMEDY),
+    );
+    assert.equal(packaged.hookgateMarkerPath("/proj"), HOST_MARKER);
   });
 
   it("keeps the adopted state's own entry for a specifier both hold", async () => {

--- a/type-fixtures/consumer/hooks-consumer.mts
+++ b/type-fixtures/consumer/hooks-consumer.mts
@@ -24,6 +24,8 @@ import {
 import {
   lazyImport,
   registerLazyModules,
+  hookIoSharedState,
+  adoptHookIoSharedState,
   makeDeadline,
   readFlag,
   HookEvent,
@@ -100,6 +102,9 @@ const _remaining: number = makeDeadline(1000).remainingMs();
 const _flag: string | undefined = readFlag(["--hook=x"], "hook");
 const _lazy: Record<string, any> = await lazyImport("agent-sanitizer");
 registerLazyModules({});
+// The cross-instance seam, at the shape a host bundle uses it: read one
+// instance's state object and hand it to another.
+adoptHookIoSharedState(hookIoSharedState());
 
 // The remaining exported pieces, called at their documented signatures.
 const _threshold: number = LONG_RUN_THRESHOLD;


### PR DESCRIPTION
## Summary

A program can end up with two copies of this module's state loaded at the same time. That happens when a host application ships its own hook-io module next to the one inside this package: a bundler such as esbuild inlines each file it resolves, and two different paths give two separate module records. Each record kept its own private copy of all four slots a host can steer — the registry of pre-loaded npm packages, the "the command-line slot is taken" flag, the missing-package remedy, and the cold-start marker path. So the host had to configure each slot twice, and a slot it set on only one copy was invisible to the readers on the other.

Every one of those splits fails silently:

- a package registered on one copy leaves the other's readers falling back to a real `import()` at run time; inside a bundle there is no `node_modules`, so that hook blocks every call it was meant to guard;
- a lost CLI claim lets an inlined hook's own command-line entry fire alongside the real one and consume its stdin;
- a lost remedy makes a failure message name `pnpm install` in a host whose only install entry point is its own setup script;
- a lost marker path makes the cold-start wait poll a file nobody writes — the exact "second, disagreeing wait loop" that `configureHookgateMarker` exists to prevent.

This adds a seam that lets the two copies share one state object, so one call per slot covers both.

## Changes

- `claude-hooks/lib/hook-io.mjs`: all four host-visible slots move onto one `shared` object, typed as `HookIoSharedState`. Two new exports: `hookIoSharedState()` returns that object, `adoptHookIoSharedState(state)` points this instance at another one's. Slots already set on either side survive the adopt; a value already present in the adopted root wins, since that root is the host's own choice. Adopting your own state is a no-op.
- `test/claude-hooks-shared-state.test.mjs`: new, 10 tests.
- `test/claude-hooks-exports.test.mjs`: its comment said hook-io "MUST be shared rather than copied", which now reads as contradicting the seam. It names the other case too.
- `type-fixtures/consumer/hooks-consumer.mts`: imports and calls the two new exports, so the generated `.d.mts` is type-checked from a consumer's view.
- `plugin/dist/hooks/plugin-hooks.bundle.mjs`: rebuilt, because `claude-hooks/` is one of its build inputs.

## Why an API and not a bundler alias

The cheaper fix is to collapse the two module records at build time — an esbuild `alias` from the host's module to this one — which needs no new API. It works only when the host's module is a **copy** of this one. The motivating host's is not: it exports 8 names this module does not have (`registeredModule`, `hookResponse`, `denyPreToolUse`, `parseCappedJson`, …) and lacks 9 this one exports (`awaitLazyDependency`, `hookgateMarkerPath`, `markerIsTrusted`, …), so an alias breaks every call site of the difference. The rule for a true copy still stands and is still stated in `test/claude-hooks-exports.test.mjs`; this seam serves the other case, a host with its own module that must agree with ours on state.

## Tests / verification

- `node --test test/claude-hooks-shared-state.test.mjs` — 10/10 pass. The first test asserts the two instances really are independent without the seam; without it every later assertion could pass on one shared instance and prove nothing.
- Mutation-checked: each of the three preservation guards in `adoptHookIoSharedState` is killed by exactly one test. Rewriting `if (shared.cliEntryClaimed) state.cliEntryClaimed = true` as a plain assignment reds "keeps a claim already made on the adopted state"; the same rewrite on either of the other two reds its own case. An earlier version of the remedy test did **not** kill its mutant, which is why the "both hold one" case was added.
- `node --test test/claude-hooks-*.test.mjs` — 123 pass, 0 fail.
- `node --test plugin/test/*.test.mjs` — 42 pass, 0 fail (includes the bundle reproducibility check).
- `pnpm check` — clean. `pnpm exec eslint` on the changed files — clean.

The test builds its two instances the way a bundler does, by importing the module under two distinct specifiers (`hook-io.mjs?instance=1a` and `?instance=1b`).

## Decisions made

- **Documented, not thrown, for a second adopt.** `shared` is reassigned, so every instance must adopt the same root object and none may adopt a second, different one — otherwise an earlier adopter points at an abandoned object. This is a JSDoc constraint rather than a throw: callers are bundle entry points, and a throw at their top level kills the hook before it writes a response, which reads as non-blocking — the fail-open this module exists to avoid. Under the alternative the footgun is loud but the failure mode is worse.
- **`lazyImportErrors` stays per-instance.** It is not host-configurable, so a split map changes only which cause a message names, with no reported defect asking for it.

## Downstream

`agent-glovebox` PR AlexanderMattTurner/agent-glovebox#3135 uses this seam to delete its duplicate registrations. It is a draft and cannot build until this PR merges and publishes.

## Checklist

- [x] Commits follow Conventional Commits; each subject reads as a user-facing release note.
- [x] `pnpm lint` and `pnpm check` pass locally; targeted `node --test` runs pass (see above).
- [ ] New or changed detectors have negative tests — no detector changed.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version are left untouched.