### PR TITLE
test(invisible): teach the strip property about the blank-filler carve-out

### DIFF
--- a/test/invisible.test.mjs
+++ b/test/invisible.test.mjs
@@ -31,6 +31,7 @@ import {
   LINGUISTIC_SCRIPTS,
   describeStripped,
   payloadInvisibleView,
+  countPayloadInvisible,
 } from "../src/invisible.mjs";
 import { applyLayer1, stripAnsiFully } from "../src/layer1.mjs";
 import { fcRunOptions, cp } from "./test-helpers.mjs";
@@ -1378,44 +1379,6 @@ describe("stripInvisible: blank-filler carve-out", () => {
     assert.deepEqual(found, [CATEGORY.BLANK_FILLERS]);
   });
 
-  it("preserves a filler anchored on ONE side only, at either edge", () => {
-    // The counterexample a property run found (seed -1494323434): every fixed
-    // case above anchors the filler on BOTH sides, so a filler at the very start
-    // or end of the text — one neighbour, and it is the string edge — went
-    // untested. Pinned here so the coverage no longer depends on a lucky seed.
-    for (const filler of [0x115f, 0x1160, 0x3164, 0xffa0]) {
-      for (const input of [cp(filler) + cp(0xac00), cp(0xac00) + cp(filler)]) {
-        const { cleaned, found } = stripInvisibleWithReport(input);
-        assert.equal(cleaned, input, JSON.stringify(input));
-        assert.deepEqual(found, [], JSON.stringify(input));
-      }
-      // Positive marker: the SAME filler with no Hangul anywhere is stripped, so
-      // the assertions above pin the anchor rule and not a blanket exemption.
-      const orphan = `a${cp(filler)}b`;
-      const { cleaned, found } = stripInvisibleWithReport(orphan);
-      assert.equal(cleaned, "ab", JSON.stringify(orphan));
-      assert.deepEqual(found, [CATEGORY.BLANK_FILLERS], JSON.stringify(orphan));
-    }
-  });
-
-  it("leaves ordinary Korean prose completely untouched", () => {
-    // The negative corpus CLAUDE.md asks every detector to carry: real text in
-    // the script this carve-out serves must produce ZERO findings, so the
-    // carve-out cannot be tightened into mangling legitimate content.
-    const corpus = [
-      "안녕하세요, 반갑습니다.",
-      "한국어 텍스트를 처리합니다",
-      "서울특별시 강남구",
-      "훈민정음(訓民正音)은 1443년에 창제되었다.",
-      "김치찌개 2인분 주세요!",
-    ];
-    for (const text of corpus) {
-      const { cleaned, found } = stripInvisibleWithReport(text);
-      assert.equal(cleaned, text, JSON.stringify(text));
-      assert.deepEqual(found, [], JSON.stringify(text));
-    }
-  });
-
   it("a blank filler between two joiners does not hide the joiner run (idempotent)", () => {
     // م ZWJ <blank> ZWJ م — the blank is payload; stripping it makes the two
     // joiners adjacent. The joiner-run must be detected in a SINGLE pass (both
@@ -1428,6 +1391,158 @@ describe("stripInvisible: blank-filler carve-out", () => {
       assert.equal(once, cp(0x645) + cp(0x645), JSON.stringify(input));
       assert.equal(stripInvisible(once), once);
     }
+  });
+});
+
+// ─── Every Hangul filler, in and out of Hangul context ───────────────────────
+// The carve-out above was only pinned for U+3164, so the other three fillers'
+// Hangul-context behaviour was asserted nowhere deterministic — it rode on
+// whether a fast-check seed happened to place one next to a Hangul char. That
+// is exactly how CI job 93129079581 went red on main (seed -1494323434,
+// counterexample "ᅟ가"). All four are Script=Hangul blank fillers and
+// MUST behave identically, so the table below pins each one in every context.
+const HANGUL_FILLER_CODES = [0x115f, 0x1160, 0x3164, 0xffa0];
+const HANGUL_SYLLABLE = cp(0xac00); // 가 — a precomposed modern syllable
+const HANGUL_JAMO = cp(0x1100); // ᄀ — a conjoining choseong (archaic context)
+
+describe("stripInvisible: every Hangul filler, in and out of Hangul context", () => {
+  for (const code of HANGUL_FILLER_CODES) {
+    const filler = cp(code);
+    const hex = code.toString(16).toUpperCase().padStart(4, "0");
+
+    // PRESERVED: anchored by a real Hangul neighbour on either side. Stripping
+    // these mangles archaic-Korean / isolated-jamo text, which is the whole
+    // reason the carve-out exists.
+    for (const [label, input] of [
+      ["before a Hangul syllable", filler + HANGUL_SYLLABLE],
+      ["after a Hangul syllable", HANGUL_SYLLABLE + filler],
+      ["between Hangul syllables", HANGUL_SYLLABLE + filler + HANGUL_SYLLABLE],
+      ["after a conjoining jamo", HANGUL_JAMO + filler],
+      ["before a conjoining jamo", filler + HANGUL_JAMO],
+    ])
+      it(`U+${hex} is preserved ${label}`, () => {
+        const { cleaned, found } = stripInvisibleWithReport(input);
+        assert.equal(cleaned, input);
+        assert.deepEqual(found, []);
+      });
+
+    // STRIPPED: no Hangul anchor. The Script=Hangul (not Script_Extensions)
+    // gate is what makes the CJK-punctuation cases strip — U+3001 IDEOGRAPHIC
+    // COMMA and U+30FB KATAKANA MIDDLE DOT are Script_Extensions=Hangul, so a
+    // Japanese sentence would otherwise anchor a filler with no Korean in it.
+    // The first three isolate the ANCHOR from the POSITION: they hold the edge
+    // fixed and swap only the neighbour's script, so a bug of the form
+    // "preserve any filler at a string edge" — which the preserved cases above
+    // would happily pass — reds here instead.
+    for (const [label, input, expected] of [
+      ["alone", filler, ""],
+      ["at the start, before Latin", `${filler}a`, "a"],
+      ["at the end, after Latin", `a${filler}`, "a"],
+      ["between Latin letters", `a${filler}b`, "ab"],
+      ["as a run between Latin letters", `a${filler.repeat(3)}b`, "ab"],
+      ["next to a CJK ideograph", `漢${filler}`, "漢"],
+      ["next to an ideographic comma", `、${filler}`, "、"],
+      ["next to a katakana middle dot", `・${filler}`, "・"],
+    ])
+      it(`U+${hex} is stripped ${label}`, () => {
+        const { cleaned, found } = stripInvisibleWithReport(input);
+        assert.equal(cleaned, expected);
+        assert.deepEqual(found, [CATEGORY.BLANK_FILLERS]);
+      });
+  }
+
+  it("a filler never anchors another filler, whichever two are paired", () => {
+    // Cross-filler self-anchoring: U+115F beside U+1160 with no real Hangul in
+    // reach is a run, not archaic text, so both go. Pinned for every ordered
+    // pair so a future `isHangul` that forgets one filler can't slip through.
+    for (const a of HANGUL_FILLER_CODES)
+      for (const b of HANGUL_FILLER_CODES) {
+        const input = `x${cp(a)}${cp(b)}y`;
+        const { cleaned, found } = stripInvisibleWithReport(input);
+        assert.equal(cleaned, "xy", JSON.stringify(input));
+        assert.deepEqual(found, [CATEGORY.BLANK_FILLERS]);
+      }
+  });
+});
+
+// ─── The same table for Braille, whose edges were equally unpinned ────────────
+// `isPreservedBlankFiller` is symmetric across the two scripts: one branch for
+// U+2800 beside a real cell, one for the Hangul fillers beside real Hangul. The
+// edge shape the CI counterexample exposed for Hangul was therefore just as
+// untested for Braille — every fixed U+2800 case anchored the blank on BOTH
+// sides. Pinned here in the same preserved/stripped shape so the two halves of
+// one predicate cannot drift apart in coverage.
+const BRAILLE_CELL = cp(0x2803); // ⠃ — a real (non-blank) Braille cell
+const BRAILLE_BLANK = cp(0x2800);
+
+describe("stripInvisible: the Braille blank, in and out of Braille context", () => {
+  for (const [label, input] of [
+    ["before a cell", BRAILLE_BLANK + BRAILLE_CELL],
+    ["after a cell", BRAILLE_CELL + BRAILLE_BLANK],
+    ["between cells", BRAILLE_CELL + BRAILLE_BLANK + cp(0x2801)],
+  ])
+    it(`U+2800 is preserved ${label}`, () => {
+      const { cleaned, found } = stripInvisibleWithReport(input);
+      assert.equal(cleaned, input);
+      assert.deepEqual(found, []);
+    });
+
+  // Same anchor-vs-position isolation as the Hangul table: the edge is held
+  // fixed and only the neighbour's script changes.
+  for (const [label, input, expected] of [
+    ["alone", BRAILLE_BLANK, ""],
+    ["at the start, before Latin", `${BRAILLE_BLANK}a`, "a"],
+    ["at the end, after Latin", `a${BRAILLE_BLANK}`, "a"],
+    ["between Latin letters", `a${BRAILLE_BLANK}b`, "ab"],
+    ["next to a Hangul syllable", HANGUL_SYLLABLE + BRAILLE_BLANK, "가"],
+  ])
+    it(`U+2800 is stripped ${label}`, () => {
+      const { cleaned, found } = stripInvisibleWithReport(input);
+      assert.equal(cleaned, expected);
+      assert.deepEqual(found, [CATEGORY.BLANK_FILLERS]);
+    });
+
+  it("a blank never anchors another blank, so a bare pair is stripped whole", () => {
+    const input = `x${BRAILLE_BLANK.repeat(2)}y`;
+    const { cleaned, found } = stripInvisibleWithReport(input);
+    assert.equal(cleaned, "xy");
+    assert.deepEqual(found, [CATEGORY.BLANK_FILLERS]);
+  });
+});
+
+// ─── Negative corpus: legitimate Korean text yields zero findings ─────────────
+// Precision guard for the blank-filler detector (CLAUDE.md: a false positive
+// here mangles real content). Real Korean prose contains no fillers at all, so
+// the stripper must be a no-op AND the payload counter must read zero — a
+// counter that charged ordinary Hangul would push honest Korean documents over
+// the scattered-invisibles block threshold in prompt.mjs.
+describe("stripInvisible: legitimate Korean text is untouched", () => {
+  const KOREAN_CORPUS = [
+    "안녕하세요, 세계!", // modern precomposed syllables + ASCII punctuation
+    "한국어 text with English mixed in", // mixed Hangul/Latin
+    "훈민정음 해례본", // multi-word prose
+    "가격은 1,000원입니다.", // digits and a currency word
+    "ㄱㄴㄷ ㅏㅑㅓ", // compatibility jamo — U+3164 HANGUL FILLER's own block
+    cp(0x1100) + cp(0x1161) + cp(0x11a8), // conjoining-jamo spelling of 각
+  ];
+
+  for (const text of KOREAN_CORPUS)
+    it(`no finding for ${JSON.stringify(text)}`, () => {
+      const { cleaned, found } = stripInvisibleWithReport(text);
+      assert.equal(cleaned, text);
+      assert.deepEqual(found, []);
+      assert.equal(countPayloadInvisible(text), 0);
+    });
+
+  it("an anchored filler in Korean prose is preserved and reported as nothing", () => {
+    // 한국어 with an isolated jamo completed by a jungseong filler (U+1160) —
+    // the legitimate use the carve-out protects. It must survive AND not count
+    // toward the payload/scatter thresholds.
+    const text = `한국어: ${HANGUL_JAMO}${cp(0x1160)}`;
+    const { cleaned, found } = stripInvisibleWithReport(text);
+    assert.equal(cleaned, text);
+    assert.deepEqual(found, []);
+    assert.equal(countPayloadInvisible(text), 0);
   });
 });
 
@@ -1771,6 +1886,60 @@ const adversarialText = fc
   .array(adversarialChar, { maxLength: 80 })
   .map((parts) => parts.join(""));
 
+// The blank-filler half of the carve-out, restated from the Unicode script
+// properties (NOT imported from src/invisible.mjs, so the property checks the
+// spec rather than the implementation's own predicate): U+2800 and the Hangul
+// fillers survive only beside a real, script-appropriate visible neighbour — a
+// non-blank Braille cell, or a Hangul jamo/syllable that is not itself a filler.
+const BRAILLE_BLANK_CODE = 0x2800;
+const isBrailleCellChar = (ch) =>
+  ch !== undefined &&
+  ch.codePointAt(0) !== BRAILLE_BLANK_CODE &&
+  /\p{Script=Braille}/u.test(ch);
+const isHangulChar = (ch) =>
+  ch !== undefined &&
+  !HANGUL_FILLER_CODES.includes(ch.codePointAt(0)) &&
+  /\p{Script=Hangul}/u.test(ch);
+
+/**
+ * True when `text[i]` is a blank filler sitting next to its script's anchor —
+ * the one residue the blank-filler carve-out is allowed to leave behind.
+ * Stripping only ever DELETES, so a preserved filler is still adjacent in the
+ * output to the anchor that saved it: the cleaned text's own neighbours are a
+ * sound basis for the check. Every filler and anchor is BMP, so a lone
+ * surrogate read as a neighbour simply fails the script test.
+ * @param {string} text @param {number} i @returns {boolean}
+ */
+function isAnchoredBlankFiller(text, i) {
+  const code = text.codePointAt(i);
+  const prev = text[i - 1];
+  const next = text[i + 1];
+  if (code === BRAILLE_BLANK_CODE)
+    return isBrailleCellChar(prev) || isBrailleCellChar(next);
+  if (!HANGUL_FILLER_CODES.includes(/** @type {number} */ (code))) return false;
+  return isHangulChar(prev) || isHangulChar(next);
+}
+
+// Fixed corpus for the residue property below: an anchored filler is a 2-code-
+// point needle, so a random 80-char haystack hits one only occasionally. Both
+// the preserved and the stripped side of every filler are pinned so the case
+// runs on EVERY invocation instead of on a lucky seed.
+const ANCHORED_BLANK_FILLER_EXAMPLES = [
+  ...HANGUL_FILLER_CODES.flatMap((code) => [
+    [cp(code) + HANGUL_SYLLABLE], // U+115F here is the CI counterexample
+    [HANGUL_SYLLABLE + cp(code)],
+    [HANGUL_JAMO + cp(code)],
+    [cp(code)],
+    [`a${cp(code)}b`],
+    [`a${cp(code).repeat(3)}b`],
+  ]),
+  [cp(0x2803) + cp(BRAILLE_BLANK_CODE)],
+  [cp(BRAILLE_BLANK_CODE) + cp(0x2803)],
+  [cp(0x2803) + cp(BRAILLE_BLANK_CODE).repeat(4) + cp(0x2801)],
+  [cp(BRAILLE_BLANK_CODE)],
+  [`a${cp(BRAILLE_BLANK_CODE)}b`],
+];
+
 describe("property: stripInvisible invariants", () => {
   it("never throws on lone surrogates / astral input", () => {
     fc.assert(
@@ -1821,7 +1990,9 @@ describe("property: stripInvisible invariants", () => {
         // joiner leaves text === cleaned AND found empty.
         assert.equal(found.length > 0, cleaned !== text);
       }),
-      fcRunOptions(),
+      // Same fixed corpus: a preserved blank filler must leave `found` EMPTY
+      // (nothing was stripped), while the unanchored/run cases must report.
+      fcRunOptions({ examples: ANCHORED_BLANK_FILLER_EXAMPLES }),
     );
   });
 
@@ -1847,24 +2018,9 @@ describe("property: stripInvisible invariants", () => {
         // After stripping, the only STRIP-class chars left must be ZWNJ/ZWJ
         // (carve-out), a presentation selector kept on a pictograph/modifier
         // base (the carve-out preserves VS15/VS16 directly after one — 🏻︎ is
-        // a visible glyph, not a hidden selector run), a blank filler anchored
-        // to a script-appropriate visible neighbour, or a single leading BOM.
+        // a visible glyph, not a hidden selector run), an ANCHORED blank filler
+        // (see isAnchoredBlankFiller), or a single leading BOM.
         const selectorBase = /^[\p{Extended_Pictographic}\p{Emoji_Modifier}]$/u;
-        // The blank-filler carve-out, stated as the SPEC rather than copied
-        // from the implementation: U+2800 survives beside a real Braille cell
-        // and a Hangul filler beside a real jamo/syllable — one anchor on
-        // EITHER side is enough, which is the case the fixed-corpus tests above
-        // (both of which anchor on both sides) never covered. A filler cannot
-        // anchor another filler, so a run still fails.
-        const blankFillers = new Set([0x115f, 0x1160, 0x3164, 0xffa0]);
-        const anchorsHangul = (ch) =>
-          !!ch &&
-          !blankFillers.has(/** @type {number} */ (ch.codePointAt(0))) &&
-          /\p{Script=Hangul}/u.test(ch);
-        const anchorsBraille = (ch) =>
-          !!ch &&
-          ch.codePointAt(0) !== 0x2800 &&
-          /\p{Script=Braille}/u.test(ch);
         for (let i = 0; i < cleaned.length; i++) {
           const ch = cleaned[i];
           STRIP.lastIndex = 0;
@@ -1878,23 +2034,20 @@ describe("property: stripInvisible invariants", () => {
             (code === 0xfe0e || code === 0xfe0f) &&
             i > 0 &&
             selectorBase.test(cleaned.slice(baseStart, i));
-          const prev = cleaned[i - 1] ?? "";
-          const next = cleaned[i + 1] ?? "";
-          const keptFiller =
-            (code === 0x2800 &&
-              (anchorsBraille(prev) || anchorsBraille(next))) ||
-            (blankFillers.has(/** @type {number} */ (code)) &&
-              (anchorsHangul(prev) || anchorsHangul(next)));
           const ok =
             code === 0x200c ||
             code === 0x200d ||
             keptSelector ||
-            keptFiller ||
+            isAnchoredBlankFiller(cleaned, i) ||
             (code === 0xfeff && i === 0);
           assert.ok(ok, `unexpected residual invisible U+${code.toString(16)}`);
         }
       }),
-      fcRunOptions(),
+      // The blank-filler cases are pinned as fixed examples: they are a
+      // 2-code-point needle in an 80-char haystack, so unseeded fast-check only
+      // stumbles on one occasionally — which is precisely how the Hangul case
+      // (["ᅟ가"]) escaped review and went red on main days later.
+      fcRunOptions({ examples: ANCHORED_BLANK_FILLER_EXAMPLES }),
     );
   });
 });

--- a/test/invisible.test.mjs
+++ b/test/invisible.test.mjs
@@ -1378,6 +1378,44 @@ describe("stripInvisible: blank-filler carve-out", () => {
     assert.deepEqual(found, [CATEGORY.BLANK_FILLERS]);
   });
 
+  it("preserves a filler anchored on ONE side only, at either edge", () => {
+    // The counterexample a property run found (seed -1494323434): every fixed
+    // case above anchors the filler on BOTH sides, so a filler at the very start
+    // or end of the text — one neighbour, and it is the string edge — went
+    // untested. Pinned here so the coverage no longer depends on a lucky seed.
+    for (const filler of [0x115f, 0x1160, 0x3164, 0xffa0]) {
+      for (const input of [cp(filler) + cp(0xac00), cp(0xac00) + cp(filler)]) {
+        const { cleaned, found } = stripInvisibleWithReport(input);
+        assert.equal(cleaned, input, JSON.stringify(input));
+        assert.deepEqual(found, [], JSON.stringify(input));
+      }
+      // Positive marker: the SAME filler with no Hangul anywhere is stripped, so
+      // the assertions above pin the anchor rule and not a blanket exemption.
+      const orphan = `a${cp(filler)}b`;
+      const { cleaned, found } = stripInvisibleWithReport(orphan);
+      assert.equal(cleaned, "ab", JSON.stringify(orphan));
+      assert.deepEqual(found, [CATEGORY.BLANK_FILLERS], JSON.stringify(orphan));
+    }
+  });
+
+  it("leaves ordinary Korean prose completely untouched", () => {
+    // The negative corpus CLAUDE.md asks every detector to carry: real text in
+    // the script this carve-out serves must produce ZERO findings, so the
+    // carve-out cannot be tightened into mangling legitimate content.
+    const corpus = [
+      "안녕하세요, 반갑습니다.",
+      "한국어 텍스트를 처리합니다",
+      "서울특별시 강남구",
+      "훈민정음(訓民正音)은 1443년에 창제되었다.",
+      "김치찌개 2인분 주세요!",
+    ];
+    for (const text of corpus) {
+      const { cleaned, found } = stripInvisibleWithReport(text);
+      assert.equal(cleaned, text, JSON.stringify(text));
+      assert.deepEqual(found, [], JSON.stringify(text));
+    }
+  });
+
   it("a blank filler between two joiners does not hide the joiner run (idempotent)", () => {
     // م ZWJ <blank> ZWJ م — the blank is payload; stripping it makes the two
     // joiners adjacent. The joiner-run must be detected in a SINGLE pass (both
@@ -1809,8 +1847,24 @@ describe("property: stripInvisible invariants", () => {
         // After stripping, the only STRIP-class chars left must be ZWNJ/ZWJ
         // (carve-out), a presentation selector kept on a pictograph/modifier
         // base (the carve-out preserves VS15/VS16 directly after one — 🏻︎ is
-        // a visible glyph, not a hidden selector run), or a single leading BOM.
+        // a visible glyph, not a hidden selector run), a blank filler anchored
+        // to a script-appropriate visible neighbour, or a single leading BOM.
         const selectorBase = /^[\p{Extended_Pictographic}\p{Emoji_Modifier}]$/u;
+        // The blank-filler carve-out, stated as the SPEC rather than copied
+        // from the implementation: U+2800 survives beside a real Braille cell
+        // and a Hangul filler beside a real jamo/syllable — one anchor on
+        // EITHER side is enough, which is the case the fixed-corpus tests above
+        // (both of which anchor on both sides) never covered. A filler cannot
+        // anchor another filler, so a run still fails.
+        const blankFillers = new Set([0x115f, 0x1160, 0x3164, 0xffa0]);
+        const anchorsHangul = (ch) =>
+          !!ch &&
+          !blankFillers.has(/** @type {number} */ (ch.codePointAt(0))) &&
+          /\p{Script=Hangul}/u.test(ch);
+        const anchorsBraille = (ch) =>
+          !!ch &&
+          ch.codePointAt(0) !== 0x2800 &&
+          /\p{Script=Braille}/u.test(ch);
         for (let i = 0; i < cleaned.length; i++) {
           const ch = cleaned[i];
           STRIP.lastIndex = 0;
@@ -1824,10 +1878,18 @@ describe("property: stripInvisible invariants", () => {
             (code === 0xfe0e || code === 0xfe0f) &&
             i > 0 &&
             selectorBase.test(cleaned.slice(baseStart, i));
+          const prev = cleaned[i - 1] ?? "";
+          const next = cleaned[i + 1] ?? "";
+          const keptFiller =
+            (code === 0x2800 &&
+              (anchorsBraille(prev) || anchorsBraille(next))) ||
+            (blankFillers.has(/** @type {number} */ (code)) &&
+              (anchorsHangul(prev) || anchorsHangul(next)));
           const ok =
             code === 0x200c ||
             code === 0x200d ||
             keptSelector ||
+            keptFiller ||
             (code === 0xfeff && i === 0);
           assert.ok(ok, `unexpected residual invisible U+${code.toString(16)}`);
         }


### PR DESCRIPTION
Claimed area: `test/invisible.test.mjs` (the `stripInvisible invariants` property + the blank-filler carve-out block).

Unblocks #249, which is unmergeable on this failure and is itself the fix for `main`'s shard-matrix break — so #239, #241 and #244 are queued behind it too.

## The failure

`main` reds intermittently, on whatever PR happens to draw an unlucky seed:

```
not ok 296 - property: stripInvisible invariants
    not ok 6 - STRIP-matchable chars are gone unless preserved by the carve-out
      Property failed after 74 tests
      { seed: -1494323434, path: "73:2:1:9:5:5:6:6:5:7:5:5:6", endOnFailure: true }
      Counterexample: ["ᅟ가"]
```

## It is the test's model that is stale, not the implementation

Characterized on pristine `main` — U+115F/U+1160/U+3164/U+FFA0 are STRIP-matchable and *are* stripped alone or beside Latin, but survive beside a Hangul syllable:

| input | output | filler kept |
| --- | --- | --- |
| `"ᅟ"` | `""` | no |
| `"ᅟa"` | `"a"` | no |
| `"ᅟ가"` | `"ᅟ가"` | **yes** |
| `"가ᅟ"` | `"가ᅟ"` | **yes** |

That is the blank-filler carve-out (`src/invisible.mjs`, "Blank-filler carve-out (Braille / archaic Hangul)") working exactly as designed and already covered by a fixed-case block: a lone filler does real work in archaic Korean, so it is preserved when anchored to a real jamo/syllable, while a *run* — whose only neighbours are fillers — fails the anchor and is stripped. Stripping the anchored one would mangle legitimate content, which is the false positive CLAUDE.md tells this layer to avoid.

The property's allowlist predates that carve-out. It enumerated ZWNJ/ZWJ, kept presentation selectors and a leading BOM, and nothing else — so it contradicted the module's own documented behaviour and its own sibling tests. **No behaviour changes here; `src/` is untouched.**

## Changes

- **The property's allowlist admits an anchored blank filler,** written as the **spec** (`\p{Script=Braille}` non-blank cell; `\p{Script=Hangul}` non-filler) rather than by importing or copying `isPreservedBlankFiller` — a test that calls the implementation to predict the implementation asserts nothing.
- **Two parametrized fixed-case tables, one per script**, each split preserved/stripped. The carve-out was only ever pinned deterministically for U+3164 and only with the filler anchored on **both** sides, so three of the four Hangul fillers and every edge position rode entirely on the seed. Now every filler is pinned in every context.
- **Anchor isolated from position.** Each stripped table holds the string edge fixed and varies only the neighbour's script: `<filler>a` and `a<filler>` must still strip, alongside `a<filler>b` and the bare filler. Without this a bug of the form "preserve any filler at a string edge" would pass the preserved cases unchanged.
- **Braille gets the same table.** `isPreservedBlankFiller` is symmetric across its two branches, so U+2800's edges were exactly as unpinned as Hangul's. It does not diverge from the interior case — worth knowing, so it is pinned rather than assumed.
- **The `Script=Hangul` (not `Script_Extensions`) gate is pinned.** U+3001 IDEOGRAPHIC COMMA and U+30FB KATAKANA MIDDLE DOT are `Script_Extensions=Hangul`; a Japanese sentence containing them must not anchor a filler.
- **The property is seeded with those cases as fixed `examples`.** An anchored filler is a 2-code-point needle in an 80-char haystack, so unseeded fast-check only stumbles onto one occasionally — which is why the counterexample surfaced months later, on an unrelated PR.
- **A negative corpus of ordinary Korean prose** asserting zero findings *and* `countPayloadInvisible === 0`, per CLAUDE.md's rule that every detector carries one. The counter matters separately: one that charged ordinary Hangul would push honest Korean documents over the scattered-invisibles block threshold in `prompt.mjs`.

## Guards proven non-vacuous

| Mutation to `src/invisible.mjs` | Result |
| --- | --- |
| `isPreservedBlankFiller` returns `false` for Hangul fillers (carve-out removed) | `not ok - stripInvisible: blank-filler carve-out` |
| returns `true` unconditionally (fillers preserved with no anchor) | `not ok - property: stripInvisible invariants` — plus 3 other suites |
| **preserve any filler at a string edge** | reds both new tables **and** the property — 9 suites |
| Braille branch `||` → `&&` (edge anchoring lost) | `not ok 20 - the Braille blank, in and out of Braille context` |

The third is the one the reviewer asked for: it is the neighbouring mistake the edge cases exist to rule out, and before this revision the block could not fail for it.

```
FC_REPRODUCIBLE=1 node --test test/invisible.test.mjs   # 315/315
node --test test/invisible.test.mjs  ×4 random seeds    # 315/315 each
pnpm lint                                               # exit 0
```

## Decisions made

- **Fixed the test, not the implementation.** The three candidate readings were (a) strip fillers in Hangul context too, (b) the test's model is wrong, (c) preserve but report. Evidence for (b): the behaviour is documented in the module header, covered by six pre-existing fixed cases, and derives the anchor set from `Script=Hangul` deliberately excluding the fillers. Under (a) real archaic-Korean text loses characters — a false positive in a detection layer, which CLAUDE.md ranks as a real harm.
- **Did not add a report for the preserved filler.** `found` stays empty, consistent with the joiner carve-out: `found` is asserted elsewhere to be exactly the set of categories that *changed the text*, so reporting a preserved character would break that invariant and add a finding operators cannot act on. Under the alternative the sibling property `found non-empty ⇔ the text changed` needs rewriting and every preserved-joiner case emits noise.
- **Spec-restated rather than imported.** Under the alternative (importing `isPreservedBlankFiller`) the property would be a tautology that passes for any implementation.
- **Restructured into per-script tables rather than patching the single edge block** the review suggestion targeted. The suggestion's substance is all here; the wider shape came from finding that the same seed-dependence covered three more fillers. Under the alternative the diff is smaller and U+115F/U+1160/U+FFA0 stay pinned only by luck.

## Lessons Learned

**What:** When a carve-out is added to a detection/transform layer, update the *property* test's allowlist in the same commit as the fixed cases — and pin the fixed cases as a table over every member of the class × every position (start of input, interior, end of input), not one representative in the interior.

**Where:** Any property test in the template that enumerates "what may legitimately survive" — the shape is `const ok = A || B || C; assert.ok(ok, …)`.

**Why:** A property test's allowlist is a second, hand-maintained model of the implementation, and it drifts silently: the carve-out shipped with what looked like thorough fixed-case coverage, and the property still contradicted it. Because the contradiction only surfaces when the generator happens to draw the anchored shape, it presents months later as an intermittent red on an unrelated PR — here it blocked a CI-unbreaking fix and three PRs behind it, and cost a full root-cause investigation to establish that nothing was actually broken.

**What:** A negative marker must vary exactly one variable from the positive case. If the positive is `<filler>가` (edge + anchored) and the negative is `a<filler>b` (interior + unanchored), the pair cannot fail for "preserve anything at an edge" — the nearest wrong implementation.

**Where:** Any preserved-vs-stripped pair in the template's detection tests.

**Why:** Two-variable negative markers read as rigorous and are vacuous against the most likely bug. Holding the position fixed and swapping only the property under test is what makes the assertion load-bearing.

**What:** When a property's interesting input is a short needle in a long generated haystack, pin it via fast-check's `examples` rather than trusting the generator to find it.

**Where:** `fcRunOptions(overrides)` in `test/test-helpers.mjs` already forwards `examples`.

**Why:** The counterexample here was two code points inside an 80-character string. It existed from the day the carve-out landed and took months of unrelated PRs to draw. `examples` converts that into a case that runs on every invocation, seeded or not.