### PR TITLE
fix(ci): stop the sanitizer install from running the checkout's pnpm build

### DIFF
--- a/.github/scripts/install-sanitizer.sh
+++ b/.github/scripts/install-sanitizer.sh
@@ -22,13 +22,43 @@ SANITIZER_VERSION="2.0.0"
 # HTML dependencies are not installed). Downstream template-synced repos have
 # no sanitizer src/ and keep the published pin.
 #
+# The local path installs from a STAGED COPY of the checkout with the lifecycle
+# scripts removed, not from ${PWD} directly: npm packs a `file:` dependency by
+# running that package's own `prepare`/`prepack`, and it does so even under
+# --ignore-scripts (npm 10.9). This repo's `prepare` shells out to `pnpm
+# build:types`, and the PR-review jobs install neither pnpm nor the typescript
+# devDependency — so packing the checkout in place died with `pnpm: not found`
+# and took the whole review job down before it read a single diff. Staging keeps
+# npm as the packer, so the installed tree is still exactly what `files`
+# publishes. `git archive` stages the COMMITTED tree; every caller runs on a
+# pristine actions/checkout, so that is the tree on disk.
+#
 # Only the install SPEC differs between the two paths, so the branch produces
 # just that and one invocation carries the flags — a second flag list is a
 # second thing to keep in sync. `--install-links` is inert for a registry spec
 # (it only changes how `file:` deps are materialised), so it is safe on both.
+staged=""
+cleanup() {
+  if [ -n "${staged}" ]; then rm -rf "${staged}"; fi
+}
+trap cleanup EXIT
+
 local_pkg_name="$(node -p "try { require('./package.json').name } catch { '' }")"
 if [ "${local_pkg_name}" = "agent-sanitizer" ]; then
-  install_spec="file:${PWD}"
+  staged="$(mktemp -d)"
+  git archive --format=tar HEAD | tar -x -C "${staged}"
+  # Fails loudly on an unreadable manifest or a missing `scripts` block: a
+  # silently-unstripped copy would reintroduce the pnpm dependency this exists
+  # to remove, and only in the jobs that lack pnpm.
+  node - "${staged}/package.json" <<'STRIP_LIFECYCLE'
+const fs = require("node:fs");
+const manifest = process.argv[2];
+const pkg = JSON.parse(fs.readFileSync(manifest, "utf8"));
+delete pkg.scripts.prepare;
+delete pkg.scripts.prepack;
+fs.writeFileSync(manifest, `${JSON.stringify(pkg, null, 2)}\n`);
+STRIP_LIFECYCLE
+  install_spec="file:${staged}"
 else
   install_spec="agent-sanitizer@${SANITIZER_VERSION}"
 fi

--- a/.github/scripts/install-sanitizer.test.mjs
+++ b/.github/scripts/install-sanitizer.test.mjs
@@ -1,0 +1,99 @@
+// install-sanitizer.sh, local-checkout path.
+//
+// Regression: npm packs a `file:` dependency by running that package's own
+// `prepare`/`prepack`, and does so even under --ignore-scripts (npm 10.9). This
+// repo's `prepare` is `pnpm build:types`, and the three claude-* review
+// workflows install neither pnpm nor the typescript devDependency — so the
+// install step died with `pnpm: not found` and took every review job with it
+// before it read a single diff. The fixture's lifecycle scripts below exit
+// non-zero, so this test fails exactly the way CI did if the staging that
+// strips them is removed.
+import { strict as assert } from "node:assert";
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "install-sanitizer.sh",
+);
+
+/**
+ * A miniature of this repo as the script sees it: named `agent-sanitizer` (so
+ * the local-checkout branch is taken), dependency-free (so the install needs no
+ * registry), carrying a `files` allowlist and lifecycle scripts that fail.
+ */
+function makeCheckout() {
+  const dir = mkdtempSync(join(tmpdir(), "install-sanitizer-"));
+  const manifest = {
+    name: "agent-sanitizer",
+    version: "0.0.0",
+    type: "module",
+    main: "src/index.mjs",
+    scripts: {
+      prepare: "exit 17",
+      prepack: "exit 17",
+    },
+    files: ["src/*.mjs"],
+  };
+  writeFileSync(
+    join(dir, "package.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+  mkdirSync(join(dir, "src"));
+  writeFileSync(
+    join(dir, "src", "index.mjs"),
+    "export const sanitize = () => {};\n",
+  );
+  // Outside `files`: proves the install still ships the PUBLISHED tree rather
+  // than the whole checkout, which is what staging-then-packing preserves.
+  writeFileSync(join(dir, "unpublished.txt"), "not in files\n");
+  mkdirSync(join(dir, ".github", "scripts"), { recursive: true });
+
+  // `git archive HEAD` stages the committed tree, so the fixture needs a commit.
+  const git = (...args) =>
+    execFileSync("git", ["-C", dir, ...args], { encoding: "utf8" });
+  git("init", "--quiet");
+  git("config", "user.email", "test@example.com");
+  git("config", "user.name", "test");
+  git("add", "--all");
+  git("-c", "commit.gpgsign=false", "commit", "--quiet", "-m", "fixture");
+  return dir;
+}
+
+test("installs the local checkout without running its lifecycle scripts", () => {
+  const dir = makeCheckout();
+  const res = spawnSync("bash", [SCRIPT], { cwd: dir, encoding: "utf8" });
+  const installed = join(
+    dir,
+    ".github",
+    "scripts",
+    "node_modules",
+    "agent-sanitizer",
+  );
+  const ok = res.status === 0;
+  const hasEntry = existsSync(join(installed, "src", "index.mjs"));
+  const hasUnpublished = existsSync(join(installed, "unpublished.txt"));
+  rmSync(dir, { recursive: true, force: true });
+
+  assert.equal(ok, true, `install failed:\n${res.stdout}\n${res.stderr}`);
+  assert.equal(
+    hasEntry,
+    true,
+    "the local checkout's entry point was not installed",
+  );
+  assert.equal(
+    hasUnpublished,
+    false,
+    "installed a file outside `files` — the install no longer mirrors the published package",
+  );
+});


### PR DESCRIPTION
Claims the `Install the input sanitizer` step that is failing in every claude-* review job.

## Summary

`install-sanitizer.sh` installs this repo's own checkout (`file:${PWD}`) so the PR-review scripts exercise the local sanitizer rather than the published pin. npm packs a `file:` dependency by running that package's own `prepare`/`prepack` — **and does so even under `--ignore-scripts`** (npm 10.9). This repo's `prepare` is `pnpm build:types`, and the three claude-* review workflows install neither pnpm nor the `typescript` devDependency, so the step died with:

```
npm error command sh -c pnpm build:types && …
npm error sh: 1: pnpm: not found
```

taking the whole job down before it read a single diff. `node-tests.yaml` is the only caller that survived, because there the install runs after `pnpm install`.

The fix packs a **staged, scriptless copy** of the checkout instead of the checkout in place: `git archive HEAD` into a temp dir, delete `scripts.prepare`/`scripts.prepack` from its manifest, install from there. npm still does the packing, so the installed tree is still exactly what `files` publishes — the local install keeps mirroring the published package rather than becoming a whole-repo copy. Downstream template-synced repos take the registry-pin branch and are untouched.

## Changes

- `.github/scripts/install-sanitizer.sh`: stage-and-strip before packing on the local-checkout path; the staged dir is removed on exit via a trap. The manifest edit is a here-doc'd `node -` program rather than `node -e`, so it stays readable and shellcheck-clean.
- `.github/scripts/install-sanitizer.test.mjs` (new): builds a dependency-free miniature checkout named `agent-sanitizer` whose `prepare`/`prepack` both `exit 17`, runs the real script against it, and asserts the install succeeds.

## Tests / verification

- Root cause reproduced directly: running the script on a clean `origin/main` worktree with `pnpm` off `PATH` fails with the exact CI error; with the fix it installs 88 packages and exits 0.
- Non-vacuity, checked in both directions: reverting the staging back to `file:${PWD}` fails the new test with `npm error command sh -c exit 17`; restoring it passes. The fixture's failing lifecycle scripts are the assertion — the test cannot pass while the scripts run.
- The new test also asserts a file **outside** `files` is absent from the installed tree, pinning the `files`-fidelity the staging preserves; that assertion is what would catch a future "just copy the repo" shortcut.
- `bash .github/scripts/run-script-tests.sh` (the CI discovery step): **379/379**.
- `.github/scripts/sanitize-pr-input.test.mjs` re-run against a tree installed by the patched script: 5/5 — the install is not just exit-0, the package it produces still resolves and works.
- `shellcheck` and `shfmt -i 2` clean.
- No network needed by the test (fixture has no dependencies); it runs in ~0.5s.

## Decisions made

- **Stage-and-strip rather than provisioning pnpm in the review jobs.** Adding pnpm to those jobs is not enough on its own — `prepare` also needs the `typescript` devDependency, so it would mean a full `pnpm install` plus a type build in three review jobs that need none of it. Staging keeps the install hermetic, which is what the step's comment already claimed.
- **`git archive HEAD` rather than copying the working tree.** Every caller runs on a pristine `actions/checkout`, so the committed tree is the tree on disk; `git archive` gets that without enumerating ignores by hand. Noted in the script comment, since a dirty local tree would stage its committed state.
- **Rewrote this PR rather than opening a new one.** It originally carried the `guard-pairs` count bump and the `Yelp/detect-secrets` classification; #267 landed both on `main` while this was open (with `RESOLVED_PATH_COUNT` at 30, ahead of the 28 here), so keeping them would have regressed `main`. The branch was reset onto `f3f8ddd` and now carries only the installer fix.

## Checklist

- [x] Commits follow Conventional Commits; each subject reads as a user-facing release note.
- [x] New detectors: n/a — no detector changes.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version left untouched.

## Lessons Learned

- **What:** never install a repo's own checkout as a `file:` dependency and expect `--ignore-scripts` to hold — npm runs the packed directory's `prepare`/`prepack` anyway. Pack a staged copy with those scripts deleted. **Where:** `.github/scripts/install-sanitizer.sh`. **Why:** the template's `prepare` shells out to the package manager and a type build, so any job that installs the sanitizer without a full dev install dies at the install step — and it dies in the *review* workflows, whose failure looks like a Claude/credential problem rather than a packaging one.
- **What:** a CI step whose comment claims a property (`--ignore-scripts keeps the install hermetic`) needs a test that asserts the property, not just a green pipeline. **Where:** `.github/scripts/install-sanitizer.test.mjs`. **Why:** the claim was false for the local path from the day it was written and only surfaced when the runner image stopped carrying pnpm; a fixture with failing lifecycle scripts turns the claim into something CI checks in half a second.
