### PR TITLE
ci: bump the engine pin automatically on a daily schedule

### DIFF
--- a/.github/scripts/engine-pin-bump.sh
+++ b/.github/scripts/engine-pin-bump.sh
@@ -26,7 +26,13 @@ MIN_AGE_HOURS="${MIN_AGE_HOURS:-24}"
 BRANCH_PREFIX="bot/engine-pin-bump"
 
 current="$(node -e 'import("./plugin/scripts/build-plugin.mjs").then((m) => process.stdout.write(m.enginePin()))')"
-latest="$(npm view agent-sanitizer version)"
+# Max stable X.Y.Z from the full version list, NOT `npm view … version`: that
+# reads the `latest` dist-tag, which lags or leads the real max after a partial
+# or aborted publish (the same rule release-canary.sh states). A lagging tag
+# would make this bump silently never fire — the exact failure this exists to
+# fix. npm-max-stable.mjs exits 3 when nothing stable is published, which
+# `set -e` turns into a loud failure.
+latest="$(NPM_VERSIONS="$(npm view agent-sanitizer versions --json)" node .github/scripts/npm-max-stable.mjs)"
 echo "pinned: ${current}; latest published: ${latest}"
 if [ "$current" = "$latest" ]; then
   echo "pin already current"
@@ -62,6 +68,16 @@ if [ -n "$existing" ]; then
   exit 0
 fi
 
+# The branch can outlive its PR: a human closed the PR (GitHub deletes the head
+# branch on merge, not on close), or a run died between the push and
+# `gh pr create`. A fresh commit onto it would be a non-fast-forward rejection,
+# and force-pushing is deliberately not an option here, so fail with the remedy
+# named rather than dying on a raw git error every day.
+if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null; then
+  echo "branch ${BRANCH} exists on the remote with no open PR; delete it to let the bump re-run" >&2
+  exit 1
+fi
+
 npm pkg set "devDependencies.sanitizer-engine=npm:agent-sanitizer@${latest}"
 # Lockfile only: node_modules stays on the old resolution; the PR's own CI
 # installs fresh. --no-frozen-lockfile because pnpm defaults to frozen in CI,
@@ -83,13 +99,16 @@ git push \
   "HEAD:refs/heads/${BRANCH}"
 
 # A still-open bump PR for an older version is now superseded: close it (with
-# its branch) so exactly one bump PR is ever pending.
+# its branch) so exactly one bump PR is ever pending. --limit 100 because the
+# startswith filter runs in --jq, i.e. AFTER gh truncates to its default page of
+# 30 — an older bump PR could otherwise fall off the page and silently break
+# that invariant.
 while IFS=$'\t' read -r number head; do
   if [ "$head" = "$BRANCH" ]; then continue; fi
   echo "closing superseded bump PR #${number} (${head})"
   gh pr close "$number" --delete-branch \
     --comment "Superseded by the ${latest} bump."
-done < <(gh pr list --state open --json number,headRefName \
+done < <(gh pr list --state open --limit 100 --json number,headRefName \
   --jq ".[] | select(.headRefName | startswith(\"${BRANCH_PREFIX}-\")) | [.number, .headRefName] | @tsv")
 
 gh pr create --head "$BRANCH" \
@@ -101,5 +120,8 @@ gh pr create --head "$BRANCH" \
 Automated bump of the \`sanitizer-engine\` npm alias from ${current} to ${latest} (published ≥ ${MIN_AGE_HOURS}h ago on both npm and PyPI), opened by \`.github/workflows/engine-pin-bump.yaml\`. Only the alias and the lockfile move here; \`plugin-dist-autofix.yaml\` pushes the regenerated \`requirements.in\`/\`requirements.txt\` and dist artifacts onto this branch, and the committed-bundle reproducibility tests gate the merge.
 EOF
   )"
-gh pr merge --auto --merge "$BRANCH"
+# --squash matches every other automated merge here (dependabot-auto-merge,
+# template-sync-automerge); a --merge would also fail outright if merge commits
+# are disabled, leaving an open PR that never lands.
+gh pr merge --auto --squash "$BRANCH"
 echo "bump PR opened and set to auto-merge"

--- a/.github/scripts/engine-pin-bump.sh
+++ b/.github/scripts/engine-pin-bump.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Bump the plugin's pinned sanitizer engine to the newest published release and
+# open an auto-merging PR for it.
+#
+# renovate.json5's sanitizer-engine rule describes this exact flow, but the
+# hosted Renovate app is not installed on this repo, so nothing ever ran it —
+# this scheduled script performs that one bump. It moves only the npm alias and
+# the lockfile: plugin-dist-autofix.yaml regenerates requirements.in/.txt and
+# the committed dist artifacts on the PR itself, and the reproducibility tests
+# gate the merge.
+#
+# Skip conditions, each deferring to a later scheduled run:
+#   - newest npm release equals the pin (nothing to do)
+#   - release younger than MIN_AGE_HOURS: pnpm's default minimumReleaseAge
+#     policy would reject the lockfile entry, and the window doubles as the
+#     supply-chain cooldown renovate.json5 relied on
+#   - release absent from PyPI: npm and PyPI land minutes apart, and the
+#     daemon the plugin provisions installs from PyPI
+#
+# The bump branch is per-version (bot/engine-pin-bump-<version>): a newer
+# release gets a fresh plain-pushed branch, and any still-open older bump PR
+# is closed as superseded — no force-push anywhere.
+set -euo pipefail
+
+MIN_AGE_HOURS="${MIN_AGE_HOURS:-24}"
+BRANCH_PREFIX="bot/engine-pin-bump"
+
+current="$(node -e 'import("./plugin/scripts/build-plugin.mjs").then((m) => process.stdout.write(m.enginePin()))')"
+latest="$(npm view agent-sanitizer version)"
+echo "pinned: ${current}; latest published: ${latest}"
+if [ "$current" = "$latest" ]; then
+  echo "pin already current"
+  exit 0
+fi
+
+# shellcheck disable=SC2016  # the ${} below is a JS template literal, not shell
+age_check="$(npm view agent-sanitizer time --json | node -e '
+  let raw = "";
+  process.stdin.on("data", (chunk) => (raw += chunk));
+  process.stdin.on("end", () => {
+    const published = Date.parse(JSON.parse(raw)[process.argv[1]]);
+    const hours = (Date.now() - published) / 3600000;
+    const floor = Number(process.argv[2]);
+    process.stdout.write(hours >= floor ? "ok" : `young:${hours.toFixed(1)}`);
+  });
+' "$latest" "$MIN_AGE_HOURS")"
+if [ "$age_check" != "ok" ]; then
+  echo "agent-sanitizer@${latest} is ${age_check#young:}h old (< ${MIN_AGE_HOURS}h); deferring to a later run"
+  exit 0
+fi
+
+pypi_status="$(curl -sS -o /dev/null -w '%{http_code}' "https://pypi.org/pypi/agent-sanitizer/${latest}/json")"
+if [ "$pypi_status" != "200" ]; then
+  echo "PyPI has no agent-sanitizer ${latest} yet (HTTP ${pypi_status}); deferring to a later run"
+  exit 0
+fi
+
+BRANCH="${BRANCH_PREFIX}-${latest}"
+existing="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')"
+if [ -n "$existing" ]; then
+  echo "bump PR #${existing} for ${latest} is already open"
+  exit 0
+fi
+
+npm pkg set "devDependencies.sanitizer-engine=npm:agent-sanitizer@${latest}"
+# Lockfile only: node_modules stays on the old resolution; the PR's own CI
+# installs fresh. --no-frozen-lockfile because pnpm defaults to frozen in CI,
+# and updating the lockfile is the whole point here. The release is past the
+# minimumReleaseAge floor, so this resolution needs no policy exclusions.
+pnpm install --lockfile-only --no-frozen-lockfile
+if git diff --quiet; then
+  echo "working tree unchanged after the bump; nothing to push"
+  exit 0
+fi
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git checkout -B "$BRANCH"
+git add package.json pnpm-lock.yaml pnpm-workspace.yaml
+git commit -m "build(plugin): bump the pinned sanitizer engine to ${latest}"
+git push \
+  "https://x-access-token:${AUTOFIX_TOKEN_ORG}@github.com/${GITHUB_REPOSITORY}.git" \
+  "HEAD:refs/heads/${BRANCH}"
+
+# A still-open bump PR for an older version is now superseded: close it (with
+# its branch) so exactly one bump PR is ever pending.
+while IFS=$'\t' read -r number head; do
+  if [ "$head" = "$BRANCH" ]; then continue; fi
+  echo "closing superseded bump PR #${number} (${head})"
+  gh pr close "$number" --delete-branch \
+    --comment "Superseded by the ${latest} bump."
+done < <(gh pr list --state open --json number,headRefName \
+  --jq ".[] | select(.headRefName | startswith(\"${BRANCH_PREFIX}-\")) | [.number, .headRefName] | @tsv")
+
+gh pr create --head "$BRANCH" \
+  --title "build(plugin): bump the pinned sanitizer engine to ${latest}" \
+  --body "$(
+    cat <<EOF
+## What & why
+
+Automated bump of the \`sanitizer-engine\` npm alias from ${current} to ${latest} (published ≥ ${MIN_AGE_HOURS}h ago on both npm and PyPI), opened by \`.github/workflows/engine-pin-bump.yaml\`. Only the alias and the lockfile move here; \`plugin-dist-autofix.yaml\` pushes the regenerated \`requirements.in\`/\`requirements.txt\` and dist artifacts onto this branch, and the committed-bundle reproducibility tests gate the merge.
+EOF
+  )"
+gh pr merge --auto --merge "$BRANCH"
+echo "bump PR opened and set to auto-merge"

--- a/.github/workflows/engine-pin-bump.yaml
+++ b/.github/workflows/engine-pin-bump.yaml
@@ -1,0 +1,59 @@
+name: Engine pin bump
+
+# Keep the plugin's pinned engine (the `sanitizer-engine` npm alias) current.
+# renovate.json5's sanitizer-engine rule was meant to do this, but the hosted
+# Renovate app is not installed on this repo, so the pin silently aged — this
+# schedule performs that one bump instead (see .github/scripts/engine-pin-bump.sh
+# for the freshness/PyPI guards). The PR it opens is pushed with
+# AUTOFIX_TOKEN_ORG so CI actually runs on it, plugin-dist-autofix regenerates
+# the committed artifacts on the branch, and auto-merge lands it once the
+# required checks are green.
+on:
+  schedule:
+    - cron: "17 7 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: engine-pin-bump
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      # A GITHUB_TOKEN push/PR would not trigger workflows, leaving the bump PR
+      # stuck pending on its required checks. `secrets` can't be read in a
+      # job-level `if`, hence this preflight step (same pattern as
+      # plugin-dist-autofix.yaml).
+      - name: Check for AUTOFIX_TOKEN_ORG
+        id: guard
+        env:
+          AUTOFIX_TOKEN_ORG: ${{ secrets.AUTOFIX_TOKEN_ORG }}
+        run: |
+          if [ -n "$AUTOFIX_TOKEN_ORG" ]; then
+            echo "enabled=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >>"$GITHUB_OUTPUT"
+            echo "::notice::AUTOFIX_TOKEN_ORG secret is not set; skipping the engine-pin bump. The plugin keeps shipping the old engine until the pin is bumped by hand."
+          fi
+
+      - if: steps.guard.outputs.enabled == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # The push step injects the PAT explicitly; never persist it.
+          persist-credentials: false
+
+      - name: Setup base environment
+        if: steps.guard.outputs.enabled == 'true'
+        uses: ./.github/actions/setup-base-env
+
+      - name: Bump the pin and open the PR
+        if: steps.guard.outputs.enabled == 'true'
+        env:
+          AUTOFIX_TOKEN_ORG: ${{ secrets.AUTOFIX_TOKEN_ORG }}
+          GH_TOKEN: ${{ secrets.AUTOFIX_TOKEN_ORG }}
+        run: bash .github/scripts/engine-pin-bump.sh


### PR DESCRIPTION
## What & why

Make engine-pin bumps like #257 happen automatically. `renovate.json5`'s `sanitizer-engine` rule was meant to do this, but the hosted Renovate app is not installed on this repo — zero Renovate PRs, branches, or dashboard issues exist — so the pin silently aged eight releases until #257 caught it up by hand.

A new scheduled workflow (`engine-pin-bump.yaml`, daily at 07:17 UTC + `workflow_dispatch`) runs `.github/scripts/engine-pin-bump.sh`, which:

- reads the current pin via `build-plugin.mjs`'s `enginePin()` and compares it to the newest published release — the max stable `X.Y.Z` from the full `versions --json` list via the existing `npm-max-stable.mjs`, never the `latest` dist-tag — and exits quietly when current;
- defers (to a later run) while the release is younger than 24 h — pnpm's default `minimumReleaseAge` window, which also serves as the supply-chain cooldown the Renovate config relied on — or absent from PyPI (npm and PyPI publishes land minutes apart, and the provisioned daemon installs from PyPI);
- bumps only the `sanitizer-engine` alias and the lockfile, plain-pushes a per-version branch (`bot/engine-pin-bump-<version>`) with `AUTOFIX_TOKEN_ORG` so CI actually runs, closes any still-open older bump PR as superseded, opens the PR, and enables squash auto-merge.

The existing machinery does the rest on the PR itself: `plugin-dist-autofix.yaml` regenerates `requirements.in`/`.txt` and the committed dist artifacts, and the reproducibility tests gate the merge.

## Review focus

`engine-pin-bump.sh`'s ordering (version select → age/PyPI guards → open-PR and stale-branch guards → bump → push → supersede-close → PR create → auto-merge) and the token handling in `engine-pin-bump.yaml` — the PAT is injected only into the bump step, checkout uses `persist-credentials: false`, and the script runs only main's own code. No force-push anywhere: supersession is close-and-recreate, and a branch that outlived its PR fails loudly with the remedy named rather than wedging the daily run on a non-fast-forward rejection.

## How it was tested

- `shellcheck -x`, `shfmt -d`, and `bash -n` clean on the script; prettier clean on the workflow.
- Version selection dry-run against the live registry, which caught a real drift: `npm view agent-sanitizer version` (the `latest` dist-tag) reports **2.20.0**, while the max stable release is **2.20.2** — the reviewer's dist-tag finding was not hypothetical, and the script now resolves 2.20.2.
- Guard logic dry-run: `enginePin()` read the committed pin correctly, and the age check reported 2.20.0 as too young (0.6 h) at the time — the exact deferral the daily schedule is built to absorb.
- The end-to-end path (bump → autofix regenerate → reproducibility gate → auto-merge) is the one #257 exercised manually.

## Decisions made

- **Wait out the 24 h freshness window instead of excluding it.** A younger release is simply deferred to the next daily run; no `minimumReleaseAgeExclude` entries are written, keeping the supply-chain gate intact for every future release.
- **Per-version branches, no force-push.** An earlier draft force-pushed one fixed bot branch; the repo's push policy flags externalized force-pushes, and close-and-recreate is just as effective, so the force-push was removed rather than annotated around.
- **Squash auto-merge**, matching `dependabot-auto-merge.yaml` and `template-sync-automerge.sh` — a `--merge` would also fail outright wherever merge commits are disabled, leaving a bump PR that never lands.
- **`renovate.json5` left in place.** It still documents intent for `esbuild` and the runtime peers should the app ever be installed; if it is, its `sanitizer-engine` rule and this workflow would race harmlessly (both gate on the same checks), but the config could then be trimmed.

## Lessons Learned

- **What**: When shipping a `renovate.json5` in the template, pair it with a scheduled fallback workflow (or a setup-time check) that detects the Renovate app is not installed — config-only automation fails silently and pins age unnoticed. **Where**: `.github/workflows/` (a variant of `engine-pin-bump.yaml`) or `setup.sh` (verify the app installation and warn). **Why**: this repo carried a complete, correct Renovate config for its engine pin while the pin aged eight releases; nothing surfaced the missing app.
- **What**: Extend the "never `npm view <pkg> version`" rule from `release-canary.sh`'s header into a repo-wide guard (a pre-commit grep or shellcheck-style check) so any new script reaching for the `latest` dist-tag fails loudly. **Where**: `.hooks/` / `.pre-commit-config.yaml`, alongside the existing guard-pair checks. **Why**: the rule lived only as prose in one script's comment; a second consumer reintroduced the bug immediately, and the dist-tag was in fact stale (2.20.0 vs a real max of 2.20.2), so the bug would have silently under-bumped.