### PR TITLE
fix(invisible): derive Unicode script gates and charge the preserve budget per grapheme cluster

### DIFF
--- a/src/invisible.mjs
+++ b/src/invisible.mjs
@@ -891,11 +891,30 @@ function carveStrip(body) {
       if (kind[k] === "joiner") joiners++;
       if (kind[k] === "ivs" || kind[k] === "stdvs") selectors++;
     }
+    // The run counters as they stand at the cluster's FIRST preservable char.
+    // A cluster can OPEN with a genuine gap — two visible code points in a row,
+    // e.g. the second of two adjacent emoji ZWJ sequences, or a letter and its
+    // harakat — which the emit loop resets on a few lines below. Judging the
+    // caps on the stale pre-reset count would strip joiners the cap never meant
+    // to catch: a false positive on legitimate joined text. This mirrors the
+    // emit loop's gap rule exactly (only a visible char after another visible
+    // char closes a run; any invisible, payload included, does not) and stops at
+    // the first preservable, since resets past it are the emit loop's business.
+    let runJoiner = joinerRun;
+    let runSelector = selectorRun;
+    let seenVisible = prevVisible;
+    for (let k = start; k < end && kind[k] === null; k++) {
+      if (codes[k] === null && seenVisible) {
+        runJoiner = 0;
+        runSelector = 0;
+      }
+      seenVisible = codes[k] === null;
+    }
     const fits =
       allowCarveOut &&
       preservedTotal + need <= maxPreserved &&
-      joinerRun + joiners <= CONSECUTIVE_JOINER_CAP &&
-      selectorRun + selectors <= CONSECUTIVE_SELECTOR_CAP;
+      runJoiner + joiners <= CONSECUTIVE_JOINER_CAP &&
+      runSelector + selectors <= CONSECUTIVE_SELECTOR_CAP;
     for (let k = start; k < end; k++) {
       const code = codes[k];
       if (code === null) {

--- a/src/invisible.mjs
+++ b/src/invisible.mjs
@@ -333,31 +333,35 @@ const MAX_TAG_SPEC_CHARS = 6;
 // An ideographic variation sequence is a CJK ideograph followed by a selector in
 // U+E0100–U+E01EF. Preserved ONLY when the immediately preceding code point is a
 // CJK ideograph — the registry-faithful structural gate (IVS apply to ideographs
-// and nothing else). The ranges are the Unicode ideograph blocks: Unified,
-// Extensions A–I, and the two Compatibility Ideograph blocks.
+// and nothing else).
+//
+// Derived from Unicode's own data rather than hand-transcribed block spans: the
+// Unified_Ideograph property IS the set of unified ideographs (URO + every
+// extension), versioned with the runtime's ICU, so a new extension arrives with
+// the Node upgrade instead of waiting for someone to notice. A hand-written
+// table went stale exactly this way — it stopped at Extension H and so denied
+// the 4,298 Extension J ideographs (U+323B0–U+33479) a legitimate IVS base.
+//
+// Script=Han is deliberately NOT used: it also covers radicals (U+2E80–U+2EF3),
+// Kangxi radicals, U+3005/U+3007 and the ideographic-description characters,
+// none of which is an IVS base. Script_Extensions=Han is wider still (it reaches
+// U+00B7 MIDDLE DOT and the CJK punctuation shared with Kana), so it would let a
+// full stop anchor a variation selector.
+//
+// The two Compatibility Ideograph BLOCKS stay literal: they are not
+// Unified_Ideograph, and JS RegExp exposes no \p{Block=…}. Block boundaries are
+// immutable by Unicode's stability policy, so a literal span cannot drift; the
+// contract test in test/invisible-unicode-tables.test.mjs pins that every
+// ASSIGNED code point inside them is a Script=Han letter.
 const IVS_MIN = 0xe0100;
 const IVS_MAX = 0xe01ef;
-const CJK_IDEOGRAPH_RANGES = [
-  [0x3400, 0x4dbf], // CJK Unified Ideographs Extension A
-  [0x4e00, 0x9fff], // CJK Unified Ideographs
-  [0xf900, 0xfaff], // CJK Compatibility Ideographs
-  [0x20000, 0x2a6df], // Extension B
-  [0x2a700, 0x2b73f], // Extension C
-  [0x2b740, 0x2b81f], // Extension D
-  [0x2b820, 0x2ceaf], // Extension E
-  [0x2ceb0, 0x2ebef], // Extension F
-  [0x2ebf0, 0x2ee5f], // Extension I
-  [0x2f800, 0x2fa1f], // CJK Compatibility Ideographs Supplement
-  [0x30000, 0x3134f], // Extension G
-  [0x31350, 0x323af], // Extension H
-];
+const CJK_IDEOGRAPH_RE =
+  /[\p{Unified_Ideograph}\u{F900}-\u{FAFF}\u{2F800}-\u{2FA1F}]/u;
 
-/** True when `cp` is a CJK ideograph (the only base an ideographic variation
- * selector legitimately follows). @param {number} cp @returns {boolean} */
-function isCjkIdeograph(cp) {
-  for (const [start, end] of CJK_IDEOGRAPH_RANGES)
-    if (cp >= start && cp <= end) return true;
-  return false;
+/** True when `ch` is a CJK ideograph (the only base an ideographic variation
+ * selector legitimately follows). @param {string} ch @returns {boolean} */
+function isCjkIdeograph(ch) {
+  return CJK_IDEOGRAPH_RE.test(ch);
 }
 
 // Consonant (KA..HA and script-specific additional-consonant) ranges of the
@@ -366,28 +370,44 @@ function isCjkIdeograph(cp) {
 // rendering and is a smuggling channel, so the Indic joiner is preserved only
 // when its virama sits on one of these. Broad per-block spans — precision here
 // only needs "a real Brahmic letter of this script", not an exact consonant set.
-const BRAHMIC_CONSONANT_RANGES = [
-  [0x0915, 0x0939], // Devanagari KA–HA
-  [0x0958, 0x095f], // Devanagari additional consonants
-  [0x0995, 0x09b9], // Bengali
-  [0x09dc, 0x09df], // Bengali additional consonants
-  [0x0a15, 0x0a39], // Gurmukhi
-  [0x0a59, 0x0a5e], // Gurmukhi additional consonants
-  [0x0a95, 0x0ab9], // Gujarati
-  [0x0b15, 0x0b39], // Oriya
-  [0x0b5c, 0x0b5f], // Oriya additional consonants
-  [0x0b95, 0x0bb9], // Tamil
-  [0x0c15, 0x0c39], // Telugu
-  [0x0c58, 0x0c5a], // Telugu additional consonants
-  [0x0c95, 0x0cb9], // Kannada
-  [0x0d15, 0x0d3a], // Malayalam
-  [0x0d9a, 0x0dc6], // Sinhala
+//
+// UNLIKE the CJK and Hangul gates these CANNOT be derived from a property
+// escape: the UCD property that names them is Indic_Syllabic_Category=Consonant,
+// and JS RegExp exposes only General_Category, Script, Script_Extensions and the
+// binary properties. \p{Script=Devanagari} is the wrong shape — it also holds the
+// independent vowels (U+0904–U+0914), which a virama never attaches to, so
+// switching to it would preserve joiners after a bare vowel + halant. The table
+// therefore stays literal, and
+// test/invisible-unicode-tables.test.mjs pins the strongest contract that IS
+// derivable: every assigned code point in each span is a letter of the script
+// the span names, and each span holds at least one such letter. Drift (a future Unicode
+// filling a hole with a non-letter, or a typo'd span crossing into a neighbouring
+// script's block) then fails CI instead of shipping.
+// Keyed by script name so the contract test can check each span against the
+// script it claims; exported for exactly that test.
+/** @type {ReadonlyArray<readonly [string, number, number]>} */
+export const BRAHMIC_CONSONANT_RANGES = [
+  ["Devanagari", 0x0915, 0x0939], // KA–HA
+  ["Devanagari", 0x0958, 0x095f], // additional consonants
+  ["Bengali", 0x0995, 0x09b9],
+  ["Bengali", 0x09dc, 0x09df], // additional consonants
+  ["Gurmukhi", 0x0a15, 0x0a39],
+  ["Gurmukhi", 0x0a59, 0x0a5e], // additional consonants
+  ["Gujarati", 0x0a95, 0x0ab9],
+  ["Oriya", 0x0b15, 0x0b39],
+  ["Oriya", 0x0b5c, 0x0b5f], // additional consonants
+  ["Tamil", 0x0b95, 0x0bb9],
+  ["Telugu", 0x0c15, 0x0c39],
+  ["Telugu", 0x0c58, 0x0c5a], // additional consonants
+  ["Kannada", 0x0c95, 0x0cb9],
+  ["Malayalam", 0x0d15, 0x0d3a],
+  ["Sinhala", 0x0d9a, 0x0dc6],
 ];
 
 /** True when `cp` is a Brahmic consonant — the only base a virama attaches to.
  * @param {number} cp @returns {boolean} */
 function isBrahmicConsonant(cp) {
-  for (const [start, end] of BRAHMIC_CONSONANT_RANGES)
+  for (const [, start, end] of BRAHMIC_CONSONANT_RANGES)
     if (cp >= start && cp <= end) return true;
   return false;
 }
@@ -409,26 +429,30 @@ const HANGUL_FILLERS = new Set([0x115f, 0x1160, 0x3164, 0xffa0]);
 // literal is invisible to the eye and a correctness landmine for the next editor.
 const GATED_BLANK_RE = new RegExp("[\\u115F\\u1160\\u2800\\u3164\\uFFA0]", "u");
 
+// Script=Braille, from the runtime's Unicode data (identical to
+// Script_Extensions=Braille — no character is shared with another script).
+const BRAILLE_RE = /\p{Script=Braille}/u;
+
 /** A real (non-blank) Braille cell — the anchoring neighbour for a U+2800 blank.
  * @param {string} ch @returns {boolean} */
 function isBrailleCell(ch) {
-  const cp = ch ? /** @type {number} */ (ch.codePointAt(0)) : -1;
-  return cp >= 0x2801 && cp <= 0x28ff;
+  const cp = ch ? ch.codePointAt(0) : -1;
+  return cp !== BRAILLE_BLANK && BRAILLE_RE.test(ch);
 }
+
+// Script=Hangul, straight from the runtime's Unicode data. NOT
+// Script_Extensions=Hangul: that set also holds the CJK punctuation Korean text
+// shares with Chinese and Japanese (U+3001 IDEOGRAPHIC COMMA, U+30FB KATAKANA
+// MIDDLE DOT, U+FF61–U+FF65 …), so a Japanese middle dot would anchor — and
+// thereby preserve — a Hangul filler in text with no Hangul in it at all.
+const HANGUL_RE = /\p{Script=Hangul}/u;
 
 /** A Hangul jamo/syllable (NOT itself one of the fillers) — the anchoring
  * neighbour for a Hangul filler. @param {string} ch @returns {boolean} */
 function isHangul(ch) {
   const cp = ch ? /** @type {number} */ (ch.codePointAt(0)) : -1;
   if (HANGUL_FILLERS.has(cp)) return false; // a filler cannot anchor another filler
-  return (
-    (cp >= 0x1100 && cp <= 0x11ff) || // Hangul Jamo
-    (cp >= 0x3130 && cp <= 0x318f) || // Hangul Compatibility Jamo
-    (cp >= 0xa960 && cp <= 0xa97f) || // Jamo Extended-A
-    (cp >= 0xac00 && cp <= 0xd7a3) || // Hangul Syllables
-    (cp >= 0xd7b0 && cp <= 0xd7ff) || // Jamo Extended-B
-    (cp >= 0xffa1 && cp <= 0xffdc) // Halfwidth Jamo (FFA0 is the filler itself)
-  );
+  return HANGUL_RE.test(ch);
 }
 
 // Non-global single-char classifiers (CHECKS carry `g`, whose lastIndex is
@@ -583,12 +607,9 @@ function isEmojiPresentationSelector(cps, i) {
  * visible) and its preserve `kind` ("joiner" | "emojivs" | "tag" | "stdvs" |
  * "ivs" | "blank" | null). Everything invisible that is NOT preserve-eligible is
  * payload; the scatter floor counts only that, so meaningful joiners/selectors
- * never push honest prose over the threshold. `tagSpanLen[i]` is the length of a
- * tag sequence starting at `i` (0 elsewhere) so carveStrip can preserve-or-strip
- * each flag as an atomic unit (a budget cut mid-sequence would leave a malformed
- * partial run the next pass would strip — breaking idempotence).
+ * never push honest prose over the threshold.
  * @param {string[]} cps
- * @returns {{ codes: (string|null)[], kind: (string|null)[], tagSpanLen: number[], payloadInvis: number, visibleLen: number }}
+ * @returns {{ codes: (string|null)[], kind: (string|null)[], payloadInvis: number, visibleLen: number }}
  */
 function analyzeCarve(cps) {
   const codes = cps.map(classify);
@@ -603,24 +624,13 @@ function analyzeCarve(cps) {
     if (isPreservedBlankFiller(cps, i)) return "blank";
     return null;
   });
-  const tagSpanLen = new Array(cps.length).fill(0);
-  for (let i = 0; i < cps.length;) {
-    if (kind[i] !== "tag") {
-      i++;
-      continue;
-    }
-    let j = i;
-    while (j < cps.length && kind[j] === "tag") j++;
-    tagSpanLen[i] = j - i;
-    i = j;
-  }
   let payloadInvis = 0;
   let visibleLen = 0;
   for (let i = 0; i < cps.length; i++) {
     if (codes[i] === null) visibleLen++;
     else if (kind[i] === null) payloadInvis++;
   }
-  return { codes, kind, tagSpanLen, payloadInvis, visibleLen };
+  return { codes, kind, payloadInvis, visibleLen };
 }
 
 /**
@@ -754,10 +764,7 @@ function isStandardizedVariationSelector(cps, i) {
 function isIdeographicVariationSelector(cps, i) {
   const cp = /** @type {number} */ (cps[i].codePointAt(0));
   if (cp < IVS_MIN || cp > IVS_MAX) return false;
-  const prev = cps[i - 1];
-  return prev
-    ? isCjkIdeograph(/** @type {number} */ (prev.codePointAt(0)))
-    : false;
+  return isCjkIdeograph(cps[i - 1] ?? "");
 }
 
 /**
@@ -777,18 +784,55 @@ function isPreservedBlankFiller(cps, i) {
   return false;
 }
 
+// The grapheme segmenter: the real UAX #29 implementation shipped with the
+// runtime's ICU, not a hand-rolled approximation of cluster boundaries. It
+// defines the unit the preserve budget is charged against (see carveStrip).
+// Grapheme segmentation is locale-independent, so the locale is pinned to "en"
+// only for determinism across hosts.
+const GRAPHEME_SEGMENTER = new Intl.Segmenter("en", {
+  granularity: "grapheme",
+});
+
+/**
+ * The code-point index one past the end of each grapheme cluster of `body`, in
+ * order — the segmenter's UTF-16 boundaries restated in code-point space, which
+ * is the space `carveStrip`'s per-code-point arrays live in. ECMA-402 guarantees
+ * the segments partition the input, so the last entry is always the code-point
+ * length of `body`.
+ * @param {string} body
+ * @returns {number[]}
+ */
+function clusterEnds(body) {
+  const ends = [];
+  let end = 0;
+  for (const { segment } of GRAPHEME_SEGMENTER.segment(body)) {
+    end += Array.from(segment).length;
+    ends.push(end);
+  }
+  return ends;
+}
+
 /**
  * Carve-out strip (an invisible the carve-out might preserve is present): walk
- * code points, preserving a joiner/selector/tag/blank-filler only where its
- * `kind` is set AND the text stays under the scatter floor AND neither the
- * per-cluster (CONSECUTIVE_JOINER_CAP) nor the document-wide
- * (TOTAL_PRESERVED_JOINER_BUDGET) preserve limit is hit — otherwise it is
- * stripped like any other payload byte. A tag (subregional-flag) sequence is
- * preserved-or-stripped ATOMICALLY: preserving only part of it would leave a
- * malformed run the next pass strips, breaking idempotence. `found` reports only
- * categories actually removed, so a preserved char never makes the caller claim
- * a strip that did not happen, and a stuffed channel surfaces as its category
- * once it overruns the budget.
+ * GRAPHEME CLUSTERS, preserving a cluster's joiners/selectors/tags/blank-fillers
+ * only where each has its `kind` set AND the text stays under the scatter floor
+ * AND the whole cluster fits inside the remaining per-run
+ * (CONSECUTIVE_JOINER_CAP / CONSECUTIVE_SELECTOR_CAP) and document-wide
+ * (TOTAL_PRESERVED_JOINER_BUDGET) preserve allowance — otherwise every
+ * preservable char in that cluster is stripped like any other payload byte.
+ *
+ * The budget is charged against the CLUSTER, not the code point, because the
+ * cluster is the indivisible unit: charging per code point let a limit fall due
+ * mid-cluster and carve one grapheme in half (👨‍👩‍👧‍👦 with the budget exhausted
+ * after its first ZWJ came out as 👨‍👩👧👦 — three glyphs where the author wrote
+ * one). All-or-nothing per cluster makes that impossible by construction rather
+ * than merely unlikely, and it subsumes the tag (subregional-flag) sequence's
+ * hand-rolled atomicity: a flag's tag chars are Grapheme_Cluster_Break=Extend,
+ * so they are already inside their base pictograph's cluster.
+ *
+ * `found` reports only categories actually removed, so a preserved char never
+ * makes the caller claim a strip that did not happen, and a stuffed channel
+ * surfaces as its category once it overruns the budget.
  * @param {string} body
  * @returns {{ cleaned: string, found: string[] }}
  */
@@ -797,8 +841,7 @@ function carveStrip(body) {
   // Pass 1: classify + evaluate the gate once (see analyzeCarve). Only PAYLOAD
   // invisibles count toward the scatter floor, so a meaningful-joiner-dense text
   // (formal Persian, a long Devanagari conjunct run) stays under it.
-  const { codes, kind, tagSpanLen, payloadInvis, visibleLen } =
-    analyzeCarve(cps);
+  const { codes, kind, payloadInvis, visibleLen } = analyzeCarve(cps);
   // SCATTERED_THRESHOLD is the floor on payload invisibles: past it the document
   // is drowning in hidden bytes, so the carve-out is off and even a meaningful
   // joiner is stripped (threshold-evasion catch — over-strip beats under).
@@ -833,55 +876,51 @@ function carveStrip(body) {
   // char is stripped and its category reported.
   let preservedTotal = 0;
   let prevVisible = false;
-  let i = 0;
-  while (i < cps.length) {
-    const code = codes[i];
-    if (code === null) {
-      // A visible char following another visible char is a real word/segment
-      // boundary, not a join — the joined cluster (if any) ended here.
-      if (prevVisible) {
-        joinerRun = 0;
-        selectorRun = 0;
-      }
-      prevVisible = true;
-      out += cps[i]; // ordinary visible character
-      i++;
-      continue;
+  let start = 0;
+  for (const end of clusterEnds(body)) {
+    // Charge the WHOLE cluster's preservables against every limit at once: if
+    // any one of them would fall due part-way through, none of the cluster is
+    // preserved. `need === 0` (the common case: a cluster with no preservable
+    // invisible) leaves every counter untouched.
+    let need = 0;
+    let joiners = 0;
+    let selectors = 0;
+    for (let k = start; k < end; k++) {
+      if (kind[k] === null) continue;
+      need++;
+      if (kind[k] === "joiner") joiners++;
+      if (kind[k] === "ivs" || kind[k] === "stdvs") selectors++;
     }
-    // A tag (subregional-flag) sequence: atomic preserve-or-strip on the whole
-    // run so a budget cut can't leave a malformed partial run (idempotence).
-    if (kind[i] === "tag") {
-      const len = tagSpanLen[i];
-      const fits = allowCarveOut && preservedTotal + len <= maxPreserved;
-      for (let k = 0; k < len; k++) {
-        if (fits) out += cps[i + k];
-        else foundCodes.add(codes[i + k]);
-      }
-      if (fits) preservedTotal += len;
-      prevVisible = false; // the sequence keeps the cluster open
-      i += len;
-      continue;
-    }
-    const joiner = kind[i] === "joiner";
-    const selector = kind[i] === "ivs" || kind[i] === "stdvs";
-    if (
+    const fits =
       allowCarveOut &&
-      kind[i] !== null &&
-      preservedTotal < maxPreserved &&
-      (!joiner || joinerRun < CONSECUTIVE_JOINER_CAP) &&
-      (!selector || selectorRun < CONSECUTIVE_SELECTOR_CAP)
-    ) {
-      if (joiner) joinerRun++;
-      if (selector) selectorRun++;
-      preservedTotal++;
-      prevVisible = false; // a joiner/selector keeps the cluster open
-      out += cps[i];
-      i++;
-      continue;
+      preservedTotal + need <= maxPreserved &&
+      joinerRun + joiners <= CONSECUTIVE_JOINER_CAP &&
+      selectorRun + selectors <= CONSECUTIVE_SELECTOR_CAP;
+    for (let k = start; k < end; k++) {
+      const code = codes[k];
+      if (code === null) {
+        // A visible char following another visible char is a real word/segment
+        // boundary, not a join — the joined cluster (if any) ended here.
+        if (prevVisible) {
+          joinerRun = 0;
+          selectorRun = 0;
+        }
+        prevVisible = true;
+        out += cps[k]; // ordinary visible character
+        continue;
+      }
+      if (fits && kind[k] !== null) {
+        if (kind[k] === "joiner") joinerRun++;
+        if (kind[k] === "ivs" || kind[k] === "stdvs") selectorRun++;
+        preservedTotal++;
+        prevVisible = false; // a joiner/selector/tag keeps the cluster open
+        out += cps[k];
+        continue;
+      }
+      foundCodes.add(code);
+      prevVisible = false; // a stripped invisible neither opens nor closes a gap
     }
-    foundCodes.add(code);
-    prevVisible = false; // a stripped invisible neither opens nor closes a gap
-    i++;
+    start = end;
   }
   const found = CHECKS.filter(([code]) => foundCodes.has(code)).map(
     ([code]) => code,

--- a/test/invisible-mutation-kill.test.mjs
+++ b/test/invisible-mutation-kill.test.mjs
@@ -20,20 +20,29 @@ const ZWNJ = cp(0x200c);
 const ZWJ = cp(0x200d);
 const HANGUL_FILLER = cp(0x115f); // a Hangul filler; needs a Hangul anchor to survive
 
-// ─── isCjkIdeograph END boundary (line 364: `cp <= end` → `cp < end`) ──────────
+// ─── isCjkIdeograph (\p{Unified_Ideograph} ∪ the compatibility blocks) ─────────
 // An ideographic variation selector (U+E0100) is preserved only after a CJK
-// ideograph. Base U+9FFF is the LAST code point of the CJK Unified block, so a
-// `cp <= end` → `cp < end` mutant stops recognizing it and strips the selector.
-describe("mutation-kill: isCjkIdeograph end boundary", () => {
-  it("preserves an ideographic selector after U+9FFF (Unified block end)", () => {
-    const input = cp(0x9fff) + cp(0xe0100);
-    const { cleaned, found } = stripInvisibleWithReport(input);
-    assert.equal(cleaned, input);
-    assert.deepEqual(found, []);
-  });
+// ideograph. The property escape leaves no range boundaries to mutate, but the
+// two literal compatibility spans still have ends, and a ConditionalExpression
+// `false` on the regex test kills the gate outright — so pin one base from each
+// source of the union. (The exhaustive set contract lives in
+// test/invisible-unicode-tables.test.mjs.)
+describe("mutation-kill: isCjkIdeograph union members", () => {
+  for (const [label, base] of [
+    ["U+9FFF (Unified block end)", 0x9fff],
+    ["U+FA6D (compatibility block, near end)", 0xfa6d],
+    ["U+2FA1D (compatibility supplement end)", 0x2fa1d],
+  ]) {
+    it(`preserves an ideographic selector after ${label}`, () => {
+      const input = cp(base) + cp(0xe0100);
+      const { cleaned, found } = stripInvisibleWithReport(input);
+      assert.equal(cleaned, input);
+      assert.deepEqual(found, []);
+    });
+  }
 });
 
-// ─── isBrahmicConsonant END boundary (line 396: `cp <= end` → `cp < end`) ──────
+// ─── isBrahmicConsonant END boundary (`cp <= end` → `cp < end`) ───────────────
 // A ZWJ after a virama is preserved only when the virama sits on a real Brahmic
 // consonant. U+0939 (HA) is the LAST of the Devanagari KA–HA span, so the end
 // mutant strips the conjunct joiner.
@@ -46,11 +55,12 @@ describe("mutation-kill: isBrahmicConsonant end boundary", () => {
   });
 });
 
-// ─── isBrailleCell range (line 421: `cp <= 0x28ff`/`cp >= 0x2801`) ─────────────
+// ─── isBrailleCell (\p{Script=Braille} minus the blank itself) ────────────────
 // A U+2800 BRAILLE PATTERN BLANK is preserved only next to a real (non-blank)
-// Braille cell. Pin both ends of the anchor range so `cp <= 0x28ff` → `cp <
-// 0x28ff` (end) and `cp >= 0x2801` → `cp > 0x2801` (start) both strip the blank.
-describe("mutation-kill: isBrailleCell anchor range", () => {
+// Braille cell. Pin both ends of the block so a ConditionalExpression `false`
+// on the property test, or a `cp !== BRAILLE_BLANK` → `cp === BRAILLE_BLANK`
+// mutant, strips the blank.
+describe("mutation-kill: isBrailleCell anchors", () => {
   for (const [label, anchor] of [
     ["first cell U+2801", 0x2801],
     ["last cell U+28FF", 0x28ff],
@@ -64,37 +74,57 @@ describe("mutation-kill: isBrailleCell anchor range", () => {
   }
 });
 
-// ─── isHangul range boundaries (lines 430-435) ────────────────────────────────
-// A Hangul filler is preserved only next to a real Hangul jamo/syllable. Each
-// entry pins the FIRST and LAST code point of one isHangul range, killing the
-// per-range EqualityOperator mutants (`cp >= start`→`cp > start`, `cp <=
-// end`→`cp < end`), the ConditionalExpression `false` mutants (a whole range
-// forced false), and the LogicalOperator `||`→`&&` mutants across ranges (an
-// anchor in exactly one range would fail an AND-joined chain). The filler is
-// placed BEFORE the anchor (prev=""), so this also kills line 781's `isHangul(prev)
-// || isHangul(next)` → `&&`.
-describe("mutation-kill: isHangul range boundaries", () => {
-  const ranges = [
-    ["Hangul Jamo", 0x1100, 0x11ff], // line 430
-    ["Hangul Compatibility Jamo", 0x3130, 0x318f], // line 431
-    ["Jamo Extended-A", 0xa960, 0xa97f], // line 432
-    ["Hangul Syllables", 0xac00, 0xd7a3], // line 433
-    ["Jamo Extended-B", 0xd7b0, 0xd7ff], // line 434
-    ["Halfwidth Jamo", 0xffa1, 0xffdc], // line 435
+// ─── isHangul anchors (\p{Script=Hangul}) ─────────────────────────────────────
+// A Hangul filler is preserved only next to a real Hangul jamo/syllable. The
+// anchor set is Unicode's own Script=Hangul, so there are no hand-written range
+// boundaries left to mutate; what remains worth pinning is that every ASSIGNED
+// Hangul block still anchors (a ConditionalExpression `false` mutant on the
+// regex test, or a swap to a narrower property, drops them all) and that the
+// filler is found on BOTH sides — the anchor sits AFTER the filler here, killing
+// `isHangul(prev) || isHangul(next)` → `&&`.
+describe("mutation-kill: isHangul anchors across the Hangul blocks", () => {
+  const anchors = [
+    ["Hangul Jamo start U+1100", 0x1100],
+    ["Hangul Jamo end U+11FF", 0x11ff],
+    ["Compatibility Jamo start U+3131", 0x3131],
+    ["Compatibility Jamo end U+318E", 0x318e],
+    ["Jamo Extended-A start U+A960", 0xa960],
+    ["Jamo Extended-A end U+A97C", 0xa97c],
+    ["Hangul Syllables start U+AC00", 0xac00],
+    ["Hangul Syllables end U+D7A3", 0xd7a3],
+    ["Jamo Extended-B start U+D7B0", 0xd7b0],
+    ["Jamo Extended-B end U+D7FB", 0xd7fb],
+    ["Halfwidth Jamo start U+FFA1", 0xffa1],
+    ["Halfwidth Jamo end U+FFDC", 0xffdc],
+    // Only \p{Script=Hangul} reaches these: the hand-written block table missed
+    // the tone marks and the enclosed-Hangul forms entirely.
+    ["Hangul tone mark U+302E", 0x302e],
+    ["parenthesized Hangul U+3200", 0x3200],
+    ["circled Hangul U+326E", 0x326e],
   ];
-  for (const [name, start, end] of ranges) {
-    for (const [where, anchor] of [
-      ["start", start],
-      ["end", end],
-    ]) {
-      const hex = anchor.toString(16).toUpperCase();
-      it(`preserves a Hangul filler anchored by ${name} ${where} U+${hex}`, () => {
-        const input = HANGUL_FILLER + cp(anchor);
-        const { cleaned, found } = stripInvisibleWithReport(input);
-        assert.equal(cleaned, input);
-        assert.deepEqual(found, []);
-      });
-    }
+  for (const [name, anchor] of anchors) {
+    it(`preserves a Hangul filler anchored by ${name}`, () => {
+      const input = HANGUL_FILLER + cp(anchor);
+      const { cleaned, found } = stripInvisibleWithReport(input);
+      assert.equal(cleaned, input);
+      assert.deepEqual(found, []);
+    });
+  }
+
+  // Script_Extensions=Hangul is the WRONG property here: it also contains the
+  // CJK punctuation Korean shares with Chinese and Japanese, which is not a
+  // jamo and must not anchor a filler in otherwise Hangul-free text.
+  for (const [name, notAnchor] of [
+    ["U+3001 IDEOGRAPHIC COMMA", 0x3001],
+    ["U+30FB KATAKANA MIDDLE DOT", 0x30fb],
+    ["U+FF61 HALFWIDTH IDEOGRAPHIC FULL STOP", 0xff61],
+  ]) {
+    it(`strips a Hangul filler next to ${name} (Script_Extensions only)`, () => {
+      const { cleaned } = stripInvisibleWithReport(
+        HANGUL_FILLER + cp(notAnchor),
+      );
+      assert.equal(cleaned, cp(notAnchor));
+    });
   }
 });
 

--- a/test/invisible-unicode-tables.test.mjs
+++ b/test/invisible-unicode-tables.test.mjs
@@ -1,0 +1,267 @@
+/**
+ * Contract tests for the Unicode script data behind src/invisible.mjs's
+ * carve-outs.
+ *
+ * The carve-out decides whether an invisible does real rendering work from the
+ * script of its neighbour. That question is answered by Unicode's own tables, so
+ * the module asks the runtime for them (`\p{Unified_Ideograph}`,
+ * `\p{Script=Hangul}`, `\p{Script=Braille}`) instead of carrying transcribed
+ * ranges that go stale one Unicode revision at a time. These tests pin the
+ * derivation END-TO-END through the public API: for every code point in a scan
+ * window, "does the carve-out treat this as an anchor?" must equal "does the
+ * property hold?". A drift, a swapped property, or a re-introduced literal table
+ * fails here.
+ *
+ * The one table that CANNOT be derived — the Brahmic consonant spans, whose UCD
+ * property (Indic_Syllabic_Category) JS RegExp does not expose — is instead
+ * pinned by the strongest contract that IS derivable: every assigned code point
+ * in each span belongs to the script the span names and is a letter.
+ *
+ * Every set comparison also asserts non-emptiness: two empty sets are equal, and
+ * a vacuous contract guards nothing.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { stripInvisible, BRAHMIC_CONSONANT_RANGES } from "../src/invisible.mjs";
+import { cp } from "./test-helpers.mjs";
+
+const IVS17 = cp(0xe0100); // an ideographic variation selector
+const HANGUL_FILLER = cp(0x115f);
+const BRAILLE_BLANK = cp(0x2800);
+const HANGUL_FILLERS = new Set([0x115f, 0x1160, 0x3164, 0xffa0]);
+
+/** Every code point of `ranges` (inclusive), skipping the surrogate block.
+ * @param {readonly (readonly [number, number])[]} ranges
+ * @returns {number[]} */
+const expand = (ranges) => {
+  const out = [];
+  for (const [start, end] of ranges)
+    for (let c = start; c <= end; c++)
+      if (c < 0xd800 || c > 0xdfff) out.push(c);
+  return out;
+};
+
+/**
+ * Compare an observed anchor set against a property-derived one over a scan
+ * window, reporting the first few discrepancies in each direction and refusing
+ * to pass on two empty sets.
+ * @param {number[]} window
+ * @param {(ch: string) => boolean} observed  via the public API
+ * @param {(ch: string) => boolean} expected  via a Unicode property escape
+ */
+function assertAnchorSetsAgree(window, observed, expected) {
+  const hex = (c) => `U+${c.toString(16).toUpperCase()}`;
+  const missing = []; // property says anchor, carve-out disagrees
+  const extra = []; // carve-out says anchor, property disagrees
+  let anchors = 0;
+  for (const c of window) {
+    const ch = String.fromCodePoint(c);
+    const exp = expected(ch);
+    if (exp) anchors++;
+    if (exp === observed(ch)) continue;
+    (exp ? missing : extra).push(hex(c));
+  }
+  assert.deepEqual(missing.slice(0, 12), [], "property-only anchors");
+  assert.deepEqual(extra.slice(0, 12), [], "carve-out-only anchors");
+  assert.ok(anchors > 0, "scan window contains no anchors at all (vacuous)");
+}
+
+// ─── CJK ideographs (the base of an ideographic variation sequence) ───────────
+// Derived set: \p{Unified_Ideograph} plus the two CJK Compatibility Ideograph
+// BLOCKS (not Unified_Ideograph, and JS exposes no \p{Block=…}; block bounds are
+// immutable under Unicode's stability policy).
+const UNIFIED_PLUS_COMPAT =
+  /[\p{Unified_Ideograph}\u{F900}-\u{FAFF}\u{2F800}-\u{2FA1F}]/u;
+const CJK_SCAN = expand([
+  [0x2e00, 0xffff], // radicals, Kangxi, Ext A, URO, compatibility ideographs
+  [0x20000, 0x334ff], // Ext B–J and the compatibility supplement
+]);
+
+describe("Unicode contract: CJK ideograph anchors", () => {
+  it("equal \\p{Unified_Ideograph} ∪ the compatibility-ideograph blocks", () => {
+    assertAnchorSetsAgree(
+      CJK_SCAN,
+      (ch) => stripInvisible(ch + IVS17).includes(IVS17),
+      (ch) => UNIFIED_PLUS_COMPAT.test(ch),
+    );
+  });
+
+  it("cover every ASSIGNED code point the retired hand-written table listed", () => {
+    // The table that shipped before the derivation. Its block spans included
+    // unassigned padding (U+FA6E, U+2B81E, …) which cannot occur in real text;
+    // what matters is that no ASSIGNED character it recognised was lost.
+    const retired = expand([
+      [0x3400, 0x4dbf],
+      [0x4e00, 0x9fff],
+      [0xf900, 0xfaff],
+      [0x20000, 0x2a6df],
+      [0x2a700, 0x2b73f],
+      [0x2b740, 0x2b81f],
+      [0x2b820, 0x2ceaf],
+      [0x2ceb0, 0x2ebef],
+      [0x2ebf0, 0x2ee5f],
+      [0x2f800, 0x2fa1f],
+      [0x30000, 0x3134f],
+      [0x31350, 0x323af],
+    ]);
+    const unassigned = /\p{General_Category=Unassigned}/u;
+    const lost = retired.filter((c) => {
+      const ch = String.fromCodePoint(c);
+      return !unassigned.test(ch) && !UNIFIED_PLUS_COMPAT.test(ch);
+    });
+    assert.deepEqual(lost, []);
+    assert.ok(retired.length > 90_000, "retired table sample is non-vacuous");
+  });
+
+  it("add the Extension J ideographs the hand-written table went stale on", () => {
+    // The drift the derivation eliminates: the literal table stopped at
+    // Extension H, so U+323B0–U+33479 (Unicode 17) could not anchor an IVS.
+    for (const c of [0x323b0, 0x33479]) {
+      const base = cp(c);
+      const input = base + IVS17;
+      assert.equal(stripInvisible(input), input, `U+${c.toString(16)}`);
+    }
+  });
+
+  it("hold only Han letters inside the literal compatibility blocks", () => {
+    // The one part of the CJK gate that stays literal, so it gets the drift
+    // guard: a future Unicode assigning a non-Han character inside either block
+    // fails here instead of silently widening what can anchor a selector.
+    const hanLetter = /[\p{Script=Han}&&\p{General_Category=Letter}]/v;
+    const unassigned = /\p{General_Category=Unassigned}/u;
+    const blocks = expand([
+      [0xf900, 0xfaff],
+      [0x2f800, 0x2fa1f],
+    ]);
+    const assigned = blocks.filter(
+      (c) => !unassigned.test(String.fromCodePoint(c)),
+    );
+    const notHanLetter = assigned.filter(
+      (c) => !hanLetter.test(String.fromCodePoint(c)),
+    );
+    assert.deepEqual(notHanLetter, []);
+    assert.ok(assigned.length > 0, "compatibility blocks are all unassigned?");
+  });
+});
+
+// ─── Hangul and Braille anchors ───────────────────────────────────────────────
+describe("Unicode contract: blank-filler anchors", () => {
+  const BMP = expand([[0x0000, 0xffff]]);
+
+  it("Hangul filler anchors equal \\p{Script=Hangul} minus the fillers", () => {
+    assertAnchorSetsAgree(
+      BMP,
+      (ch) => stripInvisible(HANGUL_FILLER + ch).includes(HANGUL_FILLER),
+      (ch) =>
+        /\p{Script=Hangul}/u.test(ch) &&
+        !HANGUL_FILLERS.has(/** @type {number} */ (ch.codePointAt(0))),
+    );
+  });
+
+  it("Braille blank anchors equal \\p{Script=Braille} minus the blank", () => {
+    assertAnchorSetsAgree(
+      BMP,
+      (ch) => stripInvisible(ch + BRAILLE_BLANK).includes(BRAILLE_BLANK),
+      (ch) => /\p{Script=Braille}/u.test(ch) && ch !== BRAILLE_BLANK,
+    );
+  });
+});
+
+// ─── Brahmic consonants (kept literal — no property escape expresses them) ────
+describe("Unicode contract: Brahmic consonant spans", () => {
+  const unassigned = /\p{General_Category=Unassigned}/u;
+
+  it("are non-empty and name a script each", () => {
+    assert.ok(BRAHMIC_CONSONANT_RANGES.length > 0);
+    for (const [script, start, end] of BRAHMIC_CONSONANT_RANGES) {
+      assert.equal(typeof script, "string");
+      assert.ok(start < end, `${script} span is empty or inverted`);
+    }
+  });
+
+  for (const [script, start, end] of BRAHMIC_CONSONANT_RANGES) {
+    const label = `${script} U+${start.toString(16).toUpperCase()}–U+${end
+      .toString(16)
+      .toUpperCase()}`;
+    it(`holds only ${script} letters: ${label}`, () => {
+      const inScript = new RegExp(
+        `[\\p{Script=${script}}&&\\p{General_Category=Letter}]`,
+        "v",
+      );
+      const assigned = expand([[start, end]]).filter(
+        (c) => !unassigned.test(String.fromCodePoint(c)),
+      );
+      const foreign = assigned.filter(
+        (c) => !inScript.test(String.fromCodePoint(c)),
+      );
+      assert.deepEqual(
+        foreign.map((c) => `U+${c.toString(16).toUpperCase()}`),
+        [],
+      );
+      assert.ok(assigned.length > 0, `${label} is entirely unassigned`);
+    });
+  }
+
+  it("stay TIGHTER than \\p{Script=…}: an independent vowel is not a conjunct base", () => {
+    // Why the spans cannot simply become \p{Script=Devanagari}: that set also
+    // holds the independent vowels, which a virama never attaches to, so a
+    // vowel + halant + ZWJ would become a preserved (and therefore usable)
+    // zero-width channel.
+    const A = cp(0x0905); // DEVANAGARI LETTER A, an independent vowel
+    const VIRAMA = cp(0x094d);
+    const ZWJ = cp(0x200d);
+    assert.equal(
+      stripInvisible(A + VIRAMA + ZWJ + cp(0x0915)),
+      A + VIRAMA + cp(0x0915),
+    );
+    // …while the same shape on a real consonant IS preserved.
+    const KA = cp(0x0915);
+    const conjunct = KA + VIRAMA + ZWJ + KA;
+    assert.equal(stripInvisible(conjunct), conjunct);
+  });
+});
+
+// ─── Negative corpus: legitimate multi-script text, zero findings ─────────────
+// The direction that matters. Every entry is ordinary human text; a sanitizer
+// that rewrites any of it has removed content the model needed.
+describe("negative corpus: legitimate multi-script text is untouched", () => {
+  const CORPUS = {
+    "Chinese prose": "维基百科是一个多语言的百科全书协作计划。",
+    "Japanese prose with kana and kanji":
+      "東京都は日本の首都であり、人口は約一千四百万人です。",
+    "Japanese with an ideographic variation sequence": `葛${IVS17}城市は奈良県にあります。`,
+    "Traditional Chinese with a compatibility ideograph":
+      "北大寺、﨑陽、龍谷。",
+    "Korean prose": "한국어 위키백과는 누구나 참여할 수 있는 백과사전입니다.",
+    "Korean with jamo": "한글의 자모는 ㄱ, ㄴ, ㄷ 그리고 ㅏ, ㅑ 입니다.",
+    "Hindi (Devanagari) with conjuncts":
+      "हिन्दी भारत की सबसे अधिक बोली जाने वाली भाषा है।",
+    "Marathi with an explicit ZWJ half-form": "क्‍ष रचना",
+    "Bengali prose": "বাংলা ভাষা দক্ষিণ এশিয়ার একটি প্রধান ভাষা।",
+    "Tamil prose": "தமிழ் மொழி உலகின் மிகப் பழமையான மொழிகளில் ஒன்று.",
+    "Kannada prose": "ಕನ್ನಡ ಭಾಷೆ ಕರ್ನಾಟಕದ ಅಧಿಕೃತ ಭಾಷೆಯಾಗಿದೆ.",
+    "Sinhala prose": "සිංහල භාෂාව ශ්‍රී ලංකාවේ ප්‍රධාන භාෂාවකි.",
+    "Persian with a ZWNJ": "کتاب‌های خوب را می‌خوانم.",
+    // The harakat sits in the SAME grapheme cluster as the ZWNJ that follows
+    // its letter, so this is the shape the cluster-charged budget must not clip.
+    "vocalised Persian with a ZWNJ": "مِیْ‌خوانم و کِتاب‌هایِ خوب",
+    "emoji ZWJ family and couple": "👨‍👩‍👧‍👦 and 👩‍❤️‍👨 at the park",
+    "emoji ZWJ profession with skin tone": "👩🏽‍🚒 👨🏿‍💻 👩‍🔬",
+    "flag ZWJ sequences": "🏳️‍🌈 🏴‍☠️ 🏳️‍⚧️",
+    // Two flags = 12 tag chars, inside the 16-char document preserve budget. A
+    // third overruns it and is stripped — pre-existing budget behaviour this PR
+    // does not change (test/invisible.test.mjs pins it).
+    "subregional flags": "🏴󠁧󠁢󠁳󠁣󠁴󠁿 and 🏴󠁧󠁢󠁷󠁬󠁳󠁿",
+    keycaps: "1️⃣ 2️⃣ 3️⃣ #️⃣ *️⃣",
+    "Braille with blank cells": "⠓⠑⠇⠇⠕⠀⠺⠕⠗⠇⠙",
+    "mixed-script sentence":
+      "The 東京 office ships 한국어 and हिन्दी builds 👩‍💻 daily.",
+  };
+
+  for (const [name, text] of Object.entries(CORPUS)) {
+    it(`leaves ${name} byte-identical`, () => {
+      assert.equal(stripInvisible(text), text);
+    });
+  }
+});

--- a/test/invisible.test.mjs
+++ b/test/invisible.test.mjs
@@ -689,11 +689,19 @@ describe("consecutive-joiner cap", () => {
     assert.deepEqual(found, [CATEGORY.CF]);
   });
 
-  it(`caps preserved ZWJ in an alternating emoji run at ${CONSECUTIVE_JOINER_CAP}`, () => {
+  it(`strips EVERY ZWJ of an over-cap emoji run (one cluster, atomic)`, () => {
+    // An emoji ZWJ run is a SINGLE grapheme cluster, and the preserve budget is
+    // charged per cluster: over the cap, the whole cluster's joiners go, rather
+    // than the first CONSECUTIVE_JOINER_CAP surviving and carving one grapheme
+    // in half. The visible pictographs are untouched either way.
     const input =
       cp(0x1f468) + (ZWJ + cp(0x1f469)).repeat(CONSECUTIVE_JOINER_CAP + 12);
     const { cleaned, found } = stripInvisibleWithReport(input);
-    assert.equal(countOf(cleaned, ZWJ), CONSECUTIVE_JOINER_CAP);
+    assert.equal(countOf(cleaned, ZWJ), 0);
+    assert.equal(
+      cleaned,
+      cp(0x1f468) + cp(0x1f469).repeat(CONSECUTIVE_JOINER_CAP + 12),
+    );
     assert.deepEqual(found, [CATEGORY.CF]);
   });
 
@@ -817,6 +825,105 @@ describe("document-wide preserved-joiner budget", () => {
     assert.ok(joiners > TOTAL_PRESERVED_JOINER_BUDGET);
     assert.equal(countOf(cleaned, ZWNJ), joiners); // all preserved, none clipped
     assert.deepEqual(found, []);
+  });
+});
+
+// ─── The preserve budget is charged per GRAPHEME CLUSTER, never per code point ─
+// A budget accounted per code point can fall due part-way through one cluster
+// and carve a single grapheme in half: with the document budget exhausted after
+// the 6th family emoji's first ZWJ, 👨‍👩‍👧‍👦 came out as 👨‍👩👧👦 — three glyphs where
+// the author wrote one, and a "budget" whose own invariant did not hold for the
+// thing it protects. Charging the whole cluster at once makes that impossible by
+// construction.
+describe("preserve budget: grapheme clusters are indivisible", () => {
+  const FAMILY_CLUSTER =
+    cp(0x1f468) + ZWJ + cp(0x1f469) + ZWJ + cp(0x1f467) + ZWJ + cp(0x1f466);
+  const FAMILY_BARE = cp(0x1f468) + cp(0x1f469) + cp(0x1f467) + cp(0x1f466);
+  // 3 ZWJ per family against the 16-unit document budget: 5 families fit (15),
+  // the 6th needs 3 more and does not.
+  const FAMILIES_THAT_FIT = 5;
+
+  const clustersOf = (text) =>
+    Array.from(
+      new Intl.Segmenter("en", { granularity: "grapheme" }).segment(text),
+      (s) => s.segment,
+    );
+
+  /**
+   * Assert no grapheme cluster of `input` survives half-carved: each must appear
+   * in the output either byte-identical or with EVERY tracked invisible removed.
+   * Only valid for inputs whose invisibles are all carve-PRESERVABLE (a payload
+   * invisible is unconditionally stripped, which is a legitimate third outcome).
+   */
+  const assertNoPartialCarve = (input) => {
+    let rest = stripInvisible(input);
+    for (const cluster of clustersOf(input)) {
+      const bare = cluster.replace(STRIP, "");
+      if (rest.startsWith(cluster)) rest = rest.slice(cluster.length);
+      else if (rest.startsWith(bare)) rest = rest.slice(bare.length);
+      else
+        assert.fail(
+          `cluster ${JSON.stringify(cluster)} was partially carved; output continues ${JSON.stringify(rest.slice(0, 16))}`,
+        );
+    }
+    assert.equal(
+      rest,
+      "",
+      "output has trailing text no input cluster explains",
+    );
+  };
+
+  for (const n of [FAMILIES_THAT_FIT, FAMILIES_THAT_FIT + 1, 8, 12]) {
+    it(`carves ${n} family emoji all-or-nothing per cluster`, () => {
+      const input = FAMILY_CLUSTER.repeat(n);
+      const kept = Math.min(n, FAMILIES_THAT_FIT);
+      assert.equal(
+        stripInvisible(input),
+        FAMILY_CLUSTER.repeat(kept) + FAMILY_BARE.repeat(n - kept),
+      );
+      assertNoPartialCarve(input);
+    });
+  }
+
+  it("reports the strip once the budget cuts a whole cluster", () => {
+    const { found } = stripInvisibleWithReport(
+      FAMILY_CLUSTER.repeat(FAMILIES_THAT_FIT + 1),
+    );
+    assert.deepEqual(found, [CATEGORY.CF]);
+  });
+
+  it("is idempotent across the budget cut (no malformed remnant to re-strip)", () => {
+    const once = stripInvisible(FAMILY_CLUSTER.repeat(FAMILIES_THAT_FIT + 1));
+    assert.equal(stripInvisible(once), once);
+  });
+
+  it("keeps multi-preservable clusters whole under the CONSECUTIVE caps too", () => {
+    // 🏳️‍🌈 is VS16 + ZWJ inside ONE cluster: two preservables that must rise and
+    // fall together no matter which limit bites.
+    const rainbow = cp(0x1f3f3) + cp(0xfe0f) + ZWJ + cp(0x1f308);
+    for (const n of [1, 6, 9, 20]) assertNoPartialCarve(rainbow.repeat(n));
+  });
+
+  it("does not clip vocalised Arabic: a harakat still opens a fresh run", () => {
+    // Regression on the cluster rewrite: `beh + fatha + ZWNJ` is ONE cluster,
+    // and the harakat closes a genuine gap inside it. Charging per cluster must
+    // not lose that reset, or 12 ordinary words would be clipped to the
+    // consecutive-joiner cap (8) — legitimate text mangled by an accounting
+    // change. The document-wide budget (16) is the only limit in play here.
+    const unit = cp(0x628) + cp(0x64e) + ZWNJ;
+    const input = unit.repeat(12) + cp(0x628);
+    const { cleaned, found } = stripInvisibleWithReport(input);
+    assert.equal(cleaned, input);
+    assert.deepEqual(found, []);
+    assert.ok(12 > CONSECUTIVE_JOINER_CAP, "case must exceed the run cap");
+  });
+
+  it("keeps a subregional flag's tag run whole (tags are cluster-internal)", () => {
+    const flag =
+      cp(0x1f3f4) +
+      [..."gbsct"].map((c) => cp(0xe0000 + c.charCodeAt(0))).join("") +
+      CANCEL_TAG;
+    for (const n of [1, 2, 3, 5]) assertNoPartialCarve(flag.repeat(n));
   });
 });
 

--- a/test/invisible.test.mjs
+++ b/test/invisible.test.mjs
@@ -904,6 +904,23 @@ describe("preserve budget: grapheme clusters are indivisible", () => {
     for (const n of [1, 6, 9, 20]) assertNoPartialCarve(rainbow.repeat(n));
   });
 
+  it("judges each cluster on the run its own leading gap resets", () => {
+    // Two adjacent 6-pictograph ZWJ sequences, 5 joiners each. The second
+    // cluster opens with a pictograph directly after the first cluster's — a
+    // genuine gap, which resets the consecutive-joiner run. Judging cluster 2
+    // on the STALE count (5 + 5 > 8) would strip all five of its joiners even
+    // though 10 preserved chars sit well inside the document budget (16): a
+    // false positive on legitimate joined text.
+    const cluster = cp(0x1f468) + (ZWJ + cp(0x1f469)).repeat(5);
+    const input = cluster + cluster;
+    const { cleaned, found } = stripInvisibleWithReport(input);
+    assert.equal(cleaned, input);
+    assert.deepEqual(found, []);
+    assert.equal(countOf(cleaned, ZWJ), 10);
+    assert.ok(10 <= TOTAL_PRESERVED_JOINER_BUDGET, "must fit the budget");
+    assert.ok(5 < CONSECUTIVE_JOINER_CAP, "each cluster must fit the run cap");
+  });
+
   it("does not clip vocalised Arabic: a harakat still opens a fresh run", () => {
     // Regression on the cluster rewrite: `beh + fatha + ZWNJ` is ONE cluster,
     // and the harakat closes a genuine gap inside it. Charging per cluster must

--- a/tests/test_redos_js_static_guard.py
+++ b/tests/test_redos_js_static_guard.py
@@ -39,6 +39,12 @@ UNANALYZABLE_JS_ONLY = {
     ("src/invisible.mjs", r"[\p{Extended_Pictographic}\p{Emoji_Modifier}]"),
     ("src/invisible.mjs", r"\p{Extended_Pictographic}"),
     ("src/invisible.mjs", r"[\u{E0000}-\u{E007F}]"),
+    (
+        "src/invisible.mjs",
+        r"[\p{Unified_Ideograph}\u{F900}-\u{FAFF}\u{2F800}-\u{2FA1F}]",
+    ),
+    ("src/invisible.mjs", r"\p{Script=Braille}"),
+    ("src/invisible.mjs", r"\p{Script=Hangul}"),
 }
 
 # JS `(?<name>` -> Python `(?P<name>`, leaving lookbehinds `(?<=` / `(?<!`


### PR DESCRIPTION
Stacks on #238 (`claude/parallel-audit-eliminators-ie4z0e-e`) and merges after it — base is that branch, not `main`. Claims `src/invisible.mjs`'s Unicode script tables and carve-out preserve budget.

## Summary

Two eliminator findings in `src/invisible.mjs`, both re-confirmed by execution before any edit:

1. **Hand-maintained Unicode script tables drift.** The CJK / Hangul / Braille anchor tables were hand-transcribed block spans with nothing proving they matched the Unicode data they claimed to encode — and one had already gone stale. They are now derived from the runtime's own Unicode data via property escapes, so a new Unicode revision arrives with the Node upgrade.
2. **The preserve budget was charged per code point against an indivisible unit.** A grapheme cluster could be carved in half when a limit fell due mid-cluster — the budget's own invariant did not hold for the thing it protects. The budget is now charged per grapheme cluster, using `Intl.Segmenter` (the real UAX #29 segmenter, not an approximation).

## Finding 1 — script tables

### Before / after

The retired table stopped at CJK Extension H, so the 4,298 Extension J ideographs (U+323B0–U+33479, Unicode 17) could not anchor a legitimate ideographic variation sequence:

```
stripInvisible(U+323B0 + U+E0100)
before:  "\u{323B0}"            # selector stripped from valid text
after:   "\u{323B0}\u{E0100}"   # preserved
```

### `Script` vs `Script_Extensions` diff evidence

Diffed both candidate property sets against each literal table (full-plane scan, Node v22.22.2 / Unicode 17):

| table | candidate | hand-only (in table, not property) | property-only |
|---|---|---|---|
| CJK | `Script=Han` | 68 cp — all **unassigned** block padding (`FA6E–FA6F`, `FADA–FAFF`, `2B81E–2B81F`, `2CEAE–2CEAF`, `2EBE1–2EBEF`, `2EE5E–2EE5F`, `2FA1E–2FA1F`, `3134B–3134F`) | 4,651 cp — incl. radicals `2E80–2EF3`, Kangxi `2F00–2FD5`, `3005`, `3007`, and Ext J `323B0–33479` |
| CJK | `Script_Extensions=Han` | same 68 | 4,959 cp — additionally `B7` MIDDLE DOT, `3001–3003`, `30FB`, `FF61–FF65` (CJK punctuation) |
| CJK | `Unified_Ideograph` | 1,070 cp — the compatibility-ideograph blocks + the same unassigned padding | 4,298 cp — exactly Ext J |
| Hangul | `Script=Hangul` | 22 cp — **all unassigned** (`3130`, `318F`, `A97D–A97F`, `D7C7–D7CA`, `D7FC–D7FF`, `FFBF–FFC1`, `FFC8–FFC9`, `FFD0–FFD1`, `FFD8–FFD9`) | `115F/1160/3164/FFA0` (the fillers, deliberately excluded), `302E–302F` tone marks, `3200–321E` / `3260–327E` enclosed Hangul |
| Hangul | `Script_Extensions=Hangul` | same 22 | the above **plus** `3001–3003`, `30FB`, `FF61–FF65`, `FE45–FE46` — CJK punctuation shared with Chinese/Japanese |
| Braille | `Script=Braille` | none | none (identical to `Script_Extensions=Braille`; exactly `2800–28FF`) |

**The hand-written tables matched neither property exactly** — that is a finding in its own right, and the discrepancies are enumerated above. Resolution per table:

- **CJK → `\p{Unified_Ideograph}` ∪ the two compatibility-ideograph blocks (literal).** `Script=Han` is wrong (radicals, `3005`/`3007`, IDCs are not IVS bases); `Script_Extensions=Han` is worse still — it would let `U+00B7 MIDDLE DOT` or a full stop anchor a variation selector. Compatibility ideographs are not `Unified_Ideograph` and JS exposes no `\p{Block=…}`, so those two spans stay literal; block bounds are immutable under Unicode's stability policy and a contract test pins that every assigned code point inside them is a `Script=Han` letter. The only stripping this widens is after **unassigned** code points (which cannot occur in real text and are never IVD-registered bases); it *narrows* stripping for 4,298 real ideographs.
- **Hangul → `\p{Script=Hangul}` minus the fillers.** `Script_Extensions` is explicitly rejected: a Japanese `・` would otherwise anchor (and thereby preserve) a Hangul filler in text containing no Hangul at all. Net effect: strictly *more* legitimate anchors (tone marks, enclosed Hangul), and the only losses are unassigned code points.
- **Braille → `\p{Script=Braille}` minus `U+2800`.** Both properties agree exactly with the old literal range; zero behaviour change.
- **Brahmic consonants → kept literal + contract test.** No property expresses them: the UCD property is `Indic_Syllabic_Category=Consonant`, which JS RegExp does not expose, and `\p{Script=Devanagari}` is the *wrong shape* — it also holds the independent vowels `0904–0914`, so switching would preserve a joiner after a bare vowel + halant (a smuggling channel). Behaviour is unchanged. The contract test pins, per span, that every **assigned** code point is a letter of the script the span names, with a non-empty-assigned assertion so it cannot pass vacuously. The remaining hand-only members (`09A9`, `09B1`, `0A29`, `0B96–0B98`, `0C29`, `0DB2`, …) were verified to be unassigned holes inside the spans, not foreign characters.

## Finding 2 — the carve/span budget

Input: the four-person family emoji (base + 3 ZWJ) repeated 6 times.

### Before

```
found:  [ 'cf-format' ]
output: 👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩👧👦
```

The document budget (16) is exhausted after the 6th family's **first** ZWJ: one grapheme cluster comes out as three glyphs where the author wrote one.

### After

```
found:  [ 'cf-format' ]
output: 👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨👩👧👦
```

All-or-nothing per cluster. This also **subsumes** the hand-rolled tag-sequence atomicity (`tagSpanLen`): a subregional flag's tag chars are `Grapheme_Cluster_Break=Extend`, so they already live inside their base pictograph's cluster — that special case and its bookkeeping array are deleted, and the existing flag-atomicity test still passes unchanged.

### Follow-up fix (commit 2, from review)

The first cut of the cluster accounting judged the consecutive caps on `joinerRun`/`selectorRun` as they stood at the END of the previous cluster — but the emit loop resets those when a cluster opens with a genuine gap (two visible code points in a row). Two adjacent 6-pictograph emoji ZWJ sequences (5 joiners each, 10 total, inside the 16-unit budget, each cluster inside the run cap of 8) therefore had the whole second cluster stripped on a stale `5 + 5 > 8`. Verified against both branches:

```
this branch, commit 1 : preserved ZWJ 5 of 10, found [ 'cf-format' ]
base branch           : preserved ZWJ 10 of 10, found []
```

A false positive on legitimate joined text, so the cluster's own leading-gap reset is now applied to a local copy before the caps are evaluated, mirroring the emit loop's gap rule exactly. Test added first and proved red before the fix:

```
not ok 8 - judges each cluster on the run its own leading gap resets
    + actual   '👨‍👩‍👩‍👩‍👩‍👩👨👩👩👩👩👩'
    - expected '👨‍👩‍👩‍👩‍👩‍👩👨‍👩‍👩‍👩‍👩‍👩'
```

## Changes

- `src/invisible.mjs`
  - `isCjkIdeograph` / `isHangul` / `isBrailleCell` now test property escapes; `CJK_IDEOGRAPH_RANGES` and the Hangul/Braille literal ranges are gone.
  - `BRAHMIC_CONSONANT_RANGES` keeps its literal spans, now keyed by script name and exported solely so the contract test can check each span against the script it claims.
  - `carveStrip` walks grapheme clusters; `clusterEnds` restates the segmenter's UTF-16 boundaries in code-point space. `analyzeCarve` no longer computes `tagSpanLen`.
- `test/invisible-unicode-tables.test.mjs` (new) — set-equality contracts + the negative corpus.
- `test/invisible.test.mjs` — new `preserve budget: grapheme clusters are indivisible` suite.
- `test/invisible-mutation-kill.test.mjs` — the `isHangul` range-boundary suite pinned *unassigned* code points as anchors; replaced with assigned-boundary anchors per block, the three property-only additions, and three `Script_Extensions`-only non-anchors.
- `tests/test_redos_js_static_guard.py` — the three new `\p{…}` patterns added to `UNANALYZABLE_JS_ONLY` (the guard requires it; each is a bare character class with no quantifier, and the guard itself asserts skip entries stay live and unanalyzable).

## Tests / verification

All run locally on this branch head.

```
pnpm test           # 2299 tests, 2299 pass, 0 fail — invisible.mjs 100/100/100/100 coverage
pnpm lint           # clean
pnpm check          # clean
pnpm format:check   # "All matched files use Prettier code style!"
uv run --extra dev pytest tests   # 1460 passed, 5 skipped
npx stryker run --mutate src/invisible.mjs --dryRunOnly   # dry run succeeded
```

The cross-language golden corpus did **not** move — no behaviour drift on it. The Stryker dry run is included because the new contract tests neither shell out to git nor read source files as text (they import the module), so they work in the sandbox copy, which has no `.git`.

### Non-vacuity: each guard proved red when its fix is reverted

**Reverting the CJK derivation** to the literal table:

```
not ok 1 - equal \p{Unified_Ideograph} ∪ the compatibility-ideograph blocks
    property-only anchors
    +   'U+323B0', 'U+323B1', 'U+323B2', 'U+323B3', 'U+323B4', ...
```

**Reverting the Hangul derivation** to the literal ranges:

```
not ok 13 - preserves a Hangul filler anchored by Hangul tone mark U+302E
not ok 14 - preserves a Hangul filler anchored by parenthesized Hangul U+3200
not ok 15 - preserves a Hangul filler anchored by circled Hangul U+326E
not ok 1  - Hangul filler anchors equal \p{Script=Hangul} minus the fillers
    property-only anchors
    +   'U+302E', 'U+302F', 'U+3200', 'U+3201', ...
```

**Running the new tests against the base branch's `src/invisible.mjs`** (i.e. the whole cluster-budget fix reverted):

```
# tests 244 | pass 240 | fail 4
not ok 2 - strips EVERY ZWJ of an over-cap emoji run (one cluster, atomic)
not ok 2 - carves 6 family emoji all-or-nothing per cluster
    + actual   '👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩👧👦'
    - expected '👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨👩👧👦'
not ok 3 - carves 8 family emoji all-or-nothing per cluster
not ok 4 - carves 12 family emoji all-or-nothing per cluster
```

### Negative corpus (zero findings on legitimate input)

21 entries of real multi-script text asserted byte-identical after `stripInvisible`: Chinese, Japanese (incl. an ideographic variation sequence and a compatibility ideograph), Korean prose and bare jamo, Hindi/Bengali/Tamil/Kannada/Sinhala with conjuncts, an explicit Marathi ZWJ half-form, Persian and vocalised Persian ZWNJ, emoji ZWJ families/professions/skin tones, flag ZWJ sequences, subregional flags, keycaps, Braille with blank cells, and a mixed-script sentence.

### Contract-test non-vacuity

Every set comparison asserts the compared sets are non-empty (`assertAnchorSetsAgree` fails if the scan window contains no anchors at all), each Brahmic span asserts at least one assigned letter, and the retired-table coverage check asserts its own sample exceeds 90,000 code points.

## Decisions made

- **An over-cap emoji ZWJ run now loses *every* joiner in the cluster, not just the surplus.** `CONSECUTIVE_JOINER_CAP` used to preserve the first 8 joiners of a 20-joiner single-cluster run and strip the rest — itself a partial carve. Under cluster accounting the whole cluster fails the cap and all its joiners go. The existing test asserting `8` was updated to assert `0`, with an exact-equality assertion on the full output. Alternative: exempt the consecutive caps from cluster atomicity, which would reinstate partial carving for exactly the inputs the cap exists to catch. The affected input (a 21-person emoji chain; RGI sequences top out at 4 components) is not legitimate text, and the direction of the change is over-strip, not under-strip.
- **The cap decision uses a local, gap-reset copy of the run counters rather than the raw ones** (see the follow-up fix above). The alternative — leaving the emit loop's reset as the only one — is fail-closed but produces false positives on adjacent joined clusters, the expensive direction under CLAUDE.md's precision rule.
- **Two regression tests pin joined text that must survive**: two adjacent 5-joiner emoji clusters, and 12 vocalised-Arabic `beh + fatha + ZWNJ` words. Both match the base branch exactly; they lock behaviour a future accounting change could silently mangle.
- **`BRAHMIC_CONSONANT_RANGES` is exported.** The contract test needs to check each span against the script it names; re-declaring the table in the test would create a second copy to drift. Alternative: keep it private and duplicate the data in the test — rejected, that is the very failure mode this PR removes.
- **`Intl.Segmenter` is constructed once at module scope with locale `"en"`.** Grapheme segmentation is locale-independent; the pin is for determinism across hosts, and module-scope construction keeps the ICU setup off the per-call path.
- **The compatibility-ideograph blocks stay as literal spans** rather than being approximated by `Script=Han` minus `Unified_Ideograph` (which would also drag in radicals and `3005`/`3007`). Block bounds are immutable; the contract test guards their contents.

## Deferred

- **Cross-language parity.** The Python port carries no mirror of these tables (verified by search), so nothing there needed to move. `python/**` and `scripts/**` are out of scope for this PR regardless.
- **`isBrahmicConsonant` still takes a code point while the other predicates now take a character.** Harmonising the signatures is pure churn in a file sibling PRs are touching; left alone.
- **A UCD-derived generator for the Brahmic consonant spans** (the only fully drift-proof answer) would live in `scripts/`, which is out of scope here.

## Checklist

- [x] Commits follow Conventional Commits; each subject reads as a user-facing release note.
- [x] `pnpm test`, `pnpm lint`, and `pnpm check` pass locally.
- [x] New or changed detectors have negative tests (zero findings on legitimate input) and pin their invariants with contract/exact-equality tests.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version are left untouched (the release workflow owns them).
