### PR TITLE
fix(ci): add the hook-fault and layer-pipeline shard group, unbreaking main

### DIFF
--- a/.github/mutation-shards.json
+++ b/.github/mutation-shards.json
@@ -1,15 +1,42 @@
 {
   "splitEvery": 300,
   "split": [
-    { "id": "html", "file": "src/html.mjs" },
-    { "id": "standardized-variants", "file": "src/standardized-variants.mjs" },
-    { "id": "invisible", "file": "src/invisible.mjs" },
-    { "id": "output", "file": "src/output.mjs" },
-    { "id": "joining-type", "file": "src/joining-type.mjs" },
-    { "id": "rehydrate", "file": "src/rehydrate.mjs" },
-    { "id": "instructions", "file": "src/instructions.mjs" },
-    { "id": "view-map", "file": "src/view-map.mjs" },
-    { "id": "hook-io", "file": "claude-hooks/lib/hook-io.mjs" },
+    {
+      "id": "html",
+      "file": "src/html.mjs"
+    },
+    {
+      "id": "standardized-variants",
+      "file": "src/standardized-variants.mjs"
+    },
+    {
+      "id": "invisible",
+      "file": "src/invisible.mjs"
+    },
+    {
+      "id": "output",
+      "file": "src/output.mjs"
+    },
+    {
+      "id": "joining-type",
+      "file": "src/joining-type.mjs"
+    },
+    {
+      "id": "rehydrate",
+      "file": "src/rehydrate.mjs"
+    },
+    {
+      "id": "instructions",
+      "file": "src/instructions.mjs"
+    },
+    {
+      "id": "view-map",
+      "file": "src/view-map.mjs"
+    },
+    {
+      "id": "hook-io",
+      "file": "claude-hooks/lib/hook-io.mjs"
+    },
     {
       "id": "hook-sanitize-output",
       "file": "claude-hooks/sanitize-output.mjs"
@@ -26,7 +53,10 @@
       "id": "hook-scan-invisible",
       "file": "claude-hooks/scan-invisible-chars.mjs"
     },
-    { "id": "cli", "file": "bin/sanitize-cli.mjs" }
+    {
+      "id": "cli",
+      "file": "bin/sanitize-cli.mjs"
+    }
   ],
   "groups": [
     {
@@ -52,6 +82,10 @@
     {
       "id": "hook-lib-report",
       "mutate": "claude-hooks/lib/invisible-alert.mjs,claude-hooks/lib/reveal.mjs,claude-hooks/lib/secret-annotate.mjs,claude-hooks/lib/trace.mjs"
+    },
+    {
+      "id": "hook-lib-pipeline",
+      "mutate": "claude-hooks/lib/hook-fault.mjs,claude-hooks/lib/layer-pipeline.mjs"
     }
   ],
   "hookScopeBreak": 30


### PR DESCRIPTION
Claimed area: `.github/mutation-shards.json`.

**`main` is currently red.** Two contract tests fail on pristine `main` (`37549dc`), with no failing PR to point at:

```
$ node --test test/shipped-gates.test.mjs test/mutation-shards.test.mjs
# tests 15 / # pass 13 / # fail 2

not ok 1 - puts every shipped file in the shard matrix, whole files exactly once
  shard file set must equal the shipped set
  + actual - expected
  -   'claude-hooks/lib/hook-fault.mjs',
  -   'claude-hooks/lib/layer-pipeline.mjs',
```

## How it happened

Neither contributing PR was red on its own. This is a semantic conflict between two textually-clean merges:

- **#245** added `test/shipped-gates.test.mjs`, whose contract is that the shard matrix file set must *equal* the shipped set derived from `package.json` `files`+`exports`.
- **#240** added `claude-hooks/lib/hook-fault.mjs` and `claude-hooks/lib/layer-pipeline.mjs`. Both are in the shipped set. Neither was added to `.github/mutation-shards.json`.

When #240's checks last ran, its base did not yet contain #245's contract test, so the pairing that breaks was never executed anywhere before both landed. `git merge-tree` reports these branches as merging cleanly, because the conflict is not textual — nothing in the diff overlaps.

The blast radius is wider than one red PR: because Stryker's dry run executes the project's test command, a failing `pnpm test` takes **every** mutation shard down with it. #239 showed ~50 red shards plus `test` and `hook-lifecycle`, all from this single root cause, and none of them its own fault.

## The fix

Adds the two files as a new `hook-lib-pipeline` group.

Deliberately a *new* group rather than an extension of `hook-lib-config` or `hook-lib-report`: a group's `mutate` string is interpolated into its check name (`mutation (hook-lib-config, claude-hooks/lib/authored-content.mjs,…)`), and branch protection matches required checks by name. Extending an existing group renames its check; adding a group only adds one.

## Verification

Before, on pristine `main`: `# tests 15 / # pass 13 / # fail 2`.
After: `# tests 15 / # pass 15 / # fail 0`.

All mutation shards on this PR are green, including the new `mutation (hook-lib-pipeline, …)` job — that was the breakage this PR set out to fix, and it is fixed.

## Known-remaining red: a *second*, independent bug on `main`

`node-tests-passed` is still failing here, and it is not this change (this PR touches one JSON file). A property test found a latent invisible-character leak that reproduces on pristine `main`:

```
not ok 296 - property: stripInvisible invariants
    not ok 6 - STRIP-matchable chars are gone unless preserved by the carve-out
      Property failed after 74 tests
      { seed: -1494323434, path: "73:2:1:9:5:5:6:6:5:7:5:5:6", endOnFailure: true }
      Counterexample: ["ᅟ가"]
```

Characterized on pristine `main`: U+115F/U+1160/U+3164/U+FFA0 (Hangul fillers) are STRIP-matchable and are stripped when alone or beside Latin, but survive when adjacent to a Hangul syllable — the carve-out's adjacency check treats them as Hangul context. That is being fixed in a separate PR; this one will go green once that lands.

## Decisions made

- **New shard group rather than extending an existing one.** Reason above. Under the alternative the diff is two words shorter and one check gets silently renamed.
- **Grouped rather than `split`.** Both files are small enough not to need the 300-line splitting the `split` list applies to large modules; grouping keeps the shard count flat. Under the alternative each gets its own shard and the matrix grows by two jobs for no coverage gain.
- **Fixed on a branch off `main` rather than folded into #239.** #239 is blocked by this and needs it, but so are #241 and #244 — a shared fix that can merge on its own unblocks all three, where folding it into #239 would make the other two wait on M's review.
- **The Hangul filler leak is fixed in its own PR, not folded in here.** It is a detection-layer precision judgment (U+115F has legitimate use displaying isolated jamo) and does not belong in a CI-unbreaking change. Under the alternative this PR blocks on that judgment call.

## Lessons Learned

**What:** Make the "SSOT contract tests must change in the same commit as their data" rule enforceable across *concurrent* PRs, not just within one. Two mechanisms, either of which would have caught this:
1. Turn on **"Require branches to be up to date before merging"** for the required-check contexts, so a PR whose base has moved must re-run before it can land.
2. Pair the contract test with its data in `.hooks/guard-pairs.json` so it runs pre-commit — this repo already has that mechanism, and `.github/mutation-shards.json` is already paired; what was missing is that *adding a new shipped module* also invalidates the matrix, which no pairing on the new file's path can express.

**Where:** `.github/workflows/` branch-protection docs and `.hooks/guard-pairs.json` in the template.

**Why:** A contract test that asserts set *equality* between a generated-ish list and a hand-maintained one is invalidated by any PR that adds a member — including PRs that never touch the list. Per-PR CI cannot see that, because each PR is green against the base it was tested on. This cost roughly 50 red shards on an innocent PR and presented as "the merge broke everything," which is the most expensive possible way to learn it.