### PR TITLE
docs(skills): require an explore-plan gate before audit fan-outs

### DIFF
--- a/.claude/skills/audit-and-parallelize/SKILL.md
+++ b/.claude/skills/audit-and-parallelize/SKILL.md
@@ -23,6 +23,16 @@ The non-negotiable rule: **every finding is false until the code proves it true.
 
 ## Workflow
 
+### 0. Plan the partition before spawning anything (`explore-plan` gate)
+
+The surfaces you hand the agents are load-bearing: a gap means a whole area goes unaudited, a
+double-claim wastes two agents on the same files, and either defect multiplies across the fan-out.
+Run the `explore-plan` loop first — explore the tree (`git ls-files`, open PRs, the project's own
+invariants), write the partition and doctrine lenses down, self-critique it as a hostile reviewer,
+and fix what that finds. For a repo large enough to need more than ~3 agents, have a read-only
+`Plan` agent attack the partition too: it catches unowned dirs, generated bundles an agent would
+burn its context reading, and surfaces several times the median size.
+
 ### 1. Fan out over disjoint surfaces
 
 Launch 2–4 **read-only** subagents (`Explore`, or `general-purpose` for deeper traces) in a single
@@ -98,6 +108,8 @@ positives and why.
 
 ## Anti-patterns
 
+- **Fanning out before the partition is reviewed.** The reads an agent wastes on someone else's
+  surface — or the area nobody was given — are unrecoverable. Plan it, critique it, then spawn.
 - **Trusting a subagent's "CRITICAL" label.** It is a hypothesis, not a result. Read the code.
 - **Padding to a number.** If only five issues are real, plan five. The over-report is the finding.
 - **One giant PR.** Disjoint PRs parallelize and review cleanly; a mega-PR serializes everything.

--- a/.claude/skills/audit-and-parallelize/SKILL.md
+++ b/.claude/skills/audit-and-parallelize/SKILL.md
@@ -29,9 +29,9 @@ The surfaces you hand the agents are load-bearing: a gap means a whole area goes
 double-claim wastes two agents on the same files, and either defect multiplies across the fan-out.
 Run the `explore-plan` loop first — explore the tree (`git ls-files`, open PRs, the project's own
 invariants), write the partition and doctrine lenses down, self-critique it as a hostile reviewer,
-and fix what that finds. For a repo large enough to need more than ~3 agents, have a read-only
-`Plan` agent attack the partition too: it catches unowned dirs, generated bundles an agent would
-burn its context reading, and surfaces several times the median size.
+and fix what that finds. Then have a read-only `Plan` agent attack the partition too: it catches
+unowned dirs, generated bundles an agent would burn its context reading, and surfaces several
+times the median size.
 
 ### 1. Fan out over disjoint surfaces
 

--- a/.claude/skills/explore-plan/SKILL.md
+++ b/.claude/skills/explore-plan/SKILL.md
@@ -5,7 +5,9 @@ description: >
   Drives the Explore -> Plan -> Critique -> Review -> Verify discipline for non-trivial, multi-file work before
   any code is written. Activate when the user asks to "plan this", "scope this out", "figure out how
   to do X", "explore the codebase first", or is starting a change that touches several files or an
-  unfamiliar area. Enforces a self-critiqued written plan and real verification instead of trusting a success claim.
+  unfamiliar area. Also activate before launching any multi-agent fan-out — an audit, a parallel PR
+  run, a subagent sweep — where the partition handed to the agents is itself the load-bearing
+  decision. Enforces a self-critiqued written plan and real verification instead of trusting a success claim.
 ---
 
 # Explore / Plan Skill

--- a/.claude/skills/parallel-audit/SKILL.md
+++ b/.claude/skills/parallel-audit/SKILL.md
@@ -86,13 +86,31 @@ actionable; "several scripts are inconsistent" is not.
 
 ## Workflow
 
-### 1. Map the territory (main session, fast)
+### 1. Map the territory (main session, fast) — this is an `explore-plan` gate
 
-Before spawning anything, get a lay of the land so agent scopes are _disjoint_: directory tree,
-file-type counts, the key subsystems. Skim any `CLAUDE.md` / `CONTRIBUTING.md` / `SECURITY.md` —
-their stated invariants ("fail closed", "post-condition not exit code", "host code runs on BSD too")
-become the _lenses_ you hand each agent. An audit that knows the project's own doctrine finds
-violations of it; a generic audit re-discovers lint.
+The fan-out is expensive and its scopes are load-bearing, so step 1 follows the `explore-plan`
+skill's loop, not an ad-hoc skim. Before spawning any audit agent:
+
+- **Explore.** Get a lay of the land so agent scopes are _disjoint_: directory tree, file-type
+  counts, the key subsystems. When the repo spans several subsystems, fan out `Explore` agents for
+  this too — one to validate the scope partition against `git ls-files` (gaps, double-claims,
+  generated files nobody should hand-read, oversized scopes), one to extract doctrine. Skim any
+  `CLAUDE.md` / `CONTRIBUTING.md` / `SECURITY.md` — their stated invariants ("fail closed",
+  "post-condition not exit code", "host code runs on BSD too") become the _lenses_ you hand each
+  agent. An audit that knows the project's own doctrine finds violations of it; a generic audit
+  re-discovers lint. Check open PRs here too — a scope another branch already owns changes the
+  partition, not just the later clustering.
+- **Write the plan.** Record the partition (every tracked file owned by exactly one agent), the
+  doctrine lens packet per scope, pre-seeded seams from exploration, and the open-PR overlaps, as a
+  written plan — in plan mode when the harness offers it.
+- **Critique it to a fixed point, then get fresh eyes.** Self-critique the plan as a hostile
+  reviewer (double-claimed files, orphaned file classes, agents pointed at generated bundles,
+  unverified premises like "this lint gate covers these files"), fix, re-critique; then have a
+  read-only `Plan`/`code-reviewer` agent attack it before the fan-out launches. A defective
+  partition multiplies across every agent it spawns — this is the cheapest moment to catch it.
+
+Only after the plan survives review does step 2 run. (Steps 4 and 6 below are the same loop's
+Verify and Review phases applied to the audit's _output_.)
 
 ### 2. Fan out — one agent per (dimension x area), all in ONE message
 
@@ -231,7 +249,15 @@ queue and tick each off as it opens, so progress is supervisable at a glance.
   sync", "keep this layer before that one", "documented so the omission is a choice" — each names a
   contract that only a test can actually hold. Grep the tree for that phrasing early.
 - **Check open PRs before planning.** A fix may already be in flight; overlapping a sibling branch
-  wastes the work and creates a conflict the disjoint-file rule was supposed to prevent.
+  wastes the work and creates a conflict the disjoint-file rule was supposed to prevent. Check what
+  the working branch already _contains_, too: a designated branch cut from a sibling's head carries
+  that sibling's unmerged diff, so a PR opened against the default branch would ship it. Diff the
+  branch against the default branch before choosing a PR base.
+- **Have the partition reviewed before the fan-out, not after.** A gap or a double-claim in the
+  scope list multiplies across every agent it spawns, and the wasted reads are unrecoverable. One
+  `Explore` pass over `git ls-files` reliably finds unowned dirs, tests hiding under a non-test
+  scope, generated bundles an agent would have burned its context on, and scopes several times the
+  median size.
 - **Don't stop the queue to ask.** Mid-run design choices get a sensible default plus a
   `## Decisions made` entry. The one moment for questions is the plan delivery.
 
@@ -240,7 +266,9 @@ queue and tick each off as it opens, so progress is supervisable at a glance.
 **User says:** "Find dozens of security, robustness, testing, and UX issues. Use subagents and confirm
 their findings. Then plan parallel PRs to fix them, and critique the plan."
 
-1. Map the repo; pull the invariants out of `CLAUDE.md`.
+1. Map the repo under the `explore-plan` gate: parallel `Explore` agents validate the scope
+   partition against `git ls-files` and pull the invariants out of `CLAUDE.md`; write the partition
+   down, self-critique it, and have a `Plan` agent attack it before spawning anything.
 2. Launch 8 read-only `general-purpose` agents in one message — firewall, redaction, monitor,
    lifecycle, e2e-realness, UX, supply-chain, config/CI — each with a disjoint file list and the
    structured-finding contract.

--- a/.claude/skills/parallel-audit/SKILL.md
+++ b/.claude/skills/parallel-audit/SKILL.md
@@ -86,7 +86,7 @@ actionable; "several scripts are inconsistent" is not.
 
 ## Workflow
 
-### 1. Map the territory (main session, fast) — this is an `explore-plan` gate
+### 1. Map the territory (main session) — this is an `explore-plan` gate
 
 The fan-out is expensive and its scopes are load-bearing, so step 1 follows the `explore-plan`
 skill's loop, not an ad-hoc skim. Before spawning any audit agent:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,8 @@ Commits MUST use [Conventional Commits](https://www.conventionalcommits.org/) (`
 
 ## Self-Critique Loop
 
+Start non-trivial multi-file work with the `explore-plan` skill: explore first, write the plan down, critique it to a fixed point, and only then edit. This binds hardest before a **multi-agent fan-out**—the scope partition handed to N subagents is the one decision that multiplies across all of them, and a gap or double-claim costs reads you cannot recover.
+
 Before declaring any non-trivial coding task done, **iteratively critique and fix your own work until you reach a fixed point.** Read what you actually wrote (not what you intended to write) as if it came from a developer you cannot stand—assume it is wrong until proven otherwise.
 
 Each pass, hunt for: bugs, broken or missed edge cases, weakened/skipped/deleted tests, swallowed errors, dead code, unjustified abstractions, premature returns, broken invariants, sloppy naming, fragile assumptions, hidden coupling, scope creep beyond the request, comments that explain _what_ instead of _why_, anything that smells off. State each issue bluntly in one line, then fix it. Then re-review the fix—fixes introduce their own bugs.


### PR DESCRIPTION
Claimed area: `.claude/skills/{parallel-audit,explore-plan,audit-and-parallelize}/SKILL.md` + the `CLAUDE.md` Self-Critique pointer. No `src/`, `python/`, `claude-hooks/` or CI files touched.

## Summary

Both audit skills spawned an expensive read-only subagent fleet with no written, reviewed partition in front of them. The scope list handed to N subagents is the one decision that multiplies across all of them: a gap leaves an area unaudited, a double-claim burns two agents on the same files, and neither is recoverable once the reads are spent. `explore-plan` already codifies the Explore → Plan → Critique → Review → Verify loop, but its activation surface never mentioned fan-outs, so an audit request routed straight past it.

This was found the hard way: a `/parallel-audit` run started without a plan. Retrofitting one immediately surfaced defects the fan-out would otherwise have inherited — an unowned top-level directory, ~7k lines of tests sitting under a non-test scope, a scope pointed at a 70k-line generated bundle, and two scopes several times the median size.

## Changes

- `parallel-audit/SKILL.md`: step 1 is now an explicit `explore-plan` gate — Explore agents validate the partition against `git ls-files` and extract the project's doctrine, the partition is written down, self-critiqued as a hostile reviewer, then attacked by a read-only `Plan`/`code-reviewer` agent before any fan-out launches. Steps 4 and 6 are named as the same loop's Verify/Review phases. Two new "lessons baked in" bullets: review the partition before the fan-out, and check what the working branch already *contains* — a branch cut from a sibling's head carries that sibling's unmerged diff, so a PR against the default branch would ship it.
- `audit-and-parallelize/SKILL.md`: the same gate as step 0, phrased for its shorter workflow, plus a matching anti-pattern. The two skills' posture disambiguation is untouched.
- `explore-plan/SKILL.md`: `description` now also activates before any multi-agent fan-out, closing the routing gap.
- `CLAUDE.md`: one pointer line under Self-Critique Loop so the rule reaches work outside the two audit skills.

## Tests / verification

Docs-only change; no runtime code touched. `.hooks/lint-skills.sh` run directly on the three edited SKILL.md files (rc=0), and the full pre-commit suite passed on push — including `lint Claude SKILL.md files`, `validate Claude hook configuration`, and both ci-truth-serum aggregate tiers.

## Decisions made

**PR base is `main`.** This branch was cut from `claude/rn-sanitizer-html-corruption-wj7dv2` (PR #268), which was still unmerged when the work started — basing on `main` would then have carried #268's entire Layer-2 splice/rehydration rewrite plus a regenerated dist bundle alongside four doc edits, so the plan was to stack on #268's branch. #268 merged mid-run, making that moot: `git diff origin/main...HEAD` is exactly the four intended files. Had it not merged, this PR would have targeted #268's branch instead and been rebased onto `main` afterwards.

**The gate mandates a written plan, not plan mode specifically.** The skill says "in plan mode when the harness offers it" rather than requiring it, so the discipline still applies in harnesses without a plan-mode affordance. The alternative — a hard plan-mode requirement — would be unenforceable in exactly the automated contexts that most need the gate.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/); each subject reads as a user-facing release note.
- [x] Verified with the repo's own gates (skill lint + full pre-commit); no test-suite-affecting code changed.
- [x] No new or changed detectors.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version left untouched.

## Lessons Learned

- **What:** Add a plan-before-fan-out gate to any skill that spawns a subagent fleet — require the scope partition to be written down, self-critiqued, and reviewed by an independent agent before the first agent launches. **Where:** `.claude/skills/parallel-audit/SKILL.md` (step 1) and `.claude/skills/audit-and-parallelize/SKILL.md` (step 0). **Why:** a defective partition multiplies across every agent it spawns and the wasted reads are unrecoverable; one `Explore` pass over `git ls-files` reliably finds unowned directories, tests hiding under a non-test scope, generated bundles an agent would burn its context on, and scopes several times the median size.
- **What:** Extend a workflow skill's `description` to name multi-agent fan-outs as an activation trigger. **Where:** `.claude/skills/explore-plan/SKILL.md` frontmatter. **Why:** activation surfaces written only around "plan this feature" phrasing miss audit- and sweep-shaped requests, which are precisely the ones where skipping the plan is most expensive.
- **What:** Tell audits to diff the working branch against the default branch before choosing a PR base. **Where:** `.claude/skills/parallel-audit/SKILL.md` ("Lessons baked in"). **Why:** the existing "check open PRs" rule catches a sibling *editing* the same files but not a designated branch that was *cut from* a sibling's head — that branch already contains the sibling's unmerged diff, so a PR against the default branch silently ships it.

---
_Generated by [Claude Code](https://claude.ai/code/session_013gUCEpudVMyzHF5K6BLQaw)_