### PR TITLE
fix(claude-hooks): fill shared-state slots a host root object omits

### DIFF
--- a/claude-hooks/lib/hook-io.mjs
+++ b/claude-hooks/lib/hook-io.mjs
@@ -98,6 +98,20 @@ export function hookIoSharedState() {
  */
 export function adoptHookIoSharedState(state) {
   if (state === shared) return;
+  // Fill any slot `state` omits before anything reads it. A host builds this
+  // object itself, so one written against an earlier version of this package
+  // lacks the slots added since — and every reader below tests `!== null`, which
+  // an ABSENT slot satisfies. Unfilled, hookgateMarkerPath returns undefined
+  // instead of deriving a path; probeSetupAlive then throws internally on it and
+  // reports setup alive forever, so awaitLazyDependency waits out its whole
+  // ceiling, the harness kills the hook, and a killed hook is non-blocking — the
+  // fail-OPEN this module exists to prevent. `??=` and not `=`: it must not
+  // clobber a slot the host deliberately set, including `false`.
+  state.lazyModules ??= Object.create(null);
+  state.cliEntryClaimed ??= false;
+  state.missingPackageRemedy ??= null;
+  state.hookgateMarker ??= null;
+  state.hookgateMarkerResolved ??= false;
   for (const [specifier, namespace] of Object.entries(shared.lazyModules))
     if (state.lazyModules[specifier] === undefined)
       state.lazyModules[specifier] = namespace;

--- a/claude-hooks/lib/hook-io.mjs
+++ b/claude-hooks/lib/hook-io.mjs
@@ -39,14 +39,21 @@ import { pathToFileURL } from "node:url";
  * }} HookIoSharedState
  */
 
-/** @type {HookIoSharedState} */
-let shared = {
+/**
+ * A fresh state object with every slot at its default. Called per use, never
+ * hoisted to one shared literal, so each caller gets its own `lazyModules`.
+ * @returns {HookIoSharedState}
+ */
+const defaultSharedState = () => ({
   lazyModules: Object.create(null),
   cliEntryClaimed: false,
   missingPackageRemedy: null,
   hookgateMarker: null,
   hookgateMarkerResolved: false,
-};
+});
+
+/** @type {HookIoSharedState} */
+let shared = defaultSharedState();
 
 /**
  * This instance's state object, for a host to hand to another instance.
@@ -107,11 +114,9 @@ export function adoptHookIoSharedState(state) {
   // ceiling, the harness kills the hook, and a killed hook is non-blocking — the
   // fail-OPEN this module exists to prevent. `??=` and not `=`: it must not
   // clobber a slot the host deliberately set, including `false`.
-  state.lazyModules ??= Object.create(null);
-  state.cliEntryClaimed ??= false;
-  state.missingPackageRemedy ??= null;
-  state.hookgateMarker ??= null;
-  state.hookgateMarkerResolved ??= false;
+  const slots = /** @type {Record<string, any>} */ (state);
+  for (const [slot, value] of Object.entries(defaultSharedState()))
+    slots[slot] ??= value;
   for (const [specifier, namespace] of Object.entries(shared.lazyModules))
     if (state.lazyModules[specifier] === undefined)
       state.lazyModules[specifier] = namespace;

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -268,17 +268,18 @@ function writeFileNoFollow(path2, content3, mode = 384) {
     closeSync(fd);
   }
 }
-var shared, HookEvent, PermissionDecision, LONE_SURROGATE_RE, MAX_STDIN_BYTES, lazyImportErrors, DEFAULT_MISSING_PACKAGE_REMEDY, UNTRUSTED_TEXT_CAP, HOOKGATE_MARKER_STEM;
+var defaultSharedState, shared, HookEvent, PermissionDecision, LONE_SURROGATE_RE, MAX_STDIN_BYTES, lazyImportErrors, DEFAULT_MISSING_PACKAGE_REMEDY, UNTRUSTED_TEXT_CAP, HOOKGATE_MARKER_STEM;
 var init_hook_io = __esm({
   "claude-hooks/lib/hook-io.mjs"() {
     "use strict";
-    shared = {
+    defaultSharedState = () => ({
       lazyModules: /* @__PURE__ */ Object.create(null),
       cliEntryClaimed: false,
       missingPackageRemedy: null,
       hookgateMarker: null,
       hookgateMarkerResolved: false
-    };
+    });
+    shared = defaultSharedState();
     HookEvent = Object.freeze({
       PRE_TOOL_USE: "PreToolUse",
       POST_TOOL_USE: "PostToolUse",

--- a/test/claude-hooks-shared-state.test.mjs
+++ b/test/claude-hooks-shared-state.test.mjs
@@ -180,6 +180,34 @@ describe("adoptHookIoSharedState", () => {
     );
   });
 
+  it("fills a root that omits lazyModules, which would otherwise throw", async () => {
+    // The loudest of the omissions. Pre-fill, the carry-over loop indexes
+    // `state.lazyModules[specifier]` on an undefined — a TypeError at a bundle
+    // entry's top level, which kills the hook before it writes a response.
+    const [, packaged] = await twoInstances();
+    packaged.registerLazyModules({ "pkg/one": ALPHA });
+    const bareRoot = /** @type {any} */ ({});
+    packaged.adoptHookIoSharedState(bareRoot);
+    assert.equal(packaged.registeredLazyModule("pkg/one"), ALPHA);
+  });
+
+  it("carries a remedy and marker onto a root that omits those slots", async () => {
+    // What makes the fill load-bearing for these two: the carry-over arms test
+    // `state.x === null`, which is FALSE for an absent slot, so without the fill
+    // the adopting instance's own configured values are dropped on the floor
+    // rather than moved onto the root.
+    const [, packaged] = await twoInstances();
+    packaged.configureMissingPackageRemedy(HOST_REMEDY);
+    packaged.configureHookgateMarker(HOST_MARKER);
+    const legacyRoot = /** @type {any} */ ({
+      lazyModules: Object.create(null),
+      cliEntryClaimed: false,
+    });
+    packaged.adoptHookIoSharedState(legacyRoot);
+    assert.equal(legacyRoot.hookgateMarker, HOST_MARKER);
+    assert.equal(legacyRoot.missingPackageRemedy, HOST_REMEDY);
+  });
+
   it("is a no-op on the instance's own state", async () => {
     const [host] = await twoInstances();
     host.registerLazyModules({ "pkg/one": ALPHA });

--- a/test/claude-hooks-shared-state.test.mjs
+++ b/test/claude-hooks-shared-state.test.mjs
@@ -48,6 +48,12 @@ const entryUrl = pathToFileURL(process.argv[1]).href;
 const HOST_REMEDY = "run ./setup.sh in the project root and retry.";
 const HOST_MARKER = "/run/host-hookgate-inflight";
 
+/** What hookgateMarkerPath DERIVES for ("/proj", "/run") when no host path is set
+ * -- the answer an omitted `hookgateMarker` slot must not displace. */
+const DERIVED_MARKER = (
+  await import("../claude-hooks/lib/hook-io.mjs?derived")
+).hookgateMarkerPath("/proj", "/run");
+
 describe("hook-io instances are separate without the seam", () => {
   it("neither registrations nor a CLI claim cross instances", async () => {
     const [host, packaged] = await twoInstances();
@@ -152,6 +158,26 @@ describe("adoptHookIoSharedState", () => {
     packaged.registerLazyModules({ "pkg/one": BETA });
     packaged.adoptHookIoSharedState(host.hookIoSharedState());
     assert.equal(packaged.registeredLazyModule("pkg/one"), ALPHA);
+  });
+
+  it("fills slots a host root object omits", async () => {
+    // A host builds this object itself, so one written against an earlier version
+    // of the package lacks the slots added since. Every reader tests `!== null`,
+    // which an absent slot satisfies -- so unfilled, hookgateMarkerPath answers
+    // `undefined` instead of deriving a path, and the cold-start wait then treats
+    // setup as alive forever.
+    const [, packaged] = await twoInstances();
+    const legacyRoot = /** @type {any} */ ({
+      lazyModules: Object.create(null),
+      cliEntryClaimed: false,
+    });
+    packaged.adoptHookIoSharedState(legacyRoot);
+    assert.equal(packaged.hookgateMarkerPath("/proj", "/run"), DERIVED_MARKER);
+    assert.ok(
+      packaged
+        .missingPackageMessage("pkg")
+        .endsWith(packaged.DEFAULT_MISSING_PACKAGE_REMEDY),
+    );
   });
 
   it("is a no-op on the instance's own state", async () => {


### PR DESCRIPTION
## Summary

A host that adopts the hook-io shared state builds that object itself. So a host written against an earlier version of this package lacks whichever slots were added since — and readers inside this module test `!== null`, which an **absent** slot satisfies. The omission does not read as "unset"; it reads as "set to `undefined`".

This was introduced by #205, which moved four slots onto one shared object. As module-local `let` bindings those values were reachable as `null` and never as `undefined`, so a `!== null` test was sound. Once the object crosses a package boundary, it isn't.

## Three failures, in descending loudness

1. **A root omitting `lazyModules` throws.** The carry-over loop indexes `state.lazyModules[specifier]` — a `TypeError` at a bundle entry's top level. The hook dies before writing a response, and a hook that writes nothing is read as non-blocking: **fail open**.
2. **A root omitting `hookgateMarker` breaks the cold-start wait.** `hookgateMarkerPath` returns `shared.hookgateMarker` whenever it is not null, so it answers `undefined` instead of deriving a path. `probeSetupAlive(undefined)` then throws internally and its `catch` returns `true` — "setup alive" — so `awaitLazyDependency` waits out its full 900 s ceiling, the harness kills the hook, and again: **fail open**.
3. **The carry-over arms silently drop the adopting instance's own settings.** They test `state.x === null`, which is false for `undefined`, so a remedy or marker configured on the adopting instance is discarded rather than moved onto the root. Quiet, but it defeats the seam's whole purpose for those two slots.

`missingPackageMessage` survives by luck — it reads `?? DEFAULT`, and `??` treats `undefined` as unset. The readers disagree on how they spell the check, which is why the fix targets the class rather than each reader.

## Changes

- `adoptHookIoSharedState` fills every absent slot before anything reads it, restoring the invariant those values had as module-local bindings: reachable as `null`, never as `undefined`. `??=` rather than `=`, so a slot the host deliberately set — including a `false` — is never clobbered, and a frozen complete root is never written to at all.
- The defaults come from one `defaultSharedState()` factory, used for both the module's own `shared` and the fill. Restating them would mean a sixth slot needs writing in three places, and forgetting the fill one reintroduces this bug silently.
- `test/claude-hooks-shared-state.test.mjs`: three cases, one per failure above.

## Tests / verification

- `node --test test/claude-hooks-shared-state.test.mjs` — 13/13 pass.
- Non-vacuity: removing the fill reds **three** tests. Dropping any single slot from the factory also reds tests — dropping `lazyModules` reds all 13, since the module's own `shared` loses it too. That is the SSOT doing its job: with the list written twice, forgetting it in the fill half was silent.
- `node --test test/claude-hooks-*.test.mjs` — 126 pass, 0 fail. `node --test plugin/test/*.test.mjs` — 42 pass, 0 fail.
- `pnpm check` — clean. It caught a real error on the first attempt at the loop: indexing `HookIoSharedState` with a string key has no index signature, so the assignment goes through an explicitly cast local.

The marker test derives its expected path from a second, untouched instance of the module rather than restating the derivation, so it cannot drift from the real one.

## Checklist

- [x] Commits follow Conventional Commits; each subject reads as a user-facing release note.
- [x] `pnpm check` passes locally; targeted `node --test` runs pass (see above).
- [ ] New or changed detectors have negative tests — no detector changed.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version are left untouched.