### PR TITLE
ci: time the session setup end-to-end, not just its pieces

### DIFF
--- a/.github/scripts/lib/phase-timer.bash
+++ b/.github/scripts/lib/phase-timer.bash
@@ -1,0 +1,98 @@
+# shellcheck shell=bash
+# phase-timer.bash — wall-clock timing for a multi-phase setup run.
+#
+# Why: GitHub already times each *step*, but a setup that spans several scripts
+# inside one step (session-setup -> pre-commit -> pre-push) reports as a single
+# opaque duration, and the end-to-end number a session actually pays — the sum
+# across every phase — appears nowhere. This records both: one row per phase
+# plus the total, printed to the job log and appended to the step summary.
+#
+# Contract: sourced into strict-mode (set -euo pipefail) callers; do not re-set
+# shell options. Timing is advisory — nothing here fails a job on a slow run,
+# because hosted-runner variance is far wider than any regression worth gating.
+#
+# Usage:
+#   source .github/scripts/lib/phase-timer.bash
+#   timer_start
+#   timed_phase "session-setup" .claude/hooks/session-setup.sh
+#   timer_report "Hook lifecycle"
+
+# Seconds since the epoch. `date +%s` (not $SECONDS) so the total survives being
+# read in a subshell, and not %s%N because macOS `date` has no %N.
+_timer_now() { date +%s; }
+
+# Parallel arrays: phase label -> elapsed seconds, in completion order.
+_TIMER_LABELS=()
+_TIMER_SECONDS=()
+_TIMER_T0=""
+
+timer_start() {
+  _TIMER_LABELS=()
+  _TIMER_SECONDS=()
+  _TIMER_T0="$(_timer_now)"
+}
+
+# timed_phase LABEL COMMAND...
+# Runs COMMAND inside a collapsed log group, records its wall clock, and
+# propagates its exit status — a phase that fails still gets a row, so the
+# report shows how far the run got before dying.
+timed_phase() {
+  local label="$1" start end rc=0
+  shift
+  [ -n "${_TIMER_T0}" ] || {
+    printf 'timed_phase: call timer_start first\n' >&2
+    return 2
+  }
+  printf '::group::%s\n' "$label"
+  start="$(_timer_now)"
+  "$@" || rc=$?
+  end="$(_timer_now)"
+  printf '::endgroup::\n'
+  _TIMER_LABELS+=("$label")
+  _TIMER_SECONDS+=("$((end - start))")
+  printf '%s took %ds\n' "$label" "$((end - start))"
+  return "$rc"
+}
+
+# Total wall clock since timer_start, including anything between phases.
+# Reports 0 before timer_start: an EXIT-trap report can fire on a run that died
+# before the timer was armed, and an empty $_TIMER_T0 in `$(( ))` is a syntax
+# error that would replace the real failure with a confusing one.
+timer_total() {
+  [ -n "${_TIMER_T0}" ] || {
+    printf '0'
+    return 0
+  }
+  printf '%d' "$(($(_timer_now) - _TIMER_T0))"
+}
+
+# timer_report TITLE
+# Prints the phase table to stdout and, when running under Actions, appends the
+# same table to the step summary. Safe to call from an EXIT trap: a report over
+# a partial run is exactly what a crashed setup needs.
+timer_report() {
+  local title="$1" i total
+  # Nothing to report if the run died before the timer was armed; stay silent
+  # rather than publishing a fabricated 0s end-to-end.
+  [ -n "${_TIMER_T0}" ] || return 0
+  total="$(timer_total)"
+  # A zero-phase report is still worth printing (it carries the total), but
+  # `${!arr[@]}` on an empty array trips `set -u` on older bash — so index it
+  # by count instead of expanding the (possibly empty) subscript list.
+  {
+    printf '\n%s timing (total %ds)\n' "$title" "$total"
+    for ((i = 0; i < ${#_TIMER_LABELS[@]}; i++)); do
+      printf '  %-28s %6ds\n' "${_TIMER_LABELS[$i]}" "${_TIMER_SECONDS[$i]}"
+    done
+  } >&2
+
+  [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+  {
+    printf '### %s timing\n\n' "$title"
+    printf '| Phase | Seconds |\n| --- | ---: |\n'
+    for ((i = 0; i < ${#_TIMER_LABELS[@]}; i++)); do
+      printf '| %s | %d |\n' "${_TIMER_LABELS[$i]}" "${_TIMER_SECONDS[$i]}"
+    done
+    printf '| **End-to-end** | **%d** |\n\n' "$total"
+  } >>"$GITHUB_STEP_SUMMARY"
+}

--- a/.github/scripts/phase-timer.test.mjs
+++ b/.github/scripts/phase-timer.test.mjs
@@ -1,0 +1,152 @@
+// Behavioral tests for the phase timer: the real library is sourced by a real
+// bash script and every assertion reads an observable — the script's exit
+// status, its stderr, and the markdown it appended to $GITHUB_STEP_SUMMARY.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const LIB = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "lib/phase-timer.bash",
+);
+
+// Run BODY with the timer sourced, under the same strict mode the real callers
+// use. Returns the exit status, stderr, and the step summary it wrote.
+function runTimer(body, { withSummary = true } = {}) {
+  const root = mkdtempSync(join(tmpdir(), "phase-timer-"));
+  const summary = join(root, "summary.md");
+  writeFileSync(summary, "");
+  const script = join(root, "run.sh");
+  writeFileSync(script, `set -euo pipefail\nsource ${LIB}\n${body}\n`);
+  const env = { ...process.env };
+  if (withSummary) env.GITHUB_STEP_SUMMARY = summary;
+  else delete env.GITHUB_STEP_SUMMARY;
+  const res = spawnSync("bash", [script], { encoding: "utf8", env });
+  return {
+    status: res.status,
+    stdout: res.stdout,
+    stderr: res.stderr,
+    summary: readFileSync(summary, "utf8"),
+  };
+}
+
+test("every phase and the end-to-end total reach the step summary", () => {
+  const res = runTimer(`
+    timer_start
+    timed_phase "alpha" true
+    timed_phase "beta" true
+    timer_report "Setup"
+  `);
+  assert.equal(res.status, 0, res.stderr);
+  assert.match(res.summary, /### Setup timing/);
+  assert.match(res.summary, /\| alpha \| \d+ \|/);
+  assert.match(res.summary, /\| beta \| \d+ \|/);
+  // The whole point of the job: a single end-to-end number, not just pieces.
+  assert.match(res.summary, /\| \*\*End-to-end\*\* \| \*\*\d+\*\* \|/);
+});
+
+test("the total spans the whole run, not just the sum of the phases", () => {
+  const res = runTimer(`
+    timer_start
+    sleep 1
+    timed_phase "instant" true
+    sleep 1
+    timer_report "Setup"
+  `);
+  assert.equal(res.status, 0, res.stderr);
+  const total = Number(
+    /\*\*End-to-end\*\* \| \*\*(\d+)\*\*/.exec(res.summary)[1],
+  );
+  assert.ok(
+    total >= 2,
+    `untimed gaps must count toward the total, got ${total}`,
+  );
+});
+
+test("a phase's measured duration is its real wall clock", () => {
+  const res = runTimer(`
+    timer_start
+    timed_phase "slow" sleep 2
+    timer_report "Setup"
+  `);
+  assert.equal(res.status, 0, res.stderr);
+  const seconds = Number(/\| slow \| (\d+) \|/.exec(res.summary)[1]);
+  assert.ok(seconds >= 2, `expected >= 2s for a 2s phase, got ${seconds}`);
+});
+
+test("a failing phase propagates its status and is still reported", () => {
+  const res = runTimer(`
+    timer_start
+    trap 'timer_report "Setup"' EXIT
+    timed_phase "boom" bash -c 'exit 3'
+    echo "must not reach here"
+  `);
+  assert.equal(res.status, 3);
+  assert.doesNotMatch(res.stdout, /must not reach here/);
+  // The partial report is the diagnostic for a setup that died mid-run.
+  assert.match(res.summary, /\| boom \| \d+ \|/);
+});
+
+test("timed_phase wraps its command in a collapsible log group", () => {
+  const res = runTimer(`
+    timer_start
+    timed_phase "grouped" true
+    timer_report "Setup"
+  `);
+  assert.match(res.stdout, /::group::grouped/);
+  assert.match(res.stdout, /::endgroup::/);
+});
+
+test("timing is advisory: a slow phase never fails the run", () => {
+  const res = runTimer(`
+    timer_start
+    timed_phase "slow" sleep 2
+    timer_report "Setup"
+  `);
+  assert.equal(res.status, 0, res.stderr);
+});
+
+test("timed_phase before timer_start is a loud error, not a bogus duration", () => {
+  const res = runTimer(`timed_phase "orphan" true`);
+  assert.equal(res.status, 2);
+  assert.match(res.stderr, /call timer_start first/);
+  assert.equal(res.summary, "");
+});
+
+test("a zero-phase report still publishes the total", () => {
+  const res = runTimer(`
+    timer_start
+    timer_report "Setup"
+  `);
+  assert.equal(res.status, 0, res.stderr);
+  assert.match(res.summary, /\| \*\*End-to-end\*\* \| \*\*\d+\*\* \|/);
+});
+
+test("outside Actions the report goes to stderr and writes no summary", () => {
+  const res = runTimer(
+    `
+    timer_start
+    timed_phase "alpha" true
+    timer_report "Setup"
+  `,
+    { withSummary: false },
+  );
+  assert.equal(res.status, 0, res.stderr);
+  assert.match(res.stderr, /Setup timing \(total \d+s\)/);
+  assert.match(res.stderr, /alpha\s+\d+s/);
+  assert.equal(res.summary, "");
+});
+
+test("an EXIT-trap report before timer_start stays silent instead of faking 0s", () => {
+  const res = runTimer(`
+    trap 'timer_report "Setup"' EXIT
+    exit 4
+  `);
+  assert.equal(res.status, 4);
+  assert.equal(res.summary, "");
+  assert.doesNotMatch(res.stderr, /Setup timing/);
+});

--- a/.github/scripts/run-hook-lifecycle.sh
+++ b/.github/scripts/run-hook-lifecycle.sh
@@ -11,6 +11,9 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
+# shellcheck source=.github/scripts/lib/phase-timer.bash
+source "$repo_root/.github/scripts/lib/phase-timer.bash"
+
 # lint-staged stashes the working tree, which needs a committer identity that CI
 # runners don't configure by default.
 git config user.email "ci@example.com"
@@ -22,11 +25,13 @@ git config user.name "CI"
 CLAUDE_ENV_FILE=$(mktemp "${RUNNER_TEMP:-/tmp}/claude_env_XXXXXX")
 export CLAUDE_ENV_FILE
 setup_log=$(mktemp "${RUNNER_TEMP:-/tmp}/session-setup_XXXXXX.log")
-trap 'rm -f "$CLAUDE_ENV_FILE" "$setup_log"' EXIT
+# Report on the way out too, so a lifecycle that dies partway still publishes
+# how long it got through — that is the diagnostic for a hang or a timeout.
+trap 'rm -f "$CLAUDE_ENV_FILE" "$setup_log"; timer_report "Hook lifecycle"' EXIT
 
-echo "::group::session-setup.sh"
-.claude/hooks/session-setup.sh 2>&1 | tee "$setup_log"
-echo "::endgroup::"
+timer_start
+run_session_setup() { .claude/hooks/session-setup.sh 2>&1 | tee "$setup_log"; }
+timed_phase "session-setup.sh" run_session_setup
 # shellcheck disable=SC1090
 source "$CLAUDE_ENV_FILE"
 
@@ -43,22 +48,17 @@ fi
 #    (repo-wide formatting is covered by the pre-commit and format-check
 #    workflows) — this leg verifies the hook script itself runs without error.
 git add -A
-echo "::group::pre-commit"
-.hooks/pre-commit
-echo "::endgroup::"
+timed_phase "pre-commit" .hooks/pre-commit
 
 # 3. Pre-push checks (build/lint/test/ruff — whichever are configured).
 export CLAUDE_PROJECT_DIR="$repo_root"
-echo "::group::pre-push-check.sh"
-.claude/hooks/pre-push-check.sh
-echo "::endgroup::"
+timed_phase "pre-push-check.sh" .claude/hooks/pre-push-check.sh
 
 # 4. Git pre-push hook. Feed it an empty ref list (a push with nothing to push)
 #    so the pushed-range pre-commit loop is a no-op and the leg verifies the
 #    hook itself — tool discovery, the workflow pin read, the symlink check —
 #    runs without error.
-echo "::group::pre-push"
-.hooks/pre-push origin "$(git remote get-url origin)" </dev/null
-echo "::endgroup::"
+run_pre_push() { .hooks/pre-push origin "$(git remote get-url origin)" </dev/null; }
+timed_phase "pre-push" run_pre_push
 
 echo "Hook lifecycle completed successfully."

--- a/.github/scripts/time-session-setup.sh
+++ b/.github/scripts/time-session-setup.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Time the session bootstrap end-to-end, the way a real session pays for it.
+#
+# The hook-lifecycle job runs `session-setup.sh` only AFTER the composite
+# setup-base-env action has already installed node_modules and synced the venv,
+# so the duration GitHub shows for that step is a warm-cache number — it hides
+# the cold install a fresh container actually waits through before the first
+# tool call. This script is run by a job that deliberately skips that prewarm:
+# the tool binaries (pnpm, uv) are present, every cache is empty.
+#
+# Two runs, because both numbers matter and only one of them is visible today:
+#   cold — what a brand-new session waits for.
+#   warm — what a resumed session (or the second run in a container) waits for.
+#
+# Timing is ADVISORY: this script fails only when setup itself fails, never on
+# a slow run. Hosted-runner variance dwarfs any regression a threshold could
+# catch, and a flaky perf gate is a check people learn to re-run blindly.
+#
+# Run by `.github/workflows/hook-lifecycle.yaml` (setup-timing job).
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+# shellcheck source=.github/scripts/lib/phase-timer.bash
+source "$repo_root/.github/scripts/lib/phase-timer.bash"
+
+# Mirror the harness: session-setup records PATH/GH_REPO exports here.
+CLAUDE_ENV_FILE=$(mktemp "${RUNNER_TEMP:-/tmp}/claude_env_XXXXXX")
+export CLAUDE_ENV_FILE
+trap 'rm -f "$CLAUDE_ENV_FILE"; timer_report "Session setup"' EXIT
+
+timer_start
+timed_phase "session-setup (cold cache)" .claude/hooks/session-setup.sh
+
+# The second run reuses the store, the venv and the installed tools, so it
+# measures the floor: the work session-setup redoes unconditionally every time.
+timed_phase "session-setup (warm cache)" .claude/hooks/session-setup.sh
+
+echo "Session setup timed successfully."

--- a/.github/workflows/hook-lifecycle.yaml
+++ b/.github/workflows/hook-lifecycle.yaml
@@ -33,6 +33,8 @@ jobs:
           - 'uv.lock'
           - '.pre-commit-config.yaml'
           - '.github/scripts/run-hook-lifecycle.sh'
+          - '.github/scripts/time-session-setup.sh'
+          - '.github/scripts/lib/phase-timer.bash'
           - '.github/scripts/check-symlinks.sh'
           - '.github/actions/setup-base-env/**'
           - '.github/workflows/hook-lifecycle.yaml'
@@ -61,9 +63,42 @@ jobs:
       - name: Run hook lifecycle
         run: bash .github/scripts/run-hook-lifecycle.sh
 
+  # End-to-end setup timing. Deliberately does NOT use setup-base-env: that
+  # composite installs node_modules and syncs the venv first, so session-setup
+  # measured after it is a warm-cache number that hides what a fresh container
+  # actually waits through. Here only the tool binaries are provisioned (with
+  # their caches disabled) and session-setup pays for everything else itself.
+  # Advisory: reports durations, never fails on a slow run.
+  setup-timing:
+    needs: decide
+    if: needs.decide.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      # No `cache: pnpm` — a warm store is exactly what this job must not have.
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+
+      - name: Time session setup end-to-end
+        run: bash .github/scripts/time-session-setup.sh
+
   hook-lifecycle-passed: # required-check: true
     if: always()
-    needs: [decide, hook-lifecycle]
+    needs: [decide, hook-lifecycle, setup-timing]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -79,4 +114,12 @@ jobs:
         with:
           run: ${{ needs.decide.outputs.run }}
           decide-result: ${{ needs.decide.result }}
-          result: ${{ needs.hook-lifecycle.result }}
+          # Worst-of both work jobs: the reporter takes one result, so the
+          # combining happens here. setup-timing runs the real bootstrap, so a
+          # failure there is a broken setup — advisory only means it never
+          # fails on a slow run, not that its crashes are ignored. Passing the
+          # failing job's own result keeps the reporter's cancelled-vs-
+          # superseded adjudication intact.
+          result: >-
+            ${{ needs.hook-lifecycle.result != 'success' && needs.hook-lifecycle.result
+             || needs.setup-timing.result }}


### PR DESCRIPTION
Claimed area: `.github/scripts/run-hook-lifecycle.sh`, new `setup-timing` + `record-setup-timing` jobs in `hook-lifecycle.yaml`.

CI times *steps*, not the setup. The hook lifecycle spans four scripts inside one step, so its four legs report as one opaque duration, and the end-to-end number a session actually pays appears nowhere. Worse, the `session-setup.sh` leg runs *after* `setup-base-env` has already installed `node_modules` and synced the venv — so even that step's duration is a warm-cache number that hides the cold install a fresh container waits through before its first tool call. And no run's numbers survive the run, so "is setup getting slower" has never been answerable.

## What changed

- **`.github/scripts/lib/phase-timer.bash`** — sourced timing helper: `timed_phase` wraps a command in a collapsed log group, records its wall clock, and propagates its exit status; `timer_report` emits a Mermaid gantt **waterfall** (one bar per phase at its real start offset, so inter-phase gaps show, plus a Total bar spanning the run) and a duration table, to the job log and the step summary. Safe in an `EXIT` trap, so a lifecycle that dies partway still publishes how far it got. Set `TIMER_JSON_OUT` for a machine-readable record.
- **`run-hook-lifecycle.sh`** — its four legs now run through `timed_phase`. Same commands, same order, same failure semantics.
- **`.github/scripts/time-session-setup.sh` + the `setup-timing` job** — runs the real bootstrap with the prewarm deliberately omitted: `pnpm`/`uv` binaries are provisioned with their caches disabled, and `session-setup.sh` pays for everything else itself. It runs twice, so the summary carries both numbers that matter — cold (what a new session waits for) and warm (what a resumed one does).
- **`append-timing-history.sh` + `render-timing-trend.mjs` + the `record-setup-timing` job** — each push-to-main run is appended to an append-only JSONL file on an orphan `ci-timings` branch, and the trend is rendered as a Mermaid `xychart-beta` line per series (x = short SHA) for both the cold phase and the end-to-end total.
- **Units.** Every duration a human reads is now written in the unit that makes it read naturally — `850ms`, `2.4s`, `1m49s` — never scientific notation or a raw count of another unit's thousandths. Raw integer milliseconds survive only in the JSON record. Added as a repo-wide rule in `CLAUDE.md`.
- 35 behavioral tests across the three new components, including a recorder integration test driving a real local remote.

Sample summary from a local run of the lifecycle:

```mermaid
gantt
    title Hook lifecycle (end-to-end 1m26s)
    dateFormat x
    axisFormat %M:%S
    section Phases
    session-setup.sh (1.5s) :2, 1458
    pre-commit (2.3s) :1488, 3827
    pre-push-check.sh (1m19s) :3831, 82739
    pre-push (3.4s) :82742, 86187
    section Total
    end-to-end (1m26s) :crit, 0, 86192
```

| Phase | Duration |
| --- | ---: |
| session-setup.sh | 1.5s |
| pre-commit | 2.3s |
| pre-push-check.sh | 1m19s |
| pre-push | 3.4s |
| **End-to-end** | **1m26s** |

## Decisions made

- **Advisory, not gated.** No committed budget, no failure on a slow run — hosted-runner variance dwarfs any regression a threshold could catch, and a flaky perf gate is a check people learn to re-run blindly. Under the alternative the job would carry a committed ceiling and fail over it.
- **Both timing jobs are inside the required summary.** They run the real bootstrap, so a crash there is a broken setup, not a slow one; the summary takes the worst-of the work jobs, treating `record-setup-timing`'s PR-time skip as success. Advisory covers duration only.
- **The history lives on an orphan branch, written only from push-to-main.** A PR's numbers sit on a commit that may never land. PRs therefore get the waterfall and table but no trend chart; the alternative (rendering the trend on PRs too) needs a read token in the job that runs `pnpm install`, which is not worth it.
- **The recording job holds the write token, the measuring job does not.** `setup-timing` runs `pnpm install`/`uv sync` and checks out with `persist-credentials: false`; it hands the JSON over as an artifact. Under the alternative, one job would both execute lockfile install scripts and hold `contents: write`.
- **One chart per series rather than several lines on one axis.** Mermaid's `xychart` has no legend, so overlaid lines would be unlabelled. The y-axis is anchored at zero so runner noise doesn't render as a cliff.
- **Second-resolution fallback off GNU date.** `date +%s%N` gives milliseconds on CI; BSD/macOS `date` has no `%N` and falls back to whole seconds. `$EPOCHREALTIME` was rejected — its decimal separator follows `LC_NUMERIC`, so a comma locale would corrupt the arithmetic silently.

## Testing

- `node --test` over the three new test files — 35/35 pass.
- Ran `run-hook-lifecycle.sh` end-to-end locally (exit 0, output above) and `time-session-setup.sh` end-to-end (exit 0).
- The recorder is covered against a real local bare remote: branch creation, history-only tree, append-on-second-run, refusal off the default branch, loud failure on a missing record.
- `shellcheck -x` + `shfmt -d` clean; `zizmor --offline` clean on the workflow; `tests/test_workflow_job_collisions.py` + `tests/test_validate_config.py` pass.

## Lessons Learned

- **What:** add a `phase-timer.bash` helper alongside `run-hook-lifecycle.sh` and route the lifecycle legs through it. **Where:** `.github/scripts/lib/` + `.github/scripts/run-hook-lifecycle.sh`. **Why:** every downstream repo runs the same multi-script lifecycle inside one step, so nobody can see which leg is eating the runtime or what the bootstrap costs end-to-end; the fix is generic and carries no repo-specific content.
- **What:** measure cold setup in a job that skips `setup-base-env`. **Where:** `.github/workflows/hook-lifecycle.yaml`. **Why:** the composite prewarms the pnpm/uv caches, so any `session-setup.sh` timing taken after it understates a fresh container by the entire install — a trap every downstream repo inherits verbatim from the template.
- **What:** keep the write token out of any job that runs `pnpm install`/`uv sync`; hand data to a separate recorder job via an artifact. **Where:** `.github/workflows/hook-lifecycle.yaml`. **Why:** the obvious shape (one job that measures and pushes) grants `contents: write` to a job that executes lockfile install scripts, and downstream repos will copy whichever shape ships here.
- **What:** state the natural-unit rule for emitted quantities. **Where:** `CLAUDE.md` Code Style. **Why:** CI output, error strings and docs across the template drift into raw seconds or another unit's fractions; one rule next to the measurement keeps `850ms`/`1m49s` consistent everywhere.
