### PR TITLE
fix(ci): strip the prepare script before the dogfooding file: sanitizer install

### DIFF
--- a/.github/scripts/install-sanitizer.sh
+++ b/.github/scripts/install-sanitizer.sh
@@ -29,6 +29,25 @@ SANITIZER_VERSION="2.0.0"
 local_pkg_name="$(node -p "try { require('./package.json').name } catch { '' }")"
 if [ "${local_pkg_name}" = "agent-sanitizer" ]; then
   install_spec="file:${PWD}"
+  # npm packs a file: dependency through pacote, which runs the package's
+  # `prepare` script even under --ignore-scripts (npm/cli#4989). These
+  # runners have neither pnpm nor the repo's node_modules, so `prepare`
+  # (`pnpm build:types`) can only die with "pnpm: not found". The script is
+  # irrelevant here anyway — it builds .d.ts files the runtime .mjs imports
+  # never read — so strip it from the scratch checkout for the duration of
+  # the install and restore the file afterwards. prepack does NOT run for a
+  # file: install (verified against npm 10.9), so prepare is the only strip.
+  # Restore from a byte copy, not git checkout — a dev running this locally
+  # may have uncommitted package.json edits that a checkout would discard.
+  pkg_backup="$(mktemp)"
+  cp package.json "${pkg_backup}"
+  trap 'mv "${pkg_backup}" package.json' EXIT
+  node -e "
+    const fs = require('fs');
+    const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+    delete pkg.scripts.prepare;
+    fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+  "
 else
   install_spec="agent-sanitizer@${SANITIZER_VERSION}"
 fi


### PR DESCRIPTION
Claimed area: `.github/scripts/install-sanitizer.sh` only — unreds the Claude PR review / merge-delta-review / thread-resolve jobs that have failed on every PR since the dogfooding arm landed.

## What & why

Stop the dogfooding `file:${PWD}` sanitizer install from dying with `pnpm: not found`. npm packs a `file:` dependency through pacote, which runs the package's `prepare` script even under `--ignore-scripts` (npm/cli#4989 — reproduced locally on npm 10.9.7, the runner's version). The review runners have neither pnpm nor the repo's `node_modules`, so every job that reached `install-sanitizer.sh` since the dogfooding arm merged (c09e6e1, 2026-08-08) failed at the install step — visible on PRs #272 and #273, where the identical three checks are red while runs that skip the review job stay green.

The fix strips `scripts.prepare` from the scratch checkout for the duration of the install and restores the original bytes from a `mktemp` copy via an EXIT trap (not `git checkout`, so a dev running the script locally with uncommitted `package.json` edits loses nothing). `prepare` is irrelevant to this install anyway — it builds `.d.ts` files the runtime `.mjs` imports never read. `prepack` does not run for a `file:` install (verified against npm 10.9), so `prepare` is the only strip needed.

## How it was tested

- Reproduced the failure shape with a fixture package (`prepare` invoking a missing command) under the exact install flags — `prepare` runs despite `--ignore-scripts`; with `scripts.prepare` deleted the install succeeds and `prepack` never fires.
- Ran the patched `bash .github/scripts/install-sanitizer.sh` on a fresh clone with no pnpm provisioning of the install path: 88 packages installed into `.github/scripts/node_modules`, `package.json` byte-restored (`git status` clean apart from the script itself), and `src/index.mjs` imports from the installed copy with all 25 exports.
- `shellcheck .github/scripts/install-sanitizer.sh` — clean.

## Decisions made

- **Strip-and-restore over provisioning pnpm on the runners.** Making `prepare` runnable would need pnpm *plus* a full dev-dependency install (its `pnpm build:types` needs `tsc`) in three workflows, for artifacts the dogfooded install never uses. The single-site strip keeps the install hermetic, matching the existing `--ignore-scripts` intent.
- **Restore from a byte copy, not `git checkout -- package.json`**, so the EXIT trap can never discard uncommitted local edits.

---
_Generated by [Claude Code](https://claude.ai/code/session_018V3EjCxwDkjdLrxR5VjHFT)_