### PR TITLE
feat(ci): re-alert every two hours while the default branch is red

### DIFF
--- a/.github/scripts/main-health.mjs
+++ b/.github/scripts/main-health.mjs
@@ -1,0 +1,139 @@
+// Answer one question on a schedule: is the default branch red RIGHT NOW?
+//
+// `ci-failure-notify` is edge-triggered — it fires once, on the `workflow_run`
+// completion event that flipped a workflow to `failure`. One missed edge (the
+// ntfy topic unset, a dropped delivery, a maintainer who saw the push at 2am and
+// went back to sleep) and `main` stays red with no further signal until the next
+// push happens to re-run that workflow. That is not hypothetical: #169 landed on
+// `main` with nine red tests and sat there for ~30 hours.
+//
+// This turns that edge into a LEVEL. It asks the Actions API for the newest
+// completed push/schedule run of every workflow on the default branch and exits
+// non-zero if any of them concluded `failure`. Run on a schedule, it re-reports
+// for as long as the branch is red, so the alert cannot be slept through — and
+// it goes quiet by itself the moment the branch recovers.
+//
+// It is deliberately NOT a required check and takes no fixing action: its whole
+// output is "these workflows are red on this branch, go look".
+import { fileURLToPath } from "node:url";
+
+// This workflow's own path. Excluded from the sweep because including it would
+// latch: the first red run becomes the newest run, which the next run reads as
+// evidence that the branch is red, forever — long after the real failure was
+// fixed. `main-health.test.mjs` asserts this file exists, so a rename that
+// misses this constant fails the guard instead of silently disabling it.
+export const SELF_WORKFLOW_PATH = ".github/workflows/main-health.yaml";
+
+// Only these two event types say anything about the branch's own health. A
+// `pull_request` run tests a merge commit that does not exist on the branch, and
+// a `workflow_run` listener's conclusion describes the listener, not the code.
+const BRANCH_EVENTS = new Set(["push", "schedule"]);
+
+// `failure` only — matching ci-failure-notify's predicate exactly, so the two
+// signals can never disagree about what counts as red. `cancelled` is excluded
+// on purpose: a run superseded by a newer push is cancelled routinely here, and
+// treating that as a failure would make this alert fire on ordinary activity.
+// The precision matters more than the recall — an alert that cries wolf on every
+// force-push is an alert nobody reads.
+const RED = "failure";
+
+/**
+ * Every active workflow defined in `.github/workflows/`, paged to completion.
+ *
+ * Workflows GitHub synthesizes (`dynamic/dependabot/...`, CodeQL's default
+ * setup) are dropped: they carry no file in the tree, so nothing in this repo
+ * can fix or silence them, and a red one would pin this check on forever.
+ */
+async function activeWorkflows(request) {
+  const collected = [];
+  for (let page = 1; ; page += 1) {
+    const body = await request(`/actions/workflows?per_page=100&page=${page}`);
+    const batch = body.workflows ?? [];
+    collected.push(...batch);
+    if (batch.length === 0 || collected.length >= body.total_count) {
+      if (collected.length < body.total_count)
+        throw new Error(
+          `workflow listing stopped at ${collected.length} of ${body.total_count}`,
+        );
+      return collected.filter(
+        (wf) =>
+          wf.state === "active" &&
+          wf.path.startsWith(".github/workflows/") &&
+          wf.path !== SELF_WORKFLOW_PATH,
+      );
+    }
+  }
+}
+
+/**
+ * The workflows whose newest completed push/schedule run on `branch` is red.
+ *
+ * `request(path)` takes a repo-relative API path and resolves to parsed JSON;
+ * injecting it keeps this function drivable from a test without a network or a
+ * token. Returns `[]` when the branch is healthy.
+ */
+export async function redWorkflows({ request, branch }) {
+  const red = [];
+  for (const wf of await activeWorkflows(request)) {
+    // Newest-first; take the first branch-event run and judge only that one. An
+    // older red run under a newer green one is a failure that has already been
+    // fixed, and reporting it would make the check un-clearable.
+    const { workflow_runs: runs = [] } = await request(
+      `/actions/workflows/${wf.id}/runs` +
+        `?branch=${encodeURIComponent(branch)}&status=completed&per_page=20`,
+    );
+    const latest = runs.find((run) => BRANCH_EVENTS.has(run.event));
+    if (latest?.conclusion !== RED) continue;
+    red.push({
+      workflow: wf.name,
+      event: latest.event,
+      sha: latest.head_sha,
+      url: latest.html_url,
+    });
+  }
+  return red;
+}
+
+/** Human-readable verdict for the job log and the ntfy click-through. */
+export function report(branch, red) {
+  if (red.length === 0) return `${branch} is green: no red workflow runs.`;
+  const lines = red.map(
+    (r) => `  - ${r.workflow} (${r.event}, ${r.sha.slice(0, 8)}) ${r.url}`,
+  );
+  return [
+    `${branch} is RED — ${red.length} workflow(s) whose newest run failed:`,
+    ...lines,
+  ].join("\n");
+}
+
+async function main() {
+  const repo = process.env.GITHUB_REPOSITORY;
+  const branch = process.env.DEFAULT_BRANCH;
+  const token = process.env.GH_TOKEN;
+  // Fail loud rather than sweeping zero workflows and declaring victory: a
+  // health check that reports green because it was misconfigured is worse than
+  // no health check at all.
+  if (!repo) throw new Error("GITHUB_REPOSITORY is required");
+  if (!branch) throw new Error("DEFAULT_BRANCH is required");
+  if (!token) throw new Error("GH_TOKEN is required");
+
+  const base = process.env.GITHUB_API_URL ?? "https://api.github.com";
+  const request = async (path) => {
+    const res = await fetch(`${base}/repos/${repo}${path}`, {
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "x-github-api-version": "2022-11-28",
+      },
+    });
+    if (!res.ok)
+      throw new Error(`GET ${path} failed: ${res.status} ${res.statusText}`);
+    return res.json();
+  };
+
+  const red = await redWorkflows({ request, branch });
+  process.stdout.write(`${report(branch, red)}\n`);
+  if (red.length > 0) process.exitCode = 1;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) await main();

--- a/.github/scripts/main-health.mjs
+++ b/.github/scripts/main-health.mjs
@@ -8,13 +8,26 @@
 // `main` with nine red tests and sat there for ~30 hours.
 //
 // This turns that edge into a LEVEL. It asks the Actions API for the newest
-// completed push/schedule run of every workflow on the default branch and exits
+// completed push/schedule run of each workflow on the default branch and exits
 // non-zero if any of them concluded `failure`. Run on a schedule, it re-reports
 // for as long as the branch is red, so the alert cannot be slept through — and
 // it goes quiet by itself the moment the branch recovers.
 //
+// SCOPE AND PREDICATE BOTH COME FROM ci-failure-notify. The predicate is
+// `failure` because that is its `if:`; the set of workflows is read out of its
+// own `workflows:` list at runtime rather than re-derived from the tree. Those
+// are not the same set, and the difference is the whole point: `Nightly unseeded
+// fuzz`, `Mutation tests` and `Pack smoke test` are deliberately absent from it.
+// A red nightly fuzz means "go look" and is already routed to a deduped issue by
+// nightly-fuzz-issue.js precisely because nobody should be paged for it — and
+// this sweep re-fires every two hours, so paging on it would mean ~12 pushes a
+// day until the next nightly. Widening the paging set is a decision to make by
+// editing that list, never a side effect of a second scope drifting past it.
+//
 // It is deliberately NOT a required check and takes no fixing action: its whole
 // output is "these workflows are red on this branch, go look".
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 // This workflow's own path. Excluded from the sweep because including it would
@@ -23,6 +36,13 @@ import { fileURLToPath } from "node:url";
 // fixed. `main-health.test.mjs` asserts this file exists, so a rename that
 // misses this constant fails the guard instead of silently disabling it.
 export const SELF_WORKFLOW_PATH = ".github/workflows/main-health.yaml";
+
+// The SSOT for which workflows are worth paging a human about. Read at runtime
+// so the two alerts cannot drift; a ci-truth-serum pre-commit hook
+// (check-failure-notifier-coverage) already keeps this list honest against the
+// tree, so intersecting against it inherits that maintenance for free.
+export const NOTIFIER_WORKFLOW_PATH =
+  ".github/workflows/ci-failure-notify.yaml";
 
 // Only these two event types say anything about the branch's own health. A
 // `pull_request` run tests a merge commit that does not exist on the branch, and
@@ -38,13 +58,49 @@ const BRANCH_EVENTS = new Set(["push", "schedule"]);
 const RED = "failure";
 
 /**
- * Every active workflow defined in `.github/workflows/`, paged to completion.
+ * The workflow NAMES listed under ci-failure-notify's `on.workflow_run.workflows`.
  *
- * Workflows GitHub synthesizes (`dynamic/dependabot/...`, CodeQL's default
- * setup) are dropped: they carry no file in the tree, so nothing in this repo
- * can fix or silence them, and a red one would pin this check on forever.
+ * Hand-rolled rather than pulled through a YAML parser because this script runs
+ * from a bare `node` with no dependency install — but it is deliberately narrow:
+ * it anchors on a line that is exactly `workflows:`, then takes only block
+ * sequence items indented deeper than it, and throws if that yields nothing.
+ * A parse that quietly returned `[]` would make the sweep report every branch
+ * green forever, so the empty case is the one that must be loud.
  */
-async function activeWorkflows(request) {
+export function pagedWorkflowNames(yaml) {
+  const lines = yaml.split("\n");
+  const start = lines.findIndex((line) =>
+    /^\s*workflows:\s*(#.*)?$/.test(line),
+  );
+  if (start === -1)
+    throw new Error(`${NOTIFIER_WORKFLOW_PATH}: no \`workflows:\` block`);
+  const keyIndent = lines[start].match(/^\s*/)[0].length;
+
+  const names = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^\s*$/.test(line)) continue;
+    const item = line.match(/^(\s*)-\s+(.*?)\s*$/);
+    // Anything that is not a deeper-indented list item ends the block: the next
+    // top-level key, or a sibling key of `workflows:` itself.
+    if (!item || item[1].length <= keyIndent) break;
+    names.push(item[2].replace(/^["']|["']$/g, ""));
+  }
+  if (names.length === 0)
+    throw new Error(`${NOTIFIER_WORKFLOW_PATH}: \`workflows:\` block is empty`);
+  return new Set(names);
+}
+
+/**
+ * The active workflows this sweep is allowed to page on, paged to completion.
+ *
+ * `pagedNames` is the scope gate (see the header): a workflow absent from
+ * ci-failure-notify's list is not a paging surface, so it is not one here.
+ * Workflows GitHub synthesizes (`dynamic/dependabot/...`, CodeQL's default
+ * setup) are dropped on top of that: they carry no file in the tree, so nothing
+ * in this repo can fix or silence them, and a red one would pin this check on
+ * forever even if a name happened to match.
+ */
+async function sweptWorkflows(request, pagedNames) {
   const collected = [];
   for (let page = 1; ; page += 1) {
     const body = await request(`/actions/workflows?per_page=100&page=${page}`);
@@ -59,7 +115,8 @@ async function activeWorkflows(request) {
         (wf) =>
           wf.state === "active" &&
           wf.path.startsWith(".github/workflows/") &&
-          wf.path !== SELF_WORKFLOW_PATH,
+          wf.path !== SELF_WORKFLOW_PATH &&
+          pagedNames.has(wf.name),
       );
     }
   }
@@ -68,19 +125,26 @@ async function activeWorkflows(request) {
 /**
  * The workflows whose newest completed push/schedule run on `branch` is red.
  *
- * `request(path)` takes a repo-relative API path and resolves to parsed JSON;
- * injecting it keeps this function drivable from a test without a network or a
- * token. Returns `[]` when the branch is healthy.
+ * `request(path)` takes a repo-relative API path and resolves to parsed JSON,
+ * and `pagedNames` is the name set from `pagedWorkflowNames()`; injecting both
+ * keeps this function drivable from a test without a network or a token.
+ * Returns `[]` when the branch is healthy.
  */
-export async function redWorkflows({ request, branch }) {
+export async function redWorkflows({ request, branch, pagedNames }) {
   const red = [];
-  for (const wf of await activeWorkflows(request)) {
+  for (const wf of await sweptWorkflows(request, pagedNames)) {
     // Newest-first; take the first branch-event run and judge only that one. An
     // older red run under a newer green one is a failure that has already been
     // fixed, and reporting it would make the check un-clearable.
+    //
+    // `per_page=100` rather than a tighter window: `find` skipping past
+    // pull_request/workflow_run runs means a short window could contain no
+    // branch run at all and read as green — the same silent under-report the
+    // listing above throws on, in the one script whose job is not to declare
+    // victory by accident. 100 is the same single request.
     const { workflow_runs: runs = [] } = await request(
       `/actions/workflows/${wf.id}/runs` +
-        `?branch=${encodeURIComponent(branch)}&status=completed&per_page=20`,
+        `?branch=${encodeURIComponent(branch)}&status=completed&per_page=100`,
     );
     const latest = runs.find((run) => BRANCH_EVENTS.has(run.event));
     if (latest?.conclusion !== RED) continue;
@@ -131,7 +195,14 @@ async function main() {
     return res.json();
   };
 
-  const red = await redWorkflows({ request, branch });
+  // Resolved against this file, not the process cwd, so the sweep does not
+  // depend on which directory the workflow happened to invoke it from.
+  const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+  const pagedNames = pagedWorkflowNames(
+    readFileSync(join(repoRoot, NOTIFIER_WORKFLOW_PATH), "utf8"),
+  );
+
+  const red = await redWorkflows({ request, branch, pagedNames });
   process.stdout.write(`${report(branch, red)}\n`);
   if (red.length > 0) process.exitCode = 1;
 }

--- a/.github/scripts/main-health.test.mjs
+++ b/.github/scripts/main-health.test.mjs
@@ -1,10 +1,16 @@
 import { strict as assert } from "node:assert";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
-import { redWorkflows, report, SELF_WORKFLOW_PATH } from "./main-health.mjs";
+import {
+  NOTIFIER_WORKFLOW_PATH,
+  pagedWorkflowNames,
+  redWorkflows,
+  report,
+  SELF_WORKFLOW_PATH,
+} from "./main-health.mjs";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
@@ -52,11 +58,25 @@ const run = (conclusion, extra = {}) => ({
   ...extra,
 });
 
-test("reports a workflow whose newest push run failed", async () => {
-  const { request } = stubRequest([wf(1, "Node tests")], {
-    1: [run("failure")],
+/**
+ * Sweep a fixture. `pagedNames` defaults to every name the fixture defines, so
+ * the scope gate never silently masks a test about the run predicate; tests that
+ * are ABOUT the scope gate pass their own.
+ */
+async function sweep(workflows, runsById, opts = {}) {
+  const { request, seen } = stubRequest(workflows, runsById, opts);
+  const pagedNames =
+    opts.pagedNames ?? new Set(workflows.map((each) => each.name));
+  const red = await redWorkflows({
+    request,
+    branch: opts.branch ?? "main",
+    pagedNames,
   });
-  const red = await redWorkflows({ request, branch: "main" });
+  return { red, seen };
+}
+
+test("reports a workflow whose newest push run failed", async () => {
+  const { red } = await sweep([wf(1, "Node tests")], { 1: [run("failure")] });
   assert.deepEqual(
     red.map((r) => r.workflow),
     ["Node tests"],
@@ -66,50 +86,57 @@ test("reports a workflow whose newest push run failed", async () => {
 });
 
 test("reports a failed scheduled run too — a nightly is branch health", async () => {
-  const { request } = stubRequest([wf(1, "Nightly unseeded fuzz")], {
+  const { red } = await sweep([wf(1, "Release canary")], {
     1: [run("failure", { event: "schedule" })],
   });
-  const red = await redWorkflows({ request, branch: "main" });
   assert.equal(red.length, 1);
   assert.equal(red[0].event, "schedule");
 });
 
 test("an older red run under a newer green one is already fixed, not red", async () => {
-  const { request } = stubRequest([wf(1, "Node tests")], {
+  const { red } = await sweep([wf(1, "Node tests")], {
     1: [run("success"), run("failure")],
   });
-  assert.deepEqual(await redWorkflows({ request, branch: "main" }), []);
+  assert.deepEqual(red, []);
 });
 
 test("cancelled is not failure — a superseded run must not raise the alarm", async () => {
-  const { request } = stubRequest([wf(1, "Node tests")], {
+  const { red } = await sweep([wf(1, "Node tests")], {
     1: [run("cancelled"), run("success")],
   });
-  assert.deepEqual(await redWorkflows({ request, branch: "main" }), []);
+  assert.deepEqual(red, []);
 });
 
 test("skips pull_request and workflow_run conclusions, judging the next branch run", async () => {
-  const { request } = stubRequest([wf(1, "Node tests")], {
+  const { red } = await sweep([wf(1, "Node tests")], {
     1: [
       run("failure", { event: "pull_request" }),
       run("failure", { event: "workflow_run" }),
       run("success"),
     ],
   });
-  assert.deepEqual(await redWorkflows({ request, branch: "main" }), []);
+  assert.deepEqual(red, []);
 });
 
 test("a workflow with no branch run at all is not red", async () => {
-  const { request } = stubRequest([wf(1, "CI failure notify")], {
+  const { red } = await sweep([wf(1, "CI failure notify")], {
     1: [run("failure", { event: "workflow_run" })],
   });
-  assert.deepEqual(await redWorkflows({ request, branch: "main" }), []);
+  assert.deepEqual(red, []);
+});
+
+test("asks for a 100-run window, so `find` has room to skip non-branch runs", async () => {
+  const { seen } = await sweep([wf(1, "Node tests")], { 1: [] });
+  assert.ok(
+    seen.some((p) => p.includes("per_page=100") && p.includes("/runs")),
+    `run window was not 100: ${seen.join(" ")}`,
+  );
 });
 
 test("excludes itself — otherwise its own first red run latches the check on forever", async () => {
   const self = wf(1, "Main branch health", { path: SELF_WORKFLOW_PATH });
-  const { request, seen } = stubRequest([self], { 1: [run("failure")] });
-  assert.deepEqual(await redWorkflows({ request, branch: "main" }), []);
+  const { red, seen } = await sweep([self], { 1: [run("failure")] });
+  assert.deepEqual(red, []);
   assert.ok(
     !seen.some((p) => p.includes("/runs")),
     "self workflow must not even be queried",
@@ -130,12 +157,12 @@ test("the self-exclusion is load-bearing: the same run IS red under any other pa
   const notSelf = wf(1, "Main branch health", {
     path: ".github/workflows/some-other-name.yaml",
   });
-  const { request } = stubRequest([notSelf], { 1: [run("failure")] });
-  assert.equal((await redWorkflows({ request, branch: "main" })).length, 1);
+  const { red } = await sweep([notSelf], { 1: [run("failure")] });
+  assert.equal(red.length, 1);
 });
 
 test("skips inactive workflows and GitHub's synthesized ones", async () => {
-  const { request } = stubRequest(
+  const { red } = await sweep(
     [
       wf(1, "Disabled thing", { state: "disabled_manually" }),
       wf(2, "Dependency Graph", { path: "dynamic/dependabot/update-graph" }),
@@ -143,7 +170,6 @@ test("skips inactive workflows and GitHub's synthesized ones", async () => {
     ],
     { 1: [run("failure")], 2: [run("failure")], 3: [run("failure")] },
   );
-  const red = await redWorkflows({ request, branch: "main" });
   assert.deepEqual(
     red.map((r) => r.workflow),
     ["Node tests"],
@@ -152,12 +178,7 @@ test("skips inactive workflows and GitHub's synthesized ones", async () => {
 
 test("pages the workflow listing to completion", async () => {
   const many = Array.from({ length: 7 }, (_, i) => wf(i + 1, `W${i + 1}`));
-  const { request } = stubRequest(
-    many,
-    { 7: [run("failure")] },
-    { pageSize: 3 },
-  );
-  const red = await redWorkflows({ request, branch: "main" });
+  const { red } = await sweep(many, { 7: [run("failure")] }, { pageSize: 3 });
   assert.deepEqual(
     red.map((r) => r.workflow),
     ["W7"],
@@ -171,17 +192,101 @@ test("throws rather than under-reporting when the listing is short", async () =>
       ? { total_count: 5, workflows: [] }
       : { workflow_runs: [] };
   await assert.rejects(
-    () => redWorkflows({ request, branch: "main" }),
+    () => redWorkflows({ request, branch: "main", pagedNames: new Set() }),
     /stopped at 0 of 5/,
   );
 });
 
 test("the branch is passed through to the API, not hardcoded", async () => {
-  const { request, seen } = stubRequest([wf(1, "Node tests")], { 1: [] });
-  await redWorkflows({ request, branch: "release/2.x" });
+  const { seen } = await sweep(
+    [wf(1, "Node tests")],
+    { 1: [] },
+    {
+      branch: "release/2.x",
+    },
+  );
   assert.ok(
     seen.some((p) => p.includes("branch=release%2F2.x")),
     `branch never reached the API: ${seen.join(" ")}`,
+  );
+});
+
+// --- scope gate: the sweep pages on exactly what ci-failure-notify pages on ---
+
+test("a red workflow absent from the notifier list is not paged on", async () => {
+  const { red, seen } = await sweep(
+    [wf(1, "Nightly unseeded fuzz"), wf(2, "Node tests")],
+    { 1: [run("failure", { event: "schedule" })], 2: [run("failure")] },
+    { pagedNames: new Set(["Node tests"]) },
+  );
+  assert.deepEqual(
+    red.map((r) => r.workflow),
+    ["Node tests"],
+    "an unlisted workflow must not reach the paging channel",
+  );
+  assert.ok(
+    !seen.some((p) => p.startsWith("/actions/workflows/1/runs")),
+    "an unlisted workflow must not even be queried",
+  );
+});
+
+test("the scope gate is load-bearing: the same fixture IS red once listed", async () => {
+  const { red } = await sweep(
+    [wf(1, "Nightly unseeded fuzz")],
+    { 1: [run("failure", { event: "schedule" })] },
+    { pagedNames: new Set(["Nightly unseeded fuzz"]) },
+  );
+  assert.equal(red.length, 1);
+});
+
+test("parses the real ci-failure-notify list", () => {
+  const names = pagedWorkflowNames(
+    readFileSync(join(REPO_ROOT, NOTIFIER_WORKFLOW_PATH), "utf8"),
+  );
+  // Non-vacuity: a parser that silently returned a near-empty set would make
+  // the sweep report every branch green forever.
+  assert.ok(
+    names.size >= 10,
+    `parsed only ${names.size} names from ${NOTIFIER_WORKFLOW_PATH}`,
+  );
+  for (const expected of ["Node tests", "Lint", "Main branch health"])
+    assert.ok(names.has(expected), `${expected} missing from the parsed list`);
+  // The block ends where the block ends: `concurrency`/`permissions` are sibling
+  // keys, not workflow names.
+  for (const stray of ["concurrency", "permissions", "jobs"])
+    assert.ok(!names.has(stray), `parser ran past the block and took ${stray}`);
+});
+
+test("the parser stops at the end of the block and unquotes items", () => {
+  const names = pagedWorkflowNames(
+    [
+      "on:",
+      "  workflow_run:",
+      "    types: [completed]",
+      "    workflows:",
+      "      - Node tests",
+      '      - "Quoted name"',
+      "      - PR meta (privileged)",
+      "",
+      "concurrency:",
+      "  group: x",
+      "      - not a workflow",
+    ].join("\n"),
+  );
+  assert.deepEqual(
+    [...names],
+    ["Node tests", "Quoted name", "PR meta (privileged)"],
+  );
+});
+
+test("the parser throws rather than returning an empty scope", () => {
+  assert.throws(
+    () => pagedWorkflowNames("on:\n  push:\n    branches: [main]\n"),
+    /no `workflows:` block/,
+  );
+  assert.throws(
+    () => pagedWorkflowNames("    workflows:\nconcurrency:\n  group: x\n"),
+    /`workflows:` block is empty/,
   );
 });
 

--- a/.github/scripts/main-health.test.mjs
+++ b/.github/scripts/main-health.test.mjs
@@ -1,0 +1,210 @@
+import { strict as assert } from "node:assert";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { redWorkflows, report, SELF_WORKFLOW_PATH } from "./main-health.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/**
+ * Build a `request` stub over a fixture of workflows and their runs.
+ *
+ * `workflows` are listing entries; `runsById` maps workflow id -> the runs the
+ * API would return, newest first. Records every path requested so a test can
+ * assert what was NOT fetched.
+ */
+function stubRequest(workflows, runsById, { pageSize = 100 } = {}) {
+  const seen = [];
+  const request = async (path) => {
+    seen.push(path);
+    const listing = path.match(
+      /^\/actions\/workflows\?per_page=\d+&page=(\d+)$/,
+    );
+    if (listing) {
+      const page = Number(listing[1]);
+      return {
+        total_count: workflows.length,
+        workflows: workflows.slice((page - 1) * pageSize, page * pageSize),
+      };
+    }
+    const runs = path.match(/^\/actions\/workflows\/(\d+)\/runs\?/);
+    assert.ok(runs, `unexpected request path: ${path}`);
+    return { workflow_runs: runsById[runs[1]] ?? [] };
+  };
+  return { request, seen };
+}
+
+const wf = (id, name, extra = {}) => ({
+  id,
+  name,
+  state: "active",
+  path: `.github/workflows/${name.toLowerCase().replaceAll(" ", "-")}.yaml`,
+  ...extra,
+});
+
+const run = (conclusion, extra = {}) => ({
+  event: "push",
+  conclusion,
+  head_sha: "0123456789abcdef0123456789abcdef01234567",
+  html_url: "https://github.com/o/r/actions/runs/1",
+  ...extra,
+});
+
+test("reports a workflow whose newest push run failed", async () => {
+  const { request } = stubRequest([wf(1, "Node tests")], {
+    1: [run("failure")],
+  });
+  const red = await redWorkflows({ request, branch: "main" });
+  assert.deepEqual(
+    red.map((r) => r.workflow),
+    ["Node tests"],
+  );
+  assert.equal(red[0].event, "push");
+  assert.equal(red[0].sha, "0123456789abcdef0123456789abcdef01234567");
+});
+
+test("reports a failed scheduled run too — a nightly is branch health", async () => {
+  const { request } = stubRequest([wf(1, "Nightly unseeded fuzz")], {
+    1: [run("failure", { event: "schedule" })],
+  });
+  const red = await redWorkflows({ request, branch: "main" });
+  assert.equal(red.length, 1);
+  assert.equal(red[0].event, "schedule");
+});
+
+test("an older red run under a newer green one is already fixed, not red", async () => {
+  const { request } = stubRequest([wf(1, "Node tests")], {
+    1: [run("success"), run("failure")],
+  });
+  assert.deepEqual(await redWorkflows({ request, branch: "main" }), []);
+});
+
+test("cancelled is not failure — a superseded run must not raise the alarm", async () => {
+  const { request } = stubRequest([wf(1, "Node tests")], {
+    1: [run("cancelled"), run("success")],
+  });
+  assert.deepEqual(await redWorkflows({ request, branch: "main" }), []);
+});
+
+test("skips pull_request and workflow_run conclusions, judging the next branch run", async () => {
+  const { request } = stubRequest([wf(1, "Node tests")], {
+    1: [
+      run("failure", { event: "pull_request" }),
+      run("failure", { event: "workflow_run" }),
+      run("success"),
+    ],
+  });
+  assert.deepEqual(await redWorkflows({ request, branch: "main" }), []);
+});
+
+test("a workflow with no branch run at all is not red", async () => {
+  const { request } = stubRequest([wf(1, "CI failure notify")], {
+    1: [run("failure", { event: "workflow_run" })],
+  });
+  assert.deepEqual(await redWorkflows({ request, branch: "main" }), []);
+});
+
+test("excludes itself — otherwise its own first red run latches the check on forever", async () => {
+  const self = wf(1, "Main branch health", { path: SELF_WORKFLOW_PATH });
+  const { request, seen } = stubRequest([self], { 1: [run("failure")] });
+  assert.deepEqual(await redWorkflows({ request, branch: "main" }), []);
+  assert.ok(
+    !seen.some((p) => p.includes("/runs")),
+    "self workflow must not even be queried",
+  );
+});
+
+test("the self-exclusion names a workflow that exists", () => {
+  // Non-vacuity: without this, renaming the workflow file turns the exclusion
+  // above into a no-op that excludes nothing and silently re-latches.
+  assert.ok(
+    existsSync(join(REPO_ROOT, SELF_WORKFLOW_PATH)),
+    `${SELF_WORKFLOW_PATH} does not exist — update SELF_WORKFLOW_PATH`,
+  );
+});
+
+test("the self-exclusion is load-bearing: the same run IS red under any other path", async () => {
+  // Proves the previous test's exclusion is doing the work, not the fixture.
+  const notSelf = wf(1, "Main branch health", {
+    path: ".github/workflows/some-other-name.yaml",
+  });
+  const { request } = stubRequest([notSelf], { 1: [run("failure")] });
+  assert.equal((await redWorkflows({ request, branch: "main" })).length, 1);
+});
+
+test("skips inactive workflows and GitHub's synthesized ones", async () => {
+  const { request } = stubRequest(
+    [
+      wf(1, "Disabled thing", { state: "disabled_manually" }),
+      wf(2, "Dependency Graph", { path: "dynamic/dependabot/update-graph" }),
+      wf(3, "Node tests"),
+    ],
+    { 1: [run("failure")], 2: [run("failure")], 3: [run("failure")] },
+  );
+  const red = await redWorkflows({ request, branch: "main" });
+  assert.deepEqual(
+    red.map((r) => r.workflow),
+    ["Node tests"],
+  );
+});
+
+test("pages the workflow listing to completion", async () => {
+  const many = Array.from({ length: 7 }, (_, i) => wf(i + 1, `W${i + 1}`));
+  const { request } = stubRequest(
+    many,
+    { 7: [run("failure")] },
+    { pageSize: 3 },
+  );
+  const red = await redWorkflows({ request, branch: "main" });
+  assert.deepEqual(
+    red.map((r) => r.workflow),
+    ["W7"],
+    "the workflow on the last page must still be swept",
+  );
+});
+
+test("throws rather than under-reporting when the listing is short", async () => {
+  const request = async (path) =>
+    path.startsWith("/actions/workflows?")
+      ? { total_count: 5, workflows: [] }
+      : { workflow_runs: [] };
+  await assert.rejects(
+    () => redWorkflows({ request, branch: "main" }),
+    /stopped at 0 of 5/,
+  );
+});
+
+test("the branch is passed through to the API, not hardcoded", async () => {
+  const { request, seen } = stubRequest([wf(1, "Node tests")], { 1: [] });
+  await redWorkflows({ request, branch: "release/2.x" });
+  assert.ok(
+    seen.some((p) => p.includes("branch=release%2F2.x")),
+    `branch never reached the API: ${seen.join(" ")}`,
+  );
+});
+
+test("report() names every red workflow and stays quiet when green", () => {
+  assert.match(report("main", []), /main is green/);
+  const body = report("main", [
+    {
+      workflow: "Node tests",
+      event: "push",
+      sha: "0123456789abcdef",
+      url: "https://example.invalid/1",
+    },
+    {
+      workflow: "Lint",
+      event: "push",
+      sha: "fedcba9876543210",
+      url: "https://example.invalid/2",
+    },
+  ]);
+  assert.match(body, /main is RED — 2 workflow\(s\)/);
+  assert.match(
+    body,
+    /Node tests \(push, 01234567\) https:\/\/example.invalid\/1/,
+  );
+  assert.match(body, /Lint \(push, fedcba98\) https:\/\/example.invalid\/2/);
+});

--- a/.github/workflows/ci-failure-notify.yaml
+++ b/.github/workflows/ci-failure-notify.yaml
@@ -30,6 +30,7 @@ on: # zizmor: ignore[dangerous-triggers]
       - Gitleaks Secret Scanning
       - Hook lifecycle
       - Lint
+      - Main branch health
       - Node tests
       - PR meta (privileged)
       - pre-commit

--- a/.github/workflows/main-health.yaml
+++ b/.github/workflows/main-health.yaml
@@ -44,7 +44,11 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          sparse-checkout: .github/scripts
+          # ci-failure-notify.yaml is an INPUT, not just a sibling: the sweep
+          # reads its `workflows:` list to decide what it may page on.
+          sparse-checkout: |
+            .github/scripts
+            .github/workflows
           persist-credentials: false
 
       - name: Sweep the default branch for red workflows

--- a/.github/workflows/main-health.yaml
+++ b/.github/workflows/main-health.yaml
@@ -1,0 +1,55 @@
+name: Main branch health
+
+# Level-triggered counterpart to `CI failure notify`.
+#
+# That workflow is edge-triggered: it fires once, on the `workflow_run` event
+# that flipped a workflow to `failure`. Miss that one edge and `main` stays red
+# with no further signal until some later push happens to re-run the same
+# workflow. #169 merged with nine red tests and `main` stayed red for ~30 hours
+# on exactly that gap.
+#
+# This job re-asks "is main red?" every two hours and fails while the answer is
+# yes. Its own failure is a push/schedule failure on the default branch, so
+# `CI failure notify` picks it up and sends the ntfy push — the alert path is the
+# vetted one, not a second copy. It clears itself the moment the branch recovers.
+#
+# Not a required check (no pull_request trigger) and it changes nothing: the
+# whole output is a list of red workflows and their run URLs.
+on:
+  schedule:
+    # Offset from the top of the hour so this doesn't queue behind the runner
+    # stampede that lands on :00.
+    - cron: "23 */2 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize; never cancel — a dropped run is a dropped alert. The static group
+  # is intentional and safe: no pull_request trigger, so this never backs a
+  # required check that a cancelled run could hang.
+  group: main-health
+  cancel-in-progress: false
+  # static-concurrency-ok: not a required check (schedule/dispatch only)
+
+jobs:
+  health:
+    name: Default branch has no failing workflow
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read # read workflow + workflow-run conclusions via the REST API
+      contents: read # job-level permissions replace the workflow default
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: .github/scripts
+          persist-credentials: false
+
+      - name: Sweep the default branch for red workflows
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: node .github/scripts/main-health.mjs

--- a/.github/workflows/node-tests.yaml
+++ b/.github/workflows/node-tests.yaml
@@ -83,6 +83,13 @@ jobs:
       - name: Run workflow step-reference guard
         run: node --test .github/scripts/workflow-step-refs.test.mjs
 
+      # Same dot-directory blind spot. This suite pins the main-branch health
+      # sweep: which run conclusions count as red, and the self-exclusion that
+      # stops the checker latching on its own first failure. Both are the kind
+      # of predicate that reads as obviously-correct and silently inverts.
+      - name: Run main-branch health sweep tests
+        run: node --test .github/scripts/main-health.test.mjs
+
       # Named explicitly rather than left to `pnpm test`'s discovery. This suite
       # gates the shipped plugin artifact — the reproducibility byte-compare and
       # every hook's fail-closed verdict — so which invocation reaches it must be

--- a/.hooks/guard-pairs.json
+++ b/.hooks/guard-pairs.json
@@ -26,6 +26,9 @@
     ".github/workflows/main-health.yaml": [
       ".github/scripts/main-health.test.mjs"
     ],
+    ".github/workflows/ci-failure-notify.yaml": [
+      ".github/scripts/main-health.test.mjs"
+    ],
     "src/invisible.mjs": [
       "test/invisible-charset.test.mjs",
       "test/instructions.test.mjs"

--- a/.hooks/guard-pairs.json
+++ b/.hooks/guard-pairs.json
@@ -22,6 +22,10 @@
     ".github/scripts/nightly-fuzz-issue.js": [
       ".github/scripts/nightly-fuzz-issue.test.mjs"
     ],
+    ".github/scripts/main-health.mjs": [".github/scripts/main-health.test.mjs"],
+    ".github/workflows/main-health.yaml": [
+      ".github/scripts/main-health.test.mjs"
+    ],
     "src/invisible.mjs": [
       "test/invisible-charset.test.mjs",
       "test/instructions.test.mjs"


### PR DESCRIPTION
Claims: `.github/scripts/main-health.{mjs,test.mjs}` (new), `.github/workflows/main-health.yaml` (new), plus wiring edits to `ci-failure-notify.yaml`, `node-tests.yaml`, `.hooks/guard-pairs.json`. Touches no existing logic.

## Summary

**`main` is green right now.** The last red window was `ae17eb74` (2026-08-04 01:44Z) → `549cda3d` (2026-08-05 07:27Z) — about 30 hours, 9 failing tests.

**Why it went red.** Template-sync PR #169 was merged with its own required check `node-tests-passed` red. That check had failed on *every one of its 17 CI runs* over the 11 days the PR was open (2026-07-24 → 2026-08-04); the final run on the merged SHA `aacab869` was cancelled by the merge itself. The sync clobbered this repo's local CI work, the drift guards over `auto-version.yaml` caught it, and the merge went in over the red. #213 fixed the nine tests; #217 fixed the CI plumbing the same sync broke.

**Why it stayed red for 30 hours.** `ci-failure-notify` is **edge-triggered**: it fires once, on the `workflow_run` completion event that flips a workflow to `failure`. There is exactly one notification per red transition. Miss it — topic unset, delivery dropped, seen at 2am — and `main` sits red with no further signal until some later push happens to re-run that same workflow.

This PR adds the **level-triggered** half. `Main branch health` runs every two hours, asks the Actions API for each workflow's newest *completed* `push`/`schedule` run on the default branch, and fails while any concluded `failure`. Its own failure is a schedule failure on `main`, so `ci-failure-notify` picks it up and sends the ntfy push through the already-vetted path — no second alert implementation. It goes quiet by itself the moment the branch recovers.

**Scope and predicate both come from `ci-failure-notify`.** The predicate is `failure` because that is its `if:`; the workflow set is read out of its own `workflows:` block at runtime. Those are not the same set, and the difference is load-bearing: `Nightly unseeded fuzz`, `Mutation tests` and `Pack smoke test` are deliberately absent from it. A red nightly fuzz means "go look" and already files a deduped issue, so paging on it would have meant ~12 phone pushes a day until the next nightly.

**What this does not fix, and who owns it.** The merge itself was a branch-protection bypass: the ruleset *did* require `node-tests-passed` at the time (the annotation predates the merge — `08f2df4`, 2026-07-30 — and `sync-required-checks` ran green on 2026-07-30 and on `ae17eb74`). I re-ran `sync-required-checks` in `--check` mode against today's `main` ([run 31226550395](https://github.com/AlexanderMattTurner/agent-sanitizer/actions/runs/31226550395)): **success, no drift**, so the gate is correctly configured and was simply overridden. Closing that hole means removing the bypass-actors entry from the org ruleset — a setting outside this repo that needs an admin token, so it is yours to make, not mine.

**The same landmine is loaded again.** PR #212 (`template-sync`, open) is red on `node-tests-passed` today, with 4 failing drift guards (`the deduplicated duplicate release scripts stay gone`, `the release checkout pushes with the org ruleset-bypass token…`, `a release stamps the plugin manifest…`, `release-docs push rebases onto a branch that advanced mid-run`) and literal `<<<<<<< local` conflict markers committed into `.github/workflows/template-sync.yaml`. Reproduced locally on the branch: 2186 pass, 4 fail. Do not merge it as-is.

## Changes

- **`.github/scripts/main-health.mjs`** (new)
  - `pagedWorkflowNames(yaml)` — reads `ci-failure-notify.yaml`'s `workflows:` block. Throws on a missing or empty block; a parse that quietly returned `[]` would make the sweep report every branch green forever, so the empty case is the one that must be loud.
  - `redWorkflows({request, branch, pagedNames})` — lists active workflows (paged to completion, throwing rather than under-reporting a short page), gates on `pagedNames`, and for each takes the newest completed run whose event is `push` or `schedule`, reporting it when the conclusion is `failure`.
  - **`failure` only.** `cancelled` is excluded on purpose — superseded runs are routine here, and an alert that fires on every force-push is one nobody reads.
  - **Newest run only.** An older red under a newer green is already fixed; reporting it would make the check un-clearable.
  - **Excludes itself.** Without that, its own first red run becomes the newest run, which the next run reads as evidence the branch is red — latching on forever after the real failure is fixed.
  - **`per_page=100` run window.** `find` skipping past `pull_request`/`workflow_run` runs means a short window could contain no branch run at all and read as green — the same silent under-report the listing throws on. Same single request.
  - Fails loud on missing `GITHUB_REPOSITORY` / `DEFAULT_BRANCH` / `GH_TOKEN` rather than sweeping zero workflows and declaring victory.
- **`.github/workflows/main-health.yaml`** (new) — `cron: 23 */2 * * *` + dispatch, `actions: read`, non-cancelling concurrency, not a required check. `sparse-checkout` covers `.github/workflows` because the notifier file is an input, not a sibling.
- **`.github/workflows/ci-failure-notify.yaml`** — add `Main branch health` to `workflows:`; the sweep's failure is what actually reaches your phone.
- **`.github/workflows/node-tests.yaml`** — explicit `node --test` step. `node --test`'s discovery skips dot-directories, so a suite under `.github/scripts/` never runs via `pnpm test`.
- **`.hooks/guard-pairs.json`** — pairs the script, its workflow, **and `ci-failure-notify.yaml`** with the suite, so editing the paging list runs the guard.

## Review focus

The `RED = "failure"` choice. Treating `cancelled`/`timed_out` as red would catch strictly more real breakage at the cost of firing on ordinary superseded runs; I took precision, and matched the existing notifier so the two can't drift. If you want `timed_out` in, that's the line.

Second, `pagedWorkflowNames()` is regex over YAML, not a parser — this script runs from a bare `node` with no dependency install. It is deliberately narrow (anchors on a line that is exactly `workflows:`, takes only deeper-indented block-sequence items, throws on empty), and it is pinned against the real file, but if you'd rather it went through the same route `workflow-step-refs.test.mjs` uses, that's the line to push on.

## Tests / verification

- **20 tests, proven non-vacuous by mutation.** `RED = "cancelled"` → 6 fail. Self-exclusion removed → 1. Event filter dropped → 2. Scope gate dropped → 1. Parser returning `[]` instead of throwing → 1. Block-end break removed → 1. `per_page` back to 20 → 1. Restored → 20/20.
- `node --test`: **2222 pass, 0 fail**. `uv run --extra dev pytest tests/`: **1461 passed, 5 skipped**. `pre-commit run --files …` on every touched file: clean, including zizmor and the ci-truth-serum aggregates (the failure-notifier-coverage hook is what validates the `ci-failure-notify` list edit).
- **Not yet exercised against the live API.** `workflow_dispatch` only accepts a ref for a workflow that already exists on the default branch, so the first real run is the first scheduled one after merge. The API-shaped behaviour is covered by the injected-`request` suite; the thin uncovered layer is the `fetch` wrapper and the `DEFAULT_BRANCH` expression. I will dispatch it once it is on `main`.

## Decisions made

- **Scope intersected against `ci-failure-notify`'s list rather than an explicit `NOT_PAGED` set.** The reviewer offered both; the intersect is self-maintaining, and the `check-failure-notifier-coverage` hook already keeps that list honest against the tree. Under the alternative, a new never-paged workflow silently joins the paging set until someone remembers to deny-list it.
- **Reused `ci-failure-notify` instead of calling ntfy directly.** The sweep just fails; the existing listener notifies. One alert path, one place to change the topic. Alternative was embedding `notify-ntfy` here, which duplicates the delivery logic and its secret handling.
- **Two-hour cadence.** ~500 API calls/day against GITHUB_TOKEN's 1000/hour ceiling, 12 short runs/day. Hourly would halve worst-case detection latency at double the cost; daily would not have meaningfully beaten the 30-hour incident.
- **Did not touch PR #212 or the org ruleset.** #212 is a live PR with its own review surface, and the ruleset is an admin-token change outside this repo. Both are reported above rather than acted on.
- **No `timed_out`/`startup_failure` in the red set.** Kept the predicate byte-identical to the existing notifier; widening it is a one-line change if you disagree.

## Checklist

- [x] Commits follow Conventional Commits; each subject reads as a user-facing release note.
- [x] `node --test`, `pytest`, `prettier`, and `pre-commit` pass locally.
- [x] New guard has negative tests (green branch, cancelled, older-red, foreign-event, unlisted workflow → zero findings).
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version left untouched.

## Lessons Learned

- **What**: pair every edge-triggered CI alert with a scheduled level-triggered sweep that re-asserts the condition. **Where**: `.github/scripts/main-health.mjs` + `.github/workflows/main-health.yaml`, with the sweep's own failure routed through the existing `ci-failure-notify` listener. **Why**: `workflow_run`-based notification fires exactly once per red transition, so a single missed delivery leaves the default branch red and silent until the next push happens to re-run that workflow — 30 hours in this repo. Every downstream consumer of the template inherits the same one-shot alert and the same gap.
- **What**: when a second signal claims to mirror an existing one, it must inherit that one's SCOPE at runtime, not just copy its predicate. **Where**: `pagedWorkflowNames()` reading `ci-failure-notify.yaml`'s `workflows:` block, rather than re-deriving the set from the tree. **Why**: the notifier's list is a curated subset — `Nightly unseeded fuzz` is off it on purpose, its failures routed to a deduped issue — so a sweep that swept the tree would have paged ~12×/day on a nightly counterexample. A matching predicate over a wider scope is scope drift wearing a consistency argument.
- **What**: a self-observing health check must exclude its own workflow from the set it observes. **Where**: `SELF_WORKFLOW_PATH` in `.github/scripts/main-health.mjs`, pinned by an existence test plus an inverse test proving the exclusion is load-bearing. **Why**: without it the checker's first red run becomes the newest run it reads next cycle, so it reports red forever after the underlying failure is fixed — and a permanently-red health check is indistinguishable from a permanently-red branch, which is exactly the signal it exists to provide.