### PR TITLE
feat(plugin): ship /agent-sanitizer:enable-auto-update and document staying current

### DIFF
--- a/.hooks/guard-pairs.json
+++ b/.hooks/guard-pairs.json
@@ -16,7 +16,12 @@
       "scripts/set-plugin-version.test.mjs"
     ],
     "plugin/.claude-plugin/plugin.json": [
-      "scripts/set-plugin-version.test.mjs"
+      "scripts/set-plugin-version.test.mjs",
+      "plugin/test/enable-auto-update.test.mjs"
+    ],
+    ".claude-plugin/marketplace.json": [
+      "plugin/test/enable-auto-update.test.mjs",
+      "plugin/test/plugin-manifest.test.mjs"
     ],
     ".github/mutation-shards.json": ["test/mutation-shards.test.mjs"],
     ".github/scripts/nightly-fuzz-issue.js": [

--- a/README.md
+++ b/README.md
@@ -138,6 +138,19 @@ needs only `python3` on PATH, for Layer 4 — the plugin ships the engine itself
 /plugin install agent-sanitizer@agent-sanitizer
 ```
 
+Claude Code auto-updates Anthropic's own marketplaces by default and nobody
+else's, so that install pins you to the release you added and later detector
+fixes never arrive. There is no slash command for the toggle: run `/plugin`,
+open the **Marketplaces** tab, select `agent-sanitizer`, and choose **Enable
+auto-update**. To pull a release by hand instead:
+
+```
+/plugin marketplace update agent-sanitizer
+/plugin update agent-sanitizer@agent-sanitizer
+```
+
+`plugin/README.md` has the managed-settings form for enabling it fleet-wide.
+
 To wire them yourself instead, one entry dispatches all four modes on `--hook=`:
 
 ```jsonc

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ npm install agent-sanitizer
 ```
 /plugin marketplace add AlexanderMattTurner/agent-sanitizer
 /plugin install agent-sanitizer@agent-sanitizer
+/agent-sanitizer:enable-auto-update
 ```
 
 [What installing entails](#what-installing-entails) covers the footprint of each
@@ -136,6 +137,7 @@ needs only `python3` on PATH, for Layer 4 — the plugin ships the engine itself
 ```
 /plugin marketplace add AlexanderMattTurner/agent-sanitizer
 /plugin install agent-sanitizer@agent-sanitizer
+/agent-sanitizer:enable-auto-update
 ```
 
 Claude Code auto-updates Anthropic's own marketplaces by default and nobody

--- a/README.md
+++ b/README.md
@@ -140,9 +140,10 @@ needs only `python3` on PATH, for Layer 4 — the plugin ships the engine itself
 
 Claude Code auto-updates Anthropic's own marketplaces by default and nobody
 else's, so that install pins you to the release you added and later detector
-fixes never arrive. There is no slash command for the toggle: run `/plugin`,
-open the **Marketplaces** tab, select `agent-sanitizer`, and choose **Enable
-auto-update**. To pull a release by hand instead:
+fixes never arrive. Claude Code ships no slash command for the toggle, so the
+plugin ships one — `/agent-sanitizer:enable-auto-update` writes the same bit the
+`/plugin` picker's **Enable auto-update** does, and refuses loudly rather than
+guessing if the marketplace was never added. To pull a release by hand instead:
 
 ```
 /plugin marketplace update agent-sanitizer

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -17,6 +17,39 @@ The first session after install provisions the Python secret-redaction engine
 reaches the model **unredacted** — set `AGENT_SANITIZER_FAIL_OPEN=0` to have it
 suppressed instead.
 
+### Staying current
+
+Claude Code auto-updates Anthropic's own marketplaces by default and nobody
+else's, so an install of this one pins you to the release you added and later
+detector fixes never arrive. There is no slash command for the toggle: run
+`/plugin`, open the **Marketplaces** tab, select `agent-sanitizer`, and choose
+**Enable auto-update**. Updates are fetched in the background shortly after a
+session starts and load on `/reload-plugins` or at the next launch.
+
+To pull a release by hand instead:
+
+```
+/plugin marketplace update agent-sanitizer
+/plugin update agent-sanitizer@agent-sanitizer
+```
+
+Fleet-wide, an administrator can enable it from managed settings rather than
+per user:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "agent-sanitizer": {
+      "source": {
+        "source": "github",
+        "repo": "AlexanderMattTurner/agent-sanitizer"
+      },
+      "autoUpdate": true
+    }
+  }
+}
+```
+
 ## What it does
 
 | Hook                   | Event            | Protection                                                                                                                                                                                    |

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -21,12 +21,24 @@ suppressed instead.
 
 Claude Code auto-updates Anthropic's own marketplaces by default and nobody
 else's, so an install of this one pins you to the release you added and later
-detector fixes never arrive. There is no slash command for the toggle: run
-`/plugin`, open the **Marketplaces** tab, select `agent-sanitizer`, and choose
-**Enable auto-update**. Updates are fetched in the background shortly after a
-session starts and load on `/reload-plugins` or at the next launch.
+detector fixes never arrive. Claude Code ships no slash command for the toggle,
+so the plugin ships one:
 
-To pull a release by hand instead:
+```
+/agent-sanitizer:enable-auto-update
+```
+
+It flips `autoUpdate` on this marketplace's existing entry in Claude Code's
+registry — the same bit the picker's **Enable auto-update** writes — and prints
+the file it touched. It never creates the entry: with the marketplace not yet
+added it says so and exits non-zero, as it does if a Claude Code release changes
+the registry's shape. `--disable` puts it back. The picker route
+(`/plugin` → **Marketplaces** → `agent-sanitizer` → **Enable auto-update**)
+stays available and is the fallback the skill points you to.
+
+Either way, updates are fetched in the background shortly after a session starts
+and load on `/reload-plugins` or at the next launch. To pull a release by hand
+instead:
 
 ```
 /plugin marketplace update agent-sanitizer
@@ -117,7 +129,9 @@ listens on a private Unix socket.
 ```
 .claude-plugin/plugin.json   plugin manifest
 hooks/hooks.json             the four hook registrations
+skills/enable-auto-update/   /agent-sanitizer:enable-auto-update
 scripts/safe-launch.sh       launcher (prints a response even when node is missing)
+scripts/enable-auto-update.mjs  flips autoUpdate on this marketplace's registry entry
 scripts/provision-redactor.sh  SessionStart provisioning of the Python redactor
 scripts/build-plugin.mjs     builds dist/ from claude-hooks/ against the pinned engine
 scripts/lock-redactor-deps.mjs  compiles requirements.in into the hash-pinned requirements.txt

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -9,6 +9,7 @@ warning by default; `AGENT_SANITIZER_FAIL_OPEN=0` makes them block instead.
 ```
 /plugin marketplace add AlexanderMattTurner/agent-sanitizer
 /plugin install agent-sanitizer@agent-sanitizer
+/agent-sanitizer:enable-auto-update
 ```
 
 The first session after install provisions the Python secret-redaction engine
@@ -22,11 +23,7 @@ suppressed instead.
 Claude Code auto-updates Anthropic's own marketplaces by default and nobody
 else's, so an install of this one pins you to the release you added and later
 detector fixes never arrive. Claude Code ships no slash command for the toggle,
-so the plugin ships one:
-
-```
-/agent-sanitizer:enable-auto-update
-```
+so the plugin ships one — the third line of the install block above.
 
 It flips `autoUpdate` on this marketplace's existing entry in Claude Code's
 registry — the same bit the picker's **Enable auto-update** writes — and prints

--- a/plugin/scripts/enable-auto-update.mjs
+++ b/plugin/scripts/enable-auto-update.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * Turn Claude Code's background auto-update on (or, with `--disable`, off) for
  * the marketplace this plugin ships from.

--- a/plugin/scripts/enable-auto-update.mjs
+++ b/plugin/scripts/enable-auto-update.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * Turn Claude Code's background auto-update on (or, with `--disable`, off) for
+ * the marketplace this plugin ships from.
+ *
+ * Claude Code enables auto-update by default only for Anthropic's own
+ * marketplaces, and exposes the toggle for everyone else's through the
+ * interactive `/plugin` picker alone — there is no `/plugin marketplace
+ * autoupdate <name>` command to call. Left off, an install pins the session to
+ * the catalog snapshot taken when the marketplace was added, so a detector fix
+ * released here never reaches it.
+ *
+ * The flag lives in Claude Code's own `known_marketplaces.json`, which is
+ * internal state with no compatibility promise: this script therefore only ever
+ * flips `autoUpdate` on an entry that is already there, and refuses loudly
+ * rather than creating the file, inventing an entry, or writing through a shape
+ * it does not recognize. A Claude Code release that moves or restructures the
+ * file makes this exit non-zero with what it found — never silently no-op.
+ */
+import { readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+// Must equal `name` in .claude-plugin/marketplace.json — that is what Claude
+// Code keys the entry by. plugin/test/enable-auto-update.test.mjs pins the pair;
+// the manifest does not ship inside the plugin, so it cannot be read at runtime.
+export const MARKETPLACE = "agent-sanitizer";
+
+const isTruthy = (value) => value === "1" || value === "true";
+
+/** Where Claude Code keeps the marketplace registry, honouring its own overrides. */
+export function knownMarketplacesPath(env = process.env) {
+  const cache =
+    env.CLAUDE_CODE_PLUGIN_CACHE_DIR ??
+    join(
+      env.CLAUDE_CONFIG_DIR ?? join(homedir(), ".claude"),
+      // Cowork keeps a separate plugin root; writing the wrong one would leave
+      // the toggle looking applied while changing nothing.
+      isTruthy(env.CLAUDE_CODE_USE_COWORK_PLUGINS)
+        ? "cowork_plugins"
+        : "plugins",
+    );
+  return join(cache, "known_marketplaces.json");
+}
+
+/** Exits with `message` on stderr — for a state the user is expected to fix. */
+function fail(message) {
+  process.stderr.write(`agent-sanitizer: ${message}\n`);
+  process.exit(1);
+}
+
+export function main(argv = process.argv.slice(2), env = process.env) {
+  const disable = argv.includes("--disable");
+  const unknown = argv.filter((arg) => arg !== "--disable");
+  if (unknown.length)
+    fail(`unrecognized argument(s): ${unknown.join(" ")} (only --disable)`);
+  const desired = !disable;
+
+  const path = knownMarketplacesPath(env);
+  let raw;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+    return fail(
+      `no marketplace registry at ${path} — add the marketplace first:\n` +
+        `  /plugin marketplace add AlexanderMattTurner/agent-sanitizer`,
+    );
+  }
+
+  // A corrupt registry is Claude Code's to report, not ours to repair: parse
+  // errors propagate rather than being rewritten over.
+  const config = JSON.parse(raw);
+  const entry = config[MARKETPLACE];
+  if (!entry)
+    return fail(
+      `marketplace '${MARKETPLACE}' is not registered (found: ` +
+        `${Object.keys(config).join(", ") || "none"}) — add it first:\n` +
+        `  /plugin marketplace add AlexanderMattTurner/agent-sanitizer`,
+    );
+  if (typeof entry !== "object" || Array.isArray(entry) || !entry.source)
+    return fail(
+      `entry for '${MARKETPLACE}' in ${path} is not the shape this script ` +
+        `knows how to edit — toggle auto-update from /plugin instead`,
+    );
+  if (entry.autoUpdate !== undefined && typeof entry.autoUpdate !== "boolean")
+    return fail(
+      `autoUpdate for '${MARKETPLACE}' in ${path} is ${JSON.stringify(entry.autoUpdate)}, ` +
+        `not a boolean — toggle auto-update from /plugin instead`,
+    );
+
+  if ((entry.autoUpdate ?? false) === desired) {
+    process.stdout.write(
+      `agent-sanitizer: auto-update already ${desired ? "enabled" : "disabled"} for '${MARKETPLACE}'\n`,
+    );
+    return 0;
+  }
+
+  const updated = {
+    ...config,
+    [MARKETPLACE]: { ...entry, autoUpdate: desired },
+  };
+  // Same 2-space encoding Claude Code writes, staged through a sibling temp file
+  // so an interrupted write cannot leave the registry truncated.
+  const temp = `${path}.agent-sanitizer.tmp`;
+  writeFileSync(temp, JSON.stringify(updated, null, 2), "utf-8");
+  renameSync(temp, path);
+
+  process.stdout.write(
+    desired
+      ? `agent-sanitizer: auto-update enabled for '${MARKETPLACE}' in ${path}.\n` +
+          `Claude Code refreshes the catalog in the background shortly after a session starts; ` +
+          `updates load on /reload-plugins or at the next launch.\n`
+      : `agent-sanitizer: auto-update disabled for '${MARKETPLACE}' in ${path}.\n` +
+          `Pull releases by hand with /plugin marketplace update ${MARKETPLACE} ` +
+          `then /plugin update ${MARKETPLACE}@${MARKETPLACE}.\n`,
+  );
+  return 0;
+}
+
+// Compared as URLs, not as a `file://` string splice: a marketplace install path
+// carries a version segment and may sit under a directory with a space in it,
+// which the naive form mis-compares — and a mis-compare here is the one failure
+// mode this script must not have, a silent no-op that reports nothing at all.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href)
+  main();

--- a/plugin/scripts/enable-auto-update.mjs
+++ b/plugin/scripts/enable-auto-update.mjs
@@ -26,9 +26,14 @@ import { pathToFileURL } from "node:url";
 // the manifest does not ship inside the plugin, so it cannot be read at runtime.
 export const MARKETPLACE = "agent-sanitizer";
 
+/** @param {string | undefined} value */
 const isTruthy = (value) => value === "1" || value === "true";
 
-/** Where Claude Code keeps the marketplace registry, honouring its own overrides. */
+/**
+ * Where Claude Code keeps the marketplace registry, honouring its own overrides.
+ *
+ * @param {Record<string, string | undefined>} [env]
+ */
 export function knownMarketplacesPath(env = process.env) {
   const cache =
     env.CLAUDE_CODE_PLUGIN_CACHE_DIR ??
@@ -43,12 +48,21 @@ export function knownMarketplacesPath(env = process.env) {
   return join(cache, "known_marketplaces.json");
 }
 
-/** Exits with `message` on stderr — for a state the user is expected to fix. */
+/**
+ * Exits with `message` on stderr — for a state the user is expected to fix.
+ *
+ * @param {string} message
+ * @returns {never}
+ */
 function fail(message) {
   process.stderr.write(`agent-sanitizer: ${message}\n`);
   process.exit(1);
 }
 
+/**
+ * @param {string[]} [argv]
+ * @param {Record<string, string | undefined>} [env]
+ */
 export function main(argv = process.argv.slice(2), env = process.env) {
   const disable = argv.includes("--disable");
   const unknown = argv.filter((arg) => arg !== "--disable");
@@ -61,7 +75,8 @@ export function main(argv = process.argv.slice(2), env = process.env) {
   try {
     raw = readFileSync(path, "utf-8");
   } catch (error) {
-    if (error.code !== "ENOENT") throw error;
+    if (/** @type {NodeJS.ErrnoException} */ (error).code !== "ENOENT")
+      throw error;
     return fail(
       `no marketplace registry at ${path} — add the marketplace first:\n` +
         `  /plugin marketplace add AlexanderMattTurner/agent-sanitizer`,

--- a/plugin/skills/enable-auto-update/SKILL.md
+++ b/plugin/skills/enable-auto-update/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: enable-auto-update
+description: >
+  Turns Claude Code's background auto-update on for the agent-sanitizer marketplace, so this
+  plugin picks up new releases instead of staying pinned to the catalog snapshot taken when the
+  marketplace was added. Activate when the user asks to enable (or, with --disable, turn off)
+  auto-update for agent-sanitizer, asks how to keep the sanitizer up to date, or asks why an
+  installed version is stale. Claude Code has no slash command for this toggle — the only other
+  route is the /plugin picker's Marketplaces tab.
+---
+
+# Enable auto-update for the agent-sanitizer marketplace
+
+Run the script. It flips `autoUpdate` on the marketplace's existing entry in
+Claude Code's registry:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/enable-auto-update.mjs"
+```
+
+Pass `--disable` to turn it back off.
+
+Report the script's output verbatim; it names the file it wrote and when the
+change takes effect. Do not paraphrase a failure into a success.
+
+## When it exits non-zero
+
+The script refuses rather than guessing, and each refusal has one fix:
+
+- **No registry file / marketplace not registered** — the marketplace was never
+  added, or was added under a different Claude Code config directory. Tell the
+  user to run `/plugin marketplace add AlexanderMattTurner/agent-sanitizer`
+  first, then re-run this skill.
+- **Unrecognized entry shape** — a Claude Code release changed the registry
+  format. Do not edit the file by hand: send the user to `/plugin` →
+  **Marketplaces** → `agent-sanitizer` → **Enable auto-update**, and report that
+  the script needs updating for this Claude Code version.
+
+Auto-update fetches in the background shortly after a session starts; the new
+version loads on `/reload-plugins` or at the next launch. To pull a release
+immediately instead, `/plugin marketplace update agent-sanitizer` followed by
+`/plugin update agent-sanitizer@agent-sanitizer`.

--- a/plugin/test/enable-auto-update.test.mjs
+++ b/plugin/test/enable-auto-update.test.mjs
@@ -1,0 +1,240 @@
+/**
+ * `plugin/scripts/enable-auto-update.mjs` edits Claude Code's own marketplace
+ * registry, so every case here runs the real script against a temp registry:
+ * what it writes, and — more importantly — the states it must refuse to write
+ * through rather than corrupting a file it does not own.
+ */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  copyFileSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import {
+  MARKETPLACE,
+  knownMarketplacesPath,
+} from "../scripts/enable-auto-update.mjs";
+
+const ROOT = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+  encoding: "utf-8",
+}).trim();
+const SCRIPT = join(ROOT, "plugin", "scripts", "enable-auto-update.mjs");
+const readJson = (path) => JSON.parse(readFileSync(path, "utf-8"));
+
+/** A registry Claude Code could plausibly have written, plus a bystander entry. */
+function registry(entry) {
+  const dir = mkdtempSync(join(tmpdir(), "agent-sanitizer-registry-"));
+  const path = join(dir, "known_marketplaces.json");
+  const config = {
+    "claude-plugins-official": {
+      source: { source: "github", repo: "anthropics/claude-plugins-official" },
+      installLocation: join(dir, "marketplaces", "official"),
+      lastUpdated: "2026-01-01T00:00:00.000Z",
+      autoUpdate: true,
+    },
+    ...(entry ? { [MARKETPLACE]: entry } : {}),
+  };
+  writeFileSync(path, JSON.stringify(config, null, 2), "utf-8");
+  return { dir, path };
+}
+
+const ENTRY = {
+  source: { source: "github", repo: "AlexanderMattTurner/agent-sanitizer" },
+  installLocation: "/tmp/marketplaces/agent-sanitizer",
+  lastUpdated: "2026-02-02T00:00:00.000Z",
+};
+
+/** Runs the script against registry dir `dir`; returns its stdout. */
+function run(dir, args = [], script = SCRIPT) {
+  const result = execFileSync(process.execPath, [script, ...args], {
+    env: { ...process.env, CLAUDE_CODE_PLUGIN_CACHE_DIR: dir },
+    encoding: "utf-8",
+    // Non-zero is an expected outcome for half these cases, not a test failure.
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return result;
+}
+
+function runExpectingFailure(dir, args = []) {
+  try {
+    run(dir, args);
+  } catch (error) {
+    return error;
+  }
+  return assert.fail("script exited 0 where it should have refused");
+}
+
+test("the hardcoded marketplace name matches the manifest Claude Code keys by", () => {
+  // The manifest lives at the repo root, outside the installed plugin, so the
+  // script cannot read it at runtime — this pair is the only thing keeping the
+  // constant honest through a marketplace rename.
+  const manifest = readJson(join(ROOT, ".claude-plugin", "marketplace.json"));
+  assert.equal(MARKETPLACE, manifest.name);
+});
+
+test("the `/plugin marketplace add` line in its errors names this repo", () => {
+  const { url } = readJson(join(ROOT, "package.json")).repository;
+  const slug = /github\.com\/(?<slug>[^/]+\/[^/.]+)/.exec(url)?.groups.slug;
+  assert.ok(slug, `could not read an owner/repo slug from ${url}`);
+  const source = readFileSync(SCRIPT, "utf-8");
+  const advertised = [
+    ...source.matchAll(/\/plugin marketplace add (?<slug>[\w.-]+\/[\w.-]+)/g),
+  ].map((m) => m.groups.slug);
+  assert.ok(advertised.length, "script no longer tells the user how to add it");
+  for (const named of advertised) assert.equal(named, slug);
+});
+
+test("enabling writes autoUpdate through and leaves other entries alone", () => {
+  const { dir, path } = registry(ENTRY);
+  const stdout = run(dir);
+  const after = readJson(path);
+  assert.deepEqual(after[MARKETPLACE], { ...ENTRY, autoUpdate: true });
+  assert.equal(after["claude-plugins-official"].autoUpdate, true);
+  assert.match(stdout, /auto-update enabled/);
+});
+
+test("--disable writes false rather than dropping the key", () => {
+  const { dir, path } = registry({ ...ENTRY, autoUpdate: true });
+  run(dir, ["--disable"]);
+  assert.equal(readJson(path)[MARKETPLACE].autoUpdate, false);
+});
+
+test("an already-enabled registry is left byte-identical", () => {
+  const { dir, path } = registry({ ...ENTRY, autoUpdate: true });
+  const before = readFileSync(path, "utf-8");
+  const stdout = run(dir);
+  assert.equal(readFileSync(path, "utf-8"), before);
+  assert.match(stdout, /already enabled/);
+});
+
+test("a missing registry refuses instead of creating one", () => {
+  const dir = mkdtempSync(join(tmpdir(), "agent-sanitizer-empty-"));
+  const { status, stderr } = runExpectingFailure(dir);
+  assert.equal(status, 1);
+  assert.match(stderr, /no marketplace registry/);
+  assert.match(stderr, /plugin marketplace add/);
+});
+
+test("an unregistered marketplace refuses instead of inventing an entry", () => {
+  const { dir, path } = registry(null);
+  const before = readFileSync(path, "utf-8");
+  const { status, stderr } = runExpectingFailure(dir);
+  assert.equal(status, 1);
+  assert.match(stderr, /is not registered/);
+  // The bystander entry is named, so the user can see what Claude Code did register.
+  assert.match(stderr, /claude-plugins-official/);
+  assert.equal(readFileSync(path, "utf-8"), before);
+});
+
+test("an entry shape it does not recognize refuses instead of rewriting it", () => {
+  const { dir, path } = registry({ installLocation: "/tmp/x" });
+  const before = readFileSync(path, "utf-8");
+  const { status, stderr } = runExpectingFailure(dir);
+  assert.equal(status, 1);
+  assert.match(stderr, /not the shape this script knows how to edit/);
+  assert.equal(readFileSync(path, "utf-8"), before);
+});
+
+test("a non-boolean autoUpdate refuses instead of overwriting it", () => {
+  const { dir, path } = registry({ ...ENTRY, autoUpdate: "yes" });
+  const before = readFileSync(path, "utf-8");
+  const { status, stderr } = runExpectingFailure(dir);
+  assert.equal(status, 1);
+  assert.match(stderr, /not a boolean/);
+  assert.equal(readFileSync(path, "utf-8"), before);
+});
+
+test("a corrupt registry propagates rather than being rewritten over", () => {
+  const dir = mkdtempSync(join(tmpdir(), "agent-sanitizer-corrupt-"));
+  writeFileSync(join(dir, "known_marketplaces.json"), "{not json", "utf-8");
+  const { status, stderr } = runExpectingFailure(dir);
+  assert.notEqual(status, 0);
+  assert.match(stderr, /JSON/);
+});
+
+test("an unrecognized flag refuses rather than silently enabling", () => {
+  const { dir } = registry(ENTRY);
+  const { status, stderr } = runExpectingFailure(dir, ["--disble"]);
+  assert.equal(status, 1);
+  assert.match(stderr, /unrecognized argument/);
+});
+
+test("it still runs from an install path containing a space", () => {
+  // Marketplace installs live under a generated, versioned directory, and a home
+  // directory with a space in it is ordinary on macOS and Windows. A main-module
+  // check that mis-compares there would exit 0 having done nothing — the one
+  // failure this script must not have.
+  const dir = mkdtempSync(join(tmpdir(), "agent sanitizer path-"));
+  const copied = join(dir, "enable-auto-update.mjs");
+  copyFileSync(SCRIPT, copied);
+  const { dir: registryDir, path } = registry(ENTRY);
+  const stdout = run(registryDir, [], copied);
+  assert.match(stdout, /auto-update enabled/);
+  assert.equal(readJson(path)[MARKETPLACE].autoUpdate, true);
+});
+
+test("the registry path follows Claude Code's own overrides", () => {
+  const cache = join("/tmp", "cache");
+  assert.equal(
+    knownMarketplacesPath({ CLAUDE_CODE_PLUGIN_CACHE_DIR: cache }),
+    join(cache, "known_marketplaces.json"),
+  );
+  assert.equal(
+    knownMarketplacesPath({ CLAUDE_CONFIG_DIR: "/tmp/cfg" }),
+    join("/tmp/cfg", "plugins", "known_marketplaces.json"),
+  );
+  // Cowork keeps a separate plugin root; the wrong one would write a file that
+  // Claude Code never reads, and the toggle would look applied but do nothing.
+  assert.equal(
+    knownMarketplacesPath({
+      CLAUDE_CONFIG_DIR: "/tmp/cfg",
+      CLAUDE_CODE_USE_COWORK_PLUGINS: "1",
+    }),
+    join("/tmp/cfg", "cowork_plugins", "known_marketplaces.json"),
+  );
+});
+
+test("both READMEs advertise the skill under the name it is invoked by", () => {
+  // Claude Code namespaces a plugin skill as /<plugin name>:<skill name>, so the
+  // command in the docs is a function of two manifests and a directory name —
+  // rename any one of them and the docs advertise a command that does not exist.
+  const plugin = readJson(
+    join(ROOT, "plugin", ".claude-plugin", "plugin.json"),
+  );
+  const command = `/${plugin.name}:enable-auto-update`;
+  for (const doc of ["README.md", join("plugin", "README.md")]) {
+    const text = readFileSync(join(ROOT, doc), "utf-8");
+    assert.ok(text.includes(command), `${doc} is missing: ${command}`);
+  }
+  assert.ok(
+    existsSync(
+      join(ROOT, "plugin", "skills", "enable-auto-update", "SKILL.md"),
+    ),
+    `no skill directory backs ${command}`,
+  );
+});
+
+test("the skill points at the script that exists", () => {
+  const skill = readFileSync(
+    join(ROOT, "plugin", "skills", "enable-auto-update", "SKILL.md"),
+    "utf-8",
+  );
+  const invocation = /node "\$\{CLAUDE_PLUGIN_ROOT\}\/(?<rel>[^"]+)"/.exec(
+    skill,
+  )?.groups.rel;
+  assert.ok(
+    invocation,
+    "SKILL.md no longer runs a script from the plugin root",
+  );
+  assert.ok(
+    existsSync(join(ROOT, "plugin", invocation)),
+    `SKILL.md runs plugin/${invocation}, which does not exist`,
+  );
+});

--- a/plugin/test/plugin-manifest.test.mjs
+++ b/plugin/test/plugin-manifest.test.mjs
@@ -224,12 +224,17 @@ test("both READMEs advertise the marketplace and plugin these manifests define",
     for (const command of [install, add, refresh, update])
       assert.ok(text.includes(command), `${doc} is missing: ${command}`);
   }
-  // The managed-settings snippet re-states the repo as JSON, out of reach of the
-  // `add` shorthand check above.
+  // The managed-settings snippet re-states both rename-sensitive values as JSON,
+  // out of reach of the command checks above: the repo, and the object key —
+  // which is the marketplace name `/plugin update ...@<name>` resolves against.
   const pluginReadme = readFileSync(join(ROOT, "plugin", "README.md"), "utf-8");
   assert.ok(
     pluginReadme.includes(`"repo": "${slug}"`),
     `plugin/README.md's extraKnownMarketplaces entry does not name ${slug}`,
+  );
+  assert.ok(
+    pluginReadme.includes(`"${marketplace.name}": {`),
+    `plugin/README.md's extraKnownMarketplaces entry is not keyed ${marketplace.name}`,
   );
   assert.equal(manifest.repository, `https://github.com/${slug}`);
   assert.equal(manifest.homepage, `https://github.com/${slug}#readme`);

--- a/plugin/test/plugin-manifest.test.mjs
+++ b/plugin/test/plugin-manifest.test.mjs
@@ -215,11 +215,22 @@ test("both READMEs advertise the marketplace and plugin these manifests define",
   const slug = /github\.com\/(?<slug>[^/]+\/[^/.]+)/.exec(url)?.groups.slug;
   assert.ok(slug, `could not read an owner/repo slug from ${url}`);
   const add = `/plugin marketplace add ${slug}`;
+  // Auto-update is off by default for a third-party marketplace, so both READMEs
+  // also advertise the manual refresh. Same rename hazard as the install pair.
+  const refresh = `/plugin marketplace update ${marketplace.name}`;
+  const update = `/plugin update ${entry.name}@${marketplace.name}`;
   for (const doc of ["README.md", join("plugin", "README.md")]) {
     const text = readFileSync(join(ROOT, doc), "utf-8");
-    assert.ok(text.includes(install), `${doc} is missing: ${install}`);
-    assert.ok(text.includes(add), `${doc} is missing: ${add}`);
+    for (const command of [install, add, refresh, update])
+      assert.ok(text.includes(command), `${doc} is missing: ${command}`);
   }
+  // The managed-settings snippet re-states the repo as JSON, out of reach of the
+  // `add` shorthand check above.
+  const pluginReadme = readFileSync(join(ROOT, "plugin", "README.md"), "utf-8");
+  assert.ok(
+    pluginReadme.includes(`"repo": "${slug}"`),
+    `plugin/README.md's extraKnownMarketplaces entry does not name ${slug}`,
+  );
   assert.equal(manifest.repository, `https://github.com/${slug}`);
   assert.equal(manifest.homepage, `https://github.com/${slug}#readme`);
 });


### PR DESCRIPTION
Claims the install surface: both READMEs' plugin-install instructions, plus a new plugin skill.

Installing this plugin pins you to whatever release the marketplace catalog held when you added it. Claude Code enables marketplace auto-update by default only for Anthropic's own marketplaces, and exposes the toggle for everyone else's through the interactive `/plugin` picker alone — there is no `/plugin marketplace autoupdate <name>` command to call, so a detector fix released here never reaches an installed session unless someone clicks through the picker.

**The skill.** `/agent-sanitizer:enable-auto-update` (`plugin/skills/enable-auto-update/` → `plugin/scripts/enable-auto-update.mjs`) flips `autoUpdate` on this marketplace's existing entry in Claude Code's `known_marketplaces.json` — the same bit the picker writes — and prints the file it touched. `--disable` reverts it. It is now the third line of the install block in both READMEs.

That file is Claude Code internal state with no compatibility promise, so the script is written to refuse rather than guess, and every refusal is covered by a test asserting the registry came back byte-identical:

- no registry file, or the marketplace not registered → exits 1 naming what it did find and the `/plugin marketplace add` line to run first; never creates the file or invents an entry
- an entry shape or a non-boolean `autoUpdate` it does not recognize → exits 1 pointing at the picker, on the assumption a Claude Code release moved the format
- corrupt JSON → propagates rather than being rewritten over
- the main-module guard compares URLs via `pathToFileURL` rather than splicing `file://` onto `argv[1]`, since the naive form mis-compares under a path with a space and would exit 0 having done nothing — the one failure this script must not have. Covered by a test that runs it from a directory with a space in the name.

**The docs.** Both READMEs now also carry the picker route, the manual pair (`/plugin marketplace update agent-sanitizer` → `/plugin update agent-sanitizer@agent-sanitizer`), and — in `plugin/README.md` — the managed-settings form for enabling it fleet-wide. `plugin/README.md`'s Contents block gains the two new paths.

**Drift guards.** The existing "both READMEs advertise the commands these manifests define" test grew the update pair and the marketplace-name key in the managed-settings JSON. New pins: the script's hardcoded `MARKETPLACE` against `.claude-plugin/marketplace.json`, its `/plugin marketplace add` line against `package.json`'s `repository.url`, the `/agent-sanitizer:enable-auto-update` command in both READMEs against `plugin.json`'s name plus the skill directory, and the `SKILL.md` invocation against the script it names.

## Decisions made

- **The script edits `known_marketplaces.json` rather than writing `extraKnownMarketplaces` into settings.** The docs describe `"autoUpdate": true` on an `extraKnownMarketplaces` entry under *managed* settings only, and the project-settings example omits it, so a settings-based route would be advertising unverified behavior. The registry file is what the picker itself writes. Cost: it depends on internal state, which is why every unrecognized shape exits non-zero with what it found. Under the alternative the script would be schema-stable but might silently not work.
- **`--disable` ships alongside enable.** A one-way script would leave users with no route back except the picker they were avoiding.
- **The skill is a skill, not a hook.** Enabling auto-update on the user's behalf at SessionStart would be a plugin editing Claude Code's config without being asked; the toggle stays an explicit invocation.
- **`plugin/README.md` carries the managed-settings snippet, the root README links to it** rather than duplicating a third copy of the same JSON.
