### PR TITLE
docs: say what installing gets you and what failure looks like

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,11 @@ Commits MUST use [Conventional Commits](https://www.conventionalcommits.org/) (`
 - **Iterating word-split command output under the shared `shellharden` + `shellcheck` hooks**: don’t write `for x in $(cmd)` — `shellharden` auto-quotes `$(cmd)`, killing the split, and `shellcheck` then fails with `SC2066`. Don’t reach for `mapfile`/`readarray` if the script must run on macOS bash 3.2 (it’s bash 4+). Use a portable `while IFS= read -r line; do arr+=("$line"); done < <(cmd)` array, consumed as `"${arr[@]}"`.
 - **Escape every metacharacter class in a single pass when embedding text into a shell/DSL.** Chained `.replace()` calls where a later pass can re-touch an earlier pass’s inserted escape character are the classic source of CodeQL’s _incomplete string escaping_ findings.
 
+## Docs
+
+- **Adding, removing, or renumbering a layer means updating every doc that counts them.** `THREAT-MODEL.md`'s opening paragraph names the layers and their count, the README's entry-point table indexes the imports, and `plugin/README.md` lists the hooks — all three go stale silently, leaving the docs advertising a smaller (or wrong) surface than what ships. Update them in the same commit as the layer.
+- Keep the layer numbering stable: `Layer N` appears in warning strings, hook messages and issue reports, so renumbering an existing layer is a breaking change, not a doc edit.
+
 ## Self-Critique Loop
 
 Before declaring any non-trivial coding task done, **iteratively critique and fix your own work until you reach a fixed point.** Read what you actually wrote (not what you intended to write) as if it came from a developer you cannot stand—assume it is wrong until proven otherwise.

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ npm install agent-sanitizer
 /plugin install agent-sanitizer@agent-sanitizer
 ```
 
-See [Using it with Claude Code](#using-it-with-claude-code) for what each hook
-covers and how to wire the hooks by hand instead.
+[What installing entails](#what-installing-entails) covers the footprint of each
+path and how a failure looks; [Using it with Claude
+Code](#using-it-with-claude-code) covers each hook and hand-wiring.
 
 ## Quick start
 
@@ -92,11 +93,61 @@ owns each message, and any value outside the enum makes `sanitizeText` **throw**
 | `filter-flagged`      | The filter flagged the output as a possible injection without deleting (content intact) |
 | `filter-error`        | The filter reported a non-fatal internal error while scanning (a fatal filter throws)   |
 
+## What installing entails
+
+**`npm install`** is inert: no hooks, no daemon, no network — it acts only when
+you call it. Node 22+; `/html` lazy-loads its parser stack (~200 ms, once per
+process). Layer 4 (secret redaction) is not in the npm package —
+`pip install 'agent-sanitizer[secrets]'` and wire `/output`'s `redact` seam.
+Layer 5 is yours to supply.
+
+**The plugin** is the opposite: four hooks on every session. It needs Node 22+
+and `python3` (3.11+) or `uv`. The first session provisions the Layer-4 engine
+into a venv (one-time download, tens of seconds); the plugin also ships a
+self-contained zipapp, so an offline cold start still redacts. Secret redaction
+**is** included here — `detect-secrets`, locally, over a private 0600 socket.
+What you'll notice:
+
+| Event         | What happens                                                                                                                |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Session start | `CLAUDE.md`/`AGENTS.md`/`.claude/**.md` scanned for hidden Unicode, auto-cleaned where possible                             |
+| Prompt submit | Blocked if it carries payload-capable invisible/ANSI (pasted SGR color passes with a note)                                  |
+| Tool input    | Confusables folded to ASCII, escapes stripped, redacted `Edit`/`Write` re-anchored onto on-disk bytes                       |
+| Tool output   | Invisibles/ANSI stripped, hidden HTML spliced out (original kept in a reveal sidecar), exfil URLs flagged, secrets redacted |
+
+Expect ~1–3 s on the first secret-shaped output (redactor cold start), ~200 ms on
+the first HTML page, and occasional over-redaction of credential-shaped text.
+`AGENT_SANITIZER_OUTPUT_DISABLED=1` opts out of the rewrites (or
+`_INVISIBLE_`/`_TERMINAL_` individually).
+
+### Warning signs
+
+Every layer fails **closed**, so breakage shows up as friction, not silence:
+
+| What you see                                                                      | Meaning                                                                |
+| --------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `[output sanitizer unavailable — original output suppressed]`                     | Hook couldn't start — `node` missing or bundle corrupt                 |
+| `[SANITIZATION FAILED — original output suppressed for safety …]`                 | The output hook threw; raw output withheld                             |
+| `CRITICAL: secret redaction failed … Failing closed`                              | Layer-4 daemon unreachable — check `python3`/`uv`, restart the session |
+| `python3 not found — the secret-redaction engine (Layer 4) cannot be provisioned` | No Python at session start                                             |
+| `User prompt blocked: payload-capable invisible/ANSI characters detected.`        | Working as intended — retype the prompt                                |
+| `… (fail-closed): unrecognized hook payload.`                                     | Payload shape mismatch — check versions                                |
+| Every tool call turning into a permission ask                                     | The input gate can't reach a verdict; the reason names the cause       |
+| `instruction files were NOT scanned`                                              | Session-start scan didn't run                                          |
+
+**Silence is the one failure that isn't loud.** Claude Code reads a crashed hook
+as "no objection", so a quiet session isn't proof of a working one. Confirm with
+`/plugin`, or set `_AGENT_SANITIZER_TRACE=info` (plus
+`_AGENT_SANITIZER_TRACE_FILE=…`) and look for `hook_ran` /
+`scan_invisible_chars_ran` lines — a missing one means that layer never engaged,
+and `"outcome":"skipped"` means it gave up before reading anything.
+
 ## Using it with Claude Code
 
 The plugin installed above puts four hooks on the tool stream: tool input, tool
 output, user prompts, and a session-start scan of the instruction files. It
-needs only `python3` on PATH, for Layer 4.
+needs only `python3` on PATH, for Layer 4 — the plugin ships the engine itself
+(see [What installing entails](#what-installing-entails)).
 
 ```
 /plugin marketplace add AlexanderMattTurner/agent-sanitizer
@@ -175,9 +226,11 @@ Beyond the credential-shaped names it infers, the env-bound redaction set unions
 variable names whose values a deployment forwards under names of its own
 choosing. A malformed entry throws rather than being dropped.
 
-**Layer 4 needs the Python engine** — `pip install 'agent-sanitizer[secrets]'`,
-version-matched to the npm package. Without it `sanitize-output` fails closed:
-secret-shaped output is suppressed, not shown unvetted. Layers 1–3 still run.
+**Layer 4 needs the Python engine.** The plugin ships it and provisions it at
+SessionStart; a hand-wired npm install does not, so install it yourself —
+`pip install 'agent-sanitizer[secrets]'`, version-matched to the npm package.
+Without it `sanitize-output` fails closed: secret-shaped output is suppressed,
+not shown unvetted. Layers 1–3 still run.
 
 **Layer 5 (second-model injection filtering) is not included.** These hooks
 never supply the `/output` seam's `filterInjection` callback, so nothing here

--- a/README.md
+++ b/README.md
@@ -95,52 +95,31 @@ owns each message, and any value outside the enum makes `sanitizeText` **throw**
 
 ## What installing entails
 
-**`npm install`** is inert: no hooks, no daemon, no network — it acts only when
-you call it. Node 22+; `/html` lazy-loads its parser stack (~200 ms, once per
-process). Layer 4 (secret redaction) is not in the npm package —
-`pip install 'agent-sanitizer[secrets]'` and wire `/output`'s `redact` seam.
-Layer 5 is yours to supply.
+Installing the plugin puts four hooks on every session, and this is what they
+buy you:
 
-**The plugin** is the opposite: four hooks on every session. It needs Node 22+
-and `python3` (3.11+) or `uv`. The first session provisions the Layer-4 engine
-into a venv (one-time download, tens of seconds); the plugin also ships a
-self-contained zipapp, so an offline cold start still redacts. Secret redaction
-**is** included here — `detect-secrets`, locally, over a private 0600 socket.
-What you'll notice:
+1. Your `CLAUDE.md`, `AGENTS.md` and `.claude/` markdown are scanned at session
+   start for hidden-Unicode payloads and auto-cleaned where possible.
+2. Prompts carrying payload-capable invisible or ANSI characters are blocked
+   before they reach the model; pasted terminal color passes with a note.
+3. Look-alike glyphs in tool inputs are folded to ASCII, so a Cyrillic `а` can't
+   walk a command past a deny rule.
+4. Tool output has invisible characters and terminal escapes stripped, hidden
+   HTML spliced out with a placeholder, and exfil-shaped URLs flagged.
+5. Secrets in tool output are redacted locally by `detect-secrets` — the engine
+   ships with the plugin and provisions itself on first run, no setup from you.
+6. Edits the model composes against the redacted view are re-anchored onto the
+   real bytes on disk, and anything ambiguous is denied rather than guessed.
+7. The costs are a few seconds on the first secret-shaped output, ~200 ms on the
+   first web page, and the occasional over-redaction of credential-shaped text —
+   `AGENT_SANITIZER_OUTPUT_DISABLED=1` opts out of the rewrites.
 
-| Event         | What happens                                                                                                                |
-| ------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| Session start | `CLAUDE.md`/`AGENTS.md`/`.claude/**.md` scanned for hidden Unicode, auto-cleaned where possible                             |
-| Prompt submit | Blocked if it carries payload-capable invisible/ANSI (pasted SGR color passes with a note)                                  |
-| Tool input    | Confusables folded to ASCII, escapes stripped, redacted `Edit`/`Write` re-anchored onto on-disk bytes                       |
-| Tool output   | Invisibles/ANSI stripped, hidden HTML spliced out (original kept in a reveal sidecar), exfil URLs flagged, secrets redacted |
-
-Expect ~1–3 s on the first secret-shaped output (redactor cold start), ~200 ms on
-the first HTML page, and occasional over-redaction of credential-shaped text.
-`AGENT_SANITIZER_OUTPUT_DISABLED=1` opts out of the rewrites (or
-`_INVISIBLE_`/`_TERMINAL_` individually).
-
-### Warning signs
-
-Every layer fails **closed**, so breakage shows up as friction, not silence:
-
-| What you see                                                                      | Meaning                                                                |
-| --------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| `[output sanitizer unavailable — original output suppressed]`                     | Hook couldn't start — `node` missing or bundle corrupt                 |
-| `[SANITIZATION FAILED — original output suppressed for safety …]`                 | The output hook threw; raw output withheld                             |
-| `CRITICAL: secret redaction failed … Failing closed`                              | Layer-4 daemon unreachable — check `python3`/`uv`, restart the session |
-| `python3 not found — the secret-redaction engine (Layer 4) cannot be provisioned` | No Python at session start                                             |
-| `User prompt blocked: payload-capable invisible/ANSI characters detected.`        | Working as intended — retype the prompt                                |
-| `… (fail-closed): unrecognized hook payload.`                                     | Payload shape mismatch — check versions                                |
-| Every tool call turning into a permission ask                                     | The input gate can't reach a verdict; the reason names the cause       |
-| `instruction files were NOT scanned`                                              | Session-start scan didn't run                                          |
-
-**Silence is the one failure that isn't loud.** Claude Code reads a crashed hook
-as "no objection", so a quiet session isn't proof of a working one. Confirm with
-`/plugin`, or set `_AGENT_SANITIZER_TRACE=info` (plus
-`_AGENT_SANITIZER_TRACE_FILE=…`) and look for `hook_ran` /
-`scan_invisible_chars_ran` lines — a missing one means that layer never engaged,
-and `"outcome":"skipped"` means it gave up before reading anything.
+Failure is loud by design: every layer fails closed, so you see suppressed tool
+output (`[output sanitizer unavailable — original output suppressed]`), blocked
+prompts, or permission asks whose reason names the cause. The exception is a
+plugin that never loaded at all — Claude Code reads a crashed hook as "no
+objection", so confirm with `/plugin` rather than reading a quiet session as a
+working one.
 
 ## Using it with Claude Code
 

--- a/THREAT-MODEL.md
+++ b/THREAT-MODEL.md
@@ -6,7 +6,13 @@ a detect/neutralize layer, not an enforcement boundary: it makes hidden content
 visible-or-gone and surfaces exfil-shaped URLs, so the model and the operator
 see the same thing. Egress controls remain your enforcement layer.
 
-The three layers are independent; use only the ones your ingress needs.
+Five sanitization layers are documented below — invisible characters/ANSI (1),
+hidden HTML (2), exfil URLs (3), secret redaction (4, an injected redactor) and
+injection filtering (5, an injected filter the caller wires) — plus the entry
+points built on them: confusable folding, instruction-file scanning, the
+user-prompt verdict and edit rehydration. All are independent; use only the ones
+your ingress needs. The README's [entry-point
+table](./README.md#entry-points) maps each to its import.
 
 ## Layer 1—invisible characters & ANSI (zero-dependency)
 


### PR DESCRIPTION
Claims `README.md`, `THREAT-MODEL.md`, `CLAUDE.md`.

The README explained the layers but never said what *installing* actually does to a session, and the threat model opened by claiming three layers while documenting five plus four entry points.

## Changes

- **`README.md`** — new "What installing entails" section: one sentence on the npm package being inert, then a numbered list of the seven things the plugin's hooks do (instruction-file scan, prompt blocking, confusable folding, output stripping/splicing/flagging, local secret redaction, edit re-anchoring, and the latency/over-redaction costs plus the opt-out), and two sentences on the fail-closed symptoms — including that a plugin which never loaded is silent, so a quiet session is not evidence it works.
- **`README.md`** — corrected the Layer-4 note: the plugin ships and provisions the redaction engine; only a hand-wired npm install needs the `pip install 'agent-sanitizer[secrets]'` step. The old wording read as though plugin users had to install it themselves.
- **`THREAT-MODEL.md`** — replaced "The three layers are independent" with the actual set (layers 1–5 plus confusable folding, instruction scanning, the prompt verdict, and rehydration), linked to the README's entry-point table.
- **`CLAUDE.md`** — new `## Docs` rule: a layer added, removed, or renumbered must update the threat model's count, the README's entry-point table, and the plugin hook list in the same commit; and layer numbers are load-bearing in warning strings, so renumbering is a breaking change.

## Decisions made

- **Depth of the install section.** First draft carried tables for prerequisites, provisioning, day-to-day behavior, and a ten-row symptom table. Cut to a numbered list plus two sentences per review feedback; version numbers and provisioning mechanics stay in `plugin/README.md`, which is where someone debugging an install already looks. The alternative — keeping the symptom table — trades scannability for a section most readers skip.
- **Layer numbering left as-is.** The threat model's headings only number layers 1–3, with 4 and 5 described inside the tool-output section. Renumbering or re-heading them would touch strings that ship in hook messages, so the intro paragraph names the full set instead.

Docs only — no code paths touched.

## Lessons Learned

- **What:** add a rule that docs stating a count of anything ("the three layers", "the four hooks") must be updated in the same commit as the thing they count.
- **Where:** `CLAUDE.md`, the `## Docs` section added here.
- **Why:** the count is invisible to every lint and test, so it degrades silently — this repo shipped "three layers" while documenting eight sections. Any downstream repo whose README summarizes a growing surface has the same failure mode.


---
_Generated by [Claude Code](https://claude.ai/code/session_011dbGMkK549HtBr8dSVJfMw)_