### PR TITLE
docs(readme): surface the Claude Code plugin install alongside npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,22 @@ HTML, confusable glyphs, exfil-shaped URLs—that let an attacker smuggle a
 payload the operator can't see but the model still reads. Every layer is a
 deterministic transform you can unit-test with equality assertions.
 
+**As a library:**
+
 ```sh
 npm install agent-sanitizer
 ```
+
+**As a Claude Code plugin** — four hooks that put Layers 1–4 on the tool stream,
+no `node_modules` and no build step:
+
+```
+/plugin marketplace add AlexanderMattTurner/agent-sanitizer
+/plugin install agent-sanitizer@agent-sanitizer
+```
+
+See [Using it with Claude Code](#using-it-with-claude-code) for what each hook
+covers and how to wire the hooks by hand instead.
 
 ## Quick start
 
@@ -82,16 +95,14 @@ owns each message, and any value outside the enum makes `sanitizeText` **throw**
 
 ## Using it with Claude Code
 
-Four hooks put Layers 1–4 on the tool stream: tool input, tool output, user
-prompts, and a session-start scan of the instruction files.
+The plugin installed above puts four hooks on the tool stream: tool input, tool
+output, user prompts, and a session-start scan of the instruction files. It
+needs only `python3` on PATH, for Layer 4.
 
 ```
 /plugin marketplace add AlexanderMattTurner/agent-sanitizer
 /plugin install agent-sanitizer@agent-sanitizer
 ```
-
-The plugin needs no `node_modules` and no build step — just `python3` on PATH
-for Layer 4.
 
 To wire them yourself instead, one entry dispatches all four modes on `--hook=`:
 


### PR DESCRIPTION
Claims `README.md` (install section only).

Follow-up to #207, which merged before this commit landed on the branch.

## Summary

The Claude Code plugin install was buried ~80 lines into the README, under "Using it with Claude Code", while the top of the file offered only `npm install agent-sanitizer`. For anyone who wants the hooks rather than the library, the fastest path was invisible above the fold. This surfaces it as the second labeled install path directly under the npm line.

Related: #207 fixed the plugin manifest reporting `0.1.0`, so the plugin a reader installs from here now advertises a real version (the 2.14.2 release stamped it automatically — the fix is confirmed working on `main`).

## Changes

- **`README.md`**: the intro now offers two labeled install paths — **As a library** (`npm install`) and **As a Claude Code plugin** (`/plugin marketplace add` + `/plugin install`), the latter noting it needs no `node_modules` and no build step, with a link to the hook detail below.
- **`README.md`**: "Using it with Claude Code" no longer repeats the install pitch — it picks up from the install above and covers what the four hooks do, the `python3` requirement for Layer 4, and the manual `settings.json` wiring.

## Tests / verification

Docs-only; no code paths touched. `prettier --check README.md` passes. `test/package-exports.test.mjs` asserts `README.md` ships in the tarball but makes no assertion on its prose, so nothing pins the wording this changes.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/); each subject reads as a user-facing release note.
- [x] `prettier --check` passes; `pnpm test`/`lint`/`check` unaffected by a docs-only change.
- [x] New or changed detectors have negative tests — n/a, no detector changes.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version are left untouched (the release workflow owns them).


---
_Generated by [Claude Code](https://claude.ai/code/session_015G8vajoZXSn1XpDdi9txSe)_