### PR TITLE
fix(html): read uppercase and escaped CSS units so hidden styles cannot be spelled past Layer 2

### DIFF
--- a/src/html.mjs
+++ b/src/html.mjs
@@ -57,6 +57,13 @@ export {
 // hand-rolled parser kept re-introducing simply cannot arise. Ambiguity still
 // fails OPEN (treated as visible): an unresolved unit, `calc()`, or `var()`
 // never counts as hidden.
+//
+// Every ident in a value — keyword, function name, dimension unit — is
+// escape-decoded and lowercased ONCE at the parse boundary (see
+// {@link canonicalizeValue}), so the detectors below compare canonical tokens
+// against literals. Doing it per-site is what let `left:-9999PX` through: CSS
+// units are ASCII case-insensitive, and every site that forgot `.toLowerCase()`
+// was a one-keystroke bypass of the whole layer.
 
 // A length/opacity/size is "near zero" when its magnitude is below this — a
 // browser renders 0.0001px text or 0.001 opacity as effectively invisible, so
@@ -206,7 +213,9 @@ function isHidingTransform(node) {
   if (!node) return false;
   for (const fn of valueTokens(node)) {
     if (fn.type !== "Function") continue;
-    const name = fn.name.toLowerCase();
+    // Function names, units and idents arrive lowercased and escape-decoded
+    // from parseDeclarations, so a literal compare is correct by construction.
+    const name = fn.name;
     const args = valueTokens(fn);
     if (/^(?:scale|scale3d|scalex|scaley|matrix|matrix3d)$/.test(name)) {
       // scale/matrix collapse to nothing when EITHER axis factor is (near-)zero —
@@ -240,12 +249,8 @@ function isHidingTransform(node) {
       // normalizes deg/grad/rad/turn to [0,360), and a near-90/270 band absorbs
       // the float drift of rad→deg.
       const a = args[0];
-      if (
-        a &&
-        a.type === "Dimension" &&
-        ANGLE_UNITS.has(a.unit.toLowerCase())
-      ) {
-        const degrees = hueDegrees(`${a.value}${a.unit}`.toLowerCase());
+      if (a && a.type === "Dimension" && ANGLE_UNITS.has(a.unit)) {
+        const degrees = hueDegrees(`${a.value}${a.unit}`);
         if (
           degrees !== null &&
           (Math.abs(degrees - 90) < NEAR_ZERO_EPSILON ||
@@ -279,7 +284,7 @@ function isHidingTransform(node) {
 function isHidingFilter(node) {
   if (!node) return false;
   for (const fn of valueTokens(node)) {
-    if (fn.type !== "Function" || fn.name.toLowerCase() !== "opacity") continue;
+    if (fn.type !== "Function" || fn.name !== "opacity") continue;
     const amount = valueTokens(fn)[0];
     if (!amount) continue;
     if (
@@ -321,7 +326,7 @@ function clipEdge(token) {
 function isClipRectHidden(node) {
   if (!node) return false;
   const rect = valueTokens(node).find(
-    (t) => t.type === "Function" && t.name.toLowerCase() === "rect",
+    (t) => t.type === "Function" && t.name === "rect",
   );
   if (!rect) return false;
   const edges = valueTokens(rect).map(clipEdge);
@@ -686,18 +691,50 @@ function canonicalizeColor(raw) {
   return canonicalizeColorFunction(value) ?? value;
 }
 
+// True when a value node paints — or cannot be proven NOT to paint — a
+// background IMAGE layer: a `url()`, a `*-gradient()` or an `image-set()`
+// anywhere in the value. The value AST is walked rather than a re-serialized
+// string regexed: an escaped function name (`\49 mage-set(…)`, which a browser
+// reads as `image-set(…)`) survives serialization escaped and slipped past the
+// regex, so the image layer went unseen and same-colored text painted over an
+// image was spliced as hidden. A `Raw` node — a value css-tree could not parse,
+// which is also what an escaped `url(` degrades to — is unresolvable and so
+// counts as an image layer (fail OPEN: no same-color hide).
+/** @param {any} node value node, or null @returns {boolean} */
+function paintsImageLayer(node) {
+  if (!node) return false;
+  let found = false;
+  csstree.walk(node, {
+    enter(/** @type {any} */ child) {
+      if (child.type === "Url" || child.type === "Raw") found = true;
+      // Names are canonicalized at the parse boundary, so a suffix test covers
+      // every gradient (`linear-`/`radial-`/`conic-`/`repeating-`/`-webkit-`)
+      // and both `image-set` spellings. `url` appears as a Function (not a Url)
+      // node when its name carried an escape — the very case the old regex on
+      // the re-serialized text missed.
+      if (
+        child.type === "Function" &&
+        (child.name === "url" ||
+          child.name.endsWith("gradient") ||
+          child.name.endsWith("image-set"))
+      )
+        found = true;
+    },
+  });
+  return found;
+}
+
 // The leading color token of a `background` shorthand (the first token that
 // canonicalizes to a real color), so `background:#fff` still compares. Returns
-// "" (fail open, no same-color hide) when the shorthand carries an IMAGE layer
-// — `url(...)`, a gradient, or `image-set(...)`: the painted image can make
-// same-colored text perfectly readable over it (and if it fails to load the
-// element's own background shows through), so the flat color token is not
-// provably the rendered backdrop.
-/** @param {string} shorthand @returns {string} */
-function backgroundColor(shorthand) {
-  if (/\burl\(|gradient\(|image-set\(/i.test(shorthand)) return "";
-  for (const token of shorthand.split(/\s+/)) {
-    const color = canonicalizeColor(token);
+// "" (fail open, no same-color hide) when the shorthand carries an IMAGE layer:
+// the painted image can make same-colored text perfectly readable over it (and
+// if it fails to load the element's own background shows through), so the flat
+// color token is not provably the rendered backdrop.
+/** @param {any} node value node for `background`, or null @returns {string} */
+function backgroundColor(node) {
+  if (!node || paintsImageLayer(node)) return "";
+  for (const token of valueTokens(node)) {
+    const color = canonicalizeColor(tokenText(token));
     if (color && (color.startsWith("#") || color === "transparent"))
       return color;
   }
@@ -727,8 +764,7 @@ function insetEdges(fn) {
   /** @type {any[]} */
   const edges = [];
   for (const token of valueTokens(fn)) {
-    if (token.type === "Identifier" && token.name.toLowerCase() === "round")
-      break;
+    if (token.type === "Identifier" && token.name === "round") break;
     edges.push(token);
   }
   return edges;
@@ -748,7 +784,7 @@ function isClipPathHidden(node) {
   if (!node) return false;
   for (const fn of valueTokens(node)) {
     if (fn.type !== "Function") continue;
-    const name = fn.name.toLowerCase();
+    const name = fn.name;
     if (name === "circle") {
       const radius = valueTokens(fn)[0];
       if (
@@ -808,6 +844,13 @@ function isTextPaintedVisible(val) {
   return isConcreteColor(stroke) && stroke !== "transparent";
 }
 
+/** True when a value is exactly the keyword `none`.
+ * @param {any} node @returns {boolean} */
+function isNoneKeyword(node) {
+  const token = soleToken(node);
+  return Boolean(token && token.type === "Identifier" && token.name === "none");
+}
+
 // True when the element paints a background IMAGE layer — a `background-image`
 // longhand set to anything but `none`, or a `background` shorthand carrying
 // `url(...)`, a gradient, or `image-set(...)`. A same-color text/background hide
@@ -819,11 +862,13 @@ function isTextPaintedVisible(val) {
 // only the flat color and missed a co-declared `background-image`, splicing
 // visible text. `background-clip:text` is NOT an image layer here — it paints
 // the background THROUGH the glyphs and is handled by {@link isTextPaintedVisible}.
-/** @param {(key: string) => string} textOf @returns {boolean} */
-function hasImageLayer(textOf) {
-  const img = textOf("background-image");
-  if (img && img !== "none") return true;
-  return /\burl\(|gradient\(|image-set\(/i.test(textOf("background"));
+/** @param {(key: string) => any} nodeOf @returns {boolean} */
+function hasImageLayer(nodeOf) {
+  const img = nodeOf("background-image");
+  // Only the single keyword `none` proves the longhand paints nothing; any
+  // other value (an unresolvable `var()` included) counts as a layer.
+  if (img && !isNoneKeyword(img)) return true;
+  return paintsImageLayer(nodeOf("background"));
 }
 
 /**
@@ -871,12 +916,23 @@ function isFontShorthandHidden(node) {
 const CSS_PROPERTY_IDENT_RE = /^-{0,2}[A-Za-z_][A-Za-z0-9_-]*$/;
 
 /**
- * Reconstruct a declaration's decoded value as a string for keyword/color
- * comparisons. Identifier tokens are escape-decoded through css-tree's ident
- * decoder (so `no\6e e`/`hi\64 den` read as `none`/`hidden`, with FF/CR/CRLF
- * terminators and invalid codepoints handled per the CSS spec); every other
- * token is re-serialized. A whole-value `Raw` (an unparsed value) is returned
- * verbatim — it never matches a hiding keyword, so it fails open.
+ * One value token as text. An Identifier's `name` is already the decoded,
+ * lowercased ident (see {@link canonicalizeValue}), so it is used verbatim
+ * rather than round-tripped through the serializer; every other token is
+ * re-serialized from its (canonicalized) node fields.
+ * @param {any} token
+ * @returns {string}
+ */
+function tokenText(token) {
+  return token.type === "Identifier" ? token.name : csstree.generate(token);
+}
+
+/**
+ * Reconstruct a declaration's canonicalized value as a string for keyword/color
+ * comparisons. Escapes and letter case were resolved at the parse boundary, so
+ * `no\6e e`, `NONE` and `none` all render as `none` here. A whole-value `Raw`
+ * (an unparsed value) is returned verbatim — it never matches a hiding keyword,
+ * so it fails open.
  * @param {any} valueNode
  * @returns {string}
  */
@@ -887,20 +943,44 @@ function declText(valueNode) {
   const parts = [];
   if (valueNode.children)
     valueNode.children.forEach((/** @type {any} */ child) =>
-      parts.push(
-        child.type === "Identifier"
-          ? csstree.ident.decode(child.name)
-          : csstree.generate(child),
-      ),
+      parts.push(tokenText(child)),
     );
   return parts.join(" ");
 }
 
 /**
+ * Canonicalize a parsed value subtree IN PLACE so every downstream comparison
+ * against a literal (`ABSOLUTE_UNITS`, `"rect"`, `"none"`) is correct by
+ * construction instead of depending on each call site remembering to decode and
+ * lowercase. CSS idents — keywords, function names and dimension units — are
+ * escape-decodable and ASCII case-insensitive for every keyword this module
+ * matches, so a browser reads `left:-9999PX`, `left:-9999p\78` and
+ * `left:-9999px` identically; the ad-hoc per-site `.toLowerCase()` did not, and
+ * a single uppercased unit walked straight past the detector.
+ *
+ * `Url.value` is deliberately NOT touched: css-tree already decodes url escapes,
+ * and a second decode would eat a legitimately backslash-bearing path.
+ * @param {any} valueNode
+ * @returns {void}
+ */
+function canonicalizeValue(valueNode) {
+  csstree.walk(valueNode, {
+    enter(/** @type {any} */ node) {
+      // ident.decode is pure string iteration and cannot throw on a token the
+      // tokenizer already produced.
+      if (node.type === "Identifier" || node.type === "Function")
+        node.name = csstree.ident.decode(node.name).toLowerCase();
+      else if (node.type === "Dimension")
+        node.unit = csstree.ident.decode(node.unit).toLowerCase();
+    },
+  });
+}
+
+/**
  * Parse a style string into a map of decoded lowercase property name -> parsed
- * value node, via css-tree's tolerant declaration-list parser. This replaces the
- * hand-rolled declaration splitter, per-declaration salvage, escape decoder, and
- * `!important` stripper in one pass: css-tree recovers per-declaration exactly
+ * and canonicalized value node, via css-tree's tolerant declaration-list
+ * parser. This replaces the hand-rolled declaration splitter, per-declaration
+ * salvage, escape decoder, and `!important` stripper in one pass: css-tree recovers per-declaration exactly
  * as a browser does (a bogus declaration is dropped, the rest kept), keeps a `;`
  * inside a string/`url()`/paren as part of the value, and exposes `!important`
  * as `node.important` (so an escaped spelling `none!\69mportant` is stripped for
@@ -934,6 +1014,7 @@ function parseDeclarations(styleStr) {
       // token; property is escape-decoded then gated to a clean CSS ident.
       const property = csstree.ident.decode(node.property).trim().toLowerCase();
       if (!CSS_PROPERTY_IDENT_RE.test(property)) return;
+      canonicalizeValue(node.value);
       decls.set(property, node.value);
     },
   });
@@ -1015,7 +1096,7 @@ export function isHiddenStyle(styleStr) {
     return true;
   const background =
     canonicalizeColor(textOf("background-color")) ||
-    backgroundColor(textOf("background"));
+    backgroundColor(nodeOf("background"));
   // Only flag same-color when BOTH sides resolve to a concrete color (`#rrggbb`
   // or `transparent`), AND no background IMAGE layer is present (an image can
   // make same-colored text readable). `var(--x)`, `inherit`, and `currentColor`
@@ -1027,7 +1108,7 @@ export function isHiddenStyle(styleStr) {
     effectiveColor &&
     effectiveColor === background &&
     isConcreteColor(effectiveColor) &&
-    !hasImageLayer(textOf)
+    !hasImageLayer(nodeOf)
   )
     return true;
 

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -980,12 +980,13 @@ function canonicalizeValue(valueNode) {
  * Parse a style string into a map of decoded lowercase property name -> parsed
  * and canonicalized value node, via css-tree's tolerant declaration-list
  * parser. This replaces the hand-rolled declaration splitter, per-declaration
- * salvage, escape decoder, and `!important` stripper in one pass: css-tree recovers per-declaration exactly
- * as a browser does (a bogus declaration is dropped, the rest kept), keeps a `;`
- * inside a string/`url()`/paren as part of the value, and exposes `!important`
- * as `node.important` (so an escaped spelling `none!\69mportant` is stripped for
- * free). Property names are escape-decoded and gated to real CSS idents;
- * anything else is dropped (fail open). Later declarations win, per the cascade.
+ * salvage, escape decoder, and `!important` stripper in one pass: css-tree
+ * recovers per-declaration exactly as a browser does (a bogus declaration is
+ * dropped, the rest kept), keeps a `;` inside a string/`url()`/paren as part of
+ * the value, and exposes `!important` as `node.important` (so an escaped
+ * spelling `none!\69mportant` is stripped for free). Property names are
+ * escape-decoded and gated to real CSS idents; anything else is dropped (fail
+ * open). Later declarations win, per the cascade.
  * @param {string} styleStr
  * @returns {Map<string, any>}
  */

--- a/test/html.test.mjs
+++ b/test/html.test.mjs
@@ -6,6 +6,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import fc from "fast-check";
+import * as csstree from "css-tree";
 
 import { fcRunOptions } from "./test-helpers.mjs";
 import {
@@ -384,6 +385,41 @@ const HIDDEN_STYLE_CASES = [
   ["display:\\0", false], // codepoint 0 is invalid
   ["display:\\d800", false], // a surrogate half is invalid
   ["display:\\ffffff", false], // past the Unicode maximum (0x10FFFF)
+  // ── CSS units and function names are ASCII case-insensitive (bug: compared
+  //    un-normalized, so ONE uppercased keystroke bypassed the whole layer) ──
+  ["position:absolute;left:-9999PX", true],
+  ["position:absolute;left:-100VW", true],
+  ["text-indent:-9999PX", true],
+  ["font:0PX/1 serif", true],
+  ["position:ABSOLUTE;clip:RECT(0,0,0,0)", true],
+  ["transform:TRANSLATEX(-9999px)", true],
+  ["transform:rotateX(100GRAD)", true], // 100grad === 90deg, edge-on
+  ["filter:OPACITY(0)", true],
+  ["clip-path:INSET(50%)", true],
+  ["overflow:HIDDEN;height:0PX", true],
+  ["position:absolute;left:-5PX", false], // uppercase unit, but not offscreen
+  // ── a unit is an ident, so it is escape-decodable too ──
+  ["position:absolute;left:-9999p\\78", true], // `\78` -> 'x' -> px
+  ["text-indent:-9999P\\58", true], // uppercase escape spelling of px
+  ["position:absolute;left:-9999\\70 x", true], // `\70` -> 'p' -> px
+  // ── an escaped IMAGE-layer function is still an image layer: reading the
+  //    re-serialized (still-escaped) text missed it and spliced visible text
+  //    painted over the image ──
+  ['color:#fff;background-color:#fff;background:IMAGE-SET("a.png" 1x)', false],
+  [
+    'color:#fff;background-color:#fff;background:\\49 mage-set("a.png" 1x)',
+    false,
+  ],
+  ["color:#fff;background-color:#fff;background:\\75 rl(x.png)", false], // escaped url()
+  [
+    "color:#fff;background-color:#fff;background:\\6c inear-gradient(#000,#111)",
+    false,
+  ],
+  [
+    'color:#fff;background-color:#fff;background-image:IMAGE-SET("a.png" 1x)',
+    false,
+  ],
+  ["color:#fff;background-color:#fff;background-image:NONE", true], // explicit none is still not a layer
 ];
 
 // Negative corpus for the raw-declaration fallback: realistic legitimate
@@ -405,6 +441,26 @@ const LEGIT_STYLE_CORPUS = [
   "a{color:red}",
   "{}; color: green",
   "12px:display",
+  // Legitimate declarations that only differ from a hiding one by a unit, a
+  // case, or an escape — canonicalizing tokens must not widen the detector
+  // into any of these (precision doctrine).
+  "POSITION: ABSOLUTE; LEFT: -5PX; COLOR: #222",
+  "position:absolute;left:calc(-100VW + 100%)",
+  "TEXT-INDENT: -0.5EM",
+  "FONT: 14PX/1.4 Georgia, serif",
+  "TRANSFORM: SCALE(0.8) ROTATE(90DEG)",
+  "FILTER: OPACITY(0.6) BLUR(2PX)",
+  "CLIP-PATH: INSET(10%)",
+  "OVERFLOW: HIDDEN; HEIGHT: 40PX",
+  "COLOR: WHITE; BACKGROUND: #FEFEFE",
+  "color:#fff;background:#fff URL(hero.png) no-repeat",
+  'color:#fff;background:#fff \\49 mage-set("hero.png" 1x)',
+  // An escaped `url` inside a multi-token shorthand parses as a Function node
+  // (not a Url node) — still an image layer, so the same-color hide fails open.
+  "color:#fff;background:#fff \\75 rl(hero.png)",
+  "color:#fff;background:#fff u\\72 l(hero.png) no-repeat",
+  "color:#fff;background-color:#fff;background-image:\\75 rl(hero.png)",
+  "displa\\79 : block; colo\\72 : #444",
 ];
 
 describe("unit: isHiddenStyle exact verdicts", () => {
@@ -427,6 +483,165 @@ describe("unit: isHiddenStyle exact verdicts", () => {
   ])
     it(`returns false (not a poisoned non-boolean) for color:${proto}`, () =>
       assert.equal(isHiddenStyle(`background:${proto}`), false));
+});
+
+// ─── metamorphic: ident spelling never changes the verdict ───────────────────
+//
+// A browser reads a CSS ident — a keyword, a function name, a dimension's unit,
+// a property name — ASCII case-insensitively and with its escapes decoded. So
+// re-spelling any ident in a style string leaves the RENDERED result identical,
+// and `isHiddenStyle` must return the identical verdict. Asserting that
+// invariant over the whole corpus, rather than one symptom per bug, fails the
+// moment ANY comparison site — today's or a future detector's — compares a
+// token that was not canonicalized at the parse boundary.
+
+const { Ident, Function: FunctionToken, Dimension, Url } = csstree.tokenTypes;
+
+/**
+ * The `[start, end)` offsets of every stretch of `style` a browser tokenizes as
+ * ident text. Derived from css-tree's TOKENIZER (the ground truth for what is
+ * an ident) rather than a hand-rolled scan, so the mutations below stay
+ * spec-faithful as the corpus grows.
+ * @param {string} style
+ * @returns {[number, number][]}
+ */
+function identSpans(style) {
+  /** @type {[number, number][]} */
+  const spans = [];
+  csstree.tokenize(style, (type, start, end) => {
+    // A Function token spans its trailing "("; a Url token spans the whole
+    // `url(…)`, of which only the 3-char function name is ident text (the
+    // payload is a URL, where case and backslashes are significant).
+    if (type === Ident) spans.push([start, end]);
+    else if (type === FunctionToken) spans.push([start, end - 1]);
+    else if (type === Url && /^url/i.test(style.slice(start, start + 3)))
+      spans.push([start, start + 3]);
+    else if (type === Dimension) {
+      // The unit is the trailing letter run: `1e3px` -> `px`, never the `e` of
+      // an exponent (which is part of the number, not an ident).
+      const unit = /[A-Za-z]+$/.exec(style.slice(start, end));
+      if (unit) spans.push([start + unit.index, end]);
+    }
+  });
+  return spans;
+}
+
+/**
+ * Offsets already inside a CSS escape sequence. Re-spelling one of those bytes
+ * would rewrite the escape itself (turning `\6e ` into something else) rather
+ * than re-spelling the ident, so they are excluded from both mutations.
+ * @param {string} style
+ * @returns {Set<number>}
+ */
+function escapedOffsets(style) {
+  /** @type {Set<number>} */
+  const covered = new Set();
+  for (const match of style.matchAll(/\\(?:[0-9a-fA-F]{1,6}[ \t\n]?|[^\n])/g))
+    for (let i = 0; i < match[0].length; i++)
+      covered.add(/** @type {number} */ (match.index) + i);
+  return covered;
+}
+
+/** Mutation (a): uppercase every ident — units and function names included.
+ * @param {string} style @returns {string} */
+function uppercaseIdents(style) {
+  const chars = style.split("");
+  const escaped = escapedOffsets(style);
+  for (const [start, end] of identSpans(style))
+    for (let i = start; i < end; i++)
+      if (!escaped.has(i)) chars[i] = chars[i].toUpperCase();
+  return chars.join("");
+}
+
+/** Every offset mutation (b) may re-spell: an unescaped ASCII letter of an ident.
+ * @param {string} style @returns {number[]} */
+function escapableOffsets(style) {
+  const escaped = escapedOffsets(style);
+  /** @type {number[]} */
+  const offsets = [];
+  for (const [start, end] of identSpans(style))
+    for (let i = start; i < end; i++)
+      if (/[A-Za-z]/.test(style[i]) && !escaped.has(i)) offsets.push(i);
+  return offsets;
+}
+
+/** Mutation (b): rewrite the character at `offset` as a `\XX ` hex escape.
+ * @param {string} style @param {number} offset @returns {string} */
+function escapeIdentChar(style, offset) {
+  const hex = style.charCodeAt(offset).toString(16);
+  return `${style.slice(0, offset)}\\${hex} ${style.slice(offset + 1)}`;
+}
+
+const METAMORPHIC_CORPUS = [
+  ...HIDDEN_STYLE_CASES.map(([style]) => style),
+  ...LEGIT_STYLE_CORPUS,
+];
+
+describe("metamorphic: isHiddenStyle is blind to ident spelling", () => {
+  // Pin the mutators themselves: a silently no-op mutation would make every
+  // assertion below pass vacuously.
+  it("uppercases units and function names, not url payloads or escapes", () => {
+    assert.equal(
+      uppercaseIdents("position:absolute;left:-9999px"),
+      "POSITION:ABSOLUTE;LEFT:-9999PX",
+    );
+    assert.equal(
+      uppercaseIdents("background:#fff url(Img/a.png) no-repeat"),
+      "BACKGROUND:#fff URL(Img/a.png) NO-REPEAT",
+    );
+    assert.equal(uppercaseIdents("display:no\\6e e"), "DISPLAY:NO\\6e E");
+  });
+
+  it("rewrites one ident character as a hex escape", () => {
+    assert.equal(escapeIdentChar("display:none", 0), "\\64 isplay:none");
+    assert.equal(escapeIdentChar("left:-9999px", 10), "left:-9999\\70 x");
+    // Escape-internal bytes and the url payload are never offered as targets:
+    // `display` (0-6) and the `one` tail of `\6e one` (12-14), but not the
+    // escape's own bytes (8-11).
+    assert.deepEqual(
+      escapableOffsets("display:\\6e one"),
+      [0, 1, 2, 3, 4, 5, 6, 12, 13, 14],
+    );
+    // `background` (0-9) and the `url` function name (11-13) — never the
+    // `ab.png` payload.
+    assert.deepEqual(
+      escapableOffsets("background:url(ab.png)"),
+      [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13],
+    );
+  });
+
+  it("every corpus style keeps its verdict when its idents are uppercased", () => {
+    /** @type {string[]} */
+    const mismatches = [];
+    for (const style of METAMORPHIC_CORPUS) {
+      const mutant = uppercaseIdents(style);
+      if (isHiddenStyle(mutant) !== isHiddenStyle(style))
+        mismatches.push(
+          `${JSON.stringify(style)} -> ${JSON.stringify(mutant)}`,
+        );
+    }
+    assert.deepEqual(mismatches, []);
+  });
+
+  it("every corpus style keeps its verdict when one ident char is escaped", () => {
+    /** @type {string[]} */
+    const mismatches = [];
+    let mutants = 0;
+    for (const style of METAMORPHIC_CORPUS) {
+      const expected = isHiddenStyle(style);
+      for (const offset of escapableOffsets(style)) {
+        const mutant = escapeIdentChar(style, offset);
+        mutants += 1;
+        if (isHiddenStyle(mutant) !== expected)
+          mismatches.push(
+            `${JSON.stringify(style)} -> ${JSON.stringify(mutant)}`,
+          );
+      }
+    }
+    assert.deepEqual(mismatches, []);
+    // Non-vacuity: the corpus must actually produce a large mutant set.
+    assert.ok(mutants > 1000, `only ${mutants} mutants generated`);
+  });
 });
 
 describe("unit: isHiddenElement exact verdicts", () => {

--- a/test/html.test.mjs
+++ b/test/html.test.mjs
@@ -420,6 +420,18 @@ const HIDDEN_STYLE_CASES = [
     false,
   ],
   ["color:#fff;background-color:#fff;background-image:NONE", true], // explicit none is still not a layer
+  // ── WIDENING: a CSS Color 4 space-separated color in the `background`
+  //    SHORTHAND now resolves. Splitting the serialized shorthand on
+  //    whitespace tore `rgb(0 0 0)` into `rgb(0` / `0` / `0)`, none of which
+  //    canonicalized, so the shorthand read as "no color" and the same-color
+  //    hide never fired — while the comma form `rgb(0,0,0)` (one token) was
+  //    flagged. Reading the Function NODE closes that spelling bypass, so these
+  //    styles are spliced where they previously were not.
+  ["color:#000;background:rgb(0 0 0) no-repeat", true],
+  ["color:#fff;background:hsl(0 0% 100%) padding-box", true],
+  ["color:#000;background:rgb(0 0 0) border-box padding-box", true],
+  ["color:#000;background:rgb(255 0 0) no-repeat", false], // distinct color — visible
+  ["color:#000;background:rgb(0 0 0) url(x.png)", false], // image layer still fails open
 ];
 
 // Negative corpus for the raw-declaration fallback: realistic legitimate
@@ -626,12 +638,18 @@ describe("metamorphic: isHiddenStyle is blind to ident spelling", () => {
   it("every corpus style keeps its verdict when one ident char is escaped", () => {
     /** @type {string[]} */
     const mismatches = [];
-    let mutants = 0;
+    /** @type {string[]} */
+    const unmutated = [];
     for (const style of METAMORPHIC_CORPUS) {
       const expected = isHiddenStyle(style);
-      for (const offset of escapableOffsets(style)) {
+      const offsets = escapableOffsets(style);
+      // Per-style non-vacuity: a corpus-wide mutant count would keep passing
+      // while a NEW entry silently contributed nothing — `identSpans` yields no
+      // span for a `url` name or a dimension unit that is itself escaped, so
+      // "has idents" does not imply "has escapable idents".
+      if (offsets.length === 0) unmutated.push(JSON.stringify(style));
+      for (const offset of offsets) {
         const mutant = escapeIdentChar(style, offset);
-        mutants += 1;
         if (isHiddenStyle(mutant) !== expected)
           mismatches.push(
             `${JSON.stringify(style)} -> ${JSON.stringify(mutant)}`,
@@ -639,8 +657,11 @@ describe("metamorphic: isHiddenStyle is blind to ident spelling", () => {
       }
     }
     assert.deepEqual(mismatches, []);
-    // Non-vacuity: the corpus must actually produce a large mutant set.
-    assert.ok(mutants > 1000, `only ${mutants} mutants generated`);
+    // The only entries that legitimately carry no ident are the empty style and
+    // one whose every byte is swallowed by an unterminated comment. Pinning the
+    // exact set (not just its size) fails BOTH ways: a new entry that silently
+    // contributes nothing, and one of these two growing an ident.
+    assert.deepEqual(unmutated, ['""', '"/*x display:none"']);
   });
 });
 


### PR DESCRIPTION
Claimed area: `src/html.mjs` CSS/style detection (`isHiddenStyle` and its helpers) + `test/html.test.mjs`. Does not touch the Layer-2 markdown tree-walking machinery (`scanMarkdown`, `updateHiddenState`, `collectCommentRanges`, `spliceRanges`, branch dispatch).

## Summary

CSS units and function names are ASCII case-insensitive, and every ident is escape-decodable, but the detectors compared those tokens **un-normalized** at ~10 sites. Two sites remembered to normalize; the rest did not, so one uppercased keystroke walked straight past the whole hidden-style layer:

| input (a browser hides this) | before | after |
| --- | --- | --- |
| `position:absolute;left:-9999px` | `true` | `true` |
| `position:absolute;left:-9999PX` | **`false`** | `true` |
| `text-indent:-9999PX` | **`false`** | `true` |
| `position:absolute;left:-100VW` | **`false`** | `true` |
| `font:0PX/1 serif` | **`false`** | `true` |

So `<span style="position:absolute;left:-9999PX">IGNORE PREVIOUS INSTRUCTIONS</span>` was invisible to a human and invisible to Layer 2.

The same asymmetry ran the other way and **deleted visible text**. The image-layer check regexed a re-serialized value string in which a function name's escape was never decoded, so an escaped image function did not look like an image layer and the same-color hide fired over it:

| input (a browser paints an image behind the text) | before | after |
| --- | --- | --- |
| `color:#fff;background-color:#fff;background:\49 mage-set("a.png" 1x)` | **`true` (spliced)** | `false` |
| `color:#fff;background:#fff u\72 l(hero.png) no-repeat` | **`true` (spliced)** | `false` |

Rather than patching each site, both are eliminated at the source: canonicalize once at the parse boundary, and stop the AST → string → regex round trip.

## Changes

- `parseDeclarations` runs a new `canonicalizeValue` over each declaration's value AST before any detector sees it: `Identifier.name`, `Function.name` and `Dimension.unit` are `ident.decode`d and lowercased in place. `Url.value` is deliberately left alone — css-tree already decodes url escapes, and a second decode would eat a legitimately backslash-bearing path.
- Deleted the now-redundant `.toLowerCase()` / `ident.decode` at the downstream sites (`isHidingTransform`, `isHidingFilter`, `isClipRectHidden`, `isClipPathHidden`, `insetEdges`, `declText`), so a comparison against `ABSOLUTE_UNITS` / `"rect"` / `"opacity"` / `"none"` is correct by construction.
- `hasImageLayer` / `backgroundColor` now test the value **AST** (a `Url` node, or a `Function` named `url` / `*gradient` / `*image-set`) instead of regexing `declText` output, and take value nodes rather than text.
- Fail-open preserved and widened where the parser gives up: a `Raw` value (unparsed CSS, which is what a standalone escaped `url(` degrades to) counts as an unresolvable image layer, so no same-color splice happens on a value we cannot read. `calc()`, unknown units and `var()` still fail open exactly as before.

### One deliberate widening that deletes content it previously kept

`backgroundColor` used to split the *serialized* `background` shorthand on whitespace, which tore a CSS Color 4 space-separated color into non-colors (`rgb(0 0 0)` → `rgb(0` / `0` / `0)`) and returned "no color" — while the comma form `rgb(0,0,0)`, being a single token, was flagged. Reading value **nodes** closes that spelling gap, so these styles are now spliced where they previously survived (verified by running both `main` and this branch):

| style | `main` | this branch |
| --- | --- | --- |
| `color:#000;background:rgb(0 0 0) no-repeat` | false | **true** |
| `color:#fff;background:hsl(0 0% 100%) padding-box` | false | **true** |
| `color:#000;background:rgb(0 0 0) border-box padding-box` | false | **true** |
| `color:#000;background:rgb(0,0,0)` (comma form) | true | true |
| `color:#000;background:rgb(255 0 0) no-repeat` | false | false |
| `color:#000;background:rgb(0 0 0) url(x.png)` | false | false |

This is a real bypass closed — the text genuinely is invisible in a browser — but it is a behavior change in its own right, not merely a re-spelling of an input that was already flagged, and it is pinned by five new exact-verdict cases.

Beyond that widening, the only `false` → `true` changes are spellings a browser renders identically to a case already flagged, and every `true` → `false` change removes a false positive that was deleting visible content.

## Tests / verification

- **Metamorphic invariant** over the full existing hidden-style corpus plus the legitimate-style corpus (`test/html.test.mjs`): for every style `s`, `isHiddenStyle(mutate(s)) === isHiddenStyle(s)` where `mutate` (a) uppercases every ident — units and function names included — and (b) rewrites one ident character as a `\XX ` hex escape, once per eligible offset. Ident spans come from css-tree's **tokenizer**, not a hand-rolled scan, so the mutation stays spec-faithful as the corpus grows. Any un-normalized comparison site, present or future, fails it immediately.
- **Non-vacuity**: the mutators themselves are pinned with exact-equality assertions (a silently no-op mutation would make the property pass for free), and the escape mutation asserts **per style** that it produced at least one mutant — the exact set of un-mutatable entries is pinned (`""` and `"/*x display:none"`, both un-mutatable by construction), so a new corpus entry that silently contributes nothing fails the guard.
- **Proved the tests can fail**: deleting the single `canonicalizeValue(node.value)` call turns 35 assertions red (including both metamorphic properties); deleting only the `url`-as-`Function` arm of the image-layer check leaves exactly the escaped-url metamorphic property red.
- **Negative corpus** extended with 15 legitimate styles that differ from a hiding one only by case, unit or escape (`POSITION: ABSOLUTE; LEFT: -5PX`, `CLIP-PATH: INSET(10%)`, `FILTER: OPACITY(0.6) BLUR(2PX)`, escaped-`url` shorthands, …), all asserting zero findings.
- 33 new exact-verdict cases covering the uppercase-unit family, escaped units, the escaped image-layer false positives, and the shorthand-color widening above.
- `pnpm test`: **2,266 tests, 2,266 pass, 0 fail**, 100% statement/branch/function/line coverage on `src/`. `pnpm lint`, `pnpm check` (both tsconfigs) and `pnpm format` clean.

## Decisions made

- **Escaped-`url()` half: confirmed, with a different mechanism than expected.** The re-serialization gap is real, but css-tree parses an escaped `url` as a plain `Function` node in a multi-token shorthand and degrades to `Raw` when it is the whole value — it is never a `Url` node. Handled both: `Function` named `url` counts as an image layer, and a `Raw` value fails open. Alternative: only handle the `Function` case, which would leave the standalone `background:\75 rl(x.png)` splicing visible text.
- **Kept the space-separated-color widening** rather than preserving the old whitespace split. It closes a spelling bypass of the same-color detector and matches what a browser renders; the cost is that it splices content the previous release kept, which is why it is called out above and pinned. Alternative: restrict `backgroundColor` to single-token colors to hold behavior fixed, which would leave `background:rgb(0 0 0)` as a live bypass.
- **`Identifier.name` is lowercased as well as decoded**, though CSS custom idents are technically case-sensitive. Every consumer in this module already lowercased the text it compared, so this is behavior-preserving and removes the last place a site could forget. Alternative: decode only, which would re-open the per-site `.toLowerCase()` discipline for keyword compares.
- **`hasImageLayer`'s `background-image` branch now requires the single keyword `none`** to prove no layer, where it previously compared serialized text to `"none"`. An unresolvable `var()` therefore counts as a layer (fail open). Alternative: treat an unresolved longhand as no layer, which would splice text over an image painted by a variable.
- **A `Raw` descendant anywhere in the value suppresses the same-color hide.** This is a recall loss on values css-tree cannot parse; precision doctrine prefers it to splicing content whose backdrop we cannot read.
- **The `mutants > 1000` corpus-wide counter was dropped** when the per-style non-vacuity guard landed — the per-style assertion strictly subsumes it, and a global floor is just another number to bump.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/); each subject reads as a user-facing release note.
- [x] `pnpm test`, `pnpm lint`, and `pnpm check` pass locally.
- [x] New or changed detectors have negative tests (zero findings on legitimate input) and pin their invariants with property/fuzz tests.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version are left untouched (the release workflow owns them).
