### PR TITLE
fix(output): stop a Layer-5 span deletion from creating a later span's match

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ owns each message, and any value outside the enum makes `sanitizeText` **throw**
 | `filter-flagged`      | The filter flagged the output as a possible injection without deleting (content intact) |
 | `filter-error`        | The filter reported a non-fatal internal error while scanning (a fatal filter throws)   |
 
+Every span is matched against the **original** text and the deletions applied in
+a single ordered pass, so the bytes a filter can remove are exactly the bytes its
+spans matched in the input — an earlier deletion can never manufacture a match
+for a later span (overlapping spans resolve first-match-wins).
+
 ## What installing entails
 
 Installing the plugin puts four hooks on every session, and this is what they

--- a/THREAT-MODEL.md
+++ b/THREAT-MODEL.md
@@ -169,8 +169,12 @@ fail-closed path: a redactor that throws makes the pipeline rethrow, so the
 caller suppresses the output rather than emit an unvetted value. Layer 5 is a
 deliberately thin, safe slot: the injected filter returns **verbatim spans to
 delete** (never replacement text), so even a compromised filter can only remove
-legitimate content—it can never inject bytes into the model’s view. A live
-second-LLM injection filter is the caller’s to wire behind that contract.
+legitimate content—it can never inject bytes into the model’s view. That removal
+is bounded to the spans the filter actually named: every span is matched against
+the **original** text and the deletions applied in a single ordered pass, so an
+earlier deletion cannot join two kept regions into a match for a later span and
+erase text neither span occurred in. A live second-LLM injection filter is the
+caller’s to wire behind that contract.
 
 The same "never inject" property governs the filter’s `warning`: it is a
 **closed enum code** (`FILTER_WARNING`: `spans-removed` / `filter-flagged` /

--- a/src/output.mjs
+++ b/src/output.mjs
@@ -27,6 +27,7 @@
 import { CATEGORY, describeStripped, isSgrOnly } from "./invisible.mjs";
 import { HTML_TAG_PRESENT, MD_LINK_HINT } from "./gates.mjs";
 import { applyLayer1, LONE_SURROGATE_RE } from "./layer1.mjs";
+import { orderedMatches, spliceOrdered } from "./view-map.mjs";
 
 /**
  * Closed enum of LIBRARY-OWNED Layer-5 warning codes — the ONLY warning values
@@ -206,22 +207,37 @@ export function describeWarned(warned) {
 /**
  * Delete each verbatim span in `spans` from `text`. The secure Layer-5
  * primitive: a filter can only ask for deletions, so this can never inject
- * bytes. Returns the new text and how many distinct span-occurrences were
- * removed (0 when no span was present).
+ * bytes. Returns the new text and how many span occurrences were removed (0
+ * when no span was present).
+ *
+ * Every occurrence is located in the ORIGINAL `text` and the deletions applied
+ * in one ordered pass ({@link spliceOrdered}), so every removed byte lies inside
+ * a match some span had in the INPUT. Deleting span-by-span with a
+ * chained `split`/`join` would not hold that line: an earlier deletion joins the
+ * bytes on either side of it and can CREATE a match for a later span that never
+ * occurred in the input — `deleteVerbatimSpans("PRE-XX-POST", ["-XX-", "PREPOST"])`
+ * then deletes the whole document. That would widen the Layer-5 seam's blast
+ * radius (see the module doc) from "a compromised filter can at most remove the
+ * content it named" to "it can remove content it never named".
+ *
+ * Overlapping spans are resolved first-match-wins, so `removed` counts the
+ * occurrences actually spliced out, never a double-count of the same bytes.
  * @param {string} text
  * @param {string[]} spans
  * @returns {{ text: string, removed: number }}
  */
 export function deleteVerbatimSpans(text, spans) {
-  let out = text;
-  let removed = 0;
-  for (const span of spans) {
-    if (!span) continue;
-    const parts = out.split(span);
-    removed += parts.length - 1;
-    out = parts.join("");
-  }
-  return { text: out, removed };
+  // Drop falsy entries before matching. An empty span is meaningless, and a
+  // filter that returns `null`/`undefined` in the array (it is untrusted JS, not
+  // a type-checked caller) must not be read as the literal text "null" —
+  // `indexOf` would coerce it and delete real content. Fail open on the
+  // malformed entry rather than mangle bytes.
+  const spliced = spliceOrdered(
+    text,
+    orderedMatches(text, spans.filter(Boolean)),
+    () => "",
+  );
+  return { text: spliced.text, removed: spliced.spans.length };
 }
 
 /**

--- a/src/output.mjs
+++ b/src/output.mjs
@@ -227,16 +227,17 @@ export function describeWarned(warned) {
  * @returns {{ text: string, removed: number }}
  */
 export function deleteVerbatimSpans(text, spans) {
-  // Drop falsy entries before matching. An empty span is meaningless, and a
-  // filter that returns `null`/`undefined` in the array (it is untrusted JS, not
-  // a type-checked caller) must not be read as the literal text "null" —
-  // `indexOf` would coerce it and delete real content. Fail open on the
-  // malformed entry rather than mangle bytes.
-  const spliced = spliceOrdered(
-    text,
-    orderedMatches(text, spans.filter(Boolean)),
-    () => "",
+  // Keep only non-empty STRING spans. The filter is untrusted JS, not a
+  // type-checked caller, so the array can hold anything: `indexOf(123)` would
+  // silently match the literal text "123" (deleting content the filter never
+  // named), and `occurrences` steps by `needle.length` — `undefined` for a
+  // number — making `indexOf(needle, NaN)` clamp back to the same index and
+  // loop forever. Fail open on a malformed entry rather than mangle bytes or
+  // hang the pipeline.
+  const usable = spans.filter(
+    (span) => typeof span === "string" && span !== "",
   );
+  const spliced = spliceOrdered(text, orderedMatches(text, usable), () => "");
   return { text: spliced.text, removed: spliced.spans.length };
 }
 

--- a/src/rehydrate.mjs
+++ b/src/rehydrate.mjs
@@ -51,6 +51,7 @@ import {
   occurrences,
   overlapAwareCount,
   orderedMatches,
+  spliceOrdered,
   alignDeletions,
   resolveSpan,
   rehydrateNewString,
@@ -415,9 +416,9 @@ async function rehydrateWrite(ti, view, io, hint) {
     };
 
   // Resolve each of this file's placeholder texts to its single secret first,
-  // then splice in ONE ordered pass (R6). A chained `out.split(ph).join(secret)`
-  // per placeholder is unsound: an inserted secret whose bytes contain a later
-  // placeholder text would be re-matched and corrupted by the next split.
+  // then splice in ONE ordered pass (R6) via the shared `spliceOrdered` — see
+  // its doc for why a chained `out.split(ph).join(secret)` per placeholder is
+  // unsound.
   const valueByPh = new Map();
   for (const phText of texts) {
     const produced = view.pairs.filter((pair) => pair.placeholder === phText);
@@ -438,23 +439,15 @@ async function rehydrateWrite(ti, view, io, hint) {
       };
     valueByPh.set(phText, values[0]);
   }
-  const matches = orderedMatches(ti.content, texts);
-  let out = "";
-  let last = 0;
-  // Byte ranges in `out` occupied by the substituted secret values. A hint
-  // occurrence inside one of these is a pathological secret whose bytes contain
-  // the hint prefix, NOT a placeholder the model pasted — so it is excluded from
-  // the foreign-placeholder scan below.
-  const secretSpans = [];
-  for (const match of matches) {
-    const secret = valueByPh.get(match.text);
-    out += ti.content.slice(last, match.index);
-    const secretStart = out.length;
-    out += secret;
-    secretSpans.push({ start: secretStart, end: out.length });
-    last = match.index + match.text.length;
-  }
-  out += ti.content.slice(last);
+  // `secretSpans`: byte ranges in `out` occupied by the substituted secret
+  // values. A hint occurrence inside one of these is a pathological secret whose
+  // bytes contain the hint prefix, NOT a placeholder the model pasted — so it is
+  // excluded from the foreign-placeholder scan below.
+  const { text: out, spans: secretSpans } = spliceOrdered(
+    ti.content,
+    orderedMatches(ti.content, texts),
+    (match) => valueByPh.get(match.text),
+  );
   const secrets = [...valueByPh.values()];
 
   // R3: the new content may mix a valid same-file placeholder (substituted

--- a/src/view-map.mjs
+++ b/src/view-map.mjs
@@ -223,9 +223,15 @@ export function resolveSpan(
 }
 
 /**
- * All occurrences of any needle in `text`, ordered by position. Placeholder
- * texts never substring-overlap one another (each ends in "]" right after its
- * distinguishing label), so the sorted matches are non-overlapping.
+ * All occurrences of any needle in `text`, ordered by position. Every index is
+ * computed against the ORIGINAL `text`, so the caller can splice them in one
+ * pass ({@link spliceOrdered}). Redaction placeholder texts never
+ * substring-overlap one another (each ends in "]" right after its
+ * distinguishing label), so for that caller the sorted matches are also
+ * non-overlapping; needles from an untrusted source (a Layer-5 filter's
+ * removeSpans) can overlap, which spliceOrdered resolves first-match-wins.
+ * Distinct needles matching at the SAME index keep `needles` order (Array#sort
+ * is stable), so first-match-wins is deterministic.
  * @param {string} text
  * @param {string[]} needles
  * @returns {{text: string, index: number}[]}
@@ -236,6 +242,47 @@ export function orderedMatches(text, needles) {
     for (const index of occurrences(text, needle))
       out.push({ text: needle, index });
   return out.sort((left, right) => left.index - right.index);
+}
+
+/**
+ * Replace every match in `matches` with `replacementFor(match, i)` in a SINGLE
+ * ordered pass over `text`. THE splice primitive for this codebase — the sole
+ * sound way to substitute several needles at once.
+ *
+ * A chained `text.split(needle).join(value)` per needle is unsound in both
+ * directions, which is why no caller may hand-roll one:
+ *   - substitution: an inserted value whose bytes contain a LATER needle is
+ *     re-matched by the next split and corrupted (or partially exposed);
+ *   - deletion: an earlier deletion joins the bytes on either side of it and
+ *     can CREATE a later needle's match, deleting text that needle never
+ *     matched in the input ("PRE-XX-POST" minus "-XX-" yields "PREPOST").
+ * Because every index in `matches` is measured against the original `text`,
+ * this pass only ever touches bytes the caller actually matched.
+ *
+ * Overlapping matches are resolved first-match-wins: a match starting before
+ * the previous one ended is skipped, never spliced at a shifted offset.
+ * `i` is the match's index in `matches` (stable across skips) so a caller
+ * pairing matches positionally with its own array stays aligned.
+ * @param {string} text
+ * @param {{text: string, index: number}[]} matches ordered by index, indices into `text`
+ * @param {(match: {text: string, index: number}, i: number) => string} replacementFor
+ * @returns {{text: string, spans: {start: number, end: number}[]}} spliced text
+ *   and the [start, end) range each replacement occupies in it
+ */
+export function spliceOrdered(text, matches, replacementFor) {
+  let out = "";
+  let last = 0;
+  /** @type {{start: number, end: number}[]} */
+  const spans = [];
+  matches.forEach((match, i) => {
+    if (match.index < last) return;
+    out += text.slice(last, match.index);
+    const start = out.length;
+    out += replacementFor(match, i);
+    spans.push({ start, end: out.length });
+    last = match.index + match.text.length;
+  });
+  return { text: out + text.slice(last), spans };
 }
 
 /**
@@ -308,24 +355,16 @@ export function rehydrateNewString(oldS, newS, spanPairs, filePairs) {
     newSeq.length === spanPairs.length &&
     newSeq.every((match, i) => match.text === spanPairs[i].placeholder)
   ) {
-    let out = "";
-    let last = 0;
-    newSeq.forEach((match, i) => {
-      out += newS.slice(last, match.index) + spanPairs[i].original;
-      last = match.index + match.text.length;
-    });
     return {
-      text: out + newS.slice(last),
+      text: spliceOrdered(newS, newSeq, (_match, i) => spanPairs[i].original)
+        .text,
       secrets: spanPairs.map((pair) => pair.original),
     };
   }
 
   // Each placeholder text must name exactly one secret; resolve that mapping
-  // first, then splice in a SINGLE ordered pass. A chained
-  // `out.split(ph).join(secret)` per placeholder is unsound: an inserted secret
-  // whose bytes happen to contain a later placeholder text would be re-matched
-  // and corrupted (or partially exposed) by the next split. One pass over the
-  // ordered match positions only ever touches the original new_string bytes.
+  // first, then splice in a SINGLE ordered pass (see spliceOrdered for why a
+  // chained `out.split(ph).join(secret)` per placeholder is unsound).
   const valueByPh = new Map();
   for (const phText of new Set(newSeq.map((match) => match.text))) {
     const values = [
@@ -344,11 +383,9 @@ export function rehydrateNewString(oldS, newS, spanPairs, filePairs) {
       };
     valueByPh.set(phText, values[0]);
   }
-  let out = "";
-  let last = 0;
-  for (const match of newSeq) {
-    out += newS.slice(last, match.index) + valueByPh.get(match.text);
-    last = match.index + match.text.length;
-  }
-  return { text: out + newS.slice(last), secrets: [...valueByPh.values()] };
+  return {
+    text: spliceOrdered(newS, newSeq, (match) => valueByPh.get(match.text))
+      .text,
+    secrets: [...valueByPh.values()],
+  };
 }

--- a/test/fuzz-coverage.test.mjs
+++ b/test/fuzz-coverage.test.mjs
@@ -72,6 +72,11 @@ const FUZZ_REQUIRED = [
   "sanitizeText",
   "sanitizeValue",
   "deleteVerbatimSpans",
+  // The needle-splice primitive behind deleteVerbatimSpans, rehydrateNewString
+  // and the whole-file Write substitution: it decides which bytes of untrusted
+  // text are removed or replaced, so it owes the "only verbatim matches of the
+  // ORIGINAL text are touched" property directly, not just via its callers.
+  "spliceOrdered",
 ];
 
 // Entry points that owe SEMANTIC-CORRECTNESS fuzzing, not just structural

--- a/test/output-property.test.mjs
+++ b/test/output-property.test.mjs
@@ -25,7 +25,7 @@ import {
 } from "../src/output.mjs";
 import { SGR_RE } from "../src/invisible.mjs";
 import { occurrences } from "../src/view-map.mjs";
-import { fcRunOptions, cp } from "./test-helpers.mjs";
+import { fcRunOptions, cp, keptOutsideNeedles } from "./test-helpers.mjs";
 
 const runOptions = fcRunOptions({ numRuns: 300 });
 
@@ -289,32 +289,17 @@ describe("property: deleteVerbatimSpans only deletes", () => {
         const { text: out, removed } = deleteVerbatimSpans(text, spans);
         // A length-only invariant can't catch an INJECTION: a buggy deleter that
         // both removed bytes and spliced new ones in could still shrink the text.
-        // Compute the expected residue INDEPENDENTLY of the deletion algorithm —
-        // a set-union of the spans' occurrences in the ORIGINAL text, keeping
-        // every index no span covered. It only ever keeps bytes already present
-        // in `text`, so any byte in `out` that did not come from `text` (or any
-        // byte deleted that no span matched in the INPUT) fails this
-        // exact-equality check. Deleting span-by-span would not satisfy it: an
-        // earlier deletion can create a later span's match (see
-        // test/splice-property.test.mjs for that regression in full).
-        const covered = new Array(text.length).fill(false);
-        for (const span of new Set(spans)) {
-          if (!span) continue;
-          for (
-            let i = text.indexOf(span);
-            i !== -1;
-            i = text.indexOf(span, i + span.length)
-          )
-            for (let k = i; k < i + span.length; k++) covered[k] = true;
-        }
-        let expected = "";
-        for (let i = 0; i < text.length; i++)
-          if (!covered[i]) expected += text[i];
+        // The expected residue comes from the shared set-union oracle (the same
+        // one test/splice-property.test.mjs asserts against, so the two suites
+        // cannot drift): every index of the ORIGINAL text no span covered. It
+        // only ever keeps bytes already present in `text`, so any byte in `out`
+        // that did not come from `text` — or any byte deleted that no span
+        // matched in the INPUT — fails this exact-equality check.
+        const expected = keptOutsideNeedles(text, spans);
         assert.equal(out, expected);
-        // Every span here is a single character, so each covered index is
-        // exactly one removed occurrence (a span repeated in the list names the
-        // same occurrences and is counted once — hence the Set above).
-        assert.equal(removed, covered.filter(Boolean).length);
+        // Every span here is a single character, so no two matches overlap and
+        // each removed byte is one removed occurrence.
+        assert.equal(removed, text.length - expected.length);
         assert.ok(out.length <= text.length, "output grew");
       }),
       runOptions,

--- a/test/output-property.test.mjs
+++ b/test/output-property.test.mjs
@@ -24,6 +24,7 @@ import {
   FILTER_WARNING,
 } from "../src/output.mjs";
 import { SGR_RE } from "../src/invisible.mjs";
+import { occurrences } from "../src/view-map.mjs";
 import { fcRunOptions, cp } from "./test-helpers.mjs";
 
 const runOptions = fcRunOptions({ numRuns: 300 });
@@ -334,6 +335,15 @@ describe("property: no filterInjection-supplied byte reaches the model-facing co
   });
   // The filter may return a valid enum code or no warning at all.
   const codeArb = fc.constantFrom(undefined, ...Object.values(FILTER_WARNING));
+  // Counterexamples this property has caught, pinned so they replay on EVERY
+  // run rather than waiting for the generator to rediscover them:
+  //   ["aZb", ["Z", "ab"]] — deleting "Z" joins "a" to "b", so a span-by-span
+  //   deleter finds an "ab" the INPUT never contained and erases the rest of
+  //   the output. Only the two spans' matches in the original text may go.
+  const deletionRunOptions = fcRunOptions({
+    numRuns: 300,
+    examples: [["aZb", ["Z", "ab"], undefined]],
+  });
 
   it("cleaned is the input with spans DELETED (never injected) and warnings are library-owned only", async () => {
     await fc.assert(
@@ -345,8 +355,28 @@ describe("property: no filterInjection-supplied byte reaches the model-facing co
         const r = await sanitizeText(text, { filterInjection });
         // Deletion-only: cleaned equals the input with those spans removed by
         // an INDEPENDENT oracle — any filter-injected byte would break this.
-        let expected = text;
-        for (const s of spans) if (s) expected = expected.replaceAll(s, "");
+        // The oracle is a left-to-right scan of the ORIGINAL text (not the
+        // collect-sort-splice the implementation uses): at each position the
+        // first span, in the order the filter listed them, whose occurrence
+        // starts there is deleted. Spans here can overlap ("X" inside "XYZ"),
+        // so the union of occurrences is NOT the answer — the second of two
+        // overlapping matches is dropped, not applied at a shifted offset. A
+        // chained per-span `replaceAll` is not the answer either: it deletes
+        // matches that only exist because an earlier deletion joined the bytes
+        // around it (deleting "Z" from "aZb" would then delete the "ab" the
+        // input never contained).
+        let expected = "";
+        for (let i = 0; i < text.length;) {
+          const hit = spans.find(
+            (span) => span && occurrences(text, span).includes(i),
+          );
+          if (hit === undefined) {
+            expected += text[i];
+            i++;
+            continue;
+          }
+          i += hit.length;
+        }
         assert.equal(r.cleaned, expected);
         // Benign input yields no Layer-1 finding, so the ONLY possible warning
         // is the filter's — and it must be a LIBRARY-owned message (the mapped
@@ -358,7 +388,7 @@ describe("property: no filterInjection-supplied byte reaches the model-facing co
         }
         assert.ok(r.warnings.length <= 1);
       }),
-      runOptions,
+      deletionRunOptions,
     );
   });
 

--- a/test/output-property.test.mjs
+++ b/test/output-property.test.mjs
@@ -288,19 +288,32 @@ describe("property: deleteVerbatimSpans only deletes", () => {
         const { text: out, removed } = deleteVerbatimSpans(text, spans);
         // A length-only invariant can't catch an INJECTION: a buggy deleter that
         // both removed bytes and spliced new ones in could still shrink the text.
-        // Compute the expected residue INDEPENDENTLY (replaceAll, a different code
-        // path than deleteVerbatimSpans's split/join) — it only ever removes bytes
-        // already present in `text`, so any byte in `out` that did not come from
-        // `text` fails this exact-equality check.
-        let expected = text;
-        let expectedRemoved = 0;
-        for (const span of spans) {
+        // Compute the expected residue INDEPENDENTLY of the deletion algorithm —
+        // a set-union of the spans' occurrences in the ORIGINAL text, keeping
+        // every index no span covered. It only ever keeps bytes already present
+        // in `text`, so any byte in `out` that did not come from `text` (or any
+        // byte deleted that no span matched in the INPUT) fails this
+        // exact-equality check. Deleting span-by-span would not satisfy it: an
+        // earlier deletion can create a later span's match (see
+        // test/splice-property.test.mjs for that regression in full).
+        const covered = new Array(text.length).fill(false);
+        for (const span of new Set(spans)) {
           if (!span) continue;
-          expectedRemoved += expected.split(span).length - 1;
-          expected = expected.replaceAll(span, "");
+          for (
+            let i = text.indexOf(span);
+            i !== -1;
+            i = text.indexOf(span, i + span.length)
+          )
+            for (let k = i; k < i + span.length; k++) covered[k] = true;
         }
+        let expected = "";
+        for (let i = 0; i < text.length; i++)
+          if (!covered[i]) expected += text[i];
         assert.equal(out, expected);
-        assert.equal(removed, expectedRemoved);
+        // Every span here is a single character, so each covered index is
+        // exactly one removed occurrence (a span repeated in the list names the
+        // same occurrences and is counted once — hence the Set above).
+        assert.equal(removed, covered.filter(Boolean).length);
         assert.ok(out.length <= text.length, "output grew");
       }),
       runOptions,

--- a/test/output.test.mjs
+++ b/test/output.test.mjs
@@ -140,6 +140,31 @@ describe("deleteVerbatimSpans", () => {
       text: "Y",
       removed: 1,
     }));
+  // The filter is untrusted JS: nothing type-checks `removeSpans` before this
+  // runs. A non-string entry must be IGNORED, not coerced — `indexOf(123)`
+  // would match the literal text "123" the filter never named, and stepping by
+  // `(123).length` (undefined) makes the scan restart at the same index
+  // forever, hanging the pipeline. Each case below returns the text untouched;
+  // a regression here shows up as a hung test, not a silent pass.
+  for (const [label, span] of [
+    ["a number", 123],
+    ["an object", {}],
+    ["an array", []],
+    ["null", null],
+    ["undefined", undefined],
+    ["false", false],
+    ["zero", 0],
+  ])
+    it(`ignores ${label} span instead of coercing it to text`, () =>
+      assert.deepEqual(deleteVerbatimSpans("a123b", [span]), {
+        text: "a123b",
+        removed: 0,
+      }));
+  it("still deletes the string spans alongside an ignored non-string one", () =>
+    assert.deepEqual(deleteVerbatimSpans("a123b", [123, "123"]), {
+      text: "ab",
+      removed: 1,
+    }));
 });
 
 // ─── Layer 1 (via sanitizeText) ──────────────────────────────────────────────

--- a/test/output.test.mjs
+++ b/test/output.test.mjs
@@ -123,6 +123,23 @@ describe("deleteVerbatimSpans", () => {
       text: "abc",
       removed: 0,
     }));
+  it("never deletes a span an earlier deletion created", () =>
+    // Deleting "-XX-" joins "PRE" to "POST"; "PREPOST" never occurred in the
+    // input, so it must NOT be deleted. Matching span-by-span would erase the
+    // whole document and report 2 removals — widening the Layer-5 seam from
+    // "a filter can at most remove the content it named" to "it can remove
+    // content it never named".
+    assert.deepEqual(deleteVerbatimSpans("PRE-XX-POST", ["-XX-", "PREPOST"]), {
+      text: "PREPOST",
+      removed: 1,
+    }));
+  it("resolves overlapping spans first-match-wins, counting each region once", () =>
+    // "abX" and "bXY" both match "abXY" from index 0 and 1. Only the first is
+    // removed; the second's bytes are not re-deleted at a shifted offset.
+    assert.deepEqual(deleteVerbatimSpans("abXY", ["abX", "bXY"]), {
+      text: "Y",
+      removed: 1,
+    }));
 });
 
 // ─── Layer 1 (via sanitizeText) ──────────────────────────────────────────────

--- a/test/splice-property.test.mjs
+++ b/test/splice-property.test.mjs
@@ -35,7 +35,7 @@ import {
 } from "../src/view-map.mjs";
 import { deleteVerbatimSpans } from "../src/output.mjs";
 import { rehydrateRedacted } from "../src/rehydrate.mjs";
-import { fcRunOptions } from "./test-helpers.mjs";
+import { fcRunOptions, keptOutsideNeedles } from "./test-helpers.mjs";
 
 const runOptions = fcRunOptions({ numRuns: 500 });
 
@@ -149,19 +149,6 @@ const overlappingNeedles = fc.array(
 const disjointNeedles = fc.array(fc.constantFrom("X", "Y", "Z", "Q", ""), {
   maxLength: 4,
 });
-
-// Independent (set-union, not the splice algorithm) computation of the bytes a
-// needle splice may NOT touch: every index of the ORIGINAL text not covered by
-// an occurrence of any needle, in order.
-const keptOutsideNeedles = (text, needles) => {
-  const covered = new Array(text.length).fill(false);
-  for (const needle of needles)
-    for (const index of occurrences(text, needle))
-      for (let i = index; i < index + needle.length; i++) covered[i] = true;
-  let out = "";
-  for (let i = 0; i < text.length; i++) if (!covered[i]) out += text[i];
-  return out;
-};
 
 // The pre-fix implementation of deleteVerbatimSpans, kept as a reference for the
 // non-vacuity test: it deletes span-by-span, so an earlier deletion joins the

--- a/test/splice-property.test.mjs
+++ b/test/splice-property.test.mjs
@@ -1,10 +1,22 @@
 /**
- * Fast-check property tests for `spliceRanges` — the byte-exactness core of
- * Layer 2. The AST path only ever feeds it disjoint, in-bounds ranges, so its
- * documented defense-in-depth behavior (merging overlapping/nested/adjacent/
- * duplicate ranges) is otherwise unexercised. The headline invariant is the
- * Layer-2 promise: every byte *outside* the union of ranges is preserved
- * verbatim, in order.
+ * Fast-check property tests for the codebase's two splice primitives.
+ *
+ * `spliceRanges` (Layer 2) splices byte RANGES the HTML AST already resolved.
+ * The AST path only ever feeds it disjoint, in-bounds ranges, so its documented
+ * defense-in-depth behavior (merging overlapping/nested/adjacent/duplicate
+ * ranges) is otherwise unexercised.
+ *
+ * `spliceOrdered` (view-map) splices NEEDLE matches, and is the single
+ * implementation behind all three needle-splicing call sites — Layer 5's
+ * `deleteVerbatimSpans`, and rehydration's `rehydrateNewString` /
+ * whole-file Write substitution. Its invariant is the same one, stated over
+ * matches instead of ranges: every match is located in the ORIGINAL text, so
+ * the only bytes that can be removed or replaced are bytes some needle actually
+ * matched in the input — a chained `split`/`join` per needle does NOT hold that
+ * line (see the non-vacuity test below).
+ *
+ * The headline invariant for both is the Layer-2/Layer-5 promise: every byte
+ * *outside* the spliced regions is preserved verbatim, in order.
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
@@ -15,6 +27,14 @@ import {
   COMMENT_PLACEHOLDER,
   HIDDEN_PLACEHOLDER,
 } from "../src/html.mjs";
+import {
+  occurrences,
+  orderedMatches,
+  spliceOrdered,
+  rehydrateNewString,
+} from "../src/view-map.mjs";
+import { deleteVerbatimSpans } from "../src/output.mjs";
+import { rehydrateRedacted } from "../src/rehydrate.mjs";
 import { fcRunOptions } from "./test-helpers.mjs";
 
 const runOptions = fcRunOptions({ numRuns: 500 });
@@ -96,6 +116,327 @@ describe("property: spliceRanges preserves bytes outside the ranges", () => {
         ),
         ([text, ranges]) => {
           assert.equal(typeof spliceRanges(text, ranges), "string");
+        },
+      ),
+      runOptions,
+    );
+  });
+});
+
+// ─── spliceOrdered: the needle-splicing primitive ────────────────────────────
+
+// Marker delimiting each spliced-in replacement in the output. Built from a code
+// point so no raw control byte sits in this source, and drawn from outside every
+// generated alphabet so the replacements can be located unambiguously.
+const MARK = String.fromCharCode(0x00);
+
+// Text over an alphabet the needles below are drawn from, so matches are dense.
+const needleText = fc
+  .array(fc.constantFrom(..."abXYZ ".split("")), { maxLength: 40 })
+  .map((chars) => chars.join(""));
+
+// Needles that can CROSS-OVERLAP each other in `needleText` ("abX" and "bXY"
+// both match "abXY"), plus a self-overlapping one and the empty needle. Overlap
+// is the case first-match-wins resolves, so it must be generated, not assumed
+// away.
+const overlappingNeedles = fc.array(
+  fc.constantFrom("X", "Y", "Z", "ab", "abX", "bXY", "aa", ""),
+  { maxLength: 4 },
+);
+
+// Single-character, pairwise-distinct needles: no two matches can overlap, so
+// the union-of-occurrences oracle below is exact rather than an upper bound.
+const disjointNeedles = fc.array(fc.constantFrom("X", "Y", "Z", "Q", ""), {
+  maxLength: 4,
+});
+
+// Independent (set-union, not the splice algorithm) computation of the bytes a
+// needle splice may NOT touch: every index of the ORIGINAL text not covered by
+// an occurrence of any needle, in order.
+const keptOutsideNeedles = (text, needles) => {
+  const covered = new Array(text.length).fill(false);
+  for (const needle of needles)
+    for (const index of occurrences(text, needle))
+      for (let i = index; i < index + needle.length; i++) covered[i] = true;
+  let out = "";
+  for (let i = 0; i < text.length; i++) if (!covered[i]) out += text[i];
+  return out;
+};
+
+// The pre-fix implementation of deleteVerbatimSpans, kept as a reference for the
+// non-vacuity test: it deletes span-by-span, so an earlier deletion joins the
+// bytes around it and can create a later span's match.
+const chainedDelete = (text, spans) => {
+  let out = text;
+  let removed = 0;
+  for (const span of spans) {
+    if (!span) continue;
+    const parts = out.split(span);
+    removed += parts.length - 1;
+    out = parts.join("");
+  }
+  return { text: out, removed };
+};
+
+/** Run a marker splice, returning the result plus the matches it consumed. */
+const markSplice = (text, needles) => {
+  /** @type {{text: string, index: number}[]} */
+  const used = [];
+  const out = spliceOrdered(text, orderedMatches(text, needles), (match) => {
+    used.push(match);
+    return MARK;
+  });
+  return { out, used };
+};
+
+describe("property: spliceOrdered only touches verbatim matches of the original text", () => {
+  it("the spliced-out chunks re-assemble the input exactly", () => {
+    fc.assert(
+      fc.property(needleText, overlappingNeedles, (text, needles) => {
+        const { out, used } = markSplice(text, needles);
+        // Every replaced chunk is a real occurrence of its needle at its
+        // reported index IN THE ORIGINAL TEXT — never a match manufactured by
+        // an earlier splice.
+        for (const match of used) {
+          assert.ok(occurrences(text, match.text).includes(match.index));
+          assert.equal(
+            text.slice(match.index, match.index + match.text.length),
+            match.text,
+          );
+        }
+        // The reported spans locate each replacement in the output.
+        assert.equal(out.spans.length, used.length);
+        for (const span of out.spans)
+          assert.equal(out.text.slice(span.start, span.end), MARK);
+        // Putting the replaced chunks back where the markers are must reproduce
+        // the input byte for byte: nothing outside a match was disturbed, and
+        // the matches were consumed in order without gaps or double-counting.
+        const kept = out.text.split(MARK);
+        assert.equal(kept.length, used.length + 1);
+        const rebuilt = used.reduce(
+          (acc, match, i) => acc + match.text + kept[i + 1],
+          kept[0],
+        );
+        assert.equal(rebuilt, text);
+      }),
+      runOptions,
+    );
+  });
+
+  it("a replacement carrying a needle's own bytes is never re-matched", () => {
+    fc.assert(
+      fc.property(needleText, overlappingNeedles, (text, needles) => {
+        // Each replacement is its needle doubled, so a second pass over the
+        // output would find and re-splice it, growing the span further. One
+        // ordered pass over the original text cannot.
+        const { used } = markSplice(text, needles);
+        const out = spliceOrdered(
+          text,
+          orderedMatches(text, needles),
+          (match) => match.text + match.text,
+        );
+        assert.equal(out.spans.length, used.length);
+        out.spans.forEach((span, i) => {
+          assert.equal(
+            out.text.slice(span.start, span.end),
+            used[i].text + used[i].text,
+          );
+        });
+        const grown = used.reduce((sum, match) => sum + match.text.length, 0);
+        assert.equal(out.text.length, text.length + grown);
+      }),
+      runOptions,
+    );
+  });
+
+  it("is a no-op when nothing matches", () => {
+    fc.assert(
+      fc.property(needleText, (text) => {
+        assert.deepEqual(
+          spliceOrdered(text, orderedMatches(text, []), () => MARK),
+          { text, spans: [] },
+        );
+      }),
+      runOptions,
+    );
+  });
+});
+
+// ─── deleteVerbatimSpans (Layer 5) ───────────────────────────────────────────
+
+describe("property: deleteVerbatimSpans removes only bytes the spans matched in the ORIGINAL text", () => {
+  it("equals the complement of the union of the spans' occurrences", () => {
+    fc.assert(
+      fc.property(needleText, disjointNeedles, (text, spans) => {
+        const { text: out, removed } = deleteVerbatimSpans(text, spans);
+        assert.equal(out, keptOutsideNeedles(text, spans));
+        // Distinct single-character spans cannot overlap, so each occurrence is
+        // one removal — but a span repeated in the list names the same
+        // occurrences twice and must still be counted once.
+        assert.equal(removed, orderedMatches(text, [...new Set(spans)]).length);
+      }),
+      runOptions,
+    );
+  });
+
+  it("with overlapping spans, deletes exactly the chunks a marker splice reports", () => {
+    fc.assert(
+      fc.property(needleText, overlappingNeedles, (text, spans) => {
+        // The marker run proves (property above) that each removed chunk was a
+        // verbatim match of the ORIGINAL text; deletion is that same pass with
+        // an empty replacement.
+        const { out: marked } = markSplice(text, spans);
+        const { text: out, removed } = deleteVerbatimSpans(text, spans);
+        assert.equal(out, marked.text.split(MARK).join(""));
+        assert.equal(removed, marked.spans.length);
+        // A deletion can only shrink, and it can never remove a byte no span
+        // covered — so it never drops below the union complement.
+        assert.ok(out.length <= text.length);
+        assert.ok(out.length >= keptOutsideNeedles(text, spans).length);
+      }),
+      runOptions,
+    );
+  });
+
+  it("the previous chained split/join implementation FAILS this invariant (non-vacuity)", () => {
+    // Deleting "-XX-" joins "PRE" to "POST", creating a "PREPOST" the input
+    // never contained; the chained implementation then deletes the whole
+    // document — a Layer-5 filter naming two short spans could erase every byte
+    // of legitimate tool output. If this reference ever stops failing, the
+    // properties above have stopped discriminating.
+    const text = "PRE-XX-POST";
+    const spans = ["-XX-", "PREPOST"];
+    assert.deepEqual(chainedDelete(text, spans), { text: "", removed: 2 });
+    assert.notEqual(
+      chainedDelete(text, spans).text,
+      keptOutsideNeedles(text, spans),
+    );
+    assert.deepEqual(deleteVerbatimSpans(text, spans), {
+      text: "PREPOST",
+      removed: 1,
+    });
+    assert.equal(
+      deleteVerbatimSpans(text, spans).text,
+      keptOutsideNeedles(text, spans),
+    );
+  });
+});
+
+// ─── rehydration: placeholder → secret substitution ──────────────────────────
+
+// Two redaction placeholders and the secrets they stand for. Each secret's
+// bytes contain the OTHER placeholder's text verbatim — the case a chained
+// `split(ph).join(secret)` corrupts in either processing order, since whichever
+// pass runs second re-matches (and mangles) the secret the first pass inserted.
+// Secrets are delimited by "«", a character the generated content never
+// contains, so the substituted values can be located in the output without
+// re-implementing the splice.
+const PH_1 = "[REDACTED:1]";
+const PH_2 = "[REDACTED:2]";
+const SECRET_1 = `«sec-one-${PH_2}«`;
+const SECRET_2 = `«sec-two-${PH_1}«`;
+const SECRET_BODIES = [SECRET_1, SECRET_2].map((secret) => secret.slice(1, -1));
+
+// Model-authored text over an alphabet with no "[" and no "«", with the two
+// placeholders interleaved at arbitrary positions.
+const authored = fc
+  .array(
+    fc.oneof(
+      fc.constantFrom(..."abc \n".split("")),
+      fc.constant(PH_1),
+      fc.constant(PH_2),
+    ),
+    { maxLength: 24 },
+  )
+  .map((parts) => parts.join(""));
+
+// Split a substitution result into the bytes that came from the input text
+// (outside any secret) and the secret bodies spliced in. Unambiguous because
+// only a substituted secret can contribute a "«".
+const partitionSecrets = (out) => {
+  const pieces = out.split("«");
+  return {
+    kept: pieces.filter((_, i) => i % 2 === 0).join(""),
+    bodies: pieces.filter((_, i) => i % 2 === 1),
+  };
+};
+
+const spanPairs = [
+  { placeholder: PH_1, original: SECRET_1, start: 0 },
+  { placeholder: PH_2, original: SECRET_2, start: PH_1.length },
+];
+
+describe("property: rehydrateNewString substitutes only the placeholders in new_string", () => {
+  it("keeps every non-placeholder byte and never re-substitutes an inserted secret", () => {
+    fc.assert(
+      fc.property(authored, (newS) => {
+        const res = rehydrateNewString(PH_1 + PH_2, newS, spanPairs, spanPairs);
+        assert.ok(!("deny" in res), `unexpected deny: ${res.deny}`);
+        const { kept, bodies } = partitionSecrets(res.text);
+        // Bytes outside a placeholder occurrence in the ORIGINAL new_string
+        // survive verbatim, in order.
+        assert.equal(kept, keptOutsideNeedles(newS, [PH_1, PH_2]));
+        // One WHOLE secret per placeholder occurrence: the placeholder each
+        // secret embeds was not re-substituted — that would nest the other
+        // secret inside it, splitting the "«" delimiter pair and yielding a
+        // partial body no SECRET_BODIES entry matches.
+        assert.equal(bodies.length, orderedMatches(newS, [PH_1, PH_2]).length);
+        for (const body of bodies)
+          assert.ok(
+            SECRET_BODIES.includes(body),
+            `secret body ${JSON.stringify(body)} is not a whole secret value`,
+          );
+      }),
+      runOptions,
+    );
+  });
+});
+
+describe("property: a whole-file Write substitutes only the placeholders in the content", () => {
+  const disk = `A=${SECRET_1}\nB=${SECRET_2}\n`;
+  const viewText = `A=${PH_1}\nB=${PH_2}\n`;
+  const view = {
+    text: viewText,
+    pairs: [
+      { placeholder: PH_1, original: SECRET_1, start: viewText.indexOf(PH_1) },
+      { placeholder: PH_2, original: SECRET_2, start: viewText.indexOf(PH_2) },
+    ],
+  };
+  // io backed by the fixture above: map mode returns the view, and plain mode
+  // re-redacts both secrets so the exposure gate passes. Neither secret is a
+  // substring of the other and the generated content carries no "«", so no pass
+  // of this stub's own chained replacement can create a match for the next.
+  const io = {
+    readFile: () => disk,
+    redactMap: () => view,
+    redact: (text) =>
+      text.split(SECRET_1).join(PH_1).split(SECRET_2).join(PH_2),
+  };
+
+  it("keeps every non-placeholder byte and never re-substitutes an inserted secret", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        // At least one placeholder, or the Write is not a rehydration candidate.
+        authored.filter(
+          (content) => content.includes(PH_1) || content.includes(PH_2),
+        ),
+        async (content) => {
+          const res = await rehydrateRedacted(
+            "Write",
+            { file_path: "/f", content },
+            io,
+          );
+          assert.ok(
+            res && "updatedInput" in res,
+            `expected a rewrite, got ${JSON.stringify(res)}`,
+          );
+          const { kept, bodies } = partitionSecrets(res.updatedInput.content);
+          assert.equal(kept, keptOutsideNeedles(content, [PH_1, PH_2]));
+          assert.equal(
+            bodies.length,
+            orderedMatches(content, [PH_1, PH_2]).length,
+          );
+          for (const body of bodies) assert.ok(SECRET_BODIES.includes(body));
         },
       ),
       runOptions,

--- a/test/test-helpers.mjs
+++ b/test/test-helpers.mjs
@@ -1,6 +1,29 @@
 /**
  * Shared test helpers.
  */
+import { occurrences } from "../src/view-map.mjs";
+
+/**
+ * The bytes a needle splice may NOT touch: every index of the ORIGINAL `text`
+ * not covered by an occurrence of any needle, in order. A set-union oracle,
+ * independent of the collect-sort-splice `spliceOrdered` performs — it is the
+ * exact expected residue of a deletion when no two needles' matches overlap,
+ * and a lower bound on what must survive when they do (an overlapping match is
+ * dropped, never applied at a shifted offset). Shared so the splice and Layer-5
+ * suites cannot drift into two subtly different oracles.
+ * @param {string} text
+ * @param {string[]} needles
+ * @returns {string}
+ */
+export function keptOutsideNeedles(text, needles) {
+  const covered = new Array(text.length).fill(false);
+  for (const needle of needles)
+    for (const index of occurrences(text, needle))
+      for (let i = index; i < index + needle.length; i++) covered[i] = true;
+  let out = "";
+  for (let i = 0; i < text.length; i++) if (!covered[i]) out += text[i];
+  return out;
+}
 
 /**
  * fast-check run options. A fixed seed is replayed when FC_REPRODUCIBLE=1, which

--- a/test/view-map.test.mjs
+++ b/test/view-map.test.mjs
@@ -10,6 +10,8 @@ import assert from "node:assert/strict";
 import {
   occurrences,
   overlapAwareCount,
+  orderedMatches,
+  spliceOrdered,
   alignDeletions,
   resolveSpan,
   rehydrateNewString,
@@ -67,6 +69,53 @@ describe("overlapAwareCount", () => {
 
   it("returns 0 for an empty needle (no infinite loop)", () => {
     assert.equal(overlapAwareCount("anything", ""), 0);
+  });
+});
+
+// ─── orderedMatches / spliceOrdered ──────────────────────────────────────────
+
+describe("spliceOrdered", () => {
+  const splice = (text, needles, replacementFor) =>
+    spliceOrdered(text, orderedMatches(text, needles), replacementFor);
+
+  it("substitutes every match in one pass over the original text", () => {
+    assert.deepEqual(
+      splice("a-X-b-Y-", ["X", "Y"], (match) => `<${match.text}>`),
+      {
+        text: "a-<X>-b-<Y>-",
+        spans: [
+          { start: 2, end: 5 },
+          { start: 8, end: 11 },
+        ],
+      },
+    );
+  });
+
+  it("never re-matches a needle its own replacement introduced", () => {
+    // Substituting "A" -> "B" and "B" -> "A" must SWAP them, not run the second
+    // needle over the first's output (which would leave both as "A").
+    assert.equal(
+      splice("AB", ["A", "B"], (match) => (match.text === "A" ? "B" : "A"))
+        .text,
+      "BA",
+    );
+  });
+
+  it("skips a match overlapping the previous one (first-match-wins)", () => {
+    // "abX" (index 0) and "bXY" (index 1) overlap; only the first is spliced,
+    // and the second is dropped rather than applied at a shifted offset.
+    const result = splice("abXY", ["abX", "bXY"], () => "#");
+    assert.deepEqual(result, { text: "#Y", spans: [{ start: 0, end: 1 }] });
+  });
+
+  it("is a no-op with no matches", () => {
+    assert.deepEqual(
+      splice("abc", ["z", ""], () => "#"),
+      {
+        text: "abc",
+        spans: [],
+      },
+    );
   });
 });
 


### PR DESCRIPTION
Claimed area: `src/view-map.mjs`, `src/rehydrate.mjs`, and `deleteVerbatimSpans` in `src/output.mjs` (the rest of `src/output.mjs` and `src/index.mjs` belong to a sibling PR).

## Summary

`deleteVerbatimSpans` chained a `split`/`join` **per span**, so each span was matched against the text the *previous* deletion left behind. A deletion joins the bytes on either side of it, which can manufacture a match for a later span that never occurred in the input:

```
$ node --input-type=module -e 'import * as o from "./src/output.mjs";
console.log(JSON.stringify(o.deleteVerbatimSpans("PRE-XX-POST", ["-XX-","PREPOST"])));'

before: {"text":"","removed":2}
after:  {"text":"PREPOST","removed":1}
```

`"PREPOST"` never occurred in the input — deleting `-XX-` created it, and the second pass then deleted the entire remaining document. The same held end to end through the public API: `sanitizeText("PRE-XX-POST", { filterInjection: () => ({ removeSpans: ["-XX-","PREPOST"] }) })` yielded `cleaned === ""` (now `"PREPOST"`).

This matters because the Layer-5 seam is sold on "a compromised filter can at most remove legitimate content" (`src/output.mjs` module doc, `THREAT-MODEL.md`). Span-by-span matching widened that: a filter naming two short spans could erase text neither span matched, and the inflated `removed` count then tripped `modified` and the re-redaction pass.

Rather than patch the one call site, this collapses the three "splice N needles into a string" implementations in the codebase down to one. Two of them (`rehydrateNewString`, the whole-file Write substitution) already did it correctly in one ordered pass and documented the rule; `deleteVerbatimSpans` was the outlier. All three now go through a single exported `spliceOrdered(text, matches, replacementFor)` in `src/view-map.mjs`, built on the existing `orderedMatches`, so no call site can hand-roll a chained `split`/`join` again.

`occurrences` (steps by needle length — correct for splicing) and `overlapAwareCount` (steps by 1 — the ambiguity gate at `src/rehydrate.mjs`) are left distinct; that separation is load-bearing and untouched.

## Changes

- `src/view-map.mjs`: new `spliceOrdered` — one ordered pass over matches located in the ORIGINAL text; overlapping matches resolve first-match-wins; returns the spliced text plus the `[start, end)` range of each replacement. Its doc states why a chained `split`/`join` is unsound in both directions (substitution corruption and deletion-created matches).
- `src/view-map.mjs` / `src/rehydrate.mjs`: `rehydrateNewString` (both branches) and `rehydrateWrite` now call it; `rehydrateWrite`'s hand-rolled `secretSpans` bookkeeping is replaced by the primitive's returned spans.
- `src/output.mjs`: `deleteVerbatimSpans` is now `spliceOrdered(..., () => "")` over `orderedMatches` of the original text. Only non-empty **string** spans are matched: the filter is untrusted JS, and `occurrences` (unlike `String.prototype.split`) is not coercion-safe — see the second decision below.
- `README.md` / `THREAT-MODEL.md`: state the bound the Layer-5 seam actually offers — deletions are limited to what the filter's spans matched in the original text.

## Tests / verification

- `pnpm test` (2261 tests), `pnpm lint`, `pnpm check`, `prettier --check .` all pass; `src/` coverage stays at 100% statements/branches/functions/lines.
- `test/splice-property.test.mjs` (extended): the invariant is stated once and applied to all three call sites — a marker splice records the chunks removed, each is asserted to be a verbatim occurrence at its reported index in the ORIGINAL text, and re-inserting the chunks must reproduce the input byte for byte. Plus: the union-complement equality for non-overlapping spans, `deleteVerbatimSpans` tied to the marker run for overlapping spans, and the same "outside bytes preserved, no secret re-substituted" property for `rehydrateNewString` and a whole-file Write (fixture secrets each embed the *other* placeholder's text, the case a chained pass corrupts in either order).
- **Non-vacuity, proven by execution**: the pre-fix chained implementation is kept in the suite as a reference and asserted to violate the invariant on `PRE-XX-POST`. Additionally, temporarily reverting `spliceOrdered` to a chained implementation turned all four new suites red (`not ok` on spliceOrdered, deleteVerbatimSpans, rehydrateNewString and Write); restoring it turned them green.
- Unit assertions pinned: the exact `PRE-XX-POST` case, the overlapping-span case and a parametrized malformed-span case (number/object/array/`null`/`undefined`/`false`/`0`) in `test/output.test.mjs`; `spliceOrdered`'s substitution/swap/overlap/no-op behavior in `test/view-map.test.mjs`.
- Both `test/output-property.test.mjs` oracles were rewritten — they encoded the buggy semantics. The delete-only property now uses the shared set-union oracle; the Layer-5 "only deletes, never injects" property now scans the ORIGINAL text and replays the pinned counterexample `["aZb", ["Z","ab"]]` on every run (verified: reverting the fix makes it fail deterministically, not by luck of the seed).
- `keptOutsideNeedles` lives in `test/test-helpers.mjs` and is consumed by both suites, so the two oracles cannot drift.
- `spliceOrdered` added to `FUZZ_REQUIRED` in `test/fuzz-coverage.test.mjs` — it decides which bytes of untrusted text are removed, so it owes its own property, not just its callers'. Gate verified directly: `node --test test/fuzz-coverage.test.mjs` → 77 pass / 0 fail.

## Decisions made

- **Overlapping spans resolve first-match-wins, silently.** Two spans that overlap in the input cannot both be spliced; the second is skipped rather than applied at a shifted offset. Ties at the same index follow the order the caller listed the needles (`Array#sort` is stable), so the outcome is deterministic. The alternative — throwing — would let an untrusted filter fail the whole pipeline with two overlapping strings; precision over recall says drop the ambiguous second deletion and keep the content.
- **A non-string span entry is now ignored rather than coerced.** `"a123b".split(123)` used to delete `"123"`; `occurrences` instead steps by `needle.length` (`undefined` for a number), so `indexOf(needle, NaN)` clamps back to the same index and loops forever — a filter returning `{ removeSpans: [123] }` hung the pipeline (reproduced: the pre-fix call times out). The predicate is now `typeof span === "string" && span !== ""`. Deleting content a filter never named is the exact harm this PR is about, so the coercion is not restored. Under the alternative (coerce, as before) a filter could delete text by naming a number.
- **`removed` now counts occurrences actually spliced out**, so overlapping spans no longer double-count the same bytes. Callers only branch on `removed > 0` (setting `modified` and triggering re-redaction), so the seam behavior is unchanged.
- **Malformed spans still fail open, not loud.** Rejecting them would change the Layer-5 seam contract, which is a sibling PR's scope.
- **`test/output-property.test.mjs` was touched** (oracles only) even though `src/output.mjs` is shared with a sibling PR: leaving oracles in place that assert the deleted semantics would have kept CI red intermittently — the injection property did fail on an unseeded run before this was fixed.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/); each subject reads as a user-facing release note.
- [x] `pnpm test`, `pnpm lint`, and `pnpm check` pass locally.
- [x] New or changed detectors have negative tests (zero findings on legitimate input) and pin their invariants with property/fuzz tests.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version are left untouched (the release workflow owns them).