### PR TITLE
fix(release): stamp the published version into the Claude Code plugin manifest

### DIFF
--- a/.github/scripts/set-plugin-version.mjs
+++ b/.github/scripts/set-plugin-version.mjs
@@ -1,0 +1,111 @@
+// Set the Claude Code plugin manifest's `version` to the version being released.
+//
+// Invoked from `.github/scripts/version-bump.sh` after a successful
+// `pnpm publish`, and committed alongside the CHANGELOG promotion.
+//
+//   NEW_VERSION — the semver string being released, e.g. "1.2.3"
+//
+// Why this is committed while package.json's version is not: Claude Code reads
+// `plugin/.claude-plugin/plugin.json` straight out of the git checkout when it
+// installs the plugin from this repo's marketplace, so the value users see is
+// whatever is committed. A working-tree-only bump (the package.json/pyproject
+// pattern) would leave the plugin advertising a frozen placeholder forever —
+// which is how it ended up reporting 0.1.0 while npm was at 2.14.1.
+//
+// Fails loudly (non-zero exit, `::error::` on stderr) on a missing manifest, a
+// manifest without a string `version`, or a bad NEW_VERSION. The caller decides
+// what to do with that: post-publish it logs the failure and continues to the
+// tag push rather than stranding an already-published release.
+//
+// Self-contained on purpose (node builtins only): the release workflow may run
+// a trusted copy of this file, which only works if it imports nothing in-repo.
+
+import { readFileSync, renameSync, writeFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+
+const MANIFEST_PATH = "plugin/.claude-plugin/plugin.json";
+const SEMVER = /^[0-9]+\.[0-9]+\.[0-9]+$/;
+
+/**
+ * @param {string} message
+ * @returns {never}
+ */
+function fail(message) {
+  process.stderr.write(`::error::plugin manifest version: ${message}\n`);
+  process.exit(1);
+}
+
+/**
+ * Write `contents` to `path` atomically: write a sibling temp file, then rename
+ * it over the target. A crash mid-write leaves the original file intact.
+ * @param {string} path
+ * @param {string} contents
+ */
+function atomicWrite(path, contents) {
+  const tmp = join(dirname(path), `.${basename(path)}.${process.pid}.tmp`);
+  writeFileSync(tmp, contents);
+  renameSync(tmp, path);
+}
+
+const newVersion = process.env.NEW_VERSION;
+if (!newVersion || !SEMVER.test(newVersion))
+  fail(
+    `NEW_VERSION must be a strict X.Y.Z semver string (got: '${newVersion ?? ""}')`,
+  );
+
+let raw;
+try {
+  raw = readFileSync(MANIFEST_PATH, "utf8");
+} catch (err) {
+  fail(
+    `could not read ${MANIFEST_PATH}: ${err instanceof Error ? err.message : String(err)}`,
+  );
+}
+
+let manifest;
+try {
+  manifest = JSON.parse(raw);
+} catch (err) {
+  fail(
+    `${MANIFEST_PATH} is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+  );
+}
+
+// Require the field to already exist: a manifest that lost its `version` key is
+// a structural change this script must not paper over by inventing one.
+if (typeof manifest.version !== "string")
+  fail(`${MANIFEST_PATH} has no string "version" field to update`);
+
+// Rewrite the value in place rather than re-serializing the parsed object:
+// `JSON.stringify` reflows arrays and drops the file's Prettier formatting, and
+// the release commit lands on the default branch where format:check runs.
+const updated = raw.replace(
+  /("version"\s*:\s*)"(?:[^"\\]|\\.)*"/,
+  (_match, key) => `${key}${JSON.stringify(newVersion)}`,
+);
+if (updated === raw && manifest.version !== newVersion)
+  fail(`could not locate the "version" value in ${MANIFEST_PATH}`);
+
+let reparsed;
+try {
+  reparsed = JSON.parse(updated);
+} catch (err) {
+  fail(
+    `rewriting the version produced invalid JSON: ${err instanceof Error ? err.message : String(err)}`,
+  );
+}
+// The regex targets the first `"version":` in the file; if the manifest ever
+// grows a nested one that comes first, this catches the wrong-field rewrite
+// instead of silently shipping it.
+if (reparsed.version !== newVersion)
+  fail(
+    `rewrite did not set the top-level "version" to ${newVersion} in ${MANIFEST_PATH}`,
+  );
+delete reparsed.version;
+const originalWithoutVersion = { ...manifest };
+delete originalWithoutVersion.version;
+if (JSON.stringify(reparsed) !== JSON.stringify(originalWithoutVersion))
+  fail(`rewriting the version changed other fields in ${MANIFEST_PATH}`);
+
+atomicWrite(MANIFEST_PATH, updated);
+process.stdout.write(`Set ${MANIFEST_PATH} version to ${newVersion}.\n`);

--- a/.github/scripts/version-bump.sh
+++ b/.github/scripts/version-bump.sh
@@ -459,9 +459,11 @@ fi
 # Retrying the identical push (what retry_cmd does) can never win: the remote
 # never rewinds. Instead, on rejection, fetch the new tip and REBASE our commits
 # onto it, then retry. The release-docs commit only touches CHANGELOG.md and the
-# plugin manifest's `version`; concurrent merges never hand-edit the
-# `## Unreleased` block nor that field, so the replay applies cleanly; a genuine conflict aborts loudly rather than force-pushing
-# over the other commit. A transient network failure degrades to the same
+# plugin manifest's `version`; concurrent merges practically never hand-edit the
+# `## Unreleased` block or that field, so the replay applies cleanly. A merge
+# that DOES hand-edit either (correcting a drifted manifest version, say)
+# conflicts here and aborts loudly rather than force-pushing over that commit.
+# A transient network failure degrades to the same
 # fetch-then-retry path (the fetch also fails, we back off and retry the push).
 # $1: branch, $2: max attempts, $3: initial backoff seconds (doubles each retry).
 #

--- a/.github/scripts/version-bump.sh
+++ b/.github/scripts/version-bump.sh
@@ -20,6 +20,10 @@ source "$SCRIPT_DIR/lib/retry.bash"
 
 log() { echo "$@" >&2; }
 
+# Claude Code plugin manifest. Its `version` is the one version string in the
+# repo that must be COMMITTED at release time (see the stamping step below).
+PLUGIN_MANIFEST="plugin/.claude-plugin/plugin.json"
+
 # Publish a step output for the workflow (no-op outside GitHub Actions). The
 # auto-version workflow reads `released`/`version` to decide whether — and at
 # what version — to also build and publish the coupled Python wheel to PyPI.
@@ -433,15 +437,30 @@ if [[ -f CHANGELOG.md ]] && [[ -n "$CHANGELOG_SECTION" ]]; then
     node "$SCRIPT_DIR/promote-changelog.mjs"
 fi
 
+# Stamp the released version into the Claude Code plugin manifest. Unlike
+# package.json (npm owns the version; the committed value is a frozen
+# placeholder), this one MUST be committed: Claude Code reads
+# plugin/.claude-plugin/plugin.json out of the git checkout when installing the
+# plugin from this repo's marketplace, so the committed value is the version
+# users are shown. Left unstamped it froze at 0.1.0 while npm climbed to 2.x.
+# A failure here is loud but non-fatal: npm has already published, and aborting
+# would skip the tag push and strand the release (the next run would re-analyze
+# these commits and cut a duplicate).
+if [[ -f "$PLUGIN_MANIFEST" ]]; then
+  if ! NEW_VERSION="$NEW_VERSION" node "$SCRIPT_DIR/set-plugin-version.mjs"; then
+    log "⚠️ Failed to stamp $NEW_VERSION into $PLUGIN_MANIFEST; the plugin manifest is now stale and must be fixed by hand."
+  fi
+fi
+
 # Push HEAD to $branch on origin, tolerating a concurrent advance of the branch.
 # The auto-version concurrency group serializes THIS workflow, but $branch can
 # still move mid-run via an ordinary PR merge from another actor — so the run
 # checked out a now-stale tip and a plain `git push` is rejected non-fast-forward.
 # Retrying the identical push (what retry_cmd does) can never win: the remote
 # never rewinds. Instead, on rejection, fetch the new tip and REBASE our commits
-# onto it, then retry. The release-docs commit only touches CHANGELOG.md and
-# concurrent merges never hand-edit the `## Unreleased` block, so the replay
-# applies cleanly; a genuine conflict aborts loudly rather than force-pushing
+# onto it, then retry. The release-docs commit only touches CHANGELOG.md and the
+# plugin manifest's `version`; concurrent merges never hand-edit the
+# `## Unreleased` block nor that field, so the replay applies cleanly; a genuine conflict aborts loudly rather than force-pushing
 # over the other commit. A transient network failure degrades to the same
 # fetch-then-retry path (the fetch also fails, we back off and retry the push).
 # $1: branch, $2: max attempts, $3: initial backoff seconds (doubles each retry).
@@ -479,8 +498,9 @@ push_with_rebase() {
   return 1
 }
 
-# Commit the CHANGELOG entry back to the default branch so users see the release
-# notes. package.json stays dirty (npm is the source of truth for version). A
+# Commit the CHANGELOG entry and the stamped plugin manifest back to the default
+# branch so users see the release notes and the plugin reports the version that
+# was actually published. package.json stays dirty (npm is the source of truth for version). A
 # bot identity and `[skip ci]` keep the resulting push from spawning another
 # workflow run. The tag is created AFTER this commit (and only when it reached
 # the branch — see RELEASE_DOCS_PUSH_FAILED) so HEAD == tag SHA. Note the tag
@@ -502,10 +522,19 @@ PUBLISHED_SHA=$(git rev-parse HEAD)
 DEFAULT_BRANCH="${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-if git diff --quiet -- CHANGELOG.md; then
-  log "No CHANGELOG changes to commit."
+# Only pass paths that exist: `git add` (unlike `git diff`) fails hard on a
+# pathspec matching nothing, which would abort the run after a successful
+# publish in a repo that ships no CHANGELOG or no plugin manifest.
+RELEASE_DOCS_PATHS=()
+for release_doc in CHANGELOG.md "$PLUGIN_MANIFEST"; do
+  if [[ -f "$release_doc" ]]; then
+    RELEASE_DOCS_PATHS+=("$release_doc")
+  fi
+done
+if [[ "${#RELEASE_DOCS_PATHS[@]}" -eq 0 ]] || git diff --quiet -- "${RELEASE_DOCS_PATHS[@]}"; then
+  log "No release-docs changes to commit."
 else
-  git add -- CHANGELOG.md
+  git add -- "${RELEASE_DOCS_PATHS[@]}"
   git commit -m "docs: release $NEW_VERSION [skip ci]"
   # Push to the default branch explicitly so this works whether actions/checkout
   # left us on a branch or in detached HEAD state. Rebase-on-reject so a racing

--- a/.github/workflows/auto-version.yaml
+++ b/.github/workflows/auto-version.yaml
@@ -3,7 +3,10 @@ name: Auto version bump and publish
 # On every push to the default branch, decide a Conventional-Commits semver bump
 # from the commits since the last vX.Y.Z tag and publish the package to npm with
 # provenance (OIDC trusted publishing — no NPM_TOKEN). The version is tracked by
-# the npm registry and git tags, never committed to package.json. The Claude API
+# the npm registry and git tags, never committed to package.json. The one
+# exception is the Claude Code plugin manifest (plugin/.claude-plugin/plugin.json):
+# Claude Code reads it out of the git checkout, so the release commit stamps the
+# published version into it alongside the CHANGELOG. The Claude API
 # drafts the CHANGELOG prose and degrades to a plain commit list when it is
 # unavailable. See .github/scripts/version-bump.sh for the full logic.
 #

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -65,6 +65,7 @@ env:
   #   .github/workflows/auto-version.yaml
   #   .github/scripts/version-bump.sh
   #   .github/scripts/promote-changelog.mjs
+  #   .github/scripts/set-plugin-version.mjs
   #   .github/scripts/lib/retry.bash
   # (CHANGELOG.md lives outside SYNC_PATHS and never syncs, so a versioned
   # consumer must create it to bootstrap the flow.)

--- a/.hooks/guard-pairs.json
+++ b/.hooks/guard-pairs.json
@@ -2,7 +2,16 @@
   "$comment": "Guard pairs: source file -> the cheap guard test(s) that cover it. When a listed source is staged, .hooks/run-guard-pairs.mjs runs the paired `node --test` files and blocks the commit on failure \u2014 so a guard test can never silently break on main because the data it reads changed without it (this bit twice: the release-token guard on auto-version.yaml, and the instructions guard tests). These are GUARDS, not an SSOT: a pair says \"run this check when that file changes\", and naming it otherwise would launder the very smell a drift guard should expose. Keep every paired test fast (~1s); test/guard-pairs.test.mjs asserts all paths here exist.",
   "pairs": {
     ".github/workflows/auto-version.yaml": ["scripts/version-bump.test.mjs"],
-    ".github/scripts/version-bump.sh": ["scripts/version-bump.test.mjs"],
+    ".github/scripts/version-bump.sh": [
+      "scripts/version-bump.test.mjs",
+      "scripts/set-plugin-version.test.mjs"
+    ],
+    ".github/scripts/set-plugin-version.mjs": [
+      "scripts/set-plugin-version.test.mjs"
+    ],
+    "plugin/.claude-plugin/plugin.json": [
+      "scripts/set-plugin-version.test.mjs"
+    ],
     ".github/mutation-shards.json": ["test/mutation-shards.test.mjs"],
     "src/invisible.mjs": [
       "test/invisible-charset.test.mjs",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-sanitizer",
   "displayName": "Agent Sanitizer",
-  "version": "0.1.0",
+  "version": "2.14.1",
   "description": "The agent-sanitizer defense pipeline as a Claude Code plugin: invisible-Unicode and ANSI stripping, hidden-HTML splicing, exfil-URL detection, confusable normalization, and detect-secrets-backed secret redaction over tool inputs, tool outputs, and user prompts. Every layer fails closed.",
   "author": {
     "name": "Alexander Matt Turner",

--- a/scripts/set-plugin-version.test.mjs
+++ b/scripts/set-plugin-version.test.mjs
@@ -1,0 +1,158 @@
+// Tests for `.github/scripts/set-plugin-version.mjs` — the release step that
+// stamps the published version into the Claude Code plugin manifest — plus the
+// standing invariant that the COMMITTED manifest version is a real release, not
+// the 0.1.0 placeholder it was frozen at while npm climbed to 2.x.
+
+import { strict as assert } from "node:assert";
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+const REPO_ROOT = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+  encoding: "utf8",
+}).trim();
+const SCRIPT = join(REPO_ROOT, ".github", "scripts", "set-plugin-version.mjs");
+const MANIFEST_REL = join("plugin", ".claude-plugin", "plugin.json");
+const LIVE_MANIFEST = join(REPO_ROOT, MANIFEST_REL);
+const CHANGELOG = join(REPO_ROOT, "CHANGELOG.md");
+const VERSION_BUMP = join(REPO_ROOT, ".github", "scripts", "version-bump.sh");
+
+/** Compare two X.Y.Z strings numerically. */
+function compareSemver(a, b) {
+  const [aMaj, aMin, aPatch] = a.split(".").map(Number);
+  const [bMaj, bMin, bPatch] = b.split(".").map(Number);
+  return aMaj - bMaj || aMin - bMin || aPatch - bPatch;
+}
+
+/** Write a manifest into a throwaway dir and run the script there. */
+function runInSandbox(manifestContents, env = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "plugin-version-"));
+  mkdirSync(join(dir, "plugin", ".claude-plugin"), { recursive: true });
+  const manifestPath = join(dir, MANIFEST_REL);
+  if (manifestContents !== null) writeFileSync(manifestPath, manifestContents);
+  const res = spawnSync("node", [SCRIPT], {
+    cwd: dir,
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+  });
+  assert.equal(res.error, undefined, "failed to spawn set-plugin-version.mjs");
+  const after =
+    manifestContents === null ? null : readFileSync(manifestPath, "utf8");
+  rmSync(dir, { recursive: true, force: true });
+  return { ...res, after };
+}
+
+const PRETTY_MANIFEST = `{
+  "name": "agent-sanitizer",
+  "version": "0.1.0",
+  "keywords": ["security", "sanitization"]
+}
+`;
+
+test("stamps the released version into the manifest", () => {
+  const { status, after, stdout } = runInSandbox(PRETTY_MANIFEST, {
+    NEW_VERSION: "3.4.5",
+  });
+  assert.equal(status, 0);
+  assert.equal(JSON.parse(after).version, "3.4.5");
+  assert.match(stdout, /version to 3\.4\.5/);
+});
+
+test("preserves the manifest's existing formatting", () => {
+  // Re-serializing the parsed object would reflow the one-line keywords array
+  // and fail format:check on the default branch, where the release commit lands.
+  const { after } = runInSandbox(PRETTY_MANIFEST, { NEW_VERSION: "3.4.5" });
+  assert.equal(after, PRETTY_MANIFEST.replace('"0.1.0"', '"3.4.5"'));
+});
+
+test("is idempotent when the manifest already names the version", () => {
+  const already = PRETTY_MANIFEST.replace('"0.1.0"', '"3.4.5"');
+  const { status, after } = runInSandbox(already, { NEW_VERSION: "3.4.5" });
+  assert.equal(status, 0);
+  assert.equal(after, already);
+});
+
+for (const { name, manifest, env } of [
+  {
+    name: "a missing NEW_VERSION",
+    manifest: PRETTY_MANIFEST,
+    env: { NEW_VERSION: "" },
+  },
+  {
+    name: "a non-semver NEW_VERSION",
+    manifest: PRETTY_MANIFEST,
+    env: { NEW_VERSION: "v3.4.5-rc.1" },
+  },
+  {
+    name: "a manifest with no version field",
+    manifest: '{\n  "name": "agent-sanitizer"\n}\n',
+    env: { NEW_VERSION: "3.4.5" },
+  },
+  {
+    name: "a manifest with a non-string version",
+    manifest: '{\n  "version": 3\n}\n',
+    env: { NEW_VERSION: "3.4.5" },
+  },
+  {
+    name: "a manifest that is not valid JSON",
+    manifest: "{ not json\n",
+    env: { NEW_VERSION: "3.4.5" },
+  },
+  {
+    name: "an absent manifest",
+    manifest: null,
+    env: { NEW_VERSION: "3.4.5" },
+  },
+]) {
+  test(`fails loudly on ${name}`, () => {
+    const { status, stderr, after } = runInSandbox(manifest, env);
+    assert.notEqual(status, 0, "must exit non-zero");
+    assert.match(stderr, /::error::plugin manifest version:/);
+    if (manifest !== null)
+      assert.equal(after, manifest, "a failed run must not rewrite the file");
+  });
+}
+
+// --- Standing invariants on the committed manifest ------------------------
+
+test("the committed plugin manifest advertises a real released version", () => {
+  const { version } = JSON.parse(readFileSync(LIVE_MANIFEST, "utf8"));
+  assert.match(
+    version,
+    /^[0-9]+\.[0-9]+\.[0-9]+$/,
+    "the plugin version must be strict X.Y.Z semver",
+  );
+
+  // The newest dated CHANGELOG section is the last version this repo released;
+  // the release commit stamps both files, so the manifest must never sit BELOW
+  // it (that is exactly the 0.1.0-vs-npm-2.14.1 drift this guards). Being ahead
+  // is tolerated: a release whose changelog body came back empty publishes and
+  // stamps the manifest without promoting an Unreleased section.
+  const dated = readFileSync(CHANGELOG, "utf8").match(
+    /^## \[([0-9]+\.[0-9]+\.[0-9]+)\]/m,
+  );
+  assert.ok(dated, "CHANGELOG.md must contain a dated release section");
+  assert.ok(
+    compareSemver(version, dated[1]) >= 0,
+    `plugin.json version ${version} is behind the latest released version ${dated[1]}`,
+  );
+});
+
+test("the release script stamps and commits the plugin manifest", () => {
+  // Positive markers, so this cannot pass vacuously if the stamping step is
+  // refactored away: the script must run the helper AND stage the manifest in
+  // the release-docs commit.
+  const src = readFileSync(VERSION_BUMP, "utf8");
+  assert.match(src, /PLUGIN_MANIFEST="plugin\/\.claude-plugin\/plugin\.json"/);
+  assert.match(src, /node "\$SCRIPT_DIR\/set-plugin-version\.mjs"/);
+  assert.match(src, /for release_doc in CHANGELOG\.md "\$PLUGIN_MANIFEST"/);
+  assert.match(src, /git add -- "\$\{RELEASE_DOCS_PATHS\[@\]\}"/);
+});

--- a/scripts/set-plugin-version.test.mjs
+++ b/scripts/set-plugin-version.test.mjs
@@ -121,6 +121,40 @@ for (const { name, manifest, env } of [
   });
 }
 
+// The rewrite is a non-global regex, so it targets the FIRST `"version":` in
+// the file. A nested one ahead of the top-level field is exactly what the
+// reparse checks exist for — and each ordering trips a different guard, so both
+// are pinned here. Without them the guards could be deleted undetected, and the
+// script would be no safer than the cheaper `set-pyproject-version.sh` awk shape.
+for (const { name, topLevelVersion, expected } of [
+  {
+    name: "leaves the top-level version stale",
+    topLevelVersion: "0.1.0",
+    expected: /rewrite did not set the top-level "version"/,
+  },
+  {
+    name: "leaves the top-level version already correct",
+    topLevelVersion: "3.4.5",
+    expected: /changed other fields/,
+  },
+]) {
+  test(`refuses a rewrite that ${name} because a nested "version" came first`, () => {
+    const nested = `{
+  "dependencies": { "some-plugin": { "version": "9.9.9" } },
+  "version": "${topLevelVersion}"
+}
+`;
+    const { status, stderr, after } = runInSandbox(nested, {
+      NEW_VERSION: "3.4.5",
+    });
+    assert.notEqual(status, 0, "must exit non-zero");
+    // Pin WHICH guard fires: each ordering exercises a different one, so a
+    // looser assertion would let one guard's deletion hide behind the other.
+    assert.match(stderr, expected);
+    assert.equal(after, nested, "a failed run must not rewrite the file");
+  });
+}
+
 // --- Standing invariants on the committed manifest ------------------------
 
 test("the committed plugin manifest advertises a real released version", () => {

--- a/scripts/version-bump.test.mjs
+++ b/scripts/version-bump.test.mjs
@@ -339,6 +339,101 @@ for (const { name, subject, body } of [
 // out from under it, and proves the release lands without clobbering the racing
 // commit.
 
+test("a release stamps the plugin manifest and commits it with the release docs", () => {
+  // The Claude Code plugin manifest is read out of the git checkout, so its
+  // version must be COMMITTED at release time — left unstamped it froze at
+  // 0.1.0 while npm climbed to 2.x, and the installed plugin reported 0.1.
+  const dir = mkdtempSync(join(tmpdir(), "vbump-plugin-"));
+  const remote = join(dir, "remote.git");
+  const work = join(dir, "work");
+  const manifestRel = "plugin/.claude-plugin/plugin.json";
+  const npmStub = `if [[ "$2" == *@* ]]; then
+  if [[ "$3" == "version" ]]; then exit 1; fi
+  exit 0
+else
+  echo '["1.0.0"]'
+fi`;
+  const gitW = (...args) =>
+    execFileSync("git", args, { cwd: work, stdio: "ignore" });
+
+  try {
+    execFileSync("git", ["init", "-q", "--bare", "-b", "main", remote]);
+    mkdirSync(work);
+    gitW("init", "-q", "-b", "main");
+    gitW("config", "user.email", "t@t.test");
+    gitW("config", "user.name", "t");
+    writeFileSync(
+      join(work, "package.json"),
+      JSON.stringify({ name: "sandbox-pkg", version: "1.0.0" }) + "\n",
+    );
+    writeFileSync(
+      join(work, "CHANGELOG.md"),
+      "# Changelog\n\n## Unreleased\n\n### Added\n\n- A thing.\n",
+    );
+    mkdirSync(join(work, "plugin", ".claude-plugin"), { recursive: true });
+    writeFileSync(
+      join(work, manifestRel),
+      '{\n  "name": "sandbox-plugin",\n  "version": "0.1.0"\n}\n',
+    );
+    const binDir = join(work, "stub-bin");
+    mkdirSync(binDir);
+    writeFileSync(join(binDir, "npm"), `#!/usr/bin/env bash\n${npmStub}\n`);
+    chmodSync(join(binDir, "npm"), 0o755);
+    writeFileSync(
+      join(binDir, "pnpm"),
+      "#!/usr/bin/env bash\necho 'stub publish ok'\nexit 0\n",
+    );
+    chmodSync(join(binDir, "pnpm"), 0o755);
+    gitW("add", "-A");
+    gitW("commit", "-q", "-m", "chore: seed");
+    gitW("tag", "v1.0.0");
+    gitW("remote", "add", "origin", remote);
+    gitW("push", "-q", "origin", "main");
+    gitW("push", "-q", "origin", "v1.0.0");
+    gitW("commit", "-q", "--allow-empty", "-m", "feat: add a thing");
+
+    const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+    delete env.ANTHROPIC_API_KEY;
+    delete env.GITHUB_OUTPUT;
+    delete env.GITHUB_REF_NAME;
+    delete env.GITHUB_REF;
+    const res = spawnSync("bash", [LIVE_SCRIPT], {
+      cwd: work,
+      env,
+      encoding: "utf8",
+    });
+    assert.equal(res.error, undefined, "failed to spawn the release script");
+    assert.equal(res.status, 0, res.stderr);
+
+    // The stamped manifest must reach the remote inside the release-docs commit
+    // — a working-tree-only bump (the package.json pattern) is exactly the bug.
+    const pushedManifest = execFileSync(
+      "git",
+      ["-C", remote, "show", `main:${manifestRel}`],
+      { encoding: "utf8" },
+    );
+    assert.equal(JSON.parse(pushedManifest).version, "1.1.0");
+    const touched = execFileSync(
+      "git",
+      ["-C", remote, "show", "--name-only", "--pretty=", "main"],
+      { encoding: "utf8" },
+    );
+    assert.match(touched, /CHANGELOG\.md/);
+    assert.match(touched, /plugin\/\.claude-plugin\/plugin\.json/);
+    // package.json must stay at its committed placeholder: npm owns that one.
+    assert.equal(
+      JSON.parse(
+        execFileSync("git", ["-C", remote, "show", "main:package.json"], {
+          encoding: "utf8",
+        }),
+      ).version,
+      "1.0.0",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("release-docs push rebases onto a branch that advanced mid-run", () => {
   const dir = mkdtempSync(join(tmpdir(), "vbump-race-"));
   const remote = join(dir, "remote.git");


### PR DESCRIPTION
Claims the release-version plumbing: `.github/scripts/version-bump.sh` + `plugin/.claude-plugin/plugin.json`.

## Summary

An installed agent-sanitizer plugin reported version **0.1**, while npm was at **2.14.1**. `plugin/.claude-plugin/plugin.json` was hand-written once at `0.1.0` and nothing ever moved it: the release flow deliberately keeps the version *out* of git (`package.json` and `python/pyproject.toml` are frozen placeholders stamped in the working tree only, with npm/PyPI/git tags as the source of truth).

That pattern is wrong for the plugin manifest, and it is the only file where it is wrong: Claude Code reads `plugin/.claude-plugin/plugin.json` straight out of the git checkout when installing from `.claude-plugin/marketplace.json`, so the **committed** value is the version users see. The fix stamps it during the release and commits it in the existing release-docs commit, next to the CHANGELOG promotion — no new commit, no new push, no new failure mode for the tag.

## Changes

- **`.github/scripts/set-plugin-version.mjs`** (new): sets the manifest's `version` to `NEW_VERSION`. Rewrites the value textually rather than re-serializing the parsed JSON — `JSON.stringify` reflows the `keywords` array and would fail `format:check` on `main` — then re-parses and asserts the top-level `version` is the target and no other field moved. Fails loudly (`::error::`, exit 1) on a missing/unparseable manifest, a manifest with no string `version`, or a non-semver `NEW_VERSION`.
- **`.github/scripts/version-bump.sh`**: runs the stamper after a successful `pnpm publish`, and stages the manifest alongside `CHANGELOG.md` in the release-docs commit. Paths are filtered to those that exist first, because `git add` (unlike `git diff`) aborts on a pathspec matching nothing — that would have stranded a release in a repo shipping no CHANGELOG or no plugin. A stamping failure is logged but non-fatal: npm has already published, and aborting would skip the tag push and let the next run cut a duplicate release.
- **`plugin/.claude-plugin/plugin.json`**: `0.1.0` → `2.14.1`, the current npm `latest`, so the drift is corrected now rather than at the next release.
- **`.hooks/guard-pairs.json`**: pairs the new guard test with the manifest, the stamper, and `version-bump.sh`.

## Tests / verification

`pnpm test` (2161 tests, 100% coverage), `pnpm lint`, `pnpm check`, `shellcheck`, and `prettier --check` all pass locally.

New — `scripts/set-plugin-version.test.mjs` (11 tests): stamping, formatting preservation, idempotence, six loud-failure cases (each asserting the file is left untouched), plus two standing invariants — the committed manifest version is strict semver and never behind the newest dated CHANGELOG section, and `version-bump.sh` still contains the stamp-and-stage idioms (positive markers, so it can't pass vacuously if the step is refactored away).

New in `scripts/version-bump.test.mjs`: an end-to-end release against a real bare remote asserting the stamped manifest lands **on the remote** inside the release-docs commit at the released version, that the commit touches both files, and that `package.json`'s committed placeholder is left alone.

## Decisions made

- **Manifest-vs-CHANGELOG invariant is `>=`, not `==`.** A release whose drafted changelog body comes back empty publishes and stamps the manifest without promoting an `## Unreleased` section, so the manifest can legitimately sit one release ahead. Under `==` that guard would go red on `main` and block every PR. The alternative — also stamping on the no-changelog path so the two always match — would mean synthesizing a changelog entry, which the release flow deliberately declines to do.
- **Stamping failure is non-fatal.** It runs after `pnpm publish`, where an abort skips the tag and causes the next run to republish. It logs `::error::` + a warning naming the manual fix instead. The alternative — hard-fail — trades a stale manifest for a stranded release.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/); each subject reads as a user-facing release note.
- [x] `pnpm test`, `pnpm lint`, and `pnpm check` pass locally.
- [x] New or changed detectors have negative tests — n/a, no detector changes; the new script has failure-path tests asserting it never rewrites a file it could not validate.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version are left untouched (the release workflow owns them).

## Lessons Learned

- **What**: teach the release script to stamp and commit `plugin/.claude-plugin/plugin.json`'s `version`, and ship `set-plugin-version.mjs` beside `promote-changelog.mjs`. **Where**: `.github/scripts/version-bump.sh` and `.github/scripts/`. **Why**: the template's rule is "the version is never committed", which is correct for `package.json`/`pyproject.toml` but silently wrong for any manifest a consumer reads out of the git checkout — a downstream repo that ships a Claude Code plugin will advertise its initial hand-written version forever.


---
_Generated by [Claude Code](https://claude.ai/code/session_015G8vajoZXSn1XpDdi9txSe)_