### PR TITLE
fix: four detection-layer eliminators (value extent, regex literals, border box, CLI bridge)

### DIFF
--- a/bin/sanitize-cli.mjs
+++ b/bin/sanitize-cli.mjs
@@ -14,7 +14,7 @@
  * Protocol — a request is a JSON object with an `op` (default `"sanitize"` so a
  * bare `{ text, html }` keeps working). Per op:
  *
- *   sanitize           { text, html? }            -> { cleaned, found, warnings, notes }
+ *   sanitize           { text, html? }            -> { cleaned, found, warnings, notes, splices? }
  *   sanitizeText       { text, html?, exfilScan? } -> { cleaned, warnings, notes, modified, sgrNote }
  *   classifyPrompt     { text }                    -> { action, reason? }
  *   scanInstructionFiles { globs, cwd? }           -> { findings: [{ file, findings }] }

--- a/bin/sanitize-cli.mjs
+++ b/bin/sanitize-cli.mjs
@@ -114,10 +114,14 @@ export const OPS = {
   /** @param {Record<string, unknown>} req */
   async sanitize(req) {
     const text = requireString(req, "text");
-    const { cleaned, found, warnings, notes } = await sanitize(text, {
-      html: Boolean(req.html),
-    });
-    return { cleaned, found, warnings, notes };
+    // Forwarded whole rather than re-listed field by field. A hand-picked
+    // projection is a second copy of the return shape that nothing keeps in
+    // sync: `splices` was part of `sanitize()`'s result and silently never
+    // reached the wire, so every non-JS caller was blind to Layer 2's spliced
+    // ranges. `test/cli-response-contract.test.mjs` pins this set against the
+    // Python client's field list, so growing the result stays a two-file edit
+    // that CI notices instead of a silent drop.
+    return await sanitize(text, { html: Boolean(req.html) });
   },
 
   /** @param {Record<string, unknown>} req */

--- a/python/agent_sanitizer/__init__.py
+++ b/python/agent_sanitizer/__init__.py
@@ -112,7 +112,7 @@ class SanitizeResult:
     #: constructs this shape.
     notes: list[str] = field(default_factory=list)
     #: Layer 2's spliced ranges. Defaulted for the same reason as ``notes``.
-    splices: list = field(default_factory=list)
+    splices: list[dict] = field(default_factory=list)
 
     @classmethod
     def from_response(cls, resp: dict) -> "SanitizeResult":

--- a/python/agent_sanitizer/__init__.py
+++ b/python/agent_sanitizer/__init__.py
@@ -59,7 +59,7 @@ import signal
 import subprocess
 import tempfile
 import threading
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from pathlib import Path
 
 # Env var to override the CLI path (e.g. pin at a specific JS checkout); takes
@@ -111,6 +111,24 @@ class SanitizeResult:
     #: Defaulted, so an older CLI that predates the severity split still
     #: constructs this shape.
     notes: list[str] = field(default_factory=list)
+    #: Layer 2's spliced ranges. Defaulted for the same reason as ``notes``.
+    splices: list = field(default_factory=list)
+
+    @classmethod
+    def from_response(cls, resp: dict) -> "SanitizeResult":
+        """Build from a CLI response, tolerating a CLI that is NEWER than this
+        client.
+
+        ``cls(**resp)`` made version skew fatal in one direction only: a field
+        this client predates raised ``TypeError`` and took down the caller,
+        while a field it postdates was covered by the defaults above. Both
+        directions are ordinary skew for a wire protocol, so both degrade the
+        same way. This is not silent drift-tolerance in the repo itself —
+        ``test/cli-response-contract.test.mjs`` asserts the CLI's live field set
+        equals this dataclass's, so a drift introduced HERE fails CI.
+        """
+        known = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in resp.items() if k in known})
 
 
 @dataclass(frozen=True)
@@ -267,7 +285,7 @@ def sanitize(
     if persist is None:
         persist = html
     resp = _dispatch({"text": text, "html": html}, persist=persist, node=node)
-    return SanitizeResult(**resp)
+    return SanitizeResult.from_response(resp)
 
 
 def sanitize_text(
@@ -460,7 +478,7 @@ class Sanitizer:
         return result[0]
 
     def sanitize(self, text: str, *, html: bool = False) -> SanitizeResult:
-        return SanitizeResult(**self.request({"text": text, "html": html}))
+        return SanitizeResult.from_response(self.request({"text": text, "html": html}))
 
     def _drain_stderr(self) -> str:
         if self._stderr is None:

--- a/python/agent_sanitizer/secrets/engine.py
+++ b/python/agent_sanitizer/secrets/engine.py
@@ -447,7 +447,15 @@ _KEYWORD_NOUN_LITERALS = frozenset(
 # polynomial backtracking. The lookbehind is always satisfied at the fullmatch
 # start position (no preceding char) and after each \s+ separator (space is not
 # in [A-Z_]), so the actual .fullmatch() semantics are unchanged.
-_CAPS_WORDS = r"(?<![A-Z_])[A-Z]+(?:_[A-Z]+)+"
+# The optional leading underscore sits INSIDE the lookbehind's protection (the
+# guard is evaluated before it, at the fullmatch start or after a \s+ separator,
+# so its semantics are unchanged). Without it a private-by-convention name was
+# not recognised as a name at all: this repo's own
+# `const EXTRA_SECRET_VARS_ENV = "_AGENT_SANITIZER_EXTRA_SECRET_VARS"` was
+# rewritten to "[REDACTED: Secret Keyword]", silently changing which environment
+# variable the program reads. The unprefixed spelling was already covered, so
+# the whole gap was that one byte.
+_CAPS_WORDS = r"(?<![A-Z_])_?[A-Z]+(?:_[A-Z]+)+"
 _PLACEHOLDER_RE = re.compile(
     rf"<[^<>]{{1,80}}>"  # <paste-token-here>
     rf"|\{{\{{[^{{}}]{{1,80}}\}}\}}"  # {{ secrets.GH_TOKEN }} (CI templates)
@@ -787,6 +795,49 @@ def _is_version(c: Candidate) -> bool:
     return _VERSION_RE.fullmatch(c.value) is not None and not _has_opaque_run(c.value)
 
 
+# The flag letters a JS/TS regular-expression literal may carry after its
+# closing delimiter.
+_REGEX_LITERAL_FLAGS = frozenset("dgimsuvy")
+
+
+def _is_regex_literal(c: Candidate) -> bool:
+    """True when the value is a regular-expression literal — code that NAMES
+    credential patterns rather than holding one.
+
+    A credential-named constant assigned a regex is the single most common way
+    a security codebase talks about secrets, and it was being rewritten into
+    invalid source: this repo's own ``src/gates.mjs`` had
+    ``export const SECRET_HINT = /secret|token|password|.../i`` turned into
+    ``export const SECRET_HINT = [REDACTED][n]a|...``. The field NAME trips the
+    keyword and the value class then cuts the literal wherever it first meets a
+    character it excludes (a ``[`` in a character class), so the value is often
+    a TRUNCATED literal rather than a well-formed one — which is why a
+    complete-literal shape alone is not enough to recognise it.
+
+    Two arms, both requiring a leading ``/``:
+
+    * a complete literal (``/…/`` plus optional flags), or
+    * a body carrying an alternation ``|`` — a byte no issuer's token alphabet
+      contains, which is what makes a truncated literal still recognisable.
+
+    Precision floor: a literal carrying an opaque credential-shaped run is NOT
+    skipped, so wrapping a real token as ``/ghp_…/i`` cannot launder it.
+
+    Implemented with string operations rather than a pattern: the obvious
+    ``/.*/[flags]*`` regex backtracks quadratically on a long value, and this
+    gate runs on every field match.
+    """
+    value = c.value
+    if not value.startswith("/") or len(value) < 2:
+        return False
+    if _has_opaque_run(value):
+        return False
+    if "|" in value:
+        return True
+    close = value.rfind("/")
+    return close > 0 and all(ch in _REGEX_LITERAL_FLAGS for ch in value[close + 1 :])
+
+
 # detect-secrets' PrivateKeyDetector only matches the "-----BEGIN-----" header
 # line, so a per-line scan leaves the base64 body unredacted. Match and collapse
 # the whole PEM block. The keyword is "PRIVATE KEY" only, so public material
@@ -990,6 +1041,12 @@ NAME_TRUST_GATES = (
     _is_filesystem_path,
     _is_metadata_field,
     _is_markdown_code_prose,
+    # A SHAPE, but a forgeable one: text arriving from the web is free to wrap a
+    # credential as `/ghp_…/i` to relabel it as a pattern. Trusted for local tool
+    # output only — the same reasoning `_is_config_attr_reference` gives for its
+    # bare-word roots. The structural prefix detectors run before this pass and
+    # remain the floor either way.
+    _is_regex_literal,
 )
 
 

--- a/python/agent_sanitizer/secrets/engine.py
+++ b/python/agent_sanitizer/secrets/engine.py
@@ -273,7 +273,21 @@ FIELD_VALUE_RE = re.compile(
     r"(?:(?:Bearer|Token|Basic)\s+)?)"
     r"(?P<openbracket>[(\[{]?)"
     r"(?P<quote>[\"']?)"
-    r"(?P<secret_value>[^\s\"'`{}()\[\]]{20,})"
+    # A trailing statement/list terminator is punctuation of the ENCLOSING
+    # syntax, never of the value, but the class above would swallow it and leave
+    # the stray byte on `secret_value` — the same false positive the operator
+    # lookahead above exists to prevent, arriving from the other end. Nine of the
+    # twelve benign-shape gates judge the value with an anchored `fullmatch`, so
+    # one un-peeled `;` disarms all of them at once and rewrites
+    # `const token = process.env.GH_TOKEN;` into `const token = [REDACTED];`.
+    # Peeling it HERE, in the one expression that decides the value's extent,
+    # means no gate can be written that forgets the normalization: no gate ever
+    # sees an un-peeled value. Precision-safe in the redacting direction too —
+    # no issuer's token alphabet contains `;` or `,`, so the peel can only ever
+    # shorten a non-credential. `.` is deliberately NOT peeled: it is a JWT's
+    # own segment separator.
+    r"(?P<secret_value>[^\s\"'`{}()\[\]]{19,}[^\s\"'`{}()\[\];,])"
+    r"(?P<terminator>[;,]*)"
     r"(?P<closequote>(?P=quote)?)"
     r"(?P<closebracket>[)\]}]?)",
     re.IGNORECASE | re.MULTILINE,
@@ -1117,6 +1131,9 @@ def _redact_core(
             + m.group("openbracket")
             + m.group("quote")
             + _mark(entries, placeholder(), candidate.value)
+            # Re-emitted in source order (value, terminator, closequote) so the
+            # bytes outside the placeholder are preserved exactly, quoted or not.
+            + m.group("terminator")
             + m.group("closequote")
             + m.group("closebracket")
         )

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -882,6 +882,95 @@ function hasImageLayer(nodeOf) {
   return paintsImageLayer(nodeOf("background"));
 }
 
+// The declarations that add to an axis's BORDER box beyond its content-box
+// length, per axis. Shorthands are listed alongside the longhands they can set,
+// because a shorthand this checker cannot resolve must fail OPEN rather than be
+// ignored — ignoring it is what let `height:0; padding-bottom:56.25%` read as
+// invisible.
+const BLOCK_AXIS_EXTENT_PROPS = [
+  "padding",
+  "padding-top",
+  "padding-bottom",
+  "border",
+  "border-width",
+  "border-top",
+  "border-bottom",
+  "border-top-width",
+  "border-bottom-width",
+];
+const INLINE_AXIS_EXTENT_PROPS = [
+  "padding",
+  "padding-left",
+  "padding-right",
+  "border",
+  "border-width",
+  "border-left",
+  "border-right",
+  "border-left-width",
+  "border-right-width",
+];
+
+// `border-width`'s keyword values. They are LENGTHS, so a border shorthand that
+// names one (or names none at all, defaulting to `medium`) has real extent.
+const BORDER_WIDTH_KEYWORDS = new Set(["thin", "medium", "thick"]);
+
+/**
+ * True when a declared axis-additive property provably contributes NO extent.
+ *
+ * Deliberately conservative: every numeric token must be near zero, no
+ * border-width keyword may appear, and a `border*` shorthand must carry an
+ * explicit numeric width (an omitted width computes to `medium`, i.e. 3px). A
+ * `calc()`, a `var()`, or any unit this cannot resolve leaves a non-numeric
+ * token behind and returns false — the fail-open the module's own policy
+ * requires, since an unresolvable value may well paint a visible box.
+ * @param {string} prop @param {any} node @returns {boolean}
+ */
+function contributesNoExtent(prop, node) {
+  const tokens = valueTokens(node);
+  if (tokens.length === 0) return false;
+  const isBorderShorthand =
+    prop === "border" ||
+    prop === "border-top" ||
+    prop === "border-bottom" ||
+    prop === "border-left" ||
+    prop === "border-right";
+  let sawNumeric = false;
+  for (const token of tokens) {
+    if (
+      token.type === "Number" ||
+      token.type === "Dimension" ||
+      token.type === "Percentage"
+    ) {
+      if (Math.abs(parseFloat(token.value)) >= NEAR_ZERO_EPSILON) return false;
+      sawNumeric = true;
+      continue;
+    }
+    // A style/color identifier (`solid`, `red`) adds no length, but a
+    // width keyword does — and anything else (a function node, `var()`) is
+    // unresolvable and must fail open.
+    if (token.type !== "Identifier") return false;
+    if (BORDER_WIDTH_KEYWORDS.has(String(token.name).toLowerCase()))
+      return false;
+  }
+  return isBorderShorthand ? sawNumeric : true;
+}
+
+/**
+ * True when every declaration that could add to `axisProps`' axis is either
+ * absent or provably zero, so a near-zero content-box length really does mean
+ * the rendered border box is empty.
+ * @param {(key: string) => any} nodeOf @param {string[]} axisProps
+ * @returns {boolean}
+ */
+function axisExtentProvablyZero(nodeOf, axisProps) {
+  for (const prop of axisProps) {
+    const node = nodeOf(prop);
+    if (!node) continue; // undeclared: contributes its initial value, 0
+    if (!contributesNoExtent(prop, node)) return false;
+  }
+  return true;
+}
+
 /**
  * @param {(key: string) => any} nodeOf value node for a property, or null
  * @param {(key: string) => string} textOf decoded/lowercased text for a property
@@ -889,10 +978,24 @@ function hasImageLayer(nodeOf) {
  */
 function isOverflowHidden(nodeOf, textOf) {
   if (textOf("overflow") !== "hidden") return false;
-  for (const dim of ["height", "width", "max-height", "max-width"])
+  for (const [dim, axisProps] of /** @type {[string, string[]][]} */ ([
+    ["height", BLOCK_AXIS_EXTENT_PROPS],
+    ["width", INLINE_AXIS_EXTENT_PROPS],
+    ["max-height", BLOCK_AXIS_EXTENT_PROPS],
+    ["max-width", INLINE_AXIS_EXTENT_PROPS],
+  ]))
     // Near-zero (epsilon band), not exact 0, so `height:0.0001px` still counts —
     // matching the standalone size checks a browser renders as invisible.
-    if (isNearZeroLength(nodeOf(dim))) return true;
+    // The content box being empty is necessary but NOT sufficient: the universal
+    // aspect-ratio wrapper (`height:0; padding-bottom:56.25%; overflow:hidden` —
+    // Bootstrap's `.ratio`, and every hand-pasted padding-bottom hack) renders
+    // at 56.25% of its container with everything inside it on screen. Reading
+    // the content-box length alone spliced that visible content out.
+    if (
+      isNearZeroLength(nodeOf(dim)) &&
+      axisExtentProvablyZero(nodeOf, axisProps)
+    )
+      return true;
   return false;
 }
 

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -887,28 +887,66 @@ function hasImageLayer(nodeOf) {
 // because a shorthand this checker cannot resolve must fail OPEN rather than be
 // ignored — ignoring it is what let `height:0; padding-bottom:56.25%` read as
 // invisible.
+// Logical spellings are listed beside their physical twins: `padding-block-end`
+// IS the aspect-ratio idiom in a logical stylesheet, so omitting it would leave
+// the exact false positive this checker exists to close.
 const BLOCK_AXIS_EXTENT_PROPS = [
   "padding",
   "padding-top",
   "padding-bottom",
+  "padding-block",
+  "padding-block-start",
+  "padding-block-end",
   "border",
   "border-width",
   "border-top",
   "border-bottom",
   "border-top-width",
   "border-bottom-width",
+  "border-block",
+  "border-block-width",
+  "border-block-start",
+  "border-block-end",
+  "border-block-start-width",
+  "border-block-end-width",
 ];
 const INLINE_AXIS_EXTENT_PROPS = [
   "padding",
   "padding-left",
   "padding-right",
+  "padding-inline",
+  "padding-inline-start",
+  "padding-inline-end",
   "border",
   "border-width",
   "border-left",
   "border-right",
   "border-left-width",
   "border-right-width",
+  "border-inline",
+  "border-inline-width",
+  "border-inline-start",
+  "border-inline-end",
+  "border-inline-start-width",
+  "border-inline-end-width",
 ];
+
+// The shorthands that can set a width alongside a style and a color. An omitted
+// width computes to `medium`, so these need an explicit numeric width before
+// the declaration can be called zero-extent.
+const BORDER_SHORTHANDS = new Set([
+  "border",
+  "border-top",
+  "border-bottom",
+  "border-left",
+  "border-right",
+  "border-block",
+  "border-inline",
+  "border-block-start",
+  "border-block-end",
+  "border-inline-start",
+  "border-inline-end",
+]);
 
 // `border-width`'s keyword values. They are LENGTHS, so a border shorthand that
 // names one (or names none at all, defaulting to `medium`) has real extent.
@@ -928,12 +966,7 @@ const BORDER_WIDTH_KEYWORDS = new Set(["thin", "medium", "thick"]);
 function contributesNoExtent(prop, node) {
   const tokens = valueTokens(node);
   if (tokens.length === 0) return false;
-  const isBorderShorthand =
-    prop === "border" ||
-    prop === "border-top" ||
-    prop === "border-bottom" ||
-    prop === "border-left" ||
-    prop === "border-right";
+  const isBorderShorthand = BORDER_SHORTHANDS.has(prop);
   let sawNumeric = false;
   for (const token of tokens) {
     if (
@@ -945,6 +978,9 @@ function contributesNoExtent(prop, node) {
       sawNumeric = true;
       continue;
     }
+    // A hex color is a `Hash` node, never a length — accepting it keeps
+    // `border:0 solid #ccc` resolvable without weakening the fail-open below.
+    if (token.type === "Hash") continue;
     // A style/color identifier (`solid`, `red`) adds no length, but a
     // width keyword does — and anything else (a function node, `var()`) is
     // unresolvable and must fail open.

--- a/test/cli-response-contract.test.mjs
+++ b/test/cli-response-contract.test.mjs
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { describe, it } from "node:test";
+
+import { OPS } from "../bin/sanitize-cli.mjs";
+
+/**
+ * The CLI is the ONLY bridge between the JS source of truth and every non-JS
+ * caller, and its `sanitize` op used to re-list the result's fields by hand.
+ * That hand-written projection was a second copy of the return shape with
+ * nothing keeping it in sync, and it had already drifted: `splices` was part of
+ * `sanitize()`'s result and silently never reached the wire.
+ *
+ * The mirror-image failure lived on the Python side, where `SanitizeResult(**resp)`
+ * made the skew fatal in one direction — a field the client predated raised
+ * `TypeError` and took the caller down, so the two ends could not be updated in
+ * either order without a broken intermediate state.
+ *
+ * This test is the partition that replaces both hand-syncs: the CLI's live
+ * response keys and the Python dataclass's fields must be the SAME SET.
+ */
+
+const PY = "python3";
+
+/** The interpreter probe is separated from the check itself on purpose: a bare
+ * `catch` around the real work cannot tell "no python3 on this runner" from
+ * "the module moved / raised", and would retire the cross-check in exactly the
+ * scenario it exists to catch. */
+function pythonAvailable() {
+  try {
+    execFileSync(PY, ["-c", "pass"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("CLI response shape is a checked projection, not a hand-written one", () => {
+  it("the sanitize op forwards every field sanitize() produces", async () => {
+    const resp = await OPS.sanitize({
+      text: '<p>hi</p><div style="height:0;overflow:hidden">payload</div>',
+      html: true,
+    });
+    const keys = Object.keys(resp).sort();
+    assert.deepEqual(keys, [
+      "cleaned",
+      "found",
+      "notes",
+      "splices",
+      "warnings",
+    ]);
+    // Non-vacuity: the op must actually have done something, or the key set
+    // above could be satisfied by a stub returning empty containers.
+    assert.equal(typeof resp.cleaned, "string");
+    assert.ok(Array.isArray(resp.splices));
+  });
+
+  it("the Python client's SanitizeResult accepts exactly those fields", (t) => {
+    if (!pythonAvailable()) {
+      t.skip("no python3 interpreter on this runner");
+      return;
+    }
+    // Deliberately OUTSIDE any catch: a moved module, a syntax error or a
+    // non-zero exit must fail this test rather than silently retire it.
+    const out = execFileSync(
+      PY,
+      [
+        "-c",
+        [
+          "import sys, json, dataclasses",
+          "sys.path.insert(0, 'python')",
+          "from agent_sanitizer import SanitizeResult",
+          "print(json.dumps(sorted(f.name for f in dataclasses.fields(SanitizeResult))))",
+        ].join("; "),
+      ],
+      { encoding: "utf-8" },
+    );
+    const pythonFields = JSON.parse(out);
+    assert.deepEqual(pythonFields, [
+      "cleaned",
+      "found",
+      "notes",
+      "splices",
+      "warnings",
+    ]);
+  });
+
+  it("a newer CLI does not brick an older Python client", (t) => {
+    if (!pythonAvailable()) {
+      t.skip("no python3 interpreter on this runner");
+      return;
+    }
+    // The forward-compat direction, asserted as behaviour rather than trusted
+    // from the docstring: an unknown field must be dropped, not raise.
+    const out = execFileSync(
+      PY,
+      [
+        "-c",
+        [
+          "import sys",
+          "sys.path.insert(0, 'python')",
+          "from agent_sanitizer import SanitizeResult",
+          "r = SanitizeResult.from_response({'cleaned': 'x', 'a_field_from_the_future': [1]})",
+          "print(r.cleaned)",
+        ].join("; "),
+      ],
+      { encoding: "utf-8" },
+    );
+    assert.equal(out.trim(), "x");
+  });
+});

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -42,12 +42,13 @@ const run = (args, input) =>
   execFileSync("node", [CLI, ...args], { input, encoding: "utf8" });
 
 /** The wire response shape, for comparing CLI output against the sanitize oracle. */
-const envelope = ({ cleaned, found, warnings, notes }) => ({
-  cleaned,
-  found,
-  warnings,
-  notes,
-});
+// The identity, deliberately. This used to re-project `sanitize()`'s result
+// down to a hand-written four-field list, which meant these "mirrors
+// sanitize()" assertions could not see a field the CLI failed to forward — and
+// one had already gone missing (`splices`). Comparing the whole object is what
+// makes the oracle a real oracle. Kept as a named function so the intent is
+// legible at the call sites rather than looking like a forgotten refactor.
+const envelope = (result) => result;
 
 // Inputs spanning every layer: a Cf char (Layer 1), clean passthrough, a hidden
 // element + an exfil-shaped URL (Layers 2/3, html mode). Each carries the html

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -41,15 +41,6 @@ const CLI = fileURLToPath(new URL("../bin/sanitize-cli.mjs", import.meta.url));
 const run = (args, input) =>
   execFileSync("node", [CLI, ...args], { input, encoding: "utf8" });
 
-/** The wire response shape, for comparing CLI output against the sanitize oracle. */
-// The identity, deliberately. This used to re-project `sanitize()`'s result
-// down to a hand-written four-field list, which meant these "mirrors
-// sanitize()" assertions could not see a field the CLI failed to forward — and
-// one had already gone missing (`splices`). Comparing the whole object is what
-// makes the oracle a real oracle. Kept as a named function so the intent is
-// legible at the call sites rather than looking like a forgotten refactor.
-const envelope = (result) => result;
-
 // Inputs spanning every layer: a Cf char (Layer 1), clean passthrough, a hidden
 // element + an exfil-shaped URL (Layers 2/3, html mode). Each carries the html
 // flag it needs so the oracle comparison covers both code paths.
@@ -93,7 +84,7 @@ describe("CLI: one-shot mode mirrors sanitize()", () => {
     it(name, async () => {
       const expected = await sanitize(text, { html });
       const got = JSON.parse(run([], JSON.stringify({ text, html })));
-      assert.deepEqual(got, envelope(expected));
+      assert.deepEqual(got, expected);
     });
   }
 });
@@ -106,10 +97,7 @@ describe("CLI: worker mode", () => {
     const lines = run(["--worker"], `${input}\n`).trim().split("\n");
     assert.equal(lines.length, CASES.length);
     for (const [i, { text, html }] of CASES.entries()) {
-      assert.deepEqual(
-        JSON.parse(lines[i]),
-        envelope(await sanitize(text, { html })),
-      );
+      assert.deepEqual(JSON.parse(lines[i]), await sanitize(text, { html }));
     }
   });
 
@@ -129,7 +117,7 @@ describe("CLI: worker mode", () => {
     const text = "line1\nline2​";
     const out = run(["--worker"], `${JSON.stringify({ text })}\n`).trim();
     assert.equal(out.split("\n").length, 1);
-    assert.deepEqual(JSON.parse(out), envelope(await sanitize(text)));
+    assert.deepEqual(JSON.parse(out), await sanitize(text));
   });
 
   it("emits exactly one error line for a blank line, keeping framing", () => {
@@ -273,7 +261,7 @@ describe("CLI: transport faithfulness (fuzz)", () => {
     await fc.assert(
       fc.asyncProperty(fuzzText, fc.boolean(), async (text, html) => {
         const got = JSON.parse(run([], JSON.stringify({ text, html })));
-        assert.deepEqual(got, envelope(await sanitize(text, { html })));
+        assert.deepEqual(got, await sanitize(text, { html }));
       }),
       fcRunOptions({ numRuns: 60 }),
     );
@@ -293,10 +281,7 @@ describe("CLI: transport faithfulness (fuzz)", () => {
           const lines = run(["--worker"], `${input}\n`).trim().split("\n");
           assert.equal(lines.length, texts.length);
           for (const [i, text] of texts.entries()) {
-            assert.deepEqual(
-              JSON.parse(lines[i]),
-              envelope(await sanitize(text)),
-            );
+            assert.deepEqual(JSON.parse(lines[i]), await sanitize(text));
           }
         },
       ),
@@ -308,7 +293,7 @@ describe("CLI: transport faithfulness (fuzz)", () => {
 describe("CLI: large input", () => {
   it("transports a payload larger than the OS pipe buffer in both modes", async () => {
     const text = `${"A".repeat(200_000)}\u200b${"B".repeat(200_000)}`;
-    const expected = envelope(await sanitize(text));
+    const expected = await sanitize(text);
     assert.deepEqual(JSON.parse(run([], JSON.stringify({ text }))), expected);
     const out = run(["--worker"], `${JSON.stringify({ text })}\n`).trim();
     assert.equal(out.split("\n").length, 1);

--- a/test/html-border-box.test.mjs
+++ b/test/html-border-box.test.mjs
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { isHiddenStyle } from "../src/html.mjs";
+
+/**
+ * The class this pins: `overflow:hidden` plus a near-zero CONTENT-box length was
+ * read as "the element renders nothing". It does not. Padding and border widths
+ * add to the BORDER box, so the universal responsive-embed idiom
+ * (`height:0; padding-bottom:56.25%; overflow:hidden` — Bootstrap's `.ratio`,
+ * and every hand-pasted padding-bottom hack) renders at 56.25% of its
+ * container's width with all of its content on screen. Splicing it out removes
+ * text the model needed, which is the harm CLAUDE.md's precision-over-recall
+ * rule exists to prevent.
+ *
+ * Asserting the Bootstrap case alone would pin one symptom. The invariant is
+ * over the whole axis-additive property set.
+ */
+
+// A style that IS provably hidden through the overflow branch, per axis.
+const HIDDEN_BASES = {
+  height: "height:0;overflow:hidden",
+  width: "width:0;overflow:hidden",
+  "max-height": "max-height:0;overflow:hidden",
+  "max-width": "max-width:0;overflow:hidden",
+};
+
+// Every declaration that adds to that axis's border box. A near-zero content
+// length plus any one of these no longer proves an empty rendered box.
+//
+// Deliberately restated here rather than imported from `src/html.mjs`. These
+// are the CSS box model's property set, not the module's opinion about it, so
+// this list is an INDEPENDENT oracle: importing the module's own array would
+// let a property dropped from the implementation vanish from the test in the
+// same edit, and the suite would agree with the bug. (Same reasoning
+// `test/shipped-gates.test.mjs` gives for re-deriving the manifest without
+// calling the module under test.)
+const BLOCK_AXIS_ADDITIVE = [
+  "padding",
+  "padding-top",
+  "padding-bottom",
+  "border",
+  "border-width",
+  "border-top",
+  "border-bottom",
+  "border-top-width",
+  "border-bottom-width",
+];
+const INLINE_AXIS_ADDITIVE = [
+  "padding",
+  "padding-left",
+  "padding-right",
+  "border",
+  "border-width",
+  "border-left",
+  "border-right",
+  "border-left-width",
+  "border-right-width",
+];
+
+const AXIS_OF = {
+  height: BLOCK_AXIS_ADDITIVE,
+  "max-height": BLOCK_AXIS_ADDITIVE,
+  width: INLINE_AXIS_ADDITIVE,
+  "max-width": INLINE_AXIS_ADDITIVE,
+};
+
+describe("zero-dimension hiding respects the border box", () => {
+  it("every base is hidden on its own (non-vacuity)", () => {
+    // Without this the cross product below could pass because the bases were
+    // never hidden in the first place, making every "no longer hidden"
+    // assertion trivially true.
+    for (const [dim, base] of Object.entries(HIDDEN_BASES))
+      assert.equal(isHiddenStyle(base), true, `${dim}: base must be hidden`);
+  });
+
+  for (const [dim, base] of Object.entries(HIDDEN_BASES))
+    for (const prop of AXIS_OF[dim])
+      it(`${dim}: a non-zero \`${prop}\` defeats the hide`, () => {
+        const value = prop.startsWith("border") ? "4px solid red" : "40px";
+        assert.equal(
+          isHiddenStyle(`${base};${prop}:${value}`),
+          false,
+          `${prop} adds to the ${dim} border box, so the element renders`,
+        );
+      });
+
+  it("an explicit zero on an additive property still hides", () => {
+    // The fix must not become a blanket exemption: a declared zero contributes
+    // no extent, so the element really is collapsed.
+    assert.equal(isHiddenStyle("height:0;padding:0;overflow:hidden"), true);
+    assert.equal(
+      isHiddenStyle("height:0;padding:0 0 0 0;overflow:hidden"),
+      true,
+    );
+    assert.equal(
+      isHiddenStyle("height:0;border:0 solid red;overflow:hidden"),
+      true,
+    );
+    assert.equal(isHiddenStyle("width:0;padding-left:0;overflow:hidden"), true);
+  });
+
+  it("a border shorthand with no explicit width computes to `medium`", () => {
+    // `border:solid red` is 3px per side — an omitted width is NOT zero.
+    assert.equal(
+      isHiddenStyle("height:0;border:solid red;overflow:hidden"),
+      false,
+    );
+    assert.equal(
+      isHiddenStyle("height:0;border:thin solid;overflow:hidden"),
+      false,
+    );
+  });
+
+  it("an unresolvable additive value fails OPEN", () => {
+    // The module's stated policy: a value this cannot resolve may well paint a
+    // visible box, so it must read as visible rather than be ignored.
+    for (const value of ["calc(50% - 2px)", "var(--gap)", "calc(var(--x) * 2)"])
+      assert.equal(
+        isHiddenStyle(`height:0;padding-bottom:${value};overflow:hidden`),
+        false,
+        `${value} is unresolvable and must not read as hidden`,
+      );
+  });
+
+  it("real layout idioms produce zero findings", () => {
+    // The negative corpus CLAUDE.md asks every new detector to carry.
+    const legitimate = [
+      "position:relative;height:0;padding-bottom:56.25%;overflow:hidden",
+      "height:0;padding-bottom:75%;overflow:hidden",
+      "height:0;padding-bottom:300px;overflow:hidden",
+      "max-height:0;padding-top:40px;overflow:hidden",
+      "width:0;padding-left:2em;overflow:hidden",
+      "height:0;border-bottom:1px solid #ccc;overflow:hidden",
+    ];
+    for (const style of legitimate)
+      assert.equal(
+        isHiddenStyle(style),
+        false,
+        `spliced a visible idiom: ${style}`,
+      );
+  });
+
+  it("the off-axis property does not defeat the hide", () => {
+    // Precision in the other direction: horizontal padding cannot make a
+    // zero-HEIGHT box tall, so the hide still holds.
+    assert.equal(
+      isHiddenStyle(
+        "height:0;padding-left:40px;padding-right:40px;overflow:hidden",
+      ),
+      true,
+    );
+    assert.equal(
+      isHiddenStyle(
+        "width:0;padding-top:40px;padding-bottom:40px;overflow:hidden",
+      ),
+      true,
+    );
+  });
+});

--- a/test/html-border-box.test.mjs
+++ b/test/html-border-box.test.mjs
@@ -39,23 +39,41 @@ const BLOCK_AXIS_ADDITIVE = [
   "padding",
   "padding-top",
   "padding-bottom",
+  "padding-block",
+  "padding-block-start",
+  "padding-block-end",
   "border",
   "border-width",
   "border-top",
   "border-bottom",
   "border-top-width",
   "border-bottom-width",
+  "border-block",
+  "border-block-width",
+  "border-block-start",
+  "border-block-end",
+  "border-block-start-width",
+  "border-block-end-width",
 ];
 const INLINE_AXIS_ADDITIVE = [
   "padding",
   "padding-left",
   "padding-right",
+  "padding-inline",
+  "padding-inline-start",
+  "padding-inline-end",
   "border",
   "border-width",
   "border-left",
   "border-right",
   "border-left-width",
   "border-right-width",
+  "border-inline",
+  "border-inline-width",
+  "border-inline-start",
+  "border-inline-end",
+  "border-inline-start-width",
+  "border-inline-end-width",
 ];
 
 const AXIS_OF = {
@@ -98,6 +116,24 @@ describe("zero-dimension hiding respects the border box", () => {
       true,
     );
     assert.equal(isHiddenStyle("width:0;padding-left:0;overflow:hidden"), true);
+    // A hex color parses as a `Hash`, not an `Identifier`. Pinned separately
+    // from the `red` case above so the two spellings cannot both rest on the
+    // identifier branch — a hex color is never a length, and treating it as
+    // unresolvable would silently give up the hide.
+    assert.equal(
+      isHiddenStyle("height:0;border:0 solid #ccc;overflow:hidden"),
+      true,
+    );
+    assert.equal(
+      isHiddenStyle("height:0;border:0 solid #cccccc;overflow:hidden"),
+      true,
+    );
+  });
+
+  it("an additive property declared with an empty value fails OPEN", () => {
+    // A declaration the parser hands back with no value tokens is not evidence
+    // of zero extent — it is evidence of nothing, so it must read as visible.
+    assert.equal(isHiddenStyle("height:0;padding-top:;overflow:hidden"), false);
   });
 
   it("a border shorthand with no explicit width computes to `medium`", () => {
@@ -132,6 +168,10 @@ describe("zero-dimension hiding respects the border box", () => {
       "max-height:0;padding-top:40px;overflow:hidden",
       "width:0;padding-left:2em;overflow:hidden",
       "height:0;border-bottom:1px solid #ccc;overflow:hidden",
+      // The logical spelling of the same aspect-ratio idiom.
+      "height:0;padding-block-end:56.25%;overflow:hidden",
+      "width:0;padding-inline-start:2em;overflow:hidden",
+      "height:0;border-block-end:1px solid #ccc;overflow:hidden",
     ];
     for (const style of legitimate)
       assert.equal(

--- a/tests/secrets/test_regex_literal_gate.py
+++ b/tests/secrets/test_regex_literal_gate.py
@@ -9,22 +9,13 @@ JavaScript. That is the harm ``CLAUDE.md``'s precision-over-recall rule names:
 splicing or rewriting legitimate content removes text the model needed.
 """
 
-from pathlib import Path
 import subprocess
 
 import pytest
 
 import agent_sanitizer.secrets.engine as E
 from agent_sanitizer.secrets import RedactorConfig
-
-REPO_ROOT = Path(
-    subprocess.run(
-        ["git", "rev-parse", "--show-toplevel"],
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout.strip()
-)
+from tests._helpers import REPO_ROOT
 
 # Regex literals assigned to credential-named constants. Each is >=20 bytes and
 # sits in exactly the `keyword = value` position the field detector targets.

--- a/tests/secrets/test_regex_literal_gate.py
+++ b/tests/secrets/test_regex_literal_gate.py
@@ -1,0 +1,127 @@
+"""A regular-expression literal is code that NAMES credential patterns.
+
+The class this pins: a credential-named constant assigned a regex is the single
+most common way a security codebase talks about secrets, and the field-value
+detector was rewriting it into invalid source. This repo's own ``src/gates.mjs``
+was the proof — its ``SECRET_HINT`` export came back as
+``export const SECRET_HINT = [REDACTED][n]a|...``, which is not parseable
+JavaScript. That is the harm ``CLAUDE.md``'s precision-over-recall rule names:
+splicing or rewriting legitimate content removes text the model needed.
+"""
+
+from pathlib import Path
+import subprocess
+
+import pytest
+
+import agent_sanitizer.secrets.engine as E
+from agent_sanitizer.secrets import RedactorConfig
+
+REPO_ROOT = Path(
+    subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+)
+
+# Regex literals assigned to credential-named constants. Each is >=20 bytes and
+# sits in exactly the `keyword = value` position the field detector targets.
+REGEX_LITERALS = [
+    # The truncated shape: the value class stops at the `[` of a character
+    # class, so what the gate sees is NOT a well-formed literal. This is the
+    # case a complete-literal check alone would miss.
+    "/secret|token|password|passwd|pwd|bearer|credential|authorization|contrase",
+    "/secret|token|password|passwd|pwd|bearer|credential/i",
+    "/secretsecretsecretsecretsecret/i",
+    "/secretsecretsecretsecretsecret/",
+]
+
+# Values that merely resemble one and must still redact.
+STILL_SECRET = [
+    # Laundering attempt: a real token wrapped in literal delimiters.
+    "/ghp_abc123def456ghi789jkl/i",
+    # Base64 can begin with `/`; it never contains `|` and does not end in flags.
+    "/9j4AAQSkZJRgABAQAAAQABAAD2wCEAAo",
+    # A bare opaque run with no delimiters at all.
+    "abc123def456ghi789jkl012mno345",
+]
+
+
+@pytest.mark.parametrize("value", REGEX_LITERALS)
+def test_a_regex_literal_is_left_verbatim(value: str) -> None:
+    text = f"export const SECRET_HINT = {value};"
+    # Non-vacuity: the detector must actually reach this value. A fixture the
+    # field regex never matches (one truncated below the 20-byte floor by an
+    # early `[`, say) would pass this test without exercising the gate at all —
+    # which is exactly what one of these fixtures did before this assertion.
+    match = E.FIELD_VALUE_RE.search(text)
+    assert match is not None, "fixture never reaches the detector"
+    assert match.group("secret_value") == value
+    out, _ = E.redact(text)
+    assert out == text
+
+
+@pytest.mark.parametrize("value", STILL_SECRET)
+def test_a_credential_is_not_laundered_by_looking_like_one(value: str) -> None:
+    """Non-vacuity in the direction that matters: the gate must not have become
+    a blanket skip for anything starting with a slash."""
+    text = f"const secret = {value};"
+    out, found = E.redact(text)
+    assert out != text, "value survived redaction"
+    assert value not in out
+    assert found
+
+
+@pytest.mark.parametrize("value", REGEX_LITERALS)
+def test_the_shape_is_not_trusted_on_web_ingress(value: str) -> None:
+    """The literal delimiters are a shape an attacker who controls the text can
+    forge, so — like the other forgeable gates — it is trusted for LOCAL tool
+    output only. Pinned so a future edit cannot quietly promote it to a
+    SHAPE_GATE, which would make `/<credential>/i` a universal bypass.
+    """
+    text = f"export const SECRET_HINT = {value};"
+    out, _ = E.redact(text, RedactorConfig(web_ingress=True))
+    assert out != text
+
+
+def test_the_gate_is_registered_as_forgeable_not_as_a_shape() -> None:
+    """The registration IS the security property, so assert it directly rather
+    than inferring it from the behaviour above."""
+    assert E._is_regex_literal in E.NAME_TRUST_GATES
+    assert E._is_regex_literal not in E.SHAPE_GATES
+
+
+def test_this_repos_own_secret_hint_export_survives_redaction() -> None:
+    """The regression that motivated the gate, asserted against the real file
+    rather than a paraphrase of it — a copy in the test could drift into a
+    shape the bug never had.
+    """
+    source = (REPO_ROOT / "src" / "gates.mjs").read_text(encoding="utf-8")
+    assert "SECRET_HINT" in source, "gates.mjs no longer exports SECRET_HINT"
+    out, _ = E.redact(source)
+    assert out == source, "the sanitizer rewrote its own source"
+
+
+def test_every_tracked_js_source_file_survives_redaction() -> None:
+    """The generalization: this repo is a security codebase, so its sources are
+    dense with credential-named constants and pattern literals — the exact
+    corpus a false-positive-prone field detector mangles. Zero findings on all
+    of it is the negative corpus CLAUDE.md asks every detector to carry.
+    """
+    files = subprocess.run(
+        ["git", "ls-files", "src/*.mjs", "claude-hooks/*.mjs"],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=REPO_ROOT,
+    ).stdout.split()
+    assert len(files) > 10, "glob matched almost nothing — the corpus is vacuous"
+    mangled = []
+    for name in files:
+        source = (REPO_ROOT / name).read_text(encoding="utf-8")
+        out, _ = E.redact(source)
+        if out != source:
+            mangled.append(name)
+    assert mangled == [], f"redaction rewrote legitimate source files: {mangled}"

--- a/tests/secrets/test_secrets_gates.py
+++ b/tests/secrets/test_secrets_gates.py
@@ -56,6 +56,10 @@ def test_field_names_materialise_to_literals():
 _SHAPE_FIXTURES = {
     "_is_placeholder_value": (
         "YOUR_API_KEY_GOES_HERE",
+        # The same spelling with a leading underscore: a private-by-convention
+        # identifier is still an identifier, and this byte used to defeat the
+        # gate entirely (see _CAPS_WORDS in engine.py).
+        "_AGENT_SANITIZER_EXTRA_SECRET_VARS",
         "<paste-your-token-here>",
         "xxxxxxxxxxxxxxxxxxxxxxxx",
         "your-api-key-here",
@@ -101,6 +105,10 @@ _NAME_TRUST_FIXTURES = {
         "/var/lib/secret-store/data/current",
     ),
     "_is_markdown_code_prose": ("run `--api-key` with your own credentials",),
+    "_is_regex_literal": (
+        "/secret|token|password/i",
+        "/secretsecretsecretsecret/i",
+    ),
     # The two gates below decide ON the field name, so "the verdict is
     # independent of the field name" is not a property they can have — the field
     # name IS their input. They are exercised by their own tests in

--- a/tests/secrets/test_value_terminator_peel.py
+++ b/tests/secrets/test_value_terminator_peel.py
@@ -1,0 +1,161 @@
+"""A trailing statement/list terminator never changes a redaction verdict.
+
+The class this pins: ``FIELD_VALUE_RE`` decides the value's EXTENT, and nine of
+the twelve benign-shape gates then judge that value with an anchored
+``fullmatch``/``\\Z``. So a single un-peeled byte glued onto the value disarms
+every one of those gates at once — ``const token = process.env.GH_TOKEN;``
+redacted to ``const token = [REDACTED];``, destroying source the model needed
+(the harm ``CLAUDE.md``'s precision-over-recall rule exists to prevent).
+
+Asserting ``;`` after ``process.env.X`` is fine would only pin the one symptom.
+The invariant is the whole cross product: for EVERY gate, and every terminator,
+the verdict is the one the bare value gets.
+"""
+
+import pytest
+
+import agent_sanitizer.secrets.engine as E
+
+# One canonical benign `field = value` per gate. Keyed by gate function name so
+# the partition assertion below can prove the cross product covers every gate
+# rather than whichever ones someone remembered — an SSOT contract test over
+# the live gate tuples (CLAUDE.md: "SSOT contract tests must change in the same
+# commit as their data").
+CASES: dict[str, tuple[str, str]] = {
+    "_is_placeholder_value": ("api_key", "YOUR_API_KEY_GOES_HERE"),
+    "_is_code_env_reference": ("token", "process.env.GH_TOKEN"),
+    "_is_content_digest": ("token", "a" * 64),
+    "_is_uuid": ("secret", "123e4567-e89b-12d3-a456-426614174000"),
+    "_is_public_endpoint_url": ("token_url", "https://example.com/v1/status"),
+    "_is_timestamp": ("secret", "2026-08-09T12:34:56.789012Z"),
+    # A pre-release/build tail is rejected by `_has_opaque_run`, so the
+    # canonical version has to be a long dotted run of short segments.
+    "_is_version": ("secret", "1.2.3.4.5.6.7.8.9.10.11"),
+    "_is_config_attr_reference": ("password", "settings.database.password_field"),
+    "_is_benign_cursor": ("next_token", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+    "_is_filesystem_path": ("token", "/etc/vault/agent/current-token"),
+    "_is_metadata_field": ("secret_name", "prod-database-primary-credential"),
+}
+
+# Gates that CANNOT fire on the field-value path, so there is no terminator case
+# to write for them. Listed with a reason rather than silently omitted: that is
+# what makes the partition assertion below a real cover check instead of a
+# restatement of whichever gates someone happened to think of.
+NOT_FIELD_REACHABLE: dict[str, str] = {
+    "_is_markdown_code_prose": (
+        "keyword-path only — FIELD_VALUE_RE's value class excludes both "
+        "whitespace and backticks, and this gate requires each, so no "
+        "field-value match can reach it (engine.py's own docstring says so)"
+    ),
+}
+
+# "" proves the bare value is benign in the first place: without it every
+# assertion below could pass because the value redacts identically with and
+# without the terminator.
+TERMINATORS = ("", ";", ",", ";;", ",,", ";\n", ",\n")
+
+
+def test_cases_cover_every_live_gate() -> None:
+    """The cross product is only as complete as this table. A gate added to
+    either tuple without a case here would never be exercised with a
+    terminator, which is exactly how this class came back."""
+    live = {gate.__name__ for gate in E.SHAPE_GATES + E.NAME_TRUST_GATES}
+    assert live, "gate tuples are empty — the cross product would be vacuous"
+    assert set(CASES) | set(NOT_FIELD_REACHABLE) == live
+    assert not (set(CASES) & set(NOT_FIELD_REACHABLE)), (
+        "a gate is both exercised and exempted"
+    )
+    for gate_name, reason in NOT_FIELD_REACHABLE.items():
+        assert len(reason) > 20, f"NOT_FIELD_REACHABLE[{gate_name}] needs a real reason"
+
+
+@pytest.mark.parametrize("gate_name", sorted(NOT_FIELD_REACHABLE))
+def test_exempt_gates_really_are_field_unreachable(gate_name: str) -> None:
+    """Stops the exemption map from becoming a place to park an inconvenient
+    gate: the claim is that no FIELD_VALUE_RE match can satisfy it, so a value
+    that does satisfy it must not be matchable in the first place."""
+    gate = next(
+        g for g in E.SHAPE_GATES + E.NAME_TRUST_GATES if g.__name__ == gate_name
+    )
+    # A value carrying whitespace and a backtick — the shape this gate needs.
+    reaching_value = "some `code` prose that spans whitespace"
+    assert gate(E.Candidate(value=reaching_value, line=reaching_value))
+    assert E.FIELD_VALUE_RE.search(f"password = {reaching_value}") is None or (
+        E.FIELD_VALUE_RE.search(f"password = {reaching_value}").group("secret_value")
+        != reaching_value
+    )
+
+
+@pytest.mark.parametrize("gate_name", sorted(CASES))
+def test_bare_value_is_benign(gate_name: str) -> None:
+    """Non-vacuity for the cross product: each canonical value must survive
+    redaction untouched on its own. A value that was never benign would make
+    its terminator cases pass by redacting identically either way."""
+    field, value = CASES[gate_name]
+    text = f"{field} = {value}"
+    out, _ = E.redact(text)
+    assert out == text
+
+
+@pytest.mark.parametrize("terminator", TERMINATORS)
+@pytest.mark.parametrize("gate_name", sorted(CASES))
+def test_terminator_never_changes_the_verdict(gate_name: str, terminator: str) -> None:
+    field, value = CASES[gate_name]
+    text = f"{field} = {value}{terminator}"
+    out, _ = E.redact(text)
+    assert out == text, (
+        f"{gate_name}: a trailing {terminator!r} defeated the gate — the value's "
+        "extent must be normalized at the mint point, not per gate"
+    )
+
+
+@pytest.mark.parametrize("terminator", (";", ",", ";;"))
+def test_a_real_secret_still_redacts_and_keeps_its_terminator(terminator: str) -> None:
+    """The peel must not become a bypass: the terminator is punctuation of the
+    enclosing syntax, so it stays OUTSIDE the placeholder and the credential
+    itself is still removed."""
+    secret = "wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY"
+    text = f"aws_secret_access_key = {secret}{terminator}"
+    out, found = E.redact(text)
+    assert secret not in out
+    assert out.endswith(terminator)
+    assert found
+
+
+def test_terminator_is_peeled_rather_than_swallowed() -> None:
+    """Pins the mechanism, not just the outcome: the match must expose the
+    terminator as its own group with the value already clean, so a future gate
+    cannot receive an un-peeled value."""
+    m = E.FIELD_VALUE_RE.search("password = abc123def456ghi789jkl012;")
+    assert m is not None
+    assert m.group("secret_value") == "abc123def456ghi789jkl012"
+    assert m.group("terminator") == ";"
+
+
+def test_a_sub_floor_value_is_no_longer_inflated_over_the_floor_by_its_terminator() -> (
+    None
+):
+    """A deliberate, narrow recall change, pinned so it stays deliberate.
+
+    The engine's 20-byte floor exists because shorter values lack the entropy to
+    be credentials. A 19-byte value followed by `;` used to clear that floor only
+    because the terminator was counted as part of the value — the floor was being
+    met by punctuation. Peeling the terminator means such a value now falls below
+    the floor and is left alone, which is the floor working as intended rather
+    than a new blind spot.
+    """
+    assert E.FIELD_VALUE_RE.search("password = abcdefghijklmnopqrs;") is None
+    # The same value one byte longer is still caught, so the floor moved by
+    # exactly one byte's worth of punctuation and nothing else.
+    m = E.FIELD_VALUE_RE.search("password = abcdefghijklmnopqrst;")
+    assert m is not None
+    assert m.group("secret_value") == "abcdefghijklmnopqrst"
+
+
+def test_a_dot_is_not_peeled() -> None:
+    """`.` is a JWT's own segment separator, so peeling it would truncate a real
+    credential. Pinned so the terminator class is never widened to it."""
+    m = E.FIELD_VALUE_RE.search("password = abc123def456ghi789jkl012.")
+    assert m is not None
+    assert m.group("secret_value").endswith(".")
+    assert m.group("terminator") == ""

--- a/tests/secrets/test_value_terminator_peel.py
+++ b/tests/secrets/test_value_terminator_peel.py
@@ -18,9 +18,15 @@ import agent_sanitizer.secrets.engine as E
 
 # One canonical benign `field = value` per gate. Keyed by gate function name so
 # the partition assertion below can prove the cross product covers every gate
-# rather than whichever ones someone remembered — an SSOT contract test over
-# the live gate tuples (CLAUDE.md: "SSOT contract tests must change in the same
-# commit as their data").
+# rather than whichever ones someone remembered.
+#
+# This is a DRIFT GUARD, not an SSOT contract test, and the distinction matters:
+# nothing derives this table from the gate tuples, because a gate function
+# cannot yield a canonical benign value for itself — the value has to be
+# hand-chosen. So the table is a genuine second copy of the gate list, and the
+# partition assertion is what keeps the two from drifting apart. The honest
+# framing is "a second list exists and is guarded", not "there is one source of
+# truth here".
 CASES: dict[str, tuple[str, str]] = {
     "_is_placeholder_value": ("api_key", "YOUR_API_KEY_GOES_HERE"),
     "_is_code_env_reference": ("token", "process.env.GH_TOKEN"),

--- a/tests/secrets/test_value_terminator_peel.py
+++ b/tests/secrets/test_value_terminator_peel.py
@@ -35,6 +35,7 @@ CASES: dict[str, tuple[str, str]] = {
     "_is_benign_cursor": ("next_token", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
     "_is_filesystem_path": ("token", "/etc/vault/agent/current-token"),
     "_is_metadata_field": ("secret_name", "prod-database-primary-credential"),
+    "_is_regex_literal": ("SECRET_HINT", "/secret|token|password/i"),
 }
 
 # Gates that CANNOT fire on the field-value path, so there is no terminator case


### PR DESCRIPTION
Claimed area: `python/agent_sanitizer/secrets/engine.py`, `src/html.mjs`, `bin/sanitize-cli.mjs`, `python/agent_sanitizer/__init__.py`. Two sibling PRs from the same eliminator audit claim `claude-hooks/`+`plugin/` (#279) and the guard/partition infrastructure (#280) — file-disjoint from this one.

## Summary

Four findings from a ten-scope eliminator audit, all confirmed by execution before any code was written. Each is a **structural** fix: the class becomes impossible by construction rather than the instance being patched.

Three of them splice or rewrite legitimate content, which is the harm `CLAUDE.md`'s precision-over-recall rule exists to prevent — a false positive here removes text the model needed.

**1. A trailing `;` disarmed every anchored value-shape gate at once.** `FIELD_VALUE_RE` decides a matched value's *extent*, and 9 of the 12 benign-shape gates then judge that value with an anchored `fullmatch`. The value class swallowed the terminator, so one byte defeated all of them simultaneously:

```
const token = process.env.GH_TOKEN;   ->   const token = [REDACTED];
```

That line is present in essentially every Node file. The fix peels the terminator in the one expression that decides the extent, so no gate can be written that forgets the normalization — no gate ever sees an un-peeled value. The regex's existing operator-continuation lookahead already defends against exactly this failure arriving from the other end; this closes the trailing side.

**2. A regex literal assigned to a credential-named constant was rewritten into invalid source.** A security codebase talks about secrets mostly by naming patterns for them, and that shape sat squarely in the field detector's `keyword = value` position with no gate to recognize it. This repo's own `src/gates.mjs` was the proof:

```
export const SECRET_HINT = /secret|token|.../i;   ->   export const SECRET_HINT = [REDACTED]a|...
```

which is not parseable JavaScript. A new `_is_regex_literal` gate recognizes the literal shape — including the *truncated* form the value class produces when it stops at a character class's `[`, which a well-formedness check alone would miss. Registered in `NAME_TRUST_GATES`, not `SHAPE_GATES`: delimiters are forgeable, so the shape is trusted for local tool output only and `/ghp_.../i` is never a bypass on web ingress.

**3. A one-byte gap let `_CAPS_WORDS` miss leading-underscore SCREAMING_SNAKE.** Found by this PR's own corpus test, which flagged a second mangled file (`claude-hooks/lib/env-config.mjs`) after the regex-literal gate landed. `_AGENT_SANITIZER_EXTRA_SECRET_VARS` was not recognized as a placeholder-shaped name purely because the pattern required the first character to be a letter. Fixed inside the existing lookbehind's protection (`_?[A-Z]+...`) rather than by adding a new gate — the gap was exactly one byte wide, and a fresh gate would have been ~95% redundant with `_is_placeholder_value`. (I did write that gate first; the repo's own `test_removing_a_gate_makes_its_fixture_redact` caught the redundancy and I reverted it.)

**4. A zero content-box length was treated as an empty rendered box.** Padding and border widths add to the *border* box, so the universal responsive-embed idiom — `height:0; padding-bottom:56.25%; overflow:hidden`, i.e. Bootstrap's `.ratio` and every hand-pasted padding-bottom hack — renders at 56.25% of its container's width with all of its content on screen, and was being spliced out. All four zero-dimension branches now route through one `axisExtentProvablyZero` chokepoint, so a future zero-size branch cannot reintroduce the omission.

**5. The CLI↔Python bridge dropped a field, and could not be updated in either order.** The `sanitize` op re-listed the result's fields by hand — a second copy of the return shape with nothing keeping it in sync, which had already drifted: `splices` is part of `sanitize()`'s result and silently never reached the wire, leaving every non-JS caller blind to Layer 2's spliced ranges. The mirror-image failure was on the Python side, where `SanitizeResult(**resp)` made version skew fatal in one direction only (a field the client predated raised `TypeError`; a field it postdated was already covered by defaults). So there was no safe order to update the two ends in.

## Changes

- `engine.py`: `FIELD_VALUE_RE` grows a `terminator` group; `_replace_field` re-emits it in source order so bytes outside the placeholder are byte-preserved, quoted or not. `.` is deliberately **not** peeled — it is a JWT's own segment separator.
- `engine.py`: new `_is_regex_literal` gate in `NAME_TRUST_GATES`, implemented with string operations rather than a regex (a `/.*/[flags]*` pattern backtracks quadratically); `_CAPS_WORDS` accepts an optional leading underscore.
- `src/html.mjs`: new `axisExtentProvablyZero` / `contributesNoExtent` chokepoint consulted by all four zero-dimension branches, with per-axis additive property sets covering both the physical and the logical spellings (`padding-block-end` *is* the aspect-ratio idiom in a logical stylesheet). A hex color parses as a `Hash`, never a length, so it resolves rather than failing open.
- `bin/sanitize-cli.mjs`: forwards the result whole instead of re-listing fields; the module's protocol table names `splices?`.
- `python/agent_sanitizer/__init__.py`: `SanitizeResult` gains `splices: list[dict]` and a `from_response` that tolerates a newer CLI.
- `test/cli.test.mjs`: the `envelope` helper — a *third* copy of the field list, and the reason the missing field could hide from the "mirrors `sanitize()`" oracle — is deleted; the assertions compare whole objects.

## Tests / verification

Every fix has a proving test that was **shown failing before the fix and passing after**:

| Test | Without fix | With fix |
|---|---|---|
| `tests/secrets/test_value_terminator_peel.py` | 53 failed | 96 passed |
| `tests/secrets/test_regex_literal_gate.py` | 8 failed | 12 passed |
| `test/html-border-box.test.mjs` | 39 of 42 failed | 79 passed |
| `test/cli-response-contract.test.mjs` | n/a (new contract) | 3 passed |

Full suites green: **2389 Python tests** (5 skipped), `pnpm test` (whole JS suite plus both coverage floors, with `src/` held at its 100% branch floor), `pnpm lint` clean, `pnpm build:types` clean.

The tests pin classes rather than symptoms:

- The terminator test is a cross product of *every* live gate × the terminator set, with a partition assertion (`CASES ∪ NOT_FIELD_REACHABLE == SHAPE_GATES ∪ NAME_TRUST_GATES`) so a gate added to either tuple without a case fails CI. That is a **drift guard, not an SSOT contract test**, and the file says so: nothing derives the case table from the gate tuples, because a gate function cannot yield a canonical benign value for itself — the value has to be hand-chosen. The table is a genuine second copy of the gate list, and the assertion is what keeps the two from separating. A separate non-vacuity test asserts each canonical value is benign *bare* — which caught two bad fixtures of mine while writing it.
- The regex-literal test carries a negative corpus over **every tracked `src/*.mjs` and `claude-hooks/*.mjs` file**, asserting the redactor rewrites none of them; that corpus is what found finding 3. It also asserts the gate's *registration* (`in NAME_TRUST_GATES`, `not in SHAPE_GATES`) directly rather than inferring it from behaviour, and a non-vacuity assertion that each fixture actually reaches the detector — which caught a fixture of mine that was passing vacuously because the value class truncated it below the 20-byte floor.
- The border-box test is the cross product of both axes × every axis-additive property (physical and logical), plus a negative corpus of real layout idioms asserting zero findings, plus fail-open cases for `calc()`/`var()`, plus an off-axis control proving the hide still holds when it should.
- The CLI contract test separates the interpreter probe from the check itself, so a moved module or a non-zero exit fails rather than silently skipping.

Verified independently of the tests: all 52 tracked JS source files under `src/`, `claude-hooks/`, `bin/`, and `scripts/` now survive redaction byte-identical.

## Decisions made

- **`.` is not peeled.** Peeling it would truncate a JWT at its first segment boundary. Pinned by a test so the terminator set is never widened to it.
- **A 19-byte value followed by `;` is no longer redacted.** It only ever cleared the engine's 20-byte entropy floor because the terminator was counted as part of the value — the floor was being met by punctuation. This is a deliberate, one-byte-wide recall change, pinned by its own test with the reasoning. *Alternative:* keep the old extent and peel only inside the gates, which would have meant re-checking every gate forever.
- **`_is_regex_literal` accepts the truncated shape** (a leading `/` plus a `|` alternation, with no closing delimiter) because that is what the value class actually produces on real source. *Alternative:* require a well-formed `/…/flags`, which would have left the motivating `src/gates.mjs` case unfixed — the character class truncates it before the closing slash.
- **The gate is `NAME_TRUST`, not `SHAPE`.** Delimiters are author-chosen, so hostile web text could wrap a live credential as `/ghp_…/i`. Trusting the shape only on local tool output keeps that from being a universal bypass; asserted directly by a test.
- **The `_CAPS_WORDS` one-byte fix instead of a new `_is_env_var_name` gate.** The new gate made two existing fixtures stop discriminating, which the repo's gate-removal guard caught. `_is_placeholder_value` already covered SCREAMING_SNAKE without the leading underscore, so the whole gap was one character. *Alternative:* the standalone gate — more surface, more overlap, same coverage.
- **The `padding` shorthand fails open on both axes.** `padding: 0 0 56.25% 0` contributes to the block axis only, but the checker does not decompose shorthand positions, so it fails open for the inline axis too. Conservative in the preserve direction, which is the doctrine-correct side. *Alternative:* position-aware shorthand decomposition — more code, more ways to be wrong, for a case that only ever over-preserves today.
- **`from_response` drops unknown fields rather than raising.** Version skew is ordinary for a wire protocol and the `notes` default already conceded the point in the other direction. This is not silent drift-tolerance *in this repo*: the new contract test makes drift introduced here fail CI, while a genuinely-skewed install degrades instead of crashing the caller.
- **The border-box test restates the CSS property set instead of importing it** from `src/html.mjs`. It is an independent oracle — importing the module's own array would let a property dropped from the implementation vanish from the test in the same edit. Same reasoning `test/shipped-gates.test.mjs` gives for re-deriving the manifest without calling the module under test.

## Checklist

- [x] Commits follow Conventional Commits; each subject reads as a user-facing release note.
- [x] `pnpm test`, `pnpm lint`, and `pnpm check` pass locally.
- [x] New or changed detectors have negative tests (zero findings on legitimate input) and pin their invariants with property tests.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version left untouched.
