### PR TITLE
docs(skills): make parallel-audit hunt eliminators by default

### DIFF
--- a/.claude/skills/parallel-audit/SKILL.md
+++ b/.claude/skills/parallel-audit/SKILL.md
@@ -39,6 +39,12 @@ explicitly asks for a list of individual bugs.
 - Reviewing a pending diff before a PR → `peer-review` / `code-review`.
 - A single-pass security look at the current branch → `security-review`.
 - Trivial / single-file questions — just read the file.
+- **Overlaps `audit-and-parallelize`**, which advertises nearly the same activation surface. They are
+  redundant and should be reconciled (disambiguated in both `description` blocks, or folded into one)
+  — a cross-skill decision out of scope here. Until then: this skill is the **eliminator-posture**
+  default (hunt bug _classes_); reach for `audit-and-parallelize` only when a caller explicitly wants
+  the plain "list individual issues" pass. Same-request routing is otherwise a coin-flip between the
+  two, so name which posture you want.
 
 ## Eliminators, not spot fixes
 
@@ -93,7 +99,10 @@ violations of it; a generic audit re-discovers lint.
 Pick axes from the request (typical: **security**, **robustness/error-handling**, **e2e-test
 realness**, **UX/DX**, **supply-chain**, **config-SSOT/CI**). Give each agent a **non-overlapping
 file list** so they don't collide or duplicate. Launch them **concurrently** (multiple Agent calls in
-a single response). Use `general-purpose` (full read tools); they must be **read-only — forbid edits**.
+a single response). Use `general-purpose` (full read tools); they are **read-only on the repo — no
+edits to files under audit**. They MAY execute code to verify a finding (run existing modules,
+`node -e`, a throwaway `/tmp` script — see the run-the-code bullet below); "read-only" bars mutating
+the tree, not running it.
 
 Each agent prompt MUST demand, per finding, the eliminator contract from
 [Eliminators, not spot fixes](#eliminators-not-spot-fixes). (In plain spot-fix mode, the reduced
@@ -102,9 +111,11 @@ shape is `TITLE` · `FILE:LINE` · `SEVERITY` · `EVIDENCE` · `WHY IT'S A DEFEC
 And MUST instruct:
 
 - **Ground every finding in real lines you read — do NOT speculate.** Skip anything you can't quote.
-- **Run the code where you can.** An agent that executes the repro and pastes real output is worth
-  five that reason from a read. Findings verified by execution survive the confirmation pass almost
-  always; findings reasoned from a read are where the drops come from.
+- **Run the code where you can — execute, but stay read-only on the tree.** An agent that runs the
+  repro and pastes real output is worth five that reason from a read. Write repro scripts to a
+  scratch dir outside the repo (e.g. `/tmp`); never edit a file under audit. Findings verified by
+  execution survive the confirmation pass almost always; findings reasoned from a read are where the
+  drops come from.
 - **Hand each agent the project's own doctrine** (`CLAUDE.md`, `THREAT-MODEL.md`, `.claude/rules/*`)
   and ask "where does the code break its own stated rules?" A repo's written invariants are the
   richest eliminator seam — a comment saying "these must stay in sync" or "keep it in this order"
@@ -146,8 +157,8 @@ reporting a crash as a finding, and correct yourself plainly if you already did.
 
 Harness note: `Bash` rejects a command string containing a literal control character (e.g. a raw
 ESC byte) — `InputValidationError`. That is the Claude Code input validator, not the code under
-audit. Write the repro to a file with a heredoc and build the byte in-language
-(`String.fromCodePoint(0x1b)`), rather than concluding the case is untestable.
+audit. Write the repro to a scratch file outside the repo (e.g. `/tmp`) with a heredoc and build the
+byte in-language (`String.fromCodePoint(0x1b)`), rather than concluding the case is untestable.
 
 For _very_ large audits, this confirmation pass can itself be a second fan-out of `code-reviewer`
 agents, each adversarially trying to **refute** one finding — keep only those that survive.

--- a/.claude/skills/parallel-audit/SKILL.md
+++ b/.claude/skills/parallel-audit/SKILL.md
@@ -22,6 +22,11 @@ for. It exists because one agent reading a large repo serially is slow and shall
 owning one dimension x area read deep, and an independent confirmation pass keeps the cheap-but-wrong
 findings out of the plan.
 
+**Default posture: hunt eliminators, not spot fixes.** See
+[Eliminators, not spot fixes](#eliminators-not-spot-fixes) — it changes the agent prompt contract,
+the ranking, and how PRs are clustered. Fall back to spot-fix reporting only when the user
+explicitly asks for a list of individual bugs.
+
 ## When to use
 
 - The user wants breadth ("dozens and dozens", "be creative", "across the whole thing") rather than a
@@ -34,6 +39,44 @@ findings out of the plan.
 - Reviewing a pending diff before a PR → `peer-review` / `code-review`.
 - A single-pass security look at the current branch → `security-review`.
 - Trivial / single-file questions — just read the file.
+
+## Eliminators, not spot fixes
+
+An **eliminator** is a structural change that makes an entire CLASS of bug impossible by
+construction. "This line has an off-by-one" is a spot fix; "offsets are untyped so any of the 40
+call sites can confuse a code-point index with a UTF-16 index" is the class. Report a spot fix only
+when it is the visible symptom of a class you can name.
+
+Hand each agent this catalog — it is what turns "look for bugs" into "look for the shape that keeps
+producing bugs":
+
+- **N parallel lists that must be hand-synced** → one derived source + a round-trip contract test.
+  (Detector tables, ignore lists, export maps, layer rosters, version pins, doc counts.)
+- **A hand-rolled approximation of a real parser** → use the real parser. Check whether it is
+  _already a dependency_ — the half-adopted case (real parser for one branch, regex for the other)
+  is common and worse than either.
+- **An untyped value whose meaning is positional convention** → a branded/carrier type. Kills whole
+  offset, coordinate-frame, and "already-sanitized vs raw" families at once.
+- **A policy decided at N call sites** (fail-open/fail-closed, retry, escaping, error rendering) →
+  one chokepoint the callers cannot bypass.
+- **An invariant re-established only on the branch that needed it** → one `applyMutation`-style
+  helper every mutating path goes through.
+- **An implicit ordering contract stated in a comment** → a declared pipeline that enforces it.
+  Comments that say "keep it in this order" are eliminator bait; grep for them.
+- **A gate checked in one direction only** (rejects stale entries, never notices a missing one) →
+  a partition assertion: `REQUIRED ∪ EXEMPT == the live surface`.
+- **A quota/budget applied per-unit to something indivisible** → make the budget unit the cluster.
+
+Per-finding contract for eliminator mode (replaces the plain finding shape in step 2):
+
+`TITLE` · `FILE:LINE` · `CLASS ELIMINATED` (the category, plus how many current/latent instances you
+can point at) · `SEVERITY` (rank by REACHABILITY in normal use, not scariness) · `EVIDENCE` (1-5
+verbatim lines) · `WHY IT'S A DEFECT` (specific input → wrong outcome) · `ELIMINATOR` (the new shape
+of the code, concretely) · `BLAST RADIUS` (files touched, S/M/L) · `TEST THAT WOULD CATCH THE CLASS`
+(an invariant, not a symptom).
+
+Ask for **counts**, not adjectives: "17 of 62 `.sh` files lack `set -u`, counted via `grep -L`" is
+actionable; "several scripts are inconsistent" is not.
 
 ## Workflow
 
@@ -52,16 +95,24 @@ realness**, **UX/DX**, **supply-chain**, **config-SSOT/CI**). Give each agent a 
 file list** so they don't collide or duplicate. Launch them **concurrently** (multiple Agent calls in
 a single response). Use `general-purpose` (full read tools); they must be **read-only — forbid edits**.
 
-Each agent prompt MUST demand, per finding:
-`TITLE` · `FILE:LINE` (exact) · `SEVERITY` · `EVIDENCE` (quote 1-5 real lines) · `WHY IT'S A DEFECT`
-(a concrete failure: specific input → wrong/leaked outcome) · `SUGGESTED FIX` (one line).
+Each agent prompt MUST demand, per finding, the eliminator contract from
+[Eliminators, not spot fixes](#eliminators-not-spot-fixes). (In plain spot-fix mode, the reduced
+shape is `TITLE` · `FILE:LINE` · `SEVERITY` · `EVIDENCE` · `WHY IT'S A DEFECT` · `SUGGESTED FIX`.)
 
 And MUST instruct:
 
 - **Ground every finding in real lines you read — do NOT speculate.** Skip anything you can't quote.
+- **Run the code where you can.** An agent that executes the repro and pastes real output is worth
+  five that reason from a read. Findings verified by execution survive the confirmation pass almost
+  always; findings reasoned from a read are where the drops come from.
+- **Hand each agent the project's own doctrine** (`CLAUDE.md`, `THREAT-MODEL.md`, `.claude/rules/*`)
+  and ask "where does the code break its own stated rules?" A repo's written invariants are the
+  richest eliminator seam — a comment saying "these must stay in sync" or "keep it in this order"
+  is an unenforced contract, i.e. a class waiting to happen.
 - **Self-flag non-findings**: if you checked something and it's actually correct, say so explicitly.
   (This is the honesty signal that tells you which agents to trust.)
 - Rank by severity; aim for a target count (e.g. 6-12) so they prioritize over dumping noise.
+  Prefer 6 excellent eliminators to 15 mediocre ones, and say so in the prompt.
 
 Scope hygiene: **never delegate edits to `.claude/` or `.devcontainer/`** (sub-agent write guards
 block them silently) — but read-only _audit_ of those dirs is fine. Keep load-bearing edits in the
@@ -83,6 +134,21 @@ function up that the agent missed, severity inflation. Drop or downgrade anythin
 your own read. Record "confirmed by independent read" per kept finding. An agent that honestly
 self-flagged its own non-findings (step 2) has earned lighter scrutiny than one that didn't.
 
+**Prefer executing to re-reading.** Where the claim is about behaviour, build the repro and run it —
+that is the difference between "confirmed" and "plausible". Keep a finding you could not execute in
+a separate **plausible, not confirmed** bucket and say so in the delivered plan; do not let it claim
+a PR slot until someone builds the repro. When a repro is cheap, build it during the audit rather
+than deferring: two of this pattern's best findings only became credible once run.
+
+Watch your own repro harness, not just the code: a repro that throws can be _your_ calling error
+(a required accumulator parameter you omitted), not a defect. Re-read the signature before
+reporting a crash as a finding, and correct yourself plainly if you already did.
+
+Harness note: `Bash` rejects a command string containing a literal control character (e.g. a raw
+ESC byte) — `InputValidationError`. That is the Claude Code input validator, not the code under
+audit. Write the repro to a file with a heredoc and build the byte in-language
+(`String.fromCodePoint(0x1b)`), rather than concluding the case is untestable.
+
 For _very_ large audits, this confirmation pass can itself be a second fan-out of `code-reviewer`
 agents, each adversarially trying to **refute** one finding — keep only those that survive.
 
@@ -95,6 +161,18 @@ one PR per subsystem (firewall, monitor, redaction, lifecycle, …), each bundli
 findings. Note cross-PR ordering only where a real dependency exists (e.g. an SSOT change others build
 on). For each PR: scope, the findings it closes, the **test that would have caught the class**
 (per the project's testing doctrine — assert the invariant, not today's symptom), and a rough size.
+
+In eliminator mode the disjoint-file rule bites harder, because eliminators are refactors and a
+refactor's blast radius is wider than a spot fix's. Two eliminators in the _same file_ are
+sequential even when their findings are unrelated — and the bigger one should land second, on top of
+the small self-contained one, so the small fix is not held hostage. Before publishing the plan,
+build the file→PR map and check for a file claimed twice; the natural "one PR per subsystem"
+grouping does NOT guarantee it once a rewrite is in the mix.
+
+**Cover every confirmed finding.** Build the finding→PR map explicitly and check for orphans: a
+subsystem whose findings never got a PR slot is the easiest thing to lose between the audit and the
+plan. If the count drifts past the number the user asked for, say so and add the PR rather than
+silently dropping confirmed work.
 
 ### 6. Critique the plan, then deliver
 
@@ -132,6 +210,19 @@ queue and tick each off as it opens, so progress is supervisable at a glance.
 - **Rank a problem by how easy it is to actually trigger, not how scary it sounds.** A "critical" bug
   that only happens when someone turns on a dangerous off-by-default option is really a minor one.
   Check the problem is reachable in normal use before calling it severe.
+- **Ask "could a real parser do this?" as a standing question.** Hand-rolled scanners for HTML, CSS,
+  ANSI, URLs, YAML, or a commit grammar are a reliable eliminator seam. Check the dependency list
+  first: the repo often already ships the parser and uses it in _one_ place, which makes the
+  half-adopted path the buggy one — and makes the fix cheap to argue for.
+- **The best evidence is a pasted terminal transcript.** "One uppercase letter turns this detector
+  off, here is the before/after table" ends the argument; a paragraph of reasoning invites one.
+- **A doc-stated invariant with no enforcement is a finding in itself.** "These three must stay in
+  sync", "keep this layer before that one", "documented so the omission is a choice" — each names a
+  contract that only a test can actually hold. Grep the tree for that phrasing early.
+- **Check open PRs before planning.** A fix may already be in flight; overlapping a sibling branch
+  wastes the work and creates a conflict the disjoint-file rule was supposed to prevent.
+- **Don't stop the queue to ask.** Mid-run design choices get a sensible default plus a
+  `## Decisions made` entry. The one moment for questions is the plan delivery.
 
 ## Examples
 
@@ -149,3 +240,19 @@ their findings. Then plan parallel PRs to fix them, and critique the plan."
    test that would catch the class.
 6. Critique: two PRs both touch `ip-validation.bash` → merge them; one "critical" is behind
    `--dangerously-skip-firewall` → downgrade. Deliver plan + critique.
+
+**User says:** "…but look for ELIMINATORS, fixing entire classes of bugs, not spot fixes."
+
+Same workflow, three changes:
+
+1. Swap the finding contract for the eliminator one and paste the genre catalog into every agent
+   prompt. Without the catalog, agents return spot fixes with the word "class" pasted on top.
+2. Confirm by **executing**, not re-reading. Worked examples from a real run: one uppercase letter
+   (`left:-9999PX` vs `px`) disabled a hidden-element detector; a nested `<p>` made the splicer
+   delete visible text; padding a token with 12 zero-width spaces suppressed a homoglyph fold and
+   the _next_ layer then erased the padding, delivering the un-normalized homoglyph downstream.
+   None of those are believable as prose; all are decisive as a transcript.
+3. Cluster with the wider blast radius in mind. Here, one file (`src/html.mjs`) hosted two
+   eliminators — a small CSS-canonicalization fix and a full parser rewrite — so they became
+   sequential, small first. Scope-lock each agent explicitly ("you own the CSS detectors; a sibling
+   owns the tree walker in the same file") or they will collide.


### PR DESCRIPTION
Claimed area: `.claude/skills/parallel-audit/SKILL.md` (docs only, no code paths).

## What changed

Reworks the `parallel-audit` skill so its default posture is hunting **eliminators** — structural changes that make a whole class of bug impossible by construction — rather than enumerating individual spot fixes.

- New **"Eliminators, not spot fixes"** section defining the term and carrying the genre catalog agents need: N hand-synced parallel lists, hand-rolled approximations of a real parser, untyped values whose meaning is positional convention, a policy decided at N call sites, an invariant re-established only on the branch that needed it, comment-only ordering contracts, one-directional gates, and per-unit budgets applied to indivisible clusters.
- Per-finding contract now carries `CLASS ELIMINATED` / `ELIMINATOR` / `BLAST RADIUS` / `TEST THAT WOULD CATCH THE CLASS`, and asks for counts rather than adjectives. The old spot-fix shape is retained as the fallback mode.
- Step 5 gains the wider-blast-radius clustering rule and an explicit finding→PR map check.
- Worked example added for the eliminator variant of the request.

## Why

Without the catalog in the prompt, agents return spot fixes with the word "class" pasted on top. The catalog is what converts "look for bugs" into "look for the shape that keeps producing bugs".

## Lessons from the run that produced this

Folded into the skill rather than left in chat:

- **Confirm by executing, not re-reading.** Findings verified by running a repro survived the confirmation pass nearly always; findings reasoned from a read are where the drops came from. Un-executed claims now get a `plausible, not confirmed` bucket and do not claim a PR slot.
- **Check your own repro harness before reporting a crash.** A `TypeError` from omitting a required accumulator parameter is a calling error, not a defect.
- **Scope-lock agents that share a file.** Two eliminators in one file are sequential, not parallel — the "one PR per subsystem" grouping stops guaranteeing disjointness once a rewrite is in the mix.
- **Build the finding→PR map explicitly.** A subsystem whose findings never got a slot is the easiest thing to lose between audit and plan.
- **"Could a real parser do this?" is a standing question.** The half-adopted case — real parser on one branch, regex on the other — is common and worse than either.

## Decisions made

- **Kept the spot-fix contract as a documented fallback** rather than replacing it outright. Eliminator mode is the default; a user asking for a plain bug list still has a defined shape. The alternative — deleting it — would have made the skill wrong for the narrower request.
- **Put the genre catalog in the skill body rather than a separate reference file.** It has to be pasted into every agent prompt, so keeping it inline avoids a second file that can drift from the contract it feeds. If it grows much past its current size, splitting it out becomes the better trade.
- **Documented the Bash control-character validator as a harness limit with a workaround** instead of omitting it. It cost real time during the run and reads as an untestable case if you hit it cold.

## Lessons Learned

Template-level, for `phone-home.yaml` propagation — all apply to `.claude/skills/parallel-audit/SKILL.md` in the template repo:

- **Add the eliminator genre catalog and per-finding contract** to the skill's step-2 prompt spec. *Why:* audits that ask only for "bugs" return a list that cannot be clustered into refactors, so the resulting plan is N spot fixes and the underlying class survives.
- **Add "confirm by executing, not re-reading" to step 4**, with a `plausible, not confirmed` bucket for claims whose repro was not built. *Why:* the confirmation pass is the skill's quality gate, and a read-only confirmation of a read-only finding adds little independent signal.
- **Document the Bash literal-control-character rejection and the heredoc + `String.fromCodePoint` workaround.** *Why:* any audit touching terminal escapes, ANSI, or invisible Unicode hits this, and the natural reading is "cannot test this here", which silently downgrades a real finding to a code-read.
- **Add the scope-lock instruction for agents sharing a file** to step 2's scope-hygiene note. *Why:* the existing disjoint-file guidance is written for the audit phase; it does not survive contact with the execution phase when one file hosts two eliminators.


---
_Generated by [Claude Code](https://claude.ai/code/session_01S3rH5QmeDYMWkEgNjcnyHW)_