### PR TITLE
fix(invisible): stop clipping word spaces out of long Braille and Korean text

### DIFF
--- a/THREAT-MODEL.md
+++ b/THREAT-MODEL.md
@@ -42,9 +42,15 @@ table](./README.md#entry-points) maps each to its import.
   filler completes a defective syllable, these are far denser in genuine text
   than joiners are, so they carry their own document-wide allowance—one
   preserved blank per two visible anchor-script characters, above a floor—rather
-  than drawing on the joiner/selector preserve budget. Past that ratio no blank
-  in the document is preserved (never half-spaced) and all of them count as
-  payload, which is the density an alternating `syllable filler …` channel needs.
+  than drawing on the joiner/selector preserve budget. The allowance is counted
+  per script (a blank never anchors cross-script, so Korean prose must not fund
+  a Braille channel). Past that ratio no blank of that script is preserved
+  (never half-spaced) and all of them count as payload, which is the density an
+  alternating `syllable filler …` channel needs. Contracted (grade-2) Braille
+  sits closest to the boundary: alphabet wordsigns are single cells, so a
+  passage of mostly one-cell words approaches 1:1 and is stripped like the
+  channel—an accepted residual false positive inherent to a density rule, not a
+  gap, and not worth widening the ratio to reach.
 
 **Reassembly hardening.** The two passes feed each other in _both_ directions:
 stripping an invisible char can reconstitute an ANSI escape its split had

--- a/THREAT-MODEL.md
+++ b/THREAT-MODEL.md
@@ -35,6 +35,16 @@ table](./README.md#entry-points) maps each to its import.
   Sinhala) or inside an emoji ZWJ sequence. The carve-out fires only when **both**
   neighbors clearly belong to the context, and it is disabled once the total
   invisible count crosses a scatter floor—over-stripping beats under-stripping.
+- **Blank fillers doing real work in their own script**: the Braille blank
+  (U+2800) beside a real cell, a Hangul filler beside a real jamo/syllable. A
+  _run_ of fillers has only fillers for neighbors, so it fails the anchor and is
+  stripped. Because U+2800 _is_ the word space of Unicode Braille and a Hangul
+  filler completes a defective syllable, these are far denser in genuine text
+  than joiners are, so they carry their own document-wide allowance—one
+  preserved blank per two visible anchor-script characters, above a floor—rather
+  than drawing on the joiner/selector preserve budget. Past that ratio no blank
+  in the document is preserved (never half-spaced) and all of them count as
+  payload, which is the density an alternating `syllable filler …` channel needs.
 
 **Reassembly hardening.** The two passes feed each other in _both_ directions:
 stripping an invisible char can reconstitute an ANSI escape its split had

--- a/src/invisible.mjs
+++ b/src/invisible.mjs
@@ -228,9 +228,10 @@ export const CONSECUTIVE_JOINER_CAP = 8;
 // visible characters in a row), exactly like CONSECUTIVE_JOINER_CAP.
 export const CONSECUTIVE_SELECTOR_CAP = 8;
 
-// Floor on the document-wide preserve budget, shared by both preserve kinds
-// (see `kind` in analyzeCarve: joiners AND presentation selectors draw from
-// the same counter). The Joining_Type gate strips joiners that do no
+// Floor on the document-wide preserve budget for joiners, selectors and tag
+// sequences (see `kind` in analyzeCarve — blank fillers are NOT charged here;
+// they have their own allowance, see TOTAL_PRESERVED_BLANK_BUDGET). The
+// Joining_Type gate strips joiners that do no
 // rendering work regardless of count, so the bulk covert channel (ZWNJ
 // scattered through Latin/ASCII/mixed text) is closed by shape, not by
 // counting. What remains is the residual channel of MEANINGFUL joiners/
@@ -259,6 +260,31 @@ export const PRESERVED_JOINER_PER_VISIBLE = 8;
 // nothing else bounds it. This caps the whole channel at a fixed width no cover
 // text can widen.
 export const PRESERVE_HARD_CAP = 64;
+
+// Floor on the document-wide allowance for PRESERVED blank fillers (the
+// Braille blank and the Hangul fillers — see the blank-filler carve-out). Kept
+// separate from the joiner/selector budget because the two have completely
+// different legitimate densities, and short blank-dense strings (a one-line
+// Braille phrase, a lone archaic syllable) must stay un-clipped.
+export const TOTAL_PRESERVED_BLANK_BUDGET = 16;
+
+// Visible ANCHOR-script code points (a non-blank Braille cell, a non-filler
+// Hangul jamo/syllable) required per preserved blank filler above the floor. A
+// blank is only ever preservable next to one of these, so this ratio is what
+// separates real text from the degenerate channel: U+2800 separates WORDS and a
+// filler completes a syllable, so genuine text spends several anchor characters
+// per blank and stays under one blank per two anchors, while the alternation an
+// attacker needs to stuff a bit per character (`가ᅟ가ᅟ…`, `⠃⠀⠃⠀…`) is exactly
+// 1:1 and fails.
+//
+// Deliberately NOT capped by PRESERVE_HARD_CAP: an absolute ceiling is what
+// truncated long Braille documents, and unlike the joiner channel this one
+// cannot scale on invisible cover text — every additional bit costs the
+// attacker two VISIBLE anchor-script characters, and the blanks themselves
+// render as spacing a reader can see. Over the ratio, NO blank in the document
+// is preserved (all-or-nothing, so a document never comes out half-spaced) and
+// every one of them becomes payload — which then also feeds the scatter floor.
+export const PRESERVED_BLANK_PER_ANCHOR = 2;
 
 // Scripts whose orthography uses ZWNJ/ZWJ between letters as a rendering
 // control. The runtime gate is now script-agnostic (it reads Joining_Type, so it
@@ -402,6 +428,17 @@ function isBrahmicConsonantChar(ch) {
 // the anchor and is stripped — the run-length gate falls out of the anchor. The
 // zero-width Mn marks in BLANK_NON_CF (U+034F/17B4/17B5) have no such benign
 // standalone use, so they are never preserved.
+//
+// Blank fillers are NOT charged against the joiner/selector preserve budget:
+// that budget's density model is "~1 preserved invisible per 8 visible chars"
+// (PRESERVED_JOINER_PER_VISIBLE), measured on Persian ZWNJ prose, with a fixed
+// PRESERVE_HARD_CAP ceiling. Blanks are an order of magnitude denser in genuine
+// text — U+2800 IS the word space of Unicode Braille, and a Hangul filler
+// completes a defective syllable — so charging them there mangled real content:
+// a 40-word Braille passage lost 14 of its 39 word spaces (words run together)
+// and a 200-word one kept 64 of 199, with `found` reporting a strip on a
+// perfectly legitimate document. They draw on the anchor-proportional allowance
+// below instead (see TOTAL_PRESERVED_BLANK_BUDGET).
 const BRAILLE_BLANK = 0x2800;
 const HANGUL_FILLERS = new Set([0x115f, 0x1160, 0x3164, 0xffa0]);
 // Code points that trigger the carve-out path for blank fillers (see
@@ -433,6 +470,16 @@ function isHangul(ch) {
   const cp = ch ? /** @type {number} */ (ch.codePointAt(0)) : -1;
   if (HANGUL_FILLERS.has(cp)) return false; // a filler cannot anchor another filler
   return HANGUL_RE.test(ch);
+}
+
+/** True when `ch` can anchor SOME blank filler — the union of the two branches
+ * of isPreservedBlankFiller, used to size the document-wide blank allowance
+ * (see PRESERVED_BLANK_PER_ANCHOR). Cross-script pairs never preserve, so this
+ * over-counts a document mixing Braille and Hangul; that direction only widens
+ * the allowance for a document already full of legitimate anchor text.
+ * @param {string} ch @returns {boolean} */
+function isBlankAnchor(ch) {
+  return isBrailleCell(ch) || isHangul(ch);
 }
 
 // Non-global single-char classifiers (CHECKS carry `g`, whose lastIndex is
@@ -600,6 +647,25 @@ function analyzeCarve(cps) {
     if (isPreservedBlankFiller(cps, i)) return "blank";
     return null;
   });
+  // Blank fillers are budgeted here, document-wide and all-or-nothing, against
+  // the visible anchor-script text rather than against the joiner/selector
+  // counter in carveStrip (see PRESERVED_BLANK_PER_ANCHOR for why the two
+  // cannot share a density model). Deciding it in analyzeCarve rather than in
+  // the emit loop keeps countPayloadInvisible and payloadInvisibleView honest:
+  // a blank the stripper will remove is payload to every consumer, so the
+  // prompt layer's scatter gate sees it without re-deriving the budget.
+  // The anchor scan is skipped below the floor: it costs two script regexes per
+  // visible character, and analyzeCarve runs on every prompt and tool output.
+  const blanks = kind.filter((k) => k === "blank").length;
+  if (blanks > TOTAL_PRESERVED_BLANK_BUDGET) {
+    const anchors = cps.reduce(
+      (n, ch, i) => n + (codes[i] === null && isBlankAnchor(ch) ? 1 : 0),
+      0,
+    );
+    if (blanks > Math.floor(anchors / PRESERVED_BLANK_PER_ANCHOR))
+      for (let i = 0; i < kind.length; i++)
+        if (kind[i] === "blank") kind[i] = null;
+  }
   let payloadInvis = 0;
   let visibleLen = 0;
   for (let i = 0; i < cps.length; i++) {
@@ -790,12 +856,15 @@ function clusterEnds(body) {
 
 /**
  * Carve-out strip (an invisible the carve-out might preserve is present): walk
- * GRAPHEME CLUSTERS, preserving a cluster's joiners/selectors/tags/blank-fillers
- * only where each has its `kind` set AND the text stays under the scatter floor
- * AND the whole cluster fits inside the remaining per-run
- * (CONSECUTIVE_JOINER_CAP / CONSECUTIVE_SELECTOR_CAP) and document-wide
- * (TOTAL_PRESERVED_JOINER_BUDGET) preserve allowance — otherwise every
- * preservable char in that cluster is stripped like any other payload byte.
+ * GRAPHEME CLUSTERS, preserving a cluster's joiners/selectors/tags only where
+ * each has its `kind` set AND the text stays under the scatter floor AND the
+ * whole cluster fits inside the remaining per-run (CONSECUTIVE_JOINER_CAP /
+ * CONSECUTIVE_SELECTOR_CAP) and document-wide (TOTAL_PRESERVED_JOINER_BUDGET)
+ * preserve allowance — otherwise every preservable char in that cluster is
+ * stripped like any other payload byte. Blank fillers are the exception: their
+ * allowance is anchor-proportional and already spent document-wide in
+ * analyzeCarve (see PRESERVED_BLANK_PER_ANCHOR), so here they answer only to
+ * the scatter floor and do not draw on the joiner/selector budget.
  *
  * The budget is charged against the CLUSTER, not the code point, because the
  * cluster is the indivisible unit: charging per code point let a limit fall due
@@ -862,7 +931,10 @@ function carveStrip(body) {
     let joiners = 0;
     let selectors = 0;
     for (let k = start; k < end; k++) {
-      if (kind[k] === null) continue;
+      // "blank" is exempt: analyzeCarve already decided it against the
+      // anchor-proportional allowance, so it neither draws on this budget nor
+      // is stripped by it (only by the scatter floor, via allowCarveOut).
+      if (kind[k] === null || kind[k] === "blank") continue;
       need++;
       if (kind[k] === "joiner") joiners++;
       if (kind[k] === "ivs" || kind[k] === "stdvs") selectors++;
@@ -904,11 +976,13 @@ function carveStrip(body) {
         out += cps[k]; // ordinary visible character
         continue;
       }
-      if (fits && kind[k] !== null) {
+      // A blank filler rides on allowCarveOut alone (its own allowance is
+      // already spent in analyzeCarve); everything else rides on `fits`.
+      if (kind[k] === "blank" ? allowCarveOut : fits && kind[k] !== null) {
         if (kind[k] === "joiner") joinerRun++;
         if (kind[k] === "ivs" || kind[k] === "stdvs") selectorRun++;
-        preservedTotal++;
-        prevVisible = false; // a joiner/selector/tag keeps the cluster open
+        if (kind[k] !== "blank") preservedTotal++;
+        prevVisible = false; // a joiner/selector/tag/blank keeps the cluster open
         out += cps[k];
         continue;
       }

--- a/src/invisible.mjs
+++ b/src/invisible.mjs
@@ -472,16 +472,6 @@ function isHangul(ch) {
   return HANGUL_RE.test(ch);
 }
 
-/** True when `ch` can anchor SOME blank filler — the union of the two branches
- * of isPreservedBlankFiller, used to size the document-wide blank allowance
- * (see PRESERVED_BLANK_PER_ANCHOR). Cross-script pairs never preserve, so this
- * over-counts a document mixing Braille and Hangul; that direction only widens
- * the allowance for a document already full of legitimate anchor text.
- * @param {string} ch @returns {boolean} */
-function isBlankAnchor(ch) {
-  return isBrailleCell(ch) || isHangul(ch);
-}
-
 // Non-global single-char classifiers (CHECKS carry `g`, whose lastIndex is
 // stateful across `.test`). carveStrip uses these to attribute each removed
 // char to its CHECKS category so `found` names exactly what was stripped.
@@ -654,17 +644,36 @@ function analyzeCarve(cps) {
   // the emit loop keeps countPayloadInvisible and payloadInvisibleView honest:
   // a blank the stripper will remove is payload to every consumer, so the
   // prompt layer's scatter gate sees it without re-deriving the budget.
-  // The anchor scan is skipped below the floor: it costs two script regexes per
-  // visible character, and analyzeCarve runs on every prompt and tool output.
-  const blanks = kind.filter((k) => k === "blank").length;
-  if (blanks > TOTAL_PRESERVED_BLANK_BUDGET) {
+  //
+  // Budgeted PER SCRIPT, because a blank never anchors cross-script: pooling the
+  // two anchor counts would let one script's cover text fund the other's
+  // channel, so 400 chars of ordinary Korean prose would buy an unreported
+  // `⠃⠀⠃⠀…` alternation of 200 Braille blanks. The anchor scan is skipped below
+  // the floor: it costs a script regex per visible character, and analyzeCarve
+  // runs on every prompt and tool output.
+  const blankScript = kind.map((k, i) =>
+    k !== "blank"
+      ? null
+      : cps[i].codePointAt(0) === BRAILLE_BLANK
+        ? "braille"
+        : "hangul",
+  );
+  for (const [
+    script,
+    isAnchor,
+  ] of /** @type {[string, (ch: string) => boolean][]} */ ([
+    ["braille", isBrailleCell],
+    ["hangul", isHangul],
+  ])) {
+    const blanks = blankScript.filter((s) => s === script).length;
+    if (blanks <= TOTAL_PRESERVED_BLANK_BUDGET) continue;
     const anchors = cps.reduce(
-      (n, ch, i) => n + (codes[i] === null && isBlankAnchor(ch) ? 1 : 0),
+      (n, ch, i) => n + (codes[i] === null && isAnchor(ch) ? 1 : 0),
       0,
     );
     if (blanks > Math.floor(anchors / PRESERVED_BLANK_PER_ANCHOR))
       for (let i = 0; i < kind.length; i++)
-        if (kind[i] === "blank") kind[i] = null;
+        if (blankScript[i] === script) kind[i] = null;
   }
   let payloadInvis = 0;
   let visibleLen = 0;

--- a/test/invisible.test.mjs
+++ b/test/invisible.test.mjs
@@ -28,6 +28,8 @@ import {
   TOTAL_PRESERVED_JOINER_BUDGET,
   PRESERVED_JOINER_PER_VISIBLE,
   PRESERVE_HARD_CAP,
+  TOTAL_PRESERVED_BLANK_BUDGET,
+  PRESERVED_BLANK_PER_ANCHOR,
   LINGUISTIC_SCRIPTS,
   describeStripped,
   payloadInvisibleView,
@@ -782,8 +784,9 @@ describe("document-wide preserved-joiner budget", () => {
   });
 
   it("standalone presentation selectors (no joiner in the document) share the same budget", () => {
-    // The budget counts every preserved item — joiners AND presentation
-    // selectors — across the whole document, not per-kind. N gap-separated
+    // The budget counts joiners AND presentation selectors across the whole
+    // document, not per-kind (blank fillers are the one exception — they draw
+    // on the anchor-proportional allowance instead, see below). N gap-separated
     // pictograph+VS16 pairs with NO ZWNJ/ZWJ anywhere still hit the same cap:
     // over-strip beats under-strip even for a purely selector-dense document.
     const pictographPlusSelector = cp(0x2764) + cp(0xfe0f) + " ";
@@ -1543,6 +1546,127 @@ describe("stripInvisible: legitimate Korean text is untouched", () => {
     assert.equal(cleaned, text);
     assert.deepEqual(found, []);
     assert.equal(countPayloadInvisible(text), 0);
+  });
+});
+
+// ─── The blank fillers' own document-wide allowance ──────────────────────────
+// U+2800 is the WORD SPACE of Unicode Braille and a Hangul filler completes a
+// defective syllable, so genuine text carries roughly one blank per word — an
+// order of magnitude denser than the joiner budget's ~1-per-8-visible model.
+// While blanks were charged against that budget, a 40-word Braille passage came
+// out having lost 14 of its 39 word spaces (words running together) and a
+// 200-word one kept 64 of 199, `found` reporting a strip on a legitimate
+// document. They are now budgeted against the visible ANCHOR-script text.
+const BRAILLE_WORD = "⠃⠁⠇⠇⠕"; // a five-cell word
+/** A Braille passage of `words` five-cell words separated by the U+2800 space.
+ * @param {number} words @returns {string} */
+const braillePassage = (words) =>
+  Array.from({ length: words }, () => BRAILLE_WORD).join(BRAILLE_BLANK);
+
+describe("stripInvisible: blank fillers have their own anchor-proportional allowance", () => {
+  // Word counts chosen to straddle every bound of the OLD shared budget: 40
+  // exceeds ceil(visible/PRESERVED_JOINER_PER_VISIBLE) for a five-cell word,
+  // and 200 exceeds PRESERVE_HARD_CAP outright. Both must now round-trip.
+  for (const words of [10, 40, PRESERVE_HARD_CAP + 16, 200])
+    it(`a ${words}-word Braille passage keeps every word space`, () => {
+      const text = braillePassage(words);
+      const { cleaned, found } = stripInvisibleWithReport(text);
+      assert.equal(countOf(text, BRAILLE_BLANK), words - 1); // the input really has them
+      assert.equal(cleaned, text);
+      assert.deepEqual(found, []);
+      assert.equal(countPayloadInvisible(text), 0);
+    });
+
+  it("a long Braille passage is idempotent under a second strip", () => {
+    const text = braillePassage(200);
+    assert.equal(stripInvisible(stripInvisible(text)), text);
+  });
+
+  it("preserved blanks do not draw on the joiner budget", () => {
+    // The regression the split exists to prevent: a Braille passage's blanks
+    // used to consume the shared allowance, so joiners LATER in the same
+    // document were stripped as surplus. Exactly TOTAL_PRESERVED_JOINER_BUDGET
+    // gap-separated Persian joiners must still all survive next to it.
+    const joined = (cp(0x645) + ZWNJ + cp(0x62e) + cp(0x62e)).repeat(
+      TOTAL_PRESERVED_JOINER_BUDGET,
+    );
+    const text = `${braillePassage(200)} ${joined}`;
+    const { cleaned, found } = stripInvisibleWithReport(text);
+    assert.equal(countOf(cleaned, ZWNJ), TOTAL_PRESERVED_JOINER_BUDGET);
+    assert.equal(cleaned, text);
+    assert.deepEqual(found, []);
+  });
+
+  // ─── The ratio boundary, isolated to ONE variable ──────────────────────────
+  // Both documents hold BLANKS fixed at the same count and each blank anchored
+  // by a real cell; they differ only in how many ANCHOR characters accompany
+  // them. So the pair can only fail for the ratio itself — not for length, not
+  // for blank count, not for "long documents are exempt".
+  const BLANKS = TOTAL_PRESERVED_BLANK_BUDGET + 24; // above the floor: the ratio decides
+  // One unit = one blank anchored on its left, plus exactly
+  // PRESERVED_BLANK_PER_ANCHOR anchor cells, plus a non-anchor separator.
+  const unit =
+    BRAILLE_CELL +
+    BRAILLE_BLANK +
+    BRAILLE_CELL.repeat(PRESERVED_BLANK_PER_ANCHOR - 1) +
+    "x";
+  const atRatio = unit.repeat(BLANKS);
+  // Same blanks, ONE fewer anchor: drops the allowance below the blank count.
+  const overRatio = atRatio.slice(0, -2) + "x";
+
+  it("exactly at the ratio, every blank is preserved", () => {
+    assert.ok(
+      BLANKS > TOTAL_PRESERVED_BLANK_BUDGET,
+      "the floor must not decide",
+    );
+    const { cleaned, found } = stripInvisibleWithReport(atRatio);
+    assert.equal(countOf(atRatio, BRAILLE_BLANK), BLANKS);
+    assert.equal(cleaned, atRatio);
+    assert.deepEqual(found, []);
+    assert.equal(countPayloadInvisible(atRatio), 0);
+  });
+
+  it("one anchor short of the ratio, EVERY blank is stripped and reported", () => {
+    // All-or-nothing by design: a document that trips the ratio must not come
+    // out half-spaced, and the blanks it loses must count as payload so the
+    // prompt layer's scatter gate sees them without re-deriving the budget.
+    assert.equal(countOf(overRatio, BRAILLE_BLANK), BLANKS); // same blanks…
+    assert.ok(
+      countOf(overRatio, BRAILLE_CELL) < countOf(atRatio, BRAILLE_CELL),
+    );
+    const { cleaned, found } = stripInvisibleWithReport(overRatio);
+    assert.equal(countOf(cleaned, BRAILLE_BLANK), 0);
+    assert.deepEqual(found, [CATEGORY.BLANK_FILLERS]);
+    assert.equal(countPayloadInvisible(overRatio), BLANKS);
+    assert.equal(stripInvisible(cleaned), cleaned); // idempotent
+  });
+
+  it("the 1:1 alternation channel is stripped whole, on both scripts", () => {
+    // The channel the allowance exists to close: one blank per anchor character
+    // stuffs a bit into every position while each blank stays individually
+    // anchored, so only a density rule can catch it.
+    for (const [anchor, blank] of [
+      [HANGUL_SYLLABLE, cp(0x1160)],
+      [BRAILLE_CELL, BRAILLE_BLANK],
+    ]) {
+      const text = (anchor + blank).repeat(TOTAL_PRESERVED_BLANK_BUDGET * 8);
+      const { cleaned, found } = stripInvisibleWithReport(text);
+      assert.equal(cleaned, anchor.repeat(TOTAL_PRESERVED_BLANK_BUDGET * 8));
+      assert.deepEqual(found, [CATEGORY.BLANK_FILLERS]);
+    }
+  });
+
+  it("the floor keeps short blank-dense text intact", () => {
+    // Below TOTAL_PRESERVED_BLANK_BUDGET the ratio never binds, so a one-line
+    // Braille phrase (or a couple of archaic syllables) is untouched even at
+    // 1:1 — the same role the joiner budget's floor plays for a lone emoji ZWJ
+    // sequence.
+    const text = (BRAILLE_CELL + BRAILLE_BLANK).repeat(
+      TOTAL_PRESERVED_BLANK_BUDGET,
+    );
+    const { cleaned, found } = stripInvisibleWithReport(text);
+    assert.equal(cleaned, text);
+    assert.deepEqual(found, []);
   });
 });
 

--- a/test/invisible.test.mjs
+++ b/test/invisible.test.mjs
@@ -1656,6 +1656,62 @@ describe("stripInvisible: blank fillers have their own anchor-proportional allow
     }
   });
 
+  it("one script's cover text cannot fund the other script's channel", () => {
+    // The allowance is per script because a blank never anchors cross-script.
+    // Pooling the anchor counts would let ordinary Korean prose pay for a
+    // Braille alternation (and vice versa) — the channel would be preserved,
+    // unreported, and countPayloadInvisible would read zero.
+    const N = TOTAL_PRESERVED_BLANK_BUDGET * 8;
+    for (const [cover, anchor, blank] of [
+      ["한국어 문서입니다. ".repeat(20), BRAILLE_CELL, BRAILLE_BLANK],
+      [braillePassage(60), HANGUL_SYLLABLE, cp(0x1160)],
+    ]) {
+      const channel = (anchor + blank).repeat(N);
+      const { cleaned, found } = stripInvisibleWithReport(cover + channel);
+      assert.equal(countOf(cleaned, blank), 0, "the channel must not survive");
+      assert.deepEqual(found, [CATEGORY.BLANK_FILLERS]);
+      assert.equal(countPayloadInvisible(cover + channel), N);
+    }
+  });
+
+  it("a tripping script does not take the other script's blanks with it", () => {
+    // The verdict is per script, so a Hangul channel small enough to stay under
+    // the scatter floor (which would otherwise disable the carve-out wholesale)
+    // is stripped while the Braille passage beside it keeps every word space.
+    const fillers = TOTAL_PRESERVED_BLANK_BUDGET + 4;
+    assert.ok(
+      fillers < SCATTERED_THRESHOLD,
+      "the scatter floor must not decide",
+    );
+    const passage = braillePassage(60);
+    const text = `${passage} ${(HANGUL_SYLLABLE + cp(0x1160)).repeat(fillers)}`;
+    const { cleaned, found } = stripInvisibleWithReport(text);
+    assert.equal(countOf(cleaned, cp(0x1160)), 0);
+    assert.equal(
+      countOf(cleaned, BRAILLE_BLANK),
+      countOf(passage, BRAILLE_BLANK),
+    );
+    assert.deepEqual(found, [CATEGORY.BLANK_FILLERS]);
+  });
+
+  it("contracted Braille near the ratio is stripped — an accepted residual", () => {
+    // Documented limitation, pinned rather than left implicit in the five-cell
+    // fixtures above: grade-2 Braille contracts common words to a single
+    // alphabet wordsign (⠮ the, ⠯ and, ⠉ can), so a passage of mostly one-cell
+    // words approaches 1:1 and is indistinguishable BY DENSITY from the
+    // channel. The collision is inherent to a density rule; it is named in
+    // THREAT-MODEL.md rather than papered over by widening the ratio, which
+    // would re-open the channel.
+    const contracted = ["⠮", "⠯", "⠉", "⠙"].join(BRAILLE_BLANK);
+    const text = Array.from(
+      { length: TOTAL_PRESERVED_BLANK_BUDGET * 4 },
+      () => contracted,
+    ).join(BRAILLE_BLANK);
+    const { cleaned, found } = stripInvisibleWithReport(text);
+    assert.equal(countOf(cleaned, BRAILLE_BLANK), 0);
+    assert.deepEqual(found, [CATEGORY.BLANK_FILLERS]);
+  });
+
   it("the floor keeps short blank-dense text intact", () => {
     // Below TOTAL_PRESERVED_BLANK_BUDGET the ratio never binds, so a one-line
     // Braille phrase (or a couple of archaic syllables) is untouched even at

--- a/test/prompt.test.mjs
+++ b/test/prompt.test.mjs
@@ -138,6 +138,28 @@ describe("classifyPrompt: preserved-joiner covert channel", () => {
     assert.deepEqual(classifyPrompt(prompt), { action: "pass" });
   });
 
+  it("still PASSES a long Braille prompt (U+2800 is its word space)", () => {
+    // The blank-filler counterpart of the two cases above, and the false
+    // positive that motivated giving blanks their own allowance: every U+2800
+    // here is a legitimate word space, so the strip layer must preserve all of
+    // them — surplus 0 — instead of clipping the surplus into a block reason on
+    // a document a Braille reader wrote. 200 words is well past the joiner
+    // budget's absolute ceiling, which is what used to decide this.
+    const prompt = Array.from({ length: 200 }, () => "⠃⠁⠇⠇⠕").join("⠀");
+    assert.deepEqual(classifyPrompt(prompt), { action: "pass" });
+  });
+
+  it("blocks a blank-filler channel alternating with its own anchors", () => {
+    // The channel the blank allowance closes: one U+1160 per Hangul syllable,
+    // each individually anchored (so payload-invisible is ZERO), at a 1:1
+    // density no genuine Korean text reaches. The strip layer strips them all,
+    // and that surplus is what the scatter gate sees.
+    const channel = (cp(0xac00) + cp(0x1160)).repeat(200);
+    const verdict = classifyPrompt(channel);
+    assert.equal(verdict.action, "block");
+    assert.match(verdict.reason, /Blank-rendering fillers/);
+  });
+
   it("still PASSES a formal-Persian ZWNJ prompt of ordinary density", () => {
     // A dozen Persian words each carrying one linguistic ZWNJ: 12 preserved
     // joiners, under budget, so it must not be mistaken for a covert channel.


### PR DESCRIPTION
Claimed area: `src/invisible.mjs` (the blank-filler carve-out's interaction with the preserve budget) + its tests.

Follow-up to #255, which fixed the *test* and explicitly deferred the implementation. Re-auditing the implementation turned up a real false positive next door — not in the anchor rule #255 characterized (that one is correct), but in what the carve-out does *after* it decides a blank is legitimate.

## The bug

An anchored blank filler was charged against the joiner/selector preserve budget. That budget's density model is `~1 preserved invisible per PRESERVED_JOINER_PER_VISIBLE (8) visible chars`, floored at 16 and hard-capped at `PRESERVE_HARD_CAP` (64) — derived, per its own comment, from measured Persian ZWNJ prose.

Blank fillers are an order of magnitude denser in genuine text: **U+2800 *is* the word space of Unicode Braille**, and a Hangul filler completes a defective syllable. So legitimate documents were mangled:

| input | blanks in | blanks kept | `found` | `classifyPrompt` |
| --- | --- | --- | --- | --- |
| 10-word Braille passage | 9 | 9 | `[]` | pass |
| **40-word** Braille passage | 39 | **25** | `["blank-fillers"]` | pass |
| **200-word** Braille passage | 199 | **64** | `["blank-fillers"]` | **block** |

Past ~40 words the words start running together — content the model needed, removed — and past the scatter floor the whole paste is *blocked* as a hidden channel, because `prompt.mjs` folds budget-stripped preservables into its invisible count. A Braille reader's own document is the false positive. Same shape for a filler-dense archaic-Korean transcription.

Both directions of CLAUDE.md's precision rule are violated at once: legitimate content is rewritten, and the flag it raises is noise.

## The fix

Blank fillers get their own document-wide allowance, sized off the thing that makes them legitimate in the first place — the **visible anchor-script text** (non-blank Braille cells, non-filler Hangul):

- `TOTAL_PRESERVED_BLANK_BUDGET = 16` — same style of floor as the joiner budget, so short blank-dense strings are never clipped.
- `PRESERVED_BLANK_PER_ANCHOR = 2` — one preserved blank per two anchor characters above the floor. A word or syllable spans several anchor chars, so genuine text sits well under it; the `syllable filler syllable filler …` alternation an attacker needs to stuff a bit per character is exactly 1:1 and fails.
- **Not** capped by `PRESERVE_HARD_CAP`: a fixed ceiling is precisely what truncated the 200-word document, and unlike the joiner channel every extra bit here costs the attacker two *visible* anchor characters (and renders as spacing a reader can see).
- Decided **all-or-nothing, document-wide, in `analyzeCarve`** — so a document never comes out half-spaced, and a blank the stripper will remove is payload to `countPayloadInvisible` / `payloadInvisibleView` / the prompt scatter gate without any consumer re-deriving the budget.

Blanks no longer draw on the joiner budget either, which was a second-order bug: a Braille passage used to eat the allowance and get *joiners later in the same document* stripped as surplus.

After: every Braille passage above round-trips unchanged with `found === []` and passes `classifyPrompt`; the 1:1 alternation channel is stripped whole and still blocks.

## Guards proven non-vacuous

| Mutation to `src/invisible.mjs` | Result |
| --- | --- |
| blanks charged against the shared budget again (the bug) | 7 failures across both suites |
| `>` → `>=` at the ratio | `not ok - exactly at the ratio, every blank is preserved` |
| `>` → `>=` at the floor | `not ok - the floor keeps short blank-dense text intact` |
| `PRESERVED_BLANK_PER_ANCHOR` 2 → 1 | 3 failures (alternation escapes) |
| allowance never enforced | 3 failures |

The ratio boundary is pinned by a **one-variable pair**: two documents with the *same* blank count, each blank anchored, differing only by a single anchor character — so the pair can only fail for the ratio itself, not for length or blank count.

```
pnpm test        # 2730/2730, coverage floors met
pnpm lint        # exit 0
tsc --noEmit     # exit 0
200k-case fuzz over blank/anchor/payload alphabets: 0 idempotency or found⇔changed violations
```

## Decisions made

- **Ratio 1:2 rather than a larger absolute cap.** A cap of any size re-introduces truncation on a long-enough document; the ratio scales with the cover text the attacker must supply visibly. Under the alternative (say `PRESERVE_HARD_CAP * 8`) a book-length Braille file breaks again, just later.
- **All-or-nothing over partial preservation.** Preserving the first N blanks and dropping the rest is exactly the half-spaced output that made the old behaviour so damaging. Under the alternative the failure is silent and localized to the tail of the document.
- **Decided in `analyzeCarve`, not the emit loop.** This keeps the strip layer and the prompt layer agreeing by construction. Under the alternative `countPayloadInvisible` would report 0 for blanks the stripper is about to remove, and `prompt.mjs` would only catch them through the `stripInvisible` length-delta hack.
- **Left the anchor rule itself alone.** #255's characterization holds: the immediate-neighbour test (no `effectiveNeighbor` skipping, unlike the joiner path) only ever over-strips, is idempotent, and archaic Korean's own tone marks (U+302E/302F) are `Script=Hangul`, so they anchor rather than block. No change warranted.
- **Skipped the anchor scan below the floor.** It costs two script regexes per visible char and `analyzeCarve` runs on every prompt and tool output; below 16 blanks the floor decides anyway, so the scan is unreachable-by-construction rather than merely cheap.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P9TGb1P3FwkqRD5aGW6mXk)_