### PR TITLE
fix(layer1): iterate the ANSI/invisible strip to a fixed point and unify the ANSI grammar

### DIFF
--- a/.github/mutation-shards.json
+++ b/.github/mutation-shards.json
@@ -13,7 +13,7 @@
   "groups": [
     {
       "id": "confusables-layer1",
-      "mutate": "src/confusables.mjs,src/layer1.mjs"
+      "mutate": "src/confusables.mjs,src/layer1.mjs,src/ansi.mjs"
     },
     {
       "id": "index-prompt-gates",

--- a/THREAT-MODEL.md
+++ b/THREAT-MODEL.md
@@ -36,12 +36,23 @@ table](./README.md#entry-points) maps each to its import.
   neighbors clearly belong to the context, and it is disabled once the total
   invisible count crosses a scatter floor—over-stripping beats under-stripping.
 
-**Reassembly hardening.** Stripping an invisible char can reconstitute an ANSI
-escape its split had hidden, and removing one ANSI sequence can reconstitute
-another. Layer 1 strips ANSI to a fixed point and then sweeps any residual raw
-control introducer—7-bit ESC (U+001B) or 8-bit C1 CSI (U+009B)—outright, so the
-result carries no raw ANSI introducer for _any_ input and the operation is
-idempotent. OSC strings (titles, clickable-hyperlink URLs) are consumed as a
+**Reassembly hardening.** The two passes feed each other in _both_ directions:
+stripping an invisible char can reconstitute an ANSI escape its split had
+hidden, removing one ANSI sequence can reconstitute another, and removing an
+ANSI sequence can make two invisibles adjacent that were not—a joiner run the
+invisible pass treats as a payload channel rather than as linguistic. So Layer 1
+does not run a fixed sequence of passes; it iterates the whole
+{ANSI, invisible} composition to a fixed point (bounded, since each round
+deletes at least one character), and only once that is stable does it sweep any
+residual raw control introducer—7-bit ESC (U+001B) or any 8-bit C1 control
+(U+0080–U+009F)—outright. Sweeping earlier would strand a hidden control as
+visible text; a final unconditional sweep after the loop keeps the
+no-raw-introducer guarantee independent of the iteration bound. The result
+carries no raw ANSI introducer for _any_ input, and re-cleaning it reproduces
+it exactly—the idempotence the Edit-repair rehydrator's soundness gate assumes.
+One tokenizer answers every ANSI question (what to splice, and whether the only
+escape content is display-only SGR colour), so the stripper and the operator
+warning cannot disagree about what a sequence is. OSC strings (titles, clickable-hyperlink URLs) are consumed as a
 whole, for every terminator form—ST (`ESC\` or 8-bit C1 ST U+009C) and the
 legacy BEL—and for the 8-bit C1 OSC introducer (U+009D); an _unterminated_ OSC
 introducer is dropped through end-of-string (fail-closed), so no OSC body

--- a/THREAT-MODEL.md
+++ b/THREAT-MODEL.md
@@ -52,7 +52,8 @@ carries no raw ANSI introducer for _any_ input, and re-cleaning it reproduces
 it exactly—the idempotence the Edit-repair rehydrator's soundness gate assumes.
 One tokenizer answers every ANSI question (what to splice, and whether the only
 escape content is display-only SGR colour), so the stripper and the operator
-warning cannot disagree about what a sequence is. OSC strings (titles, clickable-hyperlink URLs) are consumed as a
+warning cannot disagree about what a sequence is. OSC strings (titles,
+clickable-hyperlink URLs) are consumed as a
 whole, for every terminator form—ST (`ESC\` or 8-bit C1 ST U+009C) and the
 legacy BEL—and for the 8-bit C1 OSC introducer (U+009D); an _unterminated_ OSC
 introducer is dropped through end-of-string (fail-closed), so no OSC body

--- a/src/ansi.mjs
+++ b/src/ansi.mjs
@@ -1,0 +1,207 @@
+/**
+ * The ONE ANSI grammar: the raw control-introducer charset and the tokenizer
+ * every consumer scans with.
+ *
+ * Two modules need this grammar and they cannot import each other —
+ * `layer1.mjs` imports `invisible.mjs`, so `invisible.mjs` (which owns the
+ * public `isSgrOnly` / `SGR_RE`) must not import back. Before this module the
+ * grammar was therefore written out twice with DIFFERENT param rules
+ * (`invisible.mjs`'s SGR regex accepted any digit run, `layer1.mjs`'s CSI
+ * branch capped each parameter at four digits), and the introducer charset
+ * three times. The looser copy suppressed the operator warning for a sequence
+ * the stripper could not match: `ESC[12345m` read as "display-only colour"
+ * while `[12345m` was spliced into the model's view as visible text. One
+ * tokenizer, one charset, consumed by both — the disagreement cannot recur.
+ *
+ * Same precedent (and same reason) as `cf-charset.mjs`: a dependency-free leaf
+ * module both layers read from.
+ */
+
+// Raw control introducers that must not survive Layer 1: 7-bit ESC (U+001B) and
+// the entire 8-bit C1 control block (U+0080-U+009F) — which includes CSI
+// (U+009B), the string introducers DCS/SOS/OSC/PM/APC
+// (U+0090/0098/009D/009E/009F), and ST (U+009C). Gating the whole C1 block, not
+// just the introducers the sequence grammar below names, fails closed: a
+// DCS/SOS/PM/APC string the grammar does not consume still loses its introducer
+// and terminator, so no terminal can hide-render its body as a control payload.
+//
+// A SOURCE STRING, not a literal: three call sites need it with different flags
+// (`g` for the Layer-1 sweep, unflagged for the prompt gate, `g` again to drive
+// the scan below), and spelling the class out at each site is how the three
+// copies came to spell the same byte two different ways — which defeats a
+// grep-based drift check as well. Building from `\uXXXX` escapes keeps every
+// raw control byte out of the source (no `no-control-regex` disable needed).
+export const CONTROL_INTRODUCER_SOURCE = "[\\u001b\\u0080-\\u009f]";
+
+// SGR (Select Graphic Rendition): colors, bold, reset. The grammar is closed:
+// params are [0-9;:]* and the final byte is `m`, so a match can only restyle
+// text — never reposition the cursor, erase, or smuggle an OSC string. `:` is
+// included alongside `;` because ITU T.416 colon-separated SGR sub-parameters
+// (truecolor `ESC[38:2:255:0:0m`, as emitted by tmux/kitty/mintty) are pure
+// display-only SGR too. A SGR sequence has TWO encodings: the 7-bit `ESC [ … m`
+// and the 8-bit C1 form where a single U+009B (CSI) replaces `ESC [`; both must
+// be recognized, or a C1-introduced `U+009B 31m … 0m` is pure color yet is
+// misread as a non-SGR payload.
+const SGR_SOURCE = "(?:\\u001b\\[|\\u009b)[0-9;:]*m";
+
+/**
+ * Public alias kept for compatibility (re-exported by `invisible.mjs` and the
+ * package root). It is now DERIVED: {@link scanAnsi} classifies a token as SGR
+ * by testing the token's own text against this exact source, so the predicate
+ * and the regex can no longer describe different languages.
+ */
+export const SGR_RE = new RegExp(SGR_SOURCE, "g");
+
+// The same language, anchored — the SGR/CSI discriminator for a token the
+// scanner has already delimited.
+const SGR_ANCHORED_RE = new RegExp(`^${SGR_SOURCE}$`);
+
+// Private parameter-prefix and intermediate bytes that may follow an
+// introducer before the parameters (`ESC[?25h`, `ESC(B`, `ESC#8`). Also covers
+// the 7-bit `ESC [` CSI introducer's bracket itself.
+const CSI_INTRO_RE = /[[()#;?]/;
+
+// ECMA-48 parameter bytes.
+const CSI_PARAM_RE = /[0-9;:]/;
+
+// ECMA-48 final bytes, minus the ones a terminal never accepts here. Digits are
+// PARAMETER bytes and can never terminate a sequence — an unterminated `ESC[`
+// must not eat trailing visible digits (`ESC[2024 report` is NOT `ESC[` +
+// final-byte `2`; it is an incomplete intro whose ESC the residual sweep
+// removes, leaving "2024 report" intact). `<=>?` (0x3C-0x3F) are private
+// PARAMETER-prefix bytes per ECMA-48 § 5.4, not finals — including them let a
+// private-marker sequence terminate one byte too early. `~` (0x7E) IS a real
+// final byte (vt220 function keys, `ESC[3~` for Delete) and is kept.
+const CSI_FINAL_RE = /[A-PR-TZcf-nqrty~]/;
+
+const ESC = 0x1b;
+const CSI_C1 = 0x9b;
+const ST_C1 = 0x9c;
+const OSC_C1 = 0x9d;
+const BEL = 0x07;
+
+/** The four things an introducer can turn out to be. */
+export const TOKEN_KIND = Object.freeze({
+  /** A display-only `ESC[…m` / `U+009B…m` colour sequence. */
+  SGR: "sgr",
+  /** Any other complete CSI / two-byte escape (cursor move, erase, charset). */
+  CSI: "csi",
+  /** An OSC string: introducer, body and terminator as one unit. */
+  OSC: "osc",
+  /** An introducer that starts no sequence the grammar recognizes. */
+  ORPHAN: "orphan-introducer",
+});
+
+/**
+ * @typedef {object} AnsiToken
+ * @property {number} start Index of the introducer.
+ * @property {number} end Index one past the last character of the token.
+ * @property {string} kind One of {@link TOKEN_KIND}.
+ */
+
+/**
+ * End index of the OSC string starting at `start`, or -1 if no OSC introducer
+ * is there.
+ *
+ * An OSC (Operating System Command) string is `<introducer> body <terminator>`:
+ * a title, a clickable-hyperlink URL, a clipboard write — i.e. attacker-
+ * controlled PAYLOAD TEXT. Consuming the introducer alone would leave that
+ * payload in the model's view, so the whole string is one token. Three ways it
+ * can end:
+ *   1. a real terminator — ST (`ESC\` or the 8-bit C1 ST U+009C) or the legacy
+ *      BEL — which is consumed with the body.
+ *   2. an ABORT: per ECMA-48/xterm a bare ESC (one not forming ST) drops the
+ *      terminal out of the OSC string, and a nested C1 OSC introducer likewise
+ *      starts something new. The token ends BEFORE that byte so the scan
+ *      re-reads it as its own sequence — without this, an interior ESC deleted
+ *      the rest of the document via case 3.
+ *   3. end of input, for a genuinely unterminated string: fail closed and drop
+ *      everything from the introducer on, so no OSC body survives.
+ * @param {string} text
+ * @param {number} start
+ * @returns {number}
+ */
+function scanOsc(text, start) {
+  const code = text.charCodeAt(start);
+  let i = -1;
+  if (code === OSC_C1) i = start + 1;
+  if (code === ESC && text[start + 1] === "]") i = start + 2;
+  if (i < 0) return -1;
+  for (; i < text.length; i++) {
+    const byte = text.charCodeAt(i);
+    if (byte === BEL || byte === ST_C1) return i + 1;
+    if (byte === ESC) return text[i + 1] === "\\" ? i + 2 : i;
+    if (byte === OSC_C1) return i;
+  }
+  return text.length;
+}
+
+/**
+ * End index of the CSI / two-byte escape sequence starting at `start`, or -1
+ * when the introducer completes no sequence.
+ *
+ * Single-pass and greedy: intro bytes, then parameter bytes, then exactly one
+ * final byte. The previous regex form had to BOUND the intro run ({0,12})
+ * because `;` lives in both the intro and parameter classes, so an unbounded
+ * run let a `;#;#…` string be split between the two quantifiers — quadratic
+ * backtracking (CodeQL js/polynomial-redos). A hand-written scanner never
+ * backtracks, so the bound is gone and the scan is linear by construction.
+ * @param {string} text
+ * @param {number} start
+ * @returns {number}
+ */
+function scanCsi(text, start) {
+  const code = text.charCodeAt(start);
+  if (code !== ESC && code !== CSI_C1) return -1;
+  let i = start + 1;
+  while (i < text.length && CSI_INTRO_RE.test(text[i])) i++;
+  while (i < text.length && CSI_PARAM_RE.test(text[i])) i++;
+  if (i < text.length && CSI_FINAL_RE.test(text[i])) return i + 1;
+  return -1;
+}
+
+// Drives the scan: jumping introducer-to-introducer keeps the common case (text
+// with no escapes at all) a single native regex scan rather than a per-character
+// JS loop.
+const INTRODUCER_SCAN_RE = new RegExp(CONTROL_INTRODUCER_SOURCE, "g");
+
+/**
+ * Tokenize every raw control introducer in `text`.
+ *
+ * Every introducer yields exactly one token — an ORPHAN when it starts nothing
+ * the grammar recognizes — so "which introducers are in this text" and "which
+ * sequences are in this text" are answered by the same scan. That is what lets
+ * the stripper (splice every non-orphan token, then sweep) and the SGR-only
+ * predicate (every token is SGR) agree by construction.
+ *
+ * Tokens are disjoint and ordered by `start`; each `end` is strictly greater
+ * than its `start`, so the scan always advances.
+ * @param {string} text
+ * @returns {AnsiToken[]}
+ */
+export function scanAnsi(text) {
+  /** @type {AnsiToken[]} */
+  const tokens = [];
+  INTRODUCER_SCAN_RE.lastIndex = 0;
+  let match;
+  while ((match = INTRODUCER_SCAN_RE.exec(text)) !== null) {
+    const start = match.index;
+    const oscEnd = scanOsc(text, start);
+    const csiEnd = oscEnd < 0 ? scanCsi(text, start) : -1;
+    let end = start + 1;
+    /** @type {string} */
+    let kind = TOKEN_KIND.ORPHAN;
+    if (oscEnd >= 0) {
+      end = oscEnd;
+      kind = TOKEN_KIND.OSC;
+    } else if (csiEnd >= 0) {
+      end = csiEnd;
+      kind = SGR_ANCHORED_RE.test(text.slice(start, csiEnd))
+        ? TOKEN_KIND.SGR
+        : TOKEN_KIND.CSI;
+    }
+    tokens.push({ start, end, kind });
+    INTRODUCER_SCAN_RE.lastIndex = end;
+  }
+  return tokens;
+}

--- a/src/invisible.mjs
+++ b/src/invisible.mjs
@@ -12,6 +12,7 @@
 import { joiningType, isVirama } from "./joining-type.mjs";
 import { isStandardizedVariant } from "./standardized-variants.mjs";
 import { CF_CODEPOINTS } from "./cf-charset.mjs";
+import { scanAnsi, TOKEN_KIND } from "./ansi.mjs";
 
 // Unicode's Variation_Selector property, whole: the FE00 run, the Mongolian
 // free variation selectors, and the astral E0100 supplement. The Mongolian four
@@ -122,48 +123,32 @@ export const STRIP = new RegExp(
   REGEX_FLAGS,
 );
 
-// SGR (Select Graphic Rendition): colors, bold, reset. The grammar is closed:
-// params are [0-9;:]* and the final byte is `m`, so a match can only restyle
-// text, never reposition the cursor, erase, or smuggle an OSC string. `:` is
-// included alongside `;` because ITU T.416 colon-separated SGR sub-parameters
-// (truecolor `ESC[38:2:255:0:0m`, as emitted by tmux/kitty/mintty) are pure
-// display-only SGR too — excluding them left a benign colon-form sequence
-// misread as non-SGR. A SGR sequence has TWO encodings: the 7-bit `ESC [ … m`
-// and the 8-bit C1 form where a single U+009B (CSI) replaces `ESC [` — spelled
-// here as the `\x9b` escape (never a raw literal byte in source: an
-// undetectable-by-eye invisible byte in a regex literal is a correctness
-// landmine for the next person who touches this line without a hex dump).
-// Both encodings must be recognized — otherwise a C1-introduced
-// `U+009B 31m … 0m` is pure color yet is misread as a non-SGR payload (or,
-// worse, mistaken for SGR-only when its introducer was a C1 CSI that
-// isSgrOnly's ESC-only test never saw). Text is "SGR-only" when removing
-// these leaves no ANSI control introducer at all — a lone or partial escape is
-// therefore not SGR-only.
-// eslint-disable-next-line no-control-regex -- matching ESC-led sequences is the point
-export const SGR_RE = /(?:\x1b\[|\x9b)[0-9;:]*m/g;
-
-// The raw ANSI control introducers isSgrOnly must treat as NON-SGR after SGR
-// removal: 7-bit ESC (U+001B) and the entire 8-bit C1 control block
-// (U+0080–U+009F) — CSI (U+009B), the DCS/SOS/OSC/PM/APC string introducers, and
-// ST. isSgrOnly is honest only if it tests for ALL of them — a C1 cursor-move or
-// erase (`U+009B 2J`) leaves a U+009B, a C1-OSC string (`U+009D … BEL`) leaves a
-// U+009D, and a C1-DCS/APC payload (`U+0090 … ST`) leaves its introducer, after
-// SGR removal; each must read as NOT SGR-only, exactly as their 7-bit `ESC[2J` /
-// `ESC]…` / `ESC P…` twins do. Omitting any would let a residual C1 introducer
-// be misread as SGR-only.
-// eslint-disable-next-line no-control-regex -- the raw introducers are what we test for
-const CONTROL_INTRODUCER_RE = /[\x1b\u0080-\u009f]/;
+// SGR (Select Graphic Rendition) colour matching. Re-exported from ./ansi.mjs —
+// the ONE ANSI grammar, shared with the Layer-1 stripper, which cannot import
+// this module (layer1.mjs imports invisible.mjs, not the other way round). The
+// two used to be separate regexes with DIFFERENT parameter rules, and the looser
+// copy lived here: `ESC[12345m` read as SGR-only (so the operator got a
+// "display-only colour" note) while the stripper could not match it and spliced
+// a visible `[12345m` into the model's view.
+export { SGR_RE } from "./ansi.mjs";
 
 /**
  * True when every ANSI control introducer in `text` belongs to a display-only
- * SGR color sequence (so stripping the ANSI removed only cosmetic styling,
+ * SGR color sequence (so stripping the ANSI removes only cosmetic styling,
  * nothing that could move the cursor, erase, or carry a payload). Recognizes
  * both the 7-bit `ESC[…m` and 8-bit C1 (`U+009B…m`) SGR encodings.
+ *
+ * Answered by the STRIPPER'S OWN tokenizer: scanAnsi emits one token per raw
+ * introducer — 7-bit ESC and the whole C1 block, so a C1 cursor-move
+ * (`U+009B 2J`), a C1-OSC string (`U+009D … BEL`), a C1-DCS/APC payload and a
+ * lone or partial escape each yield a non-SGR token — and the predicate is
+ * "every token is SGR". Because the same scan decides what Layer 1 splices,
+ * this can no longer report "colour only" for bytes the stripper leaves behind.
  * @param {string} text
  * @returns {boolean}
  */
 export function isSgrOnly(text) {
-  return !CONTROL_INTRODUCER_RE.test(text.replace(SGR_RE, ""));
+  return scanAnsi(text).every((token) => token.kind === TOKEN_KIND.SGR);
 }
 
 export const LONG_RUN_THRESHOLD = 10;

--- a/src/layer1.mjs
+++ b/src/layer1.mjs
@@ -17,9 +17,7 @@ import { CONTROL_INTRODUCER_SOURCE, scanAnsi, TOKEN_KIND } from "./ansi.mjs";
 
 // The ANSI grammar and the introducer charset live in ./ansi.mjs so this module
 // and invisible.mjs (which owns the public isSgrOnly / SGR_RE and cannot import
-// this one) scan with the SAME tokenizer. Re-exported here because layer1 is the
-// ANSI entry point every other consumer already imports.
-export { scanAnsi, TOKEN_KIND } from "./ansi.mjs";
+// this one) scan with the SAME tokenizer.
 
 // The residual sweep: every raw control introducer, whatever the grammar made of
 // it. This — not the sequence matching — is the guarantee that no introducer

--- a/src/layer1.mjs
+++ b/src/layer1.mjs
@@ -13,98 +13,18 @@
  * point where a lone surrogate would otherwise corrupt a match or a parse.
  */
 import { stripInvisibleWithReport, CATEGORY } from "./invisible.mjs";
+import { CONTROL_INTRODUCER_SOURCE, scanAnsi, TOKEN_KIND } from "./ansi.mjs";
 
-// Raw control introducers that must not survive: 7-bit ESC (U+001B) and the
-// entire 8-bit C1 control block (U+0080–U+009F) — which includes CSI (U+009B),
-// the string introducers DCS/SOS/OSC/PM/APC (U+0090/0098/009D/009E/009F), and ST
-// (U+009C). All are category Cc, so the invisible-char pass (which targets Cf /
-// variation / blank fillers) never removes them; this residual sweep is the
-// guarantee that none survives. Sweeping the whole C1 block — not just the
-// introducers the ANSI grammar above names — fails closed: a DCS/SOS/PM/APC
-// string the grammar does not consume still loses its introducer and terminator
-// here, so no terminal can hide-render its body as a control payload.
-// eslint-disable-next-line no-control-regex -- matching the raw introducers is the point
-const CONTROL_INTRODUCER_RE = /[\u001b\u0080-\u009f]/g;
+// The ANSI grammar and the introducer charset live in ./ansi.mjs so this module
+// and invisible.mjs (which owns the public isSgrOnly / SGR_RE and cannot import
+// this one) scan with the SAME tokenizer. Re-exported here because layer1 is the
+// ANSI entry point every other consumer already imports.
+export { scanAnsi, TOKEN_KIND } from "./ansi.mjs";
 
-// An OSC (Operating System Command) string is `<introducer> … <terminator>`.
-// Introducer: 7-bit `ESC]` or 8-bit C1 OSC (U+009D). Terminator: ST (`ESC\` or
-// 8-bit C1 ST U+009C) OR the legacy BEL (U+0007). The body is everything up to
-// the terminator — a title, a clickable-hyperlink URL, a clipboard write — i.e.
-// attacker-controlled PAYLOAD TEXT. Matching the introducer alone (leaving the
-// body) would let that payload survive into the model's view, so the OSC branch
-// consumes the introducer, the whole body, AND the terminator as one unit.
-//
-// Three alternatives, tried in order:
-//   1. a properly TERMINATED string — a body of bytes that no terminator can
-//      start with (the negated class makes that run unambiguous and
-//      backtrack-free), then a terminator (ST or BEL).
-//   2. an ABORTED string — the body runs up to (but does NOT consume) an
-//      interior bare ESC or a nested C1-OSC introducer (U+009D) that is not
-//      itself part of a valid terminator. Per ECMA-48/xterm, a bare ESC (one
-//      not immediately followed by `\` to form ST) aborts the OSC string in
-//      progress — the terminal drops back to processing that ESC as the start
-//      of a NEW sequence, and everything after it is normal text/escapes, not
-//      part of this OSC's payload. Consuming only up to the lookahead (not
-//      the ESC/U+009D itself) leaves it for the next position in this same
-//      `.replace(ANSI_RE, ...)` scan to match as its own sequence (or, if it
-//      doesn't complete one, for the residual C1 sweep in applyLayer1 to
-//      remove just that one introducer byte) — so an interior ESC can no
-//      longer delete the rest of the document (it used to fall through to
-//      alternative 3 below and consume everything to EOS).
-//   3. anything else from the introducer to END-OF-STRING (`[\s\S]*$`) — the
-//      fail-closed catch-all for a GENUINELY unterminated string: no ST, BEL,
-//      interior ESC, or nested OSC intro anywhere in the remainder, so there
-//      is truly nothing left to hand to a later position. Reached only when
-//      alternatives 1 and 2 both fail to find their respective triggers.
-// All three are linear (bounded lookahead / no nested quantifiers), so the
-// branch stays linear.
-const OSC_INTRO = "(?:\\u001b\\]|\\u009d)";
-const OSC_TERM = "(?:\\u001b\\\\|\\u009c|\\u0007)";
-const OSC_BODY = "[^\\u0007\\u001b\\u009c\\u009d]";
-const OSC_BRANCH = `${OSC_INTRO}(?:${OSC_BODY}*${OSC_TERM}|${OSC_BODY}*(?=[\\u001b\\u009d])|${OSC_BODY}*$)`;
-
-// CSI / two-byte ESC sequences (cursor moves, erase, SGR color, charset/DEC
-// selectors): an introducer, a bounded private-intro run, optional numeric
-// params, and a single final byte. Not an enforcement boundary on its own — any
-// introducer this declines to match is still removed by the residual sweep in
-// applyLayer1 — but matching the whole sequence keeps the common case one clean
-// deletion (and avoids a lone-ESC residual on every styled line).
-//
-// The private-intro class is BOUNDED ({0,12}, not *) on purpose: ; and # live
-// in both this class and the parameter group that follows, so an unbounded *
-// here lets a ;#;#... run be split between the two quantifiers — O(n^2)
-// backtracking on an ESC;#;#... string that never completes a sequence
-// (CodeQL js/polynomial-redos). A constant bound makes the intro a constant
-// factor, so the whole match is linear; a real sequence never carries more than
-// a couple of intro bytes.
-//
-// Params allow BOTH `;` (standard parameter separator) and `:` (ITU T.416
-// colon-separated SGR sub-parameters, e.g. truecolor `ESC[38:2:255:0:0m` as
-// emitted by tmux/kitty/mintty) — legitimate, display-only ANSI that must not
-// leave a colon-parameter residue behind.
-//
-// The final-byte class deliberately excludes `\d`: per ECMA-48, CSI final
-// bytes occupy 0x40–0x7E (letters and a handful of punctuation) while digits
-// are PARAMETER bytes and can never terminate a sequence — an unterminated
-// `ESC[` therefore must not be allowed to eat trailing visible digits (e.g.
-// `ESC[2024 report` is NOT `ESC[` + final-byte `2` + literal `024 report`; it
-// is an incomplete CSI intro that the residual sweep in applyLayer1 cleans up,
-// leaving "2024 report" intact). `=`, `<`, `>` are excluded for the same
-// reason: 0x3C–0x3F (`<=>?`) are private PARAMETER-prefix bytes, not final
-// bytes, per ECMA-48 § 5.4 — `?` already lives in the private-intro class
-// above; `<=>` were never valid finals and including them let a private-marker
-// sequence terminate one byte too early. `~` (0x7E) IS a real final byte (vt220
-// function-key sequences, e.g. `ESC[3~` for Delete) and is kept.
-const CSI_BRANCH =
-  "[\\u001b\\u009b][[()#;?]{0,12}(?:(?:\\d{1,4}(?:[;:]\\d{0,4})*)?[A-PR-TZcf-ntqry~])";
-
-// Full ANSI escape grammar (OSC first so `ESC]` / C1-OSC is consumed as a whole
-// string, not split by the CSI branch), not just SGR: the Layer-1 guarantee is
-// that no control introducer and no OSC payload survives, and a cursor-move or
-// erase sequence is as much a display-spoofing hazard as a color one. Built from
-// `\uXXXX`-escaped string parts via `new RegExp`, so no raw control byte sits in
-// the source (no no-control-regex disable needed).
-const ANSI_RE = new RegExp(`(?:${OSC_BRANCH}|${CSI_BRANCH})`, "gu");
+// The residual sweep: every raw control introducer, whatever the grammar made of
+// it. This — not the sequence matching — is the guarantee that no introducer
+// survives Layer 1.
+const CONTROL_INTRODUCER_RE = new RegExp(CONTROL_INTRODUCER_SOURCE, "g");
 
 // Unpaired UTF-16 surrogates (high not followed by low, or low not preceded by
 // high). Normalized before any HTML parser, which throws on a stray byte —
@@ -113,6 +33,29 @@ export const LONE_SURROGATE_RE =
   /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
 
 const MAX_ANSI_PASSES = 3;
+
+/**
+ * Splice out every complete ANSI sequence {@link scanAnsi} finds — SGR, other
+ * CSI/two-byte escapes, and whole OSC strings. An ORPHAN introducer (one that
+ * starts no sequence) is deliberately LEFT: deleting it here would drop the
+ * `ESC` out of `ESC`<ZWSP>`[32m` before the invisible pass could reconstitute
+ * the sequence, turning a hidden control into visible `[32m` in the model's
+ * view. Orphans are removed by applyLayer1's residual sweep, once no
+ * reconstitution is possible.
+ * @param {string} text
+ * @returns {string}
+ */
+function stripAnsiOnce(text) {
+  let out = "";
+  let last = 0;
+  for (const token of scanAnsi(text)) {
+    if (token.kind === TOKEN_KIND.ORPHAN) continue;
+    out += text.slice(last, token.start);
+    last = token.end;
+  }
+  if (last === 0) return text;
+  return out + text.slice(last);
+}
 
 /**
  * Strip ANSI escape sequences to a fixed point. Removing one sequence can
@@ -131,54 +74,98 @@ const MAX_ANSI_PASSES = 3;
  */
 export function stripAnsiFully(input) {
   let prev = input;
-  let out = prev.replace(ANSI_RE, "");
+  let out = stripAnsiOnce(prev);
   for (let pass = 1; pass < MAX_ANSI_PASSES && out !== prev; pass++) {
     prev = out;
-    out = prev.replace(ANSI_RE, "");
+    out = stripAnsiOnce(prev);
   }
   return out;
 }
+
+// How many times the {ANSI strip, invisible strip} composition may re-run before
+// the sweep is forced. Each iteration deletes at least one character, so the
+// loop terminates on its own; the bound is a DoS guard on the same quadratic
+// argument as MAX_ANSI_PASSES (n rounds of O(n) scans on adversarial input).
+// Three rounds is what the deepest REAL reconstitution needs — strip
+// invisibles, remove the ANSI they hid, strip the joiners that ANSI removal
+// made adjacent, confirm — so four leaves a round of margin. Deeper nesting is
+// not reachable through the carve-out: preserving a joiner requires cursive or
+// emoji neighbours on BOTH sides, so a preserved joiner can never sit inside an
+// escape sequence, and every joiner that hides one is therefore stripped by the
+// FIRST invisible pass. Past the bound the composition simply stops early — the
+// final sweep still holds the no-introducer guarantee, and what is left degrades
+// to visible text (the fail-open direction), exactly as with MAX_ANSI_PASSES.
+const MAX_LAYER1_PASSES = 4;
 
 /**
  * Layer 1: ANSI + invisible-char strip with a result guaranteed free of every
  * raw ANSI control introducer (7-bit ESC U+001B and the whole 8-bit C1 control
  * block U+0080–U+009F: CSI, the DCS/SOS/OSC/PM/APC string introducers, and ST).
  *
- * Removing an invisible character can reconstitute an escape its split hid from
- * the ANSI pass (`ESC`<ZWSP>`[32m` → `ESC[32m`), so strip ANSI again after the
- * invisible pass — but only when stripInvisible changed something, since
- * reconstitution is impossible otherwise and the re-strip is a wasted pass on
- * the hot clean path. The ANSI strip still cannot match an *incomplete*
- * reconstituted sequence (a lone `ESC[` left when an inner complete sequence is
- * removed from a nested split), so a final sweep removes every residual raw
- * introducer outright — that sweep, not the regex matching, is the guarantee
- * that no control introducer survives. `deAnsi` is the ANSI strip of the
- * original (invisible runs intact), the scope a LONG_RUN payload check needs.
+ * The two passes FEED each other in both directions, so neither ordering is
+ * enough on its own and the composition is iterated to a fixed point instead:
+ * removing an invisible char reconstitutes an escape its split hid
+ * (`ESC`<ZWSP>`[32m` → `ESC[32m`), and removing an escape makes two invisibles
+ * ADJACENT that were not (`م ZWJ ESC[m ZWJ م` → a joiner run the invisible pass
+ * classifies as a payload channel rather than linguistic). A pipeline with a
+ * fixed number of alternations always leaves one of those unanswered — this used
+ * to re-strip ANSI after the invisible pass and stop, so `applyLayer1` was not
+ * idempotent and the rehydrator's "re-cleaning reproduces the view" assumption
+ * did not hold.
+ *
+ * The residual sweep runs only once the composition is STABLE, because sweeping
+ * an introducer early destroys the sequence a later ANSI pass would have removed
+ * whole, promoting a hidden control to visible text. A final UNCONDITIONAL sweep
+ * follows the loop so the no-raw-introducer guarantee does not depend on the
+ * pass bound.
+ *
+ * `deAnsi` is the ANSI strip of the ORIGINAL text (invisible runs intact), the
+ * scope a LONG_RUN payload check needs — not an intermediate of the loop.
  * @param {string} text
  * @returns {{ cleaned: string, deAnsi: string, found: string[] }}
  */
 export function applyLayer1(text) {
   const deAnsi = stripAnsiFully(text);
-  // stripInvisibleWithReport returns `found` for exactly the categories it
-  // removed — so a ZWNJ/ZWJ the carve-out PRESERVES never registers as a strip,
-  // and the leading-BOM exception is already handled inside it. Pass the ORIGINAL
-  // `text` so a BOM that was interior before the ANSI strip (`ESC[m + interior U+FEFF`, now at
-  // index 0 of `deAnsi`) is treated as interior and stripped, not preserved.
-  const { cleaned: afterInvis, found } = stripInvisibleWithReport(deAnsi, text);
-  let ansiFound = deAnsi.length !== text.length;
+  /** @type {Set<string>} Union of the categories every iteration reported. */
+  const found = new Set();
+  let cleaned = text;
+  let ansiFound = false;
 
-  let cleaned = afterInvis;
-  if (afterInvis !== deAnsi) {
-    const reStripped = stripAnsiFully(afterInvis);
-    if (reStripped.length !== afterInvis.length) ansiFound = true;
-    cleaned = reStripped;
+  for (let pass = 0; pass < MAX_LAYER1_PASSES; pass++) {
+    const afterAnsi = pass === 0 ? deAnsi : stripAnsiFully(cleaned);
+    if (afterAnsi !== cleaned) ansiFound = true;
+    // stripInvisibleWithReport returns `found` for exactly the categories it
+    // removed — so a ZWNJ/ZWJ the carve-out PRESERVES never registers as a
+    // strip. The second argument stays the ORIGINAL `text` on every iteration:
+    // the leading-BOM exception is defined against what the user actually sent,
+    // so a BOM that was interior before an ANSI strip shifted it to index 0 is
+    // treated as interior and stripped, not preserved.
+    const { cleaned: afterInvis, found: passFound } = stripInvisibleWithReport(
+      afterAnsi,
+      text,
+    );
+    for (const category of passFound) found.add(category);
+    if (afterInvis !== cleaned) {
+      cleaned = afterInvis;
+      continue;
+    }
+    // {ANSI, invisible} is stable: nothing left can reconstitute, so the
+    // residual introducers can be swept without hiding a sequence from a later
+    // pass. A sweep that changes the text feeds one more round (removing an
+    // introducer can make invisibles adjacent, exactly as removing a sequence
+    // can); one that changes nothing means the whole composition has converged.
+    const swept = cleaned.replace(CONTROL_INTRODUCER_RE, "");
+    if (swept === cleaned) break;
+    cleaned = swept;
+    ansiFound = true;
   }
+
   const swept = cleaned.replace(CONTROL_INTRODUCER_RE, "");
   if (swept !== cleaned) {
     cleaned = swept;
     ansiFound = true;
   }
 
-  if (ansiFound) found.push(CATEGORY.ANSI);
-  return { cleaned, deAnsi, found };
+  if (ansiFound) found.add(CATEGORY.ANSI);
+  return { cleaned, deAnsi, found: [...found] };
 }

--- a/src/prompt.mjs
+++ b/src/prompt.mjs
@@ -27,6 +27,7 @@ import {
   isSgrOnly,
 } from "./invisible.mjs";
 import { stripAnsiFully } from "./layer1.mjs";
+import { CONTROL_INTRODUCER_SOURCE } from "./ansi.mjs";
 
 // Every raw ANSI control a prompt can carry: 7-bit ESC (U+001B) and the entire
 // 8-bit C1 block (U+0080-U+009F). Gating on ESC alone -- or on only CSI/OSC --
@@ -34,12 +35,14 @@ import { stripAnsiFully } from "./layer1.mjs";
 // (CSI erase), `U+009D 0;...BEL` (OSC), or the string introducers DCS (U+0090),
 // SOS (U+0098), PM (U+009E), APC (U+009F): Layer 1 strips it, dropping the
 // invisible count to zero, so the prompt reads clean and passes. This gate must
-// match Layer 1's residual sweep (CONTROL_INTRODUCER_RE) exactly -- no raw C1
-// control belongs in a legitimate prompt (the SGR color carve-out is applied
-// separately, after SGR removal), so the whole block is gated, not a hand-picked
-// subset that lets DCS/SOS/PM/APC through.
-// eslint-disable-next-line no-control-regex -- the raw control introducers are exactly what we detect
-const ANSI_INTRODUCER = /[\u001b\u0080-\u009f]/;
+// match Layer 1's residual sweep exactly -- no raw C1 control belongs in a
+// legitimate prompt (the SGR color carve-out is applied separately, after SGR
+// removal), so the whole block is gated, not a hand-picked subset that lets
+// DCS/SOS/PM/APC through. Built from the SHARED charset source instead of a
+// third hand-written copy: keeping the copies in step used to be a prose
+// obligation recorded in this very comment, and two of the three spelled ESC
+// differently, so even a grep-based drift check would have missed a divergence.
+const ANSI_INTRODUCER = new RegExp(CONTROL_INTRODUCER_SOURCE);
 
 /**
  * True when every ANSI introducer in `prompt` belongs to a display-only SGR

--- a/test/layer1-ansi.test.mjs
+++ b/test/layer1-ansi.test.mjs
@@ -1,0 +1,332 @@
+/**
+ * Layer 1's ANSI/fixed-point invariants: the three properties that were
+ * assertable in principle but false in practice.
+ *
+ *   1. IDEMPOTENCE of the ANSI<->invisible COMPOSITION, not just of the ANSI
+ *      pass. rehydrate.mjs's soundness gate re-cleans text and compares it to
+ *      the view the model was shown, so a second `applyLayer1` returning
+ *      something different is a correctness bug there, not a cosmetic one.
+ *   2. CONTAINMENT: when `isSgrOnly` tells the operator "display-only colour"
+ *      (and the strip touched nothing but ANSI), what Layer 1 actually removed
+ *      must be exactly the SGR sequences — no visible residue spliced in.
+ *   3. The introducer charset is ONE charset: whatever Layer 1 removes as a raw
+ *      control introducer must read as non-SGR to `isSgrOnly`.
+ *
+ * The generators are BIASED toward the shapes that break these (cursive letter,
+ * joiner, ANSI fragment) rather than drawing uniformly over 1.1M code points —
+ * a uniform draw reaches an ESC essentially never, which is why the
+ * pre-existing idempotence property in invisible.test.mjs stayed green over a
+ * non-idempotent implementation.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fc from "fast-check";
+
+import {
+  applyLayer1,
+  stripAnsiFully,
+  scanAnsi,
+  TOKEN_KIND,
+} from "../src/layer1.mjs";
+import {
+  isSgrOnly,
+  SGR_RE,
+  CATEGORY,
+  stripInvisible,
+} from "../src/invisible.mjs";
+import { fcRunOptions, cp } from "./test-helpers.mjs";
+
+const ESC = cp(0x1b);
+const CSI = cp(0x9b);
+const OSC = cp(0x9d);
+const ST = cp(0x9c);
+const BEL = cp(0x07);
+const ZWJ = cp(0x200d);
+const ZWNJ = cp(0x200c);
+const ZWSP = cp(0x200b);
+const ARABIC_MEEM = cp(0x645);
+
+const hex = (s) => [...s].map((c) => c.codePointAt(0).toString(16)).join(" ");
+
+// ─── Generators ──────────────────────────────────────────────────────────────
+
+// Fragments of the ANSI grammar, drawn as PIECES rather than whole sequences so
+// the generator builds torn, reassemblable escapes (`ESC` + invisible + `[0m`)
+// as often as intact ones.
+const ansiFragment = fc.constantFrom(
+  ESC,
+  CSI,
+  OSC,
+  ST,
+  BEL,
+  cp(0x90),
+  cp(0x9f),
+  "[",
+  "]",
+  "(",
+  "?",
+  ";",
+  ":",
+  "m",
+  "0",
+  "31",
+  "12345",
+  "J",
+  "\\",
+);
+
+const invisibleChar = fc.constantFrom(ZWSP, ZWJ, ZWNJ, cp(0xfeff), cp(0xfe0f));
+const visibleChar = fc.constantFrom("a", "x", " ", ARABIC_MEEM, cp(0x1f600));
+
+// The shape that actually breaks idempotence: a cursive letter and a joiner (so
+// the linguistic carve-out PRESERVES the joiner on the first pass) flanking an
+// ANSI fragment, so removing the fragment can make two preserved joiners
+// adjacent — a run the invisible pass then treats as a payload channel.
+const reconstitutionUnit = fc
+  .tuple(
+    fc.constantFrom(ARABIC_MEEM, cp(0x628), cp(0x1f469)),
+    fc.constantFrom(ZWJ, ZWNJ, ""),
+    fc.constantFrom(ZWSP, ""),
+    ansiFragment,
+    fc.constantFrom(ZWJ, ZWNJ, ""),
+    fc.constantFrom(ARABIC_MEEM, cp(0x62c), cp(0x1f466)),
+  )
+  .map((parts) => parts.join(""));
+
+const reconstitutionText = fc
+  .array(reconstitutionUnit, { minLength: 1, maxLength: 6 })
+  .map((units) => units.join(""));
+
+const ansiText = fc
+  .array(fc.oneof(ansiFragment, invisibleChar, visibleChar), { maxLength: 40 })
+  .map((parts) => parts.join(""));
+
+// Text whose ONLY escape content is display-only colour, in both encodings and
+// with both parameter separators — the domain the "SGR-only" carve-out is
+// supposed to cover, including the long parameter runs the stripper's old
+// four-digit cap could not match.
+const sgrSequence = fc
+  .tuple(fc.constantFrom(ESC + "[", CSI), fc.stringMatching(/^[0-9;:]*$/))
+  .map(([intro, params]) => `${intro}${params}m`);
+
+const sgrOnlyText = fc
+  .array(fc.oneof(sgrSequence, visibleChar), { maxLength: 20 })
+  .map((parts) => parts.join(""));
+
+// The same, with invisible chars BETWEEN the sequences (never inside one, which
+// would tear it into a non-SGR fragment): the carve-out's real input is pasted
+// terminal output, which carries both.
+const sgrWithInvisibleText = fc
+  .array(fc.oneof(sgrSequence, visibleChar, invisibleChar), { maxLength: 20 })
+  .map((parts) => parts.join(""));
+
+// ─── scanAnsi: one token per raw introducer ──────────────────────────────────
+
+describe("scanAnsi", () => {
+  const kinds = (text) => scanAnsi(text).map((token) => token.kind);
+
+  it("classifies each sequence form", () => {
+    assert.deepEqual(kinds(`${ESC}[31mred${ESC}[0m`), ["sgr", "sgr"]);
+    assert.deepEqual(kinds(`${CSI}31m`), ["sgr"]);
+    assert.deepEqual(kinds(`${ESC}[2J`), ["csi"]);
+    assert.deepEqual(kinds(`${ESC}(B`), ["csi"]);
+    assert.deepEqual(kinds(`${ESC}]0;title${BEL}`), ["osc"]);
+    assert.deepEqual(kinds(`${OSC}0;title${ST}`), ["osc"]);
+    assert.deepEqual(kinds(`${ESC}]0;title${ESC}\\`), ["osc"]);
+    assert.deepEqual(kinds(`${ESC}]unterminated`), ["osc"]);
+    assert.deepEqual(kinds(`${OSC}nested${OSC}x`), ["osc", "osc"]);
+    // Introducers that complete nothing: a lone ESC, a truncated CSI, and the
+    // C1 string introducers the sequence grammar never names.
+    assert.deepEqual(kinds(ESC), ["orphan-introducer"]);
+    assert.deepEqual(kinds(`${ESC}[12`), ["orphan-introducer"]);
+    assert.deepEqual(kinds(cp(0x90) + cp(0x9e)), [
+      "orphan-introducer",
+      "orphan-introducer",
+    ]);
+  });
+
+  it("ends an OSC string before an interior ESC so the text after it survives", () => {
+    // The abort arm: the interior ESC starts a NEW sequence rather than being
+    // swallowed as OSC body — otherwise one ESC deletes the document tail.
+    const input = `${ESC}]title${ESC}[0mafter`;
+    const tokens = scanAnsi(input);
+    assert.deepEqual(
+      tokens.map((token) => token.kind),
+      [TOKEN_KIND.OSC, TOKEN_KIND.SGR],
+    );
+    assert.equal(tokens[0].end, tokens[1].start);
+    assert.equal(stripAnsiFully(input), "after");
+  });
+
+  it("reports disjoint, ordered, non-empty spans", () => {
+    fc.assert(
+      fc.property(ansiText, (text) => {
+        let previousEnd = 0;
+        for (const token of scanAnsi(text)) {
+          assert.ok(
+            token.start >= previousEnd,
+            "tokens overlap or are unordered",
+          );
+          assert.ok(token.end > token.start, "token span is empty");
+          assert.ok(token.end <= text.length, "token span runs past the input");
+          previousEnd = token.end;
+        }
+      }),
+      fcRunOptions(),
+    );
+  });
+});
+
+// ─── Defect 1: idempotence of the ANSI<->invisible composition ───────────────
+
+describe("applyLayer1 idempotence", () => {
+  it("re-cleans the reconstitution shape to itself (regression)", () => {
+    // م ZWJ ESC ZWSP [ m ZWJ م — the invisible pass strips the ZWSP, which
+    // reconstitutes `ESC[m`; removing THAT sequence makes the two ZWJs
+    // adjacent. The old pipeline ran no invisible pass after its ANSI
+    // re-strip, so the first call returned the joiner pair and only the second
+    // stripped it: `645 200d 200d 645`, then `645 645`.
+    const input = `${ARABIC_MEEM}${ZWJ}${ESC}${ZWSP}[m${ZWJ}${ARABIC_MEEM}`;
+    const once = applyLayer1(input);
+    const twice = applyLayer1(once.cleaned);
+
+    assert.equal(hex(once.cleaned), "645 645");
+    assert.deepEqual(once.found, [CATEGORY.CF, CATEGORY.ANSI]);
+    assert.equal(twice.cleaned, once.cleaned);
+    // Nothing left to remove, so the re-clean reports no finding at all — the
+    // `found` disagreement between the two calls goes with the text one.
+    assert.deepEqual(twice.found, []);
+  });
+
+  it("is idempotent over the reconstitution shape", () => {
+    fc.assert(
+      fc.property(reconstitutionText, (text) => {
+        const once = applyLayer1(text).cleaned;
+        assert.equal(applyLayer1(once).cleaned, once);
+      }),
+      fcRunOptions(),
+    );
+  });
+
+  it("is idempotent over free-form ANSI + invisible interleavings", () => {
+    fc.assert(
+      fc.property(ansiText, (text) => {
+        const once = applyLayer1(text).cleaned;
+        assert.equal(applyLayer1(once).cleaned, once);
+      }),
+      fcRunOptions(),
+    );
+  });
+
+  it("sweeps every raw introducer even when the pass bound is exhausted", () => {
+    // `ESC[` xN + `m` xN reconstitutes exactly ONE sequence per pass, so it
+    // outruns any fixed bound by construction — the no-introducer guarantee has
+    // to come from the final unconditional sweep, not from the loop converging.
+    const depth = 40;
+    const { cleaned, found } = applyLayer1(
+      `${ESC}[`.repeat(depth) + "m".repeat(depth),
+    );
+    for (const char of cleaned) {
+      const code = char.codePointAt(0);
+      assert.ok(
+        code !== 0x1b && (code < 0x80 || code > 0x9f),
+        `control introducer U+${code.toString(16)} survived the bound`,
+      );
+    }
+    assert.deepEqual(found, [CATEGORY.ANSI]);
+  });
+});
+
+// ─── Defect 2: the SGR predicate and the stripper share one grammar ──────────
+
+describe("isSgrOnly containment", () => {
+  // Each of these is a legitimate, display-only sequence the two grammars used
+  // to disagree about: the stripper's four-digit parameter cap rejected them,
+  // so it spliced the sequence's visible tail into the model's view while
+  // isSgrOnly still reported the input as colour-only.
+  const contained = [
+    ["long parameter run", `hello${ESC}[12345mworld`, "helloworld"],
+    ["leading colon sub-parameter", `hi${ESC}[:0mthere`, "hithere"],
+    ["colon-form truecolor", `${ESC}[38:2:255:0:0mred${ESC}[0m`, "red"],
+    ["C1 long parameter run", `a${CSI}12345mb`, "ab"],
+  ];
+
+  for (const [name, input, expected] of contained) {
+    it(`${name}: what was removed is exactly the SGR match set`, () => {
+      const { cleaned, found } = applyLayer1(input);
+      assert.equal(isSgrOnly(input), true);
+      assert.deepEqual(found, [CATEGORY.ANSI]);
+      assert.equal(cleaned, input.replace(SGR_RE, ""));
+      assert.equal(cleaned, expected);
+    });
+  }
+
+  it("holds over generated SGR-only text", () => {
+    fc.assert(
+      fc.property(sgrOnlyText, (text) => {
+        // Non-vacuity: this domain really is SGR-only, so the implication below
+        // is exercised on every case rather than skipped.
+        assert.equal(isSgrOnly(text), true);
+        assert.equal(applyLayer1(text).cleaned, text.replace(SGR_RE, ""));
+      }),
+      fcRunOptions(),
+    );
+  });
+
+  it("holds with invisible chars interleaved between the colour sequences", () => {
+    // Stated against the ANSI strip alone, so the invisible pass's own removals
+    // need not be excluded first: colour-only text loses exactly its colour to
+    // the stripper, whatever else is in it.
+    fc.assert(
+      fc.property(sgrWithInvisibleText, (text) => {
+        assert.equal(isSgrOnly(text), true);
+        assert.equal(stripAnsiFully(text), text.replace(SGR_RE, ""));
+      }),
+      fcRunOptions(),
+    );
+  });
+
+  it("still denies a non-SGR escape, in either encoding", () => {
+    for (const text of [
+      `${ESC}[2J`,
+      `${CSI}2J`,
+      `${ESC}]0;t${BEL}`,
+      `${OSC}0;t${ST}`,
+      `${ESC}[`,
+      ESC,
+      cp(0x90),
+    ])
+      assert.equal(isSgrOnly(text), false, `expected non-SGR: ${hex(text)}`);
+  });
+});
+
+// ─── Defect 3: one control-introducer charset, three consumers ───────────────
+
+describe("shared control-introducer charset", () => {
+  // Behavioural, not a source grep: a refactor that widened or narrowed one
+  // copy of the class would show up here as a code point Layer 1 deletes while
+  // isSgrOnly still calls it colour-only — the exact shape of the
+  // suppressed-warning bug.
+  it("every code point Layer 1 strips as an introducer reads as non-SGR", () => {
+    const stripped = [];
+    for (let code = 0; code <= 0x2ff; code++) {
+      const char = cp(code);
+      // Only the raw-introducer class is in scope: an invisible char is removed
+      // by a different pass and says nothing about the ANSI grammar.
+      if (stripInvisible(char) !== char) continue;
+      if (applyLayer1(`a${char}b`).cleaned === `a${char}b`) continue;
+      stripped.push(code);
+      assert.equal(
+        isSgrOnly(char),
+        false,
+        `U+${code.toString(16)} is stripped by Layer 1 but reads as SGR-only`,
+      );
+    }
+    // Non-vacuity: the sampled range must contain the WHOLE introducer class,
+    // or the loop above proves nothing.
+    assert.deepEqual(stripped, [
+      0x1b,
+      ...Array.from({ length: 0x20 }, (_, i) => 0x80 + i),
+    ]);
+  });
+});

--- a/test/layer1-ansi.test.mjs
+++ b/test/layer1-ansi.test.mjs
@@ -22,12 +22,10 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import fc from "fast-check";
 
-import {
-  applyLayer1,
-  stripAnsiFully,
-  scanAnsi,
-  TOKEN_KIND,
-} from "../src/layer1.mjs";
+import { applyLayer1, stripAnsiFully } from "../src/layer1.mjs";
+// The tokenizer assertions below are about src/ansi.mjs, so name it directly
+// rather than reaching it through a re-export layer1.mjs does not otherwise owe.
+import { scanAnsi, TOKEN_KIND } from "../src/ansi.mjs";
 import {
   isSgrOnly,
   SGR_RE,


### PR DESCRIPTION
## Summary

Claimed `src/layer1.mjs`, the ANSI/SGR half of `src/invisible.mjs` (`SGR_RE`, `isSgrOnly`), `src/prompt.mjs`'s introducer gate, and the new `src/ansi.mjs`. No Unicode tables, preserve-budget, `analyzeCarve`/`carveStrip`, `output.mjs` or `index.mjs` were touched.

Three defects with one shape: Layer 1's ANSI handling was spread across three places that each re-derived the grammar, and the pipeline hard-coded a pass order instead of running to a fixed point.

1. **`applyLayer1` was not idempotent.** The chain was ANSI -> invisible -> conditional ANSI re-strip -> sweep. Only the first step iterated. The re-strip could delete an escape and thereby make two preserved joiners ADJACENT — a joiner run the invisible pass classifies as a payload channel — with no invisible pass after it. `rehydrate.mjs` (~:101-106, :288) assumes re-cleaning reproduces the model's view, so this was a soundness bug there, not a cosmetic one.
2. **Two ANSI grammars disagreed, and the looser one suppressed the warning.** `SGR_RE` accepted any digit run; the stripper's CSI branch capped each parameter at four digits. `ESC[12345m` therefore could not be matched by the stripper (the residual sweep removed only the ESC, splicing a visible `[12345m` into the model's view) while `isSgrOnly` returned `true`, so `output.mjs:248-253` set `sgrNote` and skipped `describeStripped` entirely — the operator was told "display-only colour" while visible garbage was injected. A leading colon (`ESC[:0m`) hit the same path.
3. **The control-introducer class was written out three times**, in two different spellings of ESC, with the sync obligation recorded as prose.

Approach: eliminate the categories rather than patch the instances. `applyLayer1` iterates the whole `{ANSI, invisible}` composition to a fixed point, so "which pass must re-run after which" stops being a question. One tokenizer answers every ANSI question, so the stripper and the operator warning cannot describe different languages. One charset constant, three consumers.

### Before / after (real output)

| input | before | after |
| --- | --- | --- |
| `م ZWJ ESC ZWSP [ m ZWJ م` | once `645 200d 200d 645` `["cf-format","ansi"]`; twice `645 645` `["cf-format"]` | once `645 645` `["cf-format","ansi"]`; twice `645 645` `[]` |
| `hello` + `ESC[12345mworld` | cleaned `"hello[12345mworld"`, `isSgrOnly` **true** (warning suppressed, visible residue) | cleaned `"helloworld"`, `isSgrOnly` true and containment holds |
| `hi` + `ESC[:0mthere` | cleaned `"hi[:0mthere"`, `isSgrOnly` true | cleaned `"hithere"` |

## Changes

- **New `src/ansi.mjs`** — the one ANSI grammar, mirroring the `cf-charset.mjs` precedent as a dependency-free leaf (it has to be a leaf: `layer1.mjs` imports `invisible.mjs`, so `invisible.mjs` cannot import back). Exports `CONTROL_INTRODUCER_SOURCE`, the derived `SGR_RE`, `TOKEN_KIND`, and `scanAnsi(text) -> [{start, end, kind}]` with `kind` one of `sgr | csi | osc | orphan-introducer`. Every raw introducer yields exactly one token, so "which introducers are here" and "which sequences are here" come from the same scan.
- **`applyLayer1` is a bounded fixed point.** The `{ANSI, invisible}` composition re-runs until it stops changing the text; only then does the residual sweep run (sweeping earlier strands a hidden control as VISIBLE text — `ESC`+ZWSP+`[32m` would degrade to `[32m` — so the sweep must wait until nothing can reconstitute). A final unconditional sweep after the loop keeps the no-raw-introducer guarantee independent of the pass bound. `found` is the union across iterations; `deAnsi` still means the ANSI strip of the original text.
- **The tokenizer replaces the CSI/OSC regexes.** A hand-written single-pass scan never backtracks, so the `{0,12}` private-intro bound (which existed only to stop `js/polynomial-redos` quadratic backtracking between the intro and parameter quantifiers) is gone, and the parameter run is no longer capped at four digits. `stripAnsiFully`'s termination/ReDoS reasoning is unchanged and still correct: the quadratic-input argument is about the number of PASSES, not about regex backtracking, and the bound stays.
- **`isSgrOnly` is now `scanAnsi(text).every(t => t.kind === "sgr")`.** Its observable behaviour is unchanged — a token is classified SGR by testing its own text against the exact `SGR_RE` source, so the predicate's language is `SGR_RE`'s by construction. `SGR_RE` stays a public export, re-exported from `invisible.mjs` as a derived alias.
- **`prompt.mjs`'s `ANSI_INTRODUCER`** is built from the shared charset source.
- Docs: THREAT-MODEL's "Reassembly hardening" paragraph now describes the fixed point and the deferred sweep. `.github/mutation-shards.json` gains `src/ansi.mjs` (its contract test fails otherwise).

## Tests / verification

New `test/layer1-ansi.test.mjs`. Every generator is BIASED toward the reconstitution shape (`cursive (joiner)? (invisible)? ansiFragment (joiner)? cursive`) rather than drawing uniformly over 1.1M code points — the existing property at `test/invisible.test.mjs:1777` never reaches that shape, which is why it stayed green over a non-idempotent implementation.

- Idempotence: a direct unit assertion on the exact repro string (asserting the code points and both calls' `found`), plus properties over the biased shape and over free-form ANSI/invisible interleavings.
- Containment: `isSgrOnly(x)` implies `applyLayer1(x).cleaned === x.replace(SGR_RE, "")`, as four unit cases and as a property over generated SGR-only text (with invisible chars interleaved between sequences). The precondition is stated the way `output.mjs` actually uses it (`found` is exactly `[ansi]`), since an invisible-char removal would otherwise be folded into `cleaned`.
- Behavioural equivalence for the shared charset: over a sampled code-point range, anything Layer 1 strips as an introducer must read as non-SGR — with a non-vacuity assertion that the sampled set is exactly `{ESC} + U+0080-U+009F`. Not a source grep, so it survives a regex refactor.
- Tokenizer: per-form classification, the OSC abort arm, and a property that spans are disjoint, ordered and non-empty.
- Bound exhaustion: `ESC[` x40 + `m` x40 outruns any fixed bound by construction and asserts the final sweep still leaves no introducer.

**Non-vacuity, measured:** the new suite was re-run against the pre-change `src/` (checked out to a scratch dir). 7 tests fail there — every idempotence and containment assertion — and pass after. Notably the FREE-FORM idempotence property passes against the broken code and only the biased one catches it, which is the point of the generator bias.

`pnpm test` (2237 tests, 100% line/branch/function/statement coverage on `src/`), `pnpm lint`, `pnpm check`, `pnpm format:check`, and the Python suite (`uv run pytest tests`, 1460 passed) are all green. The cross-language golden (`tests/golden.json`) is unchanged — the corpus's outputs did not move.

## Decisions made

- **The tokenizer lives in `src/ansi.mjs`, not `src/layer1.mjs`.** `invisible.mjs` owns `isSgrOnly` and cannot import `layer1.mjs` (the dependency runs the other way), and an ESM cycle would put the derived `SGR_RE` in TDZ at module-eval time. The new module therefore holds the charset constant AND the tokenizer, and `layer1.mjs` re-exports `scanAnsi`/`TOKEN_KIND` so the ANSI entry point every consumer already imports still reaches it. The alternative — leaving the tokenizer in `layer1.mjs` and letting `isSgrOnly` keep its own regex — is exactly the duplication this PR removes.
- **The pass bound is 4.** Three rounds is the deepest reconstitution the carve-out can actually produce: preserving a joiner needs cursive/emoji neighbours on both sides, so a preserved joiner can never sit inside an escape sequence, and every joiner hiding one is stripped by the FIRST invisible pass. Past the bound the composition stops early and the final sweep still holds the guarantee (fail-open to visible text, the same trade as `MAX_ANSI_PASSES`). Under a larger bound the only difference is more scans on adversarial input; under a smaller one, pathological inputs stop being idempotent.
- **`found` is a Set flushed in first-seen order**, so a category discovered only on a later iteration appends rather than sorting into `CHECKS` order. Single-iteration inputs — every realistic one — are byte-identical to the old ordering. The alternative (canonical `CHECKS` order) would change the existing single-pass ordering contract for no benefit.
- **`isSgrOnly`'s language is unchanged.** Tightening the STRIPPER to the looser grammar (rather than tightening `SGR_RE` to the stricter one) was the fail-safe direction: it removes more control bytes and cannot newly block a legitimate colour-only prompt. Under the alternative, pasted `ESC[12345m` output would start being blocked instead of noted.
- **Dropping the `{0,12}` private-intro bound** means `ESC` followed by 13+ intro bytes and a final byte is now stripped rather than left visible. Strictly more stripping of control sequences, and no false-positive surface: it requires a raw ESC, which Layer 1 removes regardless.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/); each subject reads as a user-facing release note.
- [x] `pnpm test`, `pnpm lint`, and `pnpm check` pass locally.
- [x] New or changed detectors have negative tests (zero findings on legitimate input) and pin their invariants with property/fuzz tests.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version are left untouched (the release workflow owns them).