### PR TITLE
fix(ci): five one-direction gates replaced with partition assertions

### DIFF
--- a/.github/scripts/auto-resolve/land.test.mjs
+++ b/.github/scripts/auto-resolve/land.test.mjs
@@ -84,7 +84,7 @@ function runLand(landDir, bundleDir, env = {}) {
   const runnerTemp = join(root, "runner-temp");
   mkdirSync(runnerTemp, { recursive: true });
   let error = null;
-  let stdout = "";
+  let stdout;
   try {
     stdout = execFileSync("bash", [SCRIPT], {
       cwd: landDir,

--- a/.github/scripts/auto-resolve/prepare.test.mjs
+++ b/.github/scripts/auto-resolve/prepare.test.mjs
@@ -160,7 +160,7 @@ function runPrepare(work, extraEnv = {}, { mergiraf = "cannot-solve" } = {}) {
     chmodSync(mergirafPath, 0o755);
   }
   let error = null;
-  let stdout = "";
+  let stdout;
   try {
     stdout = execFileSync("bash", [SCRIPT], {
       cwd: work,

--- a/.github/scripts/auto-resolve/self-review.test.mjs
+++ b/.github/scripts/auto-resolve/self-review.test.mjs
@@ -217,7 +217,7 @@ function runSelfReview({
 
   const headBefore = git(work, "rev-parse", "HEAD").trim();
   let status = 0;
-  let stdout = "";
+  let stdout;
   try {
     stdout = execFileSync("bash", [SCRIPT], {
       cwd: work,

--- a/.github/scripts/nightly-fuzz-issue.js
+++ b/.github/scripts/nightly-fuzz-issue.js
@@ -173,7 +173,7 @@ module.exports = async ({ github, context, core }) => {
   const { owner, repo } = context.repo;
   const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
 
-  let log = "";
+  let log;
   try {
     log = fs.readFileSync(LOG_FILE, "utf8");
   } catch {

--- a/.github/scripts/post-pr-review.mjs
+++ b/.github/scripts/post-pr-review.mjs
@@ -193,6 +193,7 @@ function loadSeverities() {
     throw new Error(
       `config/review-severities.json is unparsable (${err.message}); refusing to ` +
         "review with a severity model somebody meant to set and got wrong.",
+      { cause: err },
     );
   }
   const bad = (why) => new Error(`config/review-severities.json: ${why}`);

--- a/.github/workflows/ci-failure-notify.yaml
+++ b/.github/workflows/ci-failure-notify.yaml
@@ -12,11 +12,20 @@ name: CI failure notify
 # ntfy server (defaults to https://ntfy.sh).
 #
 # `workflow_run` has no wildcard, so `workflows:` below must name every
-# workflow in this repo with a `push:` or `schedule:` trigger (matched by the
-# workflow's `name:`). A ci-truth-serum hook (check-failure-notifier-coverage)
-# keeps this list in sync with the tree. Binding is by NAME, not filename: a
-# repo that keeps its own release workflow instead of the template's
-# auto-version.yaml must give it the name listed here or add its own.
+# workflow in this repo with a push-to-main or `schedule:` trigger (matched by
+# the workflow's `name:`), minus the ones that carry a
+# `# failure-notify-exempt: <reason>` marker in their OWN yaml.
+#
+# `test/failure-notify-roster.test.mjs` asserts exactly that partition. It used
+# to say a ci-truth-serum hook (check-failure-notifier-coverage) kept the list in
+# sync; that hook does not exist — the pinned rev provides 18 `check-*` ids and
+# none of them mentions this file — and the gap it was credited with closing was
+# live: Mutation tests and Pack smoke test both run on push-to-main and routed to
+# nobody, so they could fail on main indefinitely and page no one.
+#
+# Binding is by NAME, not filename: a repo that keeps its own release workflow
+# instead of the template's auto-version.yaml must give it the name listed here
+# or add its own.
 # The dangerous-triggers finding targets workflows that check out or execute
 # the triggering ref's code with write credentials; this one checks out only its
 # own default-branch action dir, credential-less, and never runs repo code.
@@ -34,7 +43,9 @@ on: # zizmor: ignore[dangerous-triggers]
       - Hook lifecycle
       - Lint
       - Main branch health
+      - Mutation tests
       - Node tests
+      - Pack smoke test
       - PR meta (privileged)
       - pre-commit
       - Release canary

--- a/.github/workflows/fuzz-nightly.yaml
+++ b/.github/workflows/fuzz-nightly.yaml
@@ -8,6 +8,13 @@ name: Nightly unseeded fuzz
 # seed so a broader slice of the input space gets tried over time. It is
 # intentionally NOT wired into branch protection — a failure here means "go
 # look", not "block the PR".
+#
+# failure-notify-exempt: exploratory, and already routed. A failure here is a
+# newly-explored counterexample, not a broken branch, and nightly-fuzz-issue.js
+# files it as a deduplicated issue precisely so nobody is paged for it. Paging
+# would also LATCH: main-health.mjs re-reports for as long as the newest run is
+# red, so one counterexample would push every sweep until the next nightly
+# happens to clear it. test/failure-notify-roster.test.mjs reads this marker.
 on:
   schedule:
     - cron: "17 6 * * *" # daily, off-the-hour to avoid GitHub's peak-minute queueing

--- a/.hooks/guard-pairs.json
+++ b/.hooks/guard-pairs.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Guard pairs: source file -> the cheap guard test(s) that cover it. When a listed source is staged, .hooks/run-guard-pairs.mjs runs the paired guard tests and blocks the commit on failure \u2014 so a guard test can never silently break on main because the data it reads changed without it (this bit twice: the release-token guard on auto-version.yaml, and the instructions guard tests). These are GUARDS, not an SSOT: a pair says \"run this check when that file changes\", and naming it otherwise would launder the very smell a drift guard should expose. A guard test is either a `node --test` file (*.test.mjs) or a pytest module (test_*.py); the runner dispatches on the extension, so data whose only contract test is Python is pairable too. Keep every paired test fast (~1s). test/guard-pairs.test.mjs asserts all paths here exist AND, in the other direction, scans every node --test file (plus the repo modules those tests import) for the repo data files they read: each one must appear here, mapped to a test that actually reads it, or in that test's NOT_GUARDED allowlist with a reason. So this map is a checked projection of the tests, not a hand-maintained list that silently misses the next contract test. The scan covers node --test files only, so a Python-only pairing is legitimate but must be added by hand.",
+  "$comment": "Guard pairs: source file -> the cheap guard test(s) that cover it. When a listed source is staged, .hooks/run-guard-pairs.mjs runs the paired guard tests and blocks the commit on failure \u2014 so a guard test can never silently break on main because the data it reads changed without it (this bit twice: the release-token guard on auto-version.yaml, and the instructions guard tests). These are GUARDS, not an SSOT: a pair says \"run this check when that file changes\", and naming it otherwise would launder the very smell a drift guard should expose. A guard test is either a `node --test` file (*.test.mjs) or a pytest module (test_*.py); the runner dispatches on the extension, so data whose only contract test is Python is pairable too. Keep every paired test fast (~1s). test/guard-pairs.test.mjs asserts all paths here exist AND, in the other direction, scans every node --test file (plus the repo modules those tests import) for the repo data files AND the .sh/.py sources they open BY PATH: each one must appear here, mapped to a test that actually reads it, or in that test's NOT_GUARDED / NOT_MIRRORED allowlist with a reason. JS modules stay out of the scan on purpose — a moved .mjs already fails loudly at import resolution — but a shell script or Python module driven through execFileSync gets no such safety net, which is why those are in. So this map is a checked projection of the tests, not a hand-maintained list that silently misses the next contract test. The scan covers node --test files only, so a Python-only pairing is legitimate but must be added by hand.",
   "pairs": {
     ".github/workflows/auto-version.yaml": [
       "scripts/version-bump.test.mjs",
@@ -42,7 +42,11 @@
       ".github/scripts/main-health.test.mjs"
     ],
     ".github/workflows/ci-failure-notify.yaml": [
-      ".github/scripts/main-health.test.mjs"
+      ".github/scripts/main-health.test.mjs",
+      "test/failure-notify-roster.test.mjs"
+    ],
+    ".github/workflows/fuzz-nightly.yaml": [
+      "test/failure-notify-roster.test.mjs"
     ],
     ".github/workflows/template-sync.yaml": [
       ".github/scripts/synced-deps.test.mjs"
@@ -121,6 +125,59 @@
     ".github/scripts/lib/shared-names.json": ["tests/test_shared_names.py"],
     "claude-hooks/scan-invisible-chars.mjs": [
       "test/claude-hooks-scan-coverage.test.mjs"
+    ],
+    "THREAT-MODEL.md": ["test/threat-model-layers.test.mjs"],
+    ".pre-commit-config.yaml": ["test/test-runner-partition.test.mjs"],
+    ".github/scripts/run-script-tests.sh": [
+      "test/test-runner-partition.test.mjs"
+    ],
+    "plugin/scripts/lib/hook-timing.sh": [
+      "test/hook-timing-shell-parity.test.mjs"
+    ],
+    "python/agent_sanitizer/secrets/placeholders.py": [
+      "test/placeholder-guards.test.mjs"
+    ],
+    ".github/scripts/check-claude-execution.sh": [
+      ".github/scripts/check-claude-execution.test.mjs"
+    ],
+    ".github/scripts/check-pack-listing.sh": [
+      ".github/scripts/check-pack-listing.test.mjs"
+    ],
+    ".github/scripts/install-sanitizer.sh": [
+      ".github/scripts/install-sanitizer.test.mjs"
+    ],
+    ".github/scripts/claude-conflict-resolve.sh": [
+      ".github/scripts/auto-resolve/lib.test.mjs"
+    ],
+    ".github/scripts/remerge-diff-report.py": [
+      ".github/scripts/auto-resolve/self-review.test.mjs"
+    ],
+    ".github/scripts/auto-resolve/bundle.sh": [
+      ".github/scripts/auto-resolve/bundle.test.mjs"
+    ],
+    ".github/scripts/auto-resolve/discover.py": [
+      ".github/scripts/auto-resolve/discover.test.mjs"
+    ],
+    ".github/scripts/auto-resolve/fanout.sh": [
+      ".github/scripts/auto-resolve/fanout.test.mjs"
+    ],
+    ".github/scripts/auto-resolve/land.sh": [
+      ".github/scripts/auto-resolve/land.test.mjs"
+    ],
+    ".github/scripts/auto-resolve/lib.sh": [
+      ".github/scripts/auto-resolve/lib.test.mjs"
+    ],
+    ".github/scripts/auto-resolve/mark-attempt.sh": [
+      ".github/scripts/auto-resolve/mark-attempt.test.mjs"
+    ],
+    ".github/scripts/auto-resolve/prepare.sh": [
+      ".github/scripts/auto-resolve/prepare.test.mjs"
+    ],
+    ".github/scripts/auto-resolve/release-attempt.sh": [
+      ".github/scripts/auto-resolve/release-attempt.test.mjs"
+    ],
+    ".github/scripts/auto-resolve/self-review.sh": [
+      ".github/scripts/auto-resolve/self-review.test.mjs"
     ]
   }
 }

--- a/.hooks/guard-pairs.json
+++ b/.hooks/guard-pairs.json
@@ -1,156 +1,17 @@
 {
-  "$comment": "Guard pairs: source file -> the cheap guard test(s) that cover it. When a listed source is staged, .hooks/run-guard-pairs.mjs runs the paired guard tests and blocks the commit on failure \u2014 so a guard test can never silently break on main because the data it reads changed without it (this bit twice: the release-token guard on auto-version.yaml, and the instructions guard tests). These are GUARDS, not an SSOT: a pair says \"run this check when that file changes\", and naming it otherwise would launder the very smell a drift guard should expose. A guard test is either a `node --test` file (*.test.mjs) or a pytest module (test_*.py); the runner dispatches on the extension, so data whose only contract test is Python is pairable too. Keep every paired test fast (~1s). test/guard-pairs.test.mjs asserts all paths here exist AND, in the other direction, scans every node --test file (plus the repo modules those tests import) for the repo data files AND the .sh/.py sources they open BY PATH: each one must appear here, mapped to a test that actually reads it, or in that test's NOT_GUARDED / NOT_MIRRORED allowlist with a reason. JS modules stay out of the scan on purpose — a moved .mjs already fails loudly at import resolution — but a shell script or Python module driven through execFileSync gets no such safety net, which is why those are in. So this map is a checked projection of the tests, not a hand-maintained list that silently misses the next contract test. The scan covers node --test files only, so a Python-only pairing is legitimate but must be added by hand.",
+  "$comment": "Guard pairs: source file -> the cheap guard test(s) that cover it. When a listed source is staged, .hooks/run-guard-pairs.mjs runs the paired guard tests and blocks the commit on failure \u2014 so a guard test can never silently break on main because the data it reads changed without it (this bit twice: the release-token guard on auto-version.yaml, and the instructions guard tests). These are GUARDS, not an SSOT: a pair says \"run this check when that file changes\", and naming it otherwise would launder the very smell a drift guard should expose. A guard test is either a `node --test` file (*.test.mjs) or a pytest module (test_*.py); the runner dispatches on the extension, so data whose only contract test is Python is pairable too. Keep every paired test fast (~1s). test/guard-pairs.test.mjs asserts all paths here exist AND, in the other direction, scans every node --test file (plus the repo modules those tests import) for the repo data files AND the .sh/.py sources they open BY PATH: each one must appear here, mapped to a test that actually reads it, or in that test's NOT_GUARDED / NOT_MIRRORED allowlist with a reason. JS modules stay out of the scan on purpose \u2014 a moved .mjs already fails loudly at import resolution \u2014 but a shell script or Python module driven through execFileSync gets no such safety net, which is why those are in. So this map is a checked projection of the tests, not a hand-maintained list that silently misses the next contract test. The scan covers node --test files only, so a Python-only pairing is legitimate but must be added by hand.",
   "pairs": {
-    ".github/workflows/auto-version.yaml": [
-      "scripts/version-bump.test.mjs",
-      ".github/scripts/workflow-step-refs.test.mjs"
-    ],
-    ".github/actions/claude-run/action.yaml": [
-      ".github/scripts/workflow-step-refs.test.mjs"
-    ],
-    ".github/workflows/claude.yaml": [
-      ".github/scripts/workflow-step-refs.test.mjs"
-    ],
-    ".github/scripts/version-bump.sh": [
-      "scripts/version-bump.test.mjs",
-      "scripts/set-plugin-version.test.mjs"
-    ],
-    ".github/scripts/set-plugin-version.mjs": [
-      "scripts/set-plugin-version.test.mjs"
-    ],
-    "plugin/.claude-plugin/plugin.json": [
-      "scripts/set-plugin-version.test.mjs",
-      "plugin/test/enable-auto-update.test.mjs"
-    ],
     ".claude-plugin/marketplace.json": [
       "plugin/test/enable-auto-update.test.mjs",
       "plugin/test/plugin-manifest.test.mjs"
     ],
     ".claude/settings.json": ["plugin/test/plugin-manifest.test.mjs"],
+    ".github/actions/claude-run/action.yaml": [
+      ".github/scripts/workflow-step-refs.test.mjs"
+    ],
     ".github/mutation-shards.json": [
       "test/mutation-shards.test.mjs",
       "test/shipped-gates.test.mjs"
-    ],
-    ".github/scripts/nightly-fuzz-issue.js": [
-      ".github/scripts/nightly-fuzz-issue.test.mjs"
-    ],
-    ".github/scripts/main-health.mjs": [".github/scripts/main-health.test.mjs"],
-    ".github/scripts/npm-max-stable.mjs": [
-      ".github/scripts/npm-max-stable.test.mjs"
-    ],
-    ".github/workflows/main-health.yaml": [
-      ".github/scripts/main-health.test.mjs"
-    ],
-    ".github/workflows/ci-failure-notify.yaml": [
-      ".github/scripts/main-health.test.mjs",
-      "test/failure-notify-roster.test.mjs"
-    ],
-    ".github/workflows/fuzz-nightly.yaml": [
-      "test/failure-notify-roster.test.mjs"
-    ],
-    ".github/workflows/template-sync.yaml": [
-      ".github/scripts/synced-deps.test.mjs"
-    ],
-    "src/invisible.mjs": [
-      "test/invisible-charset.test.mjs",
-      "test/instructions.test.mjs"
-    ],
-    "src/instructions.mjs": ["test/instructions.test.mjs"],
-    "tests/secrets/secret-format-samples.json": [
-      "tests/secrets/test_secrets_detectors.py"
-    ],
-    "python/agent_sanitizer/secrets/data/credential-names.json": [
-      "test/credential-names-export.test.mjs",
-      "test/credential-name-matcher.test.mjs",
-      "test/credential-vocabulary.test.mjs",
-      "tests/secrets/test_credential_names.py"
-    ],
-    "config/review-severities.json": [
-      ".github/scripts/post-pr-review.test.mjs"
-    ],
-    "package.json": [
-      "test/claude-hooks-exports.test.mjs",
-      "test/shipped-gates.test.mjs",
-      "tests/test_minimum_release_age.py"
-    ],
-    "pnpm-workspace.yaml": ["tests/test_minimum_release_age.py"],
-    ".hooks/guard-pairs.json": ["test/guard-pairs.test.mjs"],
-    "CHANGELOG.md": ["scripts/set-plugin-version.test.mjs"],
-    "claude-hooks/config/inference-key-vars.json": [
-      "test/credential-vocabulary.test.mjs"
-    ],
-    "claude-hooks/config/scrubbed-env-vars.json": [
-      "test/credential-vocabulary.test.mjs"
-    ],
-    "README.md": ["test/claude-hooks-exports.test.mjs"],
-    "plugin/README.md": ["plugin/test/plugin-manifest.test.mjs"],
-    "plugin/skills/enable-auto-update/SKILL.md": [
-      "plugin/test/enable-auto-update.test.mjs"
-    ],
-    "python/agent_sanitizer/data/invisible-charset.json": [
-      "test/invisible-charset.test.mjs",
-      "test/secret-annotate-invisible.test.mjs",
-      "tests/test_textstrip.py"
-    ],
-    "python/agent_sanitizer/secrets/data/secret-detectors.json": [
-      "test/secret-detectors-portability.test.mjs"
-    ],
-    "scripts/data/StandardizedVariants.txt": [
-      "test/invisible-charset.test.mjs"
-    ],
-    "scripts/data/DerivedJoiningType.json": ["test/joining-type.test.mjs"],
-    "scripts/data/IndicSyllabicCategory.Virama.json": [
-      "test/joining-type.test.mjs"
-    ],
-    "stryker.conf.json": [
-      "test/aggregate-mutation.test.mjs",
-      "test/shipped-gates.test.mjs"
-    ],
-    "tests/golden-corpus.json": ["test/golden-corpus.test.mjs"],
-    "tests/golden.json": ["test/golden-corpus.test.mjs"],
-    "scripts/shipped-sources.mjs": ["test/shipped-gates.test.mjs"],
-    "scripts/coverage.mjs": ["test/shipped-gates.test.mjs"],
-    "scripts/mutate.mjs": ["test/shipped-gates.test.mjs"],
-    "tests/data/credential-names.cases.json": [
-      "test/credential-name-matcher.test.mjs",
-      "tests/secrets/test_credential_names.py"
-    ],
-    "src/ansi.mjs": ["test/invisible-charset.test.mjs"],
-    "python/agent_sanitizer/secrets/data/redaction-floor.json": [
-      "tests/secrets/test_secrets_config.py",
-      "test/claude-hooks-host-seams.test.mjs"
-    ],
-    ".github/workflows/mutation.yaml": ["tests/test_mutation_changed.py"],
-    ".github/scripts/mutation-changed.sh": ["tests/test_mutation_changed.py"],
-    ".github/scripts/lib/shared-names.json": ["tests/test_shared_names.py"],
-    "claude-hooks/scan-invisible-chars.mjs": [
-      "test/claude-hooks-scan-coverage.test.mjs"
-    ],
-    "THREAT-MODEL.md": ["test/threat-model-layers.test.mjs"],
-    ".pre-commit-config.yaml": ["test/test-runner-partition.test.mjs"],
-    ".github/scripts/run-script-tests.sh": [
-      "test/test-runner-partition.test.mjs"
-    ],
-    "plugin/scripts/lib/hook-timing.sh": [
-      "test/hook-timing-shell-parity.test.mjs"
-    ],
-    "python/agent_sanitizer/secrets/placeholders.py": [
-      "test/placeholder-guards.test.mjs"
-    ],
-    ".github/scripts/check-claude-execution.sh": [
-      ".github/scripts/check-claude-execution.test.mjs"
-    ],
-    ".github/scripts/check-pack-listing.sh": [
-      ".github/scripts/check-pack-listing.test.mjs"
-    ],
-    ".github/scripts/install-sanitizer.sh": [
-      ".github/scripts/install-sanitizer.test.mjs"
-    ],
-    ".github/scripts/claude-conflict-resolve.sh": [
-      ".github/scripts/auto-resolve/lib.test.mjs"
-    ],
-    ".github/scripts/remerge-diff-report.py": [
-      ".github/scripts/auto-resolve/self-review.test.mjs"
     ],
     ".github/scripts/auto-resolve/bundle.sh": [
       ".github/scripts/auto-resolve/bundle.test.mjs"
@@ -178,6 +39,146 @@
     ],
     ".github/scripts/auto-resolve/self-review.sh": [
       ".github/scripts/auto-resolve/self-review.test.mjs"
+    ],
+    ".github/scripts/check-claude-execution.sh": [
+      ".github/scripts/check-claude-execution.test.mjs"
+    ],
+    ".github/scripts/check-pack-listing.sh": [
+      ".github/scripts/check-pack-listing.test.mjs"
+    ],
+    ".github/scripts/claude-conflict-resolve.sh": [
+      ".github/scripts/auto-resolve/lib.test.mjs"
+    ],
+    ".github/scripts/install-sanitizer.sh": [
+      ".github/scripts/install-sanitizer.test.mjs"
+    ],
+    ".github/scripts/lib/shared-names.json": ["tests/test_shared_names.py"],
+    ".github/scripts/main-health.mjs": [".github/scripts/main-health.test.mjs"],
+    ".github/scripts/mutation-changed.sh": ["tests/test_mutation_changed.py"],
+    ".github/scripts/nightly-fuzz-issue.js": [
+      ".github/scripts/nightly-fuzz-issue.test.mjs"
+    ],
+    ".github/scripts/npm-max-stable.mjs": [
+      ".github/scripts/npm-max-stable.test.mjs"
+    ],
+    ".github/scripts/remerge-diff-report.py": [
+      ".github/scripts/auto-resolve/self-review.test.mjs"
+    ],
+    ".github/scripts/run-script-tests.sh": [
+      "test/test-runner-partition.test.mjs"
+    ],
+    ".github/scripts/set-plugin-version.mjs": [
+      "scripts/set-plugin-version.test.mjs"
+    ],
+    ".github/scripts/version-bump.sh": [
+      "scripts/version-bump.test.mjs",
+      "scripts/set-plugin-version.test.mjs"
+    ],
+    ".github/workflows/auto-version.yaml": [
+      "scripts/version-bump.test.mjs",
+      ".github/scripts/workflow-step-refs.test.mjs"
+    ],
+    ".github/workflows/ci-failure-notify.yaml": [
+      ".github/scripts/main-health.test.mjs",
+      "test/failure-notify-roster.test.mjs"
+    ],
+    ".github/workflows/claude.yaml": [
+      ".github/scripts/workflow-step-refs.test.mjs"
+    ],
+    ".github/workflows/fuzz-nightly.yaml": [
+      "test/failure-notify-roster.test.mjs"
+    ],
+    ".github/workflows/main-health.yaml": [
+      ".github/scripts/main-health.test.mjs"
+    ],
+    ".github/workflows/mutation.yaml": ["tests/test_mutation_changed.py"],
+    ".github/workflows/template-sync.yaml": [
+      ".github/scripts/synced-deps.test.mjs"
+    ],
+    ".hooks/commit-msg": [".github/scripts/synced-deps.test.mjs"],
+    ".hooks/guard-pairs.json": ["test/guard-pairs.test.mjs"],
+    ".pre-commit-config.yaml": ["test/test-runner-partition.test.mjs"],
+    "CHANGELOG.md": ["scripts/set-plugin-version.test.mjs"],
+    "README.md": ["test/claude-hooks-exports.test.mjs"],
+    "THREAT-MODEL.md": ["test/threat-model-layers.test.mjs"],
+    "claude-hooks/config/inference-key-vars.json": [
+      "test/credential-vocabulary.test.mjs"
+    ],
+    "claude-hooks/config/scrubbed-env-vars.json": [
+      "test/credential-vocabulary.test.mjs"
+    ],
+    "claude-hooks/scan-invisible-chars.mjs": [
+      "test/claude-hooks-scan-coverage.test.mjs"
+    ],
+    "config/review-severities.json": [
+      ".github/scripts/post-pr-review.test.mjs"
+    ],
+    "package.json": [
+      "test/claude-hooks-exports.test.mjs",
+      "test/shipped-gates.test.mjs",
+      "tests/test_minimum_release_age.py"
+    ],
+    "plugin/.claude-plugin/plugin.json": [
+      "scripts/set-plugin-version.test.mjs",
+      "plugin/test/enable-auto-update.test.mjs"
+    ],
+    "plugin/README.md": ["plugin/test/plugin-manifest.test.mjs"],
+    "plugin/scripts/lib/hook-timing.sh": [
+      "test/hook-timing-shell-parity.test.mjs"
+    ],
+    "plugin/skills/enable-auto-update/SKILL.md": [
+      "plugin/test/enable-auto-update.test.mjs"
+    ],
+    "pnpm-workspace.yaml": ["tests/test_minimum_release_age.py"],
+    "python/agent_sanitizer/data/invisible-charset.json": [
+      "test/invisible-charset.test.mjs",
+      "test/secret-annotate-invisible.test.mjs",
+      "tests/test_textstrip.py"
+    ],
+    "python/agent_sanitizer/secrets/data/credential-names.json": [
+      "test/credential-names-export.test.mjs",
+      "test/credential-name-matcher.test.mjs",
+      "test/credential-vocabulary.test.mjs",
+      "tests/secrets/test_credential_names.py"
+    ],
+    "python/agent_sanitizer/secrets/data/redaction-floor.json": [
+      "tests/secrets/test_secrets_config.py",
+      "test/claude-hooks-host-seams.test.mjs"
+    ],
+    "python/agent_sanitizer/secrets/data/secret-detectors.json": [
+      "test/secret-detectors-portability.test.mjs"
+    ],
+    "python/agent_sanitizer/secrets/placeholders.py": [
+      "test/placeholder-guards.test.mjs"
+    ],
+    "scripts/coverage.mjs": ["test/shipped-gates.test.mjs"],
+    "scripts/data/DerivedJoiningType.json": ["test/joining-type.test.mjs"],
+    "scripts/data/IndicSyllabicCategory.Virama.json": [
+      "test/joining-type.test.mjs"
+    ],
+    "scripts/data/StandardizedVariants.txt": [
+      "test/invisible-charset.test.mjs"
+    ],
+    "scripts/mutate.mjs": ["test/shipped-gates.test.mjs"],
+    "scripts/shipped-sources.mjs": ["test/shipped-gates.test.mjs"],
+    "src/ansi.mjs": ["test/invisible-charset.test.mjs"],
+    "src/instructions.mjs": ["test/instructions.test.mjs"],
+    "src/invisible.mjs": [
+      "test/invisible-charset.test.mjs",
+      "test/instructions.test.mjs"
+    ],
+    "stryker.conf.json": [
+      "test/aggregate-mutation.test.mjs",
+      "test/shipped-gates.test.mjs"
+    ],
+    "tests/data/credential-names.cases.json": [
+      "test/credential-name-matcher.test.mjs",
+      "tests/secrets/test_credential_names.py"
+    ],
+    "tests/golden-corpus.json": ["test/golden-corpus.test.mjs"],
+    "tests/golden.json": ["test/golden-corpus.test.mjs"],
+    "tests/secrets/secret-format-samples.json": [
+      "tests/secrets/test_secrets_detectors.py"
     ]
   }
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -112,6 +112,23 @@ repos:
         pass_filenames: false
         files: ^\.claude/settings\.json$
 
+      # `node --test`'s default discovery skips dot-directories, so a *.test.mjs
+      # under .claude/hooks/ or .hooks/ runs in NO job — verified by planting
+      # always-failing suites there and watching the default run stay green.
+      # This config already anticipated such suites (`exclude: \.test\.mjs$` on
+      # the .claude/hooks lints below) while nothing executed them, leaving the
+      # hook stack's own trust-boundary controls untested by construction.
+      # pre-commit passes the MATCHED paths, so `node --test` runs exactly those
+      # and nothing else; when none match the hook is skipped rather than
+      # degrading to an argument-less (default-discovery) run.
+      # test/test-runner-partition.test.mjs is what makes this the registered
+      # claim for those paths: a suite no runner claims fails there.
+      - id: dot-directory-test-suites
+        name: run the *.test.mjs suites under .claude/hooks and .hooks
+        entry: node --test
+        language: system
+        files: ^(\.claude/hooks/|\.hooks/).*\.test\.mjs$
+
       - id: check-hook-stdin-guarded
         name: require readStdinJson() in a hook's isMain block to sit in a try
         entry: python3 .github/scripts/check-hook-stdin-guarded.py

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,16 +3,15 @@ import globals from "globals";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  // Lint only the library sources; the template's automation scripts
-  // (.github, .hooks, config) carry their own conventions.
   {
     ignores: [
       "coverage/**",
       "types/**",
       "node_modules/**",
-      ".github/**",
-      ".claude/**",
-      ".hooks/**",
+      // Worktree scaffolding: a second, gitignored copy of the whole repo, so
+      // linting it would double every finding and report them at paths that do
+      // not exist on the branch.
+      ".claude/worktrees/**",
       "config/**",
       "tests/**",
       // The committed plugin bundle is generated (~1.8 MB of inlined
@@ -34,6 +33,12 @@ export default tseslint.config(
   },
   js.configs.recommended,
   {
+    // The automation layer used to be ignored wholesale ("carries its own
+    // conventions"), which meant `pnpm lint` linted 0 of the ~48 JS files under
+    // .github/, .hooks/ and .claude/hooks/ — including four hook modules that
+    // run inside a Claude session and three CommonJS scripts that run in CI
+    // with a token. Same rules as the library: an unused binding or a
+    // typo'd global is not more acceptable in a workflow script.
     files: [
       "src/**/*.mjs",
       "test/**/*.mjs",
@@ -41,6 +46,9 @@ export default tseslint.config(
       "claude-hooks/**/*.mjs",
       "plugin/scripts/**/*.mjs",
       "plugin/test/**/*.mjs",
+      ".github/**/*.mjs",
+      ".hooks/**/*.mjs",
+      ".claude/hooks/**/*.mjs",
     ],
     languageOptions: {
       // "latest" rather than a pinned year: the hook config modules are loaded
@@ -73,6 +81,17 @@ export default tseslint.config(
         },
       ],
     },
+  },
+  {
+    // `.github/scripts/package.json` declares `"type": "commonjs"`, so the `.js`
+    // scripts there are CJS: `require`/`module` are globals, not undefined names.
+    files: [".github/**/*.js"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "commonjs",
+      globals: { ...globals.node },
+    },
+    rules: { "consistent-return": "error" },
   },
   {
     // The one module allowed to call esbuild directly — it *is* the guard.

--- a/scripts/coverage.mjs
+++ b/scripts/coverage.mjs
@@ -19,7 +19,7 @@
  * Usage: node scripts/coverage.mjs [extra node --test args]
  */
 import { spawnSync } from "node:child_process";
-import { realpathSync } from "node:fs";
+import { readFileSync, realpathSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -72,9 +72,30 @@ export const SCOPES = [
   {
     name: "claude-hooks + bin (ratchet)",
     files: hookScope,
-    thresholds: { lines: 88, branches: 80, functions: 72, statements: 88 },
+    // Measured 96.34 / 91.19 / 90.15 / 96.34 — each floor sits ~3 points under.
+    thresholds: { lines: 93, branches: 88, functions: 87, statements: 93 },
   },
 ];
+
+/**
+ * How far a measurement may run ahead of its floor before the build says so.
+ *
+ * CONTRIBUTING.md says the ratchet "should only ever move up", and nothing
+ * enforced that half: c8 fails when the measurement drops BELOW the floor and is
+ * silent however far above it climbs. The hook floor had drifted to 72%
+ * functions against a measured 90% — room for 47 shipped functions to become
+ * entirely untested with CI still green. A ratchet that only ever catches
+ * regressions relative to a stale number is not a ratchet.
+ *
+ * 6 points, not the ~1 an exactly-pinned floor would allow, because the headroom
+ * noted above is real: the hooks that Claude Code drives as subprocesses run the
+ * committed `plugin/dist` BUNDLE, and those lines are attributed to the bundle
+ * rather than back to the source here, so the ratio moves when a file merely
+ * grows. 6 absorbs that drift while still being far smaller than the 18-point
+ * gap that accumulated unnoticed — and the failure it raises is "raise the
+ * floor, in both files", which is a two-line edit, not a debugging session.
+ */
+export const RATCHET_SLACK = 6;
 
 /** c8 flags shared by the collecting run and every report pass.
  * @param {string[]} includes */
@@ -129,17 +150,68 @@ function main() {
         `coverage: scope "${scope.name}" matched no shipped files`,
       );
     process.stdout.write(`\nCoverage floor — ${scope.name}\n`);
+    // json-summary rides along with the text table so the same numbers c8 just
+    // gated on are the ones the ratchet check below reads — a second report pass
+    // would be a second measurement to disagree with. It lands in the default
+    // report dir on purpose: `--report-dir` also relocates where `c8 report`
+    // LOOKS for the raw V8 output (`<report-dir>/tmp`), so pointing it at a
+    // scratch directory makes the pass report zero coverage.
+    const summaryPath = join(repoRoot, "coverage", "coverage-summary.json");
+    // Removed first so a reporter that failed to write cannot be read as the
+    // previous scope's numbers.
+    rmSync(summaryPath, { force: true });
     run(
       [
         "report",
         ...commonArgs(files),
         "--reporter=text",
+        "--reporter=json-summary",
         "--check-coverage",
         ...Object.entries(scope.thresholds).map(([k, v]) => `--${k}=${v}`),
       ],
       `coverage floor for ${scope.name}`,
     );
+    assertRatcheted(scope, readSummary(summaryPath));
   }
+}
+
+/** @param {string} path @returns {Record<string, number>} metric -> percentage */
+function readSummary(path) {
+  const { total } = JSON.parse(readFileSync(path, "utf8"));
+  return Object.fromEntries(
+    Object.entries(total).map(([metric, { pct }]) => [metric, pct]),
+  );
+}
+
+/**
+ * The other half of the ratchet: fail when a floor has fallen too far BEHIND
+ * what the suite actually covers, naming both files that have to move.
+ *
+ * @param {{ name: string, thresholds: Record<string, number> }} scope
+ * @param {Record<string, number>} measured
+ */
+export function assertRatcheted(scope, measured) {
+  // A floor naming a metric the report does not carry is gating on nothing;
+  // skipping it quietly would retire that floor without anyone editing it.
+  for (const metric of Object.keys(scope.thresholds))
+    if (typeof measured[metric] !== "number")
+      throw new Error(
+        `coverage: scope "${scope.name}" has a ${metric} floor, but the coverage summary reports no ${metric}`,
+      );
+  const stale = Object.entries(scope.thresholds)
+    .filter(([metric, floor]) => measured[metric] - floor > RATCHET_SLACK)
+    .map(
+      ([metric, floor]) =>
+        `  ${metric}: measured ${measured[metric]}%, floor ${floor}% ` +
+        `(${(measured[metric] - floor).toFixed(2)} points of slack, max ${RATCHET_SLACK})`,
+    );
+  if (stale.length === 0) return;
+  throw new Error(
+    `coverage: the "${scope.name}" floor has stopped ratcheting —\n` +
+      `${stale.join("\n")}\n` +
+      "Raise these floors to just under the measured values in BOTH " +
+      "scripts/coverage.mjs (SCOPES) and test/shipped-gates.test.mjs (HOOK_FLOORS/SRC_FLOORS).",
+  );
 }
 
 // Importable without side effects: the contract test reads SCOPES and must not

--- a/test/failure-notify-roster.test.mjs
+++ b/test/failure-notify-roster.test.mjs
@@ -1,0 +1,227 @@
+/**
+ * Every workflow that can fail unseen is either on the notifier's roster or
+ * exempt IN ITS OWN FILE — a partition, checked here.
+ *
+ * A push-to-main or scheduled run emits no PR webhook: nothing turns red on
+ * anyone's screen. `ci-failure-notify.yaml` converts such a failure into a phone
+ * push, and `workflow_run` has no wildcard, so its `workflows:` list has to name
+ * each one. That list claimed to be kept honest by "a ci-truth-serum hook
+ * (check-failure-notifier-coverage)". No such hook exists: the pinned rev
+ * provides 18 `check-*` ids and not one of them references this file. The gap
+ * that fiction covered was live — `Mutation tests` and `Pack smoke test` both
+ * run on push-to-main and were on no roster, so they could fail on `main`
+ * indefinitely and page nobody.
+ *
+ * The exemptions live as a `# failure-notify-exempt: <reason>` marker in the
+ * exempt workflow's own yaml rather than as prose in a third file (they were
+ * justified only in a comment in `.github/scripts/main-health.mjs`). A reason
+ * that travels with the thing it excuses is one a reader of that thing can find,
+ * and deleting the workflow deletes the excuse with it.
+ */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+import {
+  NOTIFIER_WORKFLOW_PATH,
+  pagedWorkflowNames,
+} from "../.github/scripts/main-health.mjs";
+
+const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+  encoding: "utf8",
+}).trim();
+
+const read = (relative) => readFileSync(join(repoRoot, relative), "utf8");
+
+const workflowFiles = execFileSync(
+  "git",
+  ["ls-files", "--", ".github/workflows/*.yaml", ".github/workflows/*.yml"],
+  { cwd: repoRoot, encoding: "utf8" },
+)
+  .split("\n")
+  .filter(Boolean);
+
+/** The lines of the top-level `on:` block, comments and blanks dropped. */
+function onBlock(yaml, path) {
+  const lines = yaml.split("\n");
+  // `on: # zizmor: ignore[…]` is a real form in this tree, so a trailing
+  // comment is allowed — but nothing else on the line is.
+  const start = lines.findIndex((line) => /^on:\s*(#.*)?$/.test(line));
+  // Fail loud: a workflow this parser cannot read must not silently count as
+  // "has no triggers", which would excuse it from the partition entirely.
+  if (start === -1) throw new Error(`${path}: no top-level \`on:\` block`);
+  const block = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^\s*(#.*)?$/.test(line)) continue;
+    if (/^\S/.test(line)) break;
+    block.push(line);
+  }
+  if (block.length === 0) throw new Error(`${path}: empty \`on:\` block`);
+  return block;
+}
+
+/** The branch names a `push:` trigger is restricted to, or null for "any". */
+function pushBranches(block) {
+  const pushAt = block.findIndex((line) => /^ {2}push:\s*(#.*)?$/.test(line));
+  if (pushAt === -1) return undefined;
+  const branches = [];
+  let inBranches = false;
+  for (const line of block.slice(pushAt + 1)) {
+    if (/^ {2}\S/.test(line)) break; // next trigger key
+    const key = line.match(/^ {4}([a-z_]+):\s*(.*?)\s*$/);
+    if (key) {
+      inBranches = key[1] === "branches";
+      // Inline form: `branches: [main]` / `branches: ["main", "next"]`.
+      if (inBranches && key[2] !== "")
+        return key[2]
+          .replace(/^\[|\]$/g, "")
+          .split(",")
+          .map((name) => name.trim().replace(/^["']|["']$/g, ""));
+      continue;
+    }
+    const item = line.match(/^ {6}-\s*(.*?)\s*$/);
+    if (inBranches && item) branches.push(item[1].replace(/^["']|["']$/g, ""));
+  }
+  // A `push:` with no `branches:` fires on every branch, main included.
+  return branches.length > 0 ? branches : null;
+}
+
+/** Whether a workflow can fail with nobody watching: push-to-main or schedule. */
+function firesUnwatched(yaml, path) {
+  const block = onBlock(yaml, path);
+  if (block.some((line) => /^ {2}schedule:\s*(#.*)?$/.test(line))) return true;
+  const branches = pushBranches(block);
+  if (branches === undefined) return false;
+  return branches === null || branches.includes("main");
+}
+
+const EXEMPT_MARKER = /^#\s*failure-notify-exempt:\s*(\S.*)$/m;
+
+const workflows = workflowFiles.map((path) => {
+  const yaml = read(path);
+  const name = yaml.match(/^name:\s*(.*?)\s*$/m)?.[1];
+  if (!name) throw new Error(`${path}: no top-level \`name:\``);
+  return {
+    path,
+    name,
+    unwatched: firesUnwatched(yaml, path),
+    exemption: yaml.match(EXEMPT_MARKER)?.[1],
+  };
+});
+
+const unwatched = workflows.filter((wf) => wf.unwatched);
+const roster = pagedWorkflowNames(read(NOTIFIER_WORKFLOW_PATH));
+
+describe("post-merge failure-notification roster", () => {
+  it("recognises the triggers it is supposed to, and only those", () => {
+    // Non-vacuity: a parser that answered `false` everywhere would make the
+    // partition below hold over an empty set.
+    assert.ok(
+      unwatched.length >= 20,
+      `only ${unwatched.length} unwatched workflows detected`,
+    );
+    const byName = new Map(workflows.map((wf) => [wf.name, wf.unwatched]));
+    for (const [name, expected] of [
+      ["Node tests", true], // push: branches: ["main"]
+      ["Main branch health", true], // schedule only
+      ["Auto-resolve merge conflicts", true], // push: branches: [main]
+      ["Nightly unseeded fuzz", true], // schedule only, and exempt below
+      ["PR meta", false], // pull_request only
+      ["Claude PR review", false], // pull_request_target only
+      ["decide", false], // workflow_call only
+      ["CI failure notify", false], // workflow_run only — it IS the listener
+    ]) {
+      assert.ok(byName.has(name), `no workflow named ${name}`);
+      assert.equal(byName.get(name), expected, `${name} classified wrongly`);
+    }
+  });
+
+  it("reads a push restricted away from main as watched", () => {
+    // Fixed inputs, because no workflow in the tree currently pushes to a
+    // non-main branch — without these the `includes("main")` arm would never be
+    // exercised against a negative and could be a constant `true`.
+    const on = (body) => `name: probe\n\non:\n${body}\njobs: {}\n`;
+    assert.equal(
+      firesUnwatched(on("  push:\n    branches: [main]\n"), "p"),
+      true,
+    );
+    assert.equal(
+      firesUnwatched(on("  push:\n    branches: [next]\n"), "p"),
+      false,
+    );
+    assert.equal(
+      firesUnwatched(
+        on("  push:\n    branches:\n      - next\n      - main\n"),
+        "p",
+      ),
+      true,
+    );
+    assert.equal(firesUnwatched(on("  push:\n"), "p"), true);
+    assert.equal(firesUnwatched(on("  pull_request:\n"), "p"), false);
+    // `paths:` under push must not be mistaken for `branches:`.
+    assert.equal(
+      firesUnwatched(on("  push:\n    paths:\n      - src/**\n"), "p"),
+      true,
+    );
+    assert.throws(
+      () => firesUnwatched("name: probe\njobs: {}\n", "p"),
+      /no top-level/,
+    );
+  });
+
+  it("partitions every unwatched workflow into roster or a declared exemption", () => {
+    const unrostered = unwatched
+      .filter((wf) => !roster.has(wf.name) && wf.exemption === undefined)
+      .map((wf) => `${wf.path} (${wf.name})`);
+    assert.deepEqual(
+      unrostered,
+      [],
+      "these run on push-to-main or a schedule and route to NOBODY: add the " +
+        "workflow's `name:` to `workflows:` in .github/workflows/ci-failure-notify.yaml, " +
+        "or put a `# failure-notify-exempt: <reason>` comment in the workflow itself",
+    );
+
+    const both = unwatched
+      .filter((wf) => roster.has(wf.name) && wf.exemption !== undefined)
+      .map((wf) => wf.path);
+    assert.deepEqual(both, [], "workflows are both rostered and exempt");
+
+    // The roster's other direction: a name matching no unwatched workflow is a
+    // dead entry, and `workflow_run` binds by name, so it can never fire.
+    const names = new Set(unwatched.map((wf) => wf.name));
+    assert.deepEqual(
+      [...roster].filter((name) => !names.has(name)),
+      [],
+      "ci-failure-notify.yaml lists workflows that no longer run on push-to-main or a schedule",
+    );
+  });
+
+  it("keeps every exemption declared in its own file, with a real reason", () => {
+    const exempt = workflows.filter((wf) => wf.exemption !== undefined);
+    // Non-vacuity for the marker regex: it has to actually match something, or
+    // the partition above degenerates into "the roster covers everything".
+    assert.deepEqual(
+      exempt.map((wf) => wf.path),
+      [".github/workflows/fuzz-nightly.yaml"],
+      "the exempt set changed — every entry needs its reasoning reviewed",
+    );
+    for (const wf of exempt)
+      assert.ok(
+        wf.exemption.length > 30,
+        `${wf.path}: failure-notify-exempt needs a real reason, got "${wf.exemption}"`,
+      );
+    // An exemption on a workflow that cannot fail unwatched excuses nothing.
+    for (const wf of exempt)
+      assert.ok(wf.unwatched, `${wf.path} is exempt from a rule it never met`);
+  });
+
+  it("routes the two workflows the missing hook left unrouted", () => {
+    // Pinned by name: these are the concrete holes the fictional
+    // check-failure-notifier-coverage was credited with preventing, and a revert
+    // that drops them again must fail here rather than only in the partition.
+    for (const name of ["Mutation tests", "Pack smoke test"])
+      assert.ok(roster.has(name), `${name} is unrouted again`);
+  });
+});

--- a/test/guard-pairs.test.mjs
+++ b/test/guard-pairs.test.mjs
@@ -153,6 +153,26 @@ const DATA_EXTENSIONS = new Set([
  */
 const MIRROR_EXTENSIONS = new Set([".py", ".sh"]);
 
+/**
+ * True for a tracked file that is a script with no extension to key on.
+ *
+ * Keying the scan on `extname` alone made MIRROR_EXTENSIONS an allowlist, and
+ * the repo's shell scripts with the strongest claim to it — `.hooks/commit-msg`,
+ * `.hooks/pre-commit`, `.hooks/pre-push` — have no extension at all. One of them
+ * is already mirrored by path (`.github/scripts/synced-deps.test.mjs` parses
+ * `commit-msg`'s `config="…"` line), so the same gap the hook-timing.sh case
+ * motivated survived one filename convention over. The shebang is what makes it
+ * a script, so that is what the scan asks.
+ * @param {string} path
+ * @returns {boolean}
+ */
+function isExtensionlessScript(path) {
+  return (
+    extname(path) === "" &&
+    readFileSync(join(repoRoot, path), "utf8").startsWith("#!")
+  );
+}
+
 /** Everything the scan is responsible for accounting for. */
 const SCANNED_EXTENSIONS = new Set([...DATA_EXTENSIONS, ...MIRROR_EXTENSIONS]);
 const MODULE_EXTENSIONS = new Set([".cjs", ".js", ".mjs"]);
@@ -539,7 +559,11 @@ function scanGuardedData() {
       seen.add(file);
       const { refs, deps } = analyzeModule(file);
       for (const path of refs) {
-        if (!SCANNED_EXTENSIONS.has(extname(path)) || !tracked.has(path))
+        if (!tracked.has(path)) continue;
+        if (
+          !SCANNED_EXTENSIONS.has(extname(path)) &&
+          !isExtensionlessScript(path)
+        )
           continue;
         if (!readers.has(path)) readers.set(path, new Set());
         readers.get(path).add(test);
@@ -557,7 +581,7 @@ const scanned = scanGuardedData();
 // floor: a path that drops out of the scan drops out of the partition and
 // direction assertions with it, so a resolver regression would quietly narrow
 // all of them at once while staying green.
-const RESOLVED_PATH_COUNT = 51;
+const RESOLVED_PATH_COUNT = 52;
 
 describe("SSOT guard-pair map", () => {
   it("is non-empty and every mapped path exists in the repo", () => {

--- a/test/guard-pairs.test.mjs
+++ b/test/guard-pairs.test.mjs
@@ -8,12 +8,13 @@
  *
  * The map is also checked in the OTHER direction, which is what keeps it from
  * rotting: `scanGuardedData()` below parses every `node --test` file (and the
- * repo modules those tests import) and resolves the repo data files they open.
- * Every data file so found must be either registered in `pairs` or listed in
- * NOT_GUARDED with a reason — a partition. Without that the map is a
- * hand-maintained list one new contract test away from its next gap, and a data
- * file whose guard test exists but is unpaired breaks only in full CI, after
- * the commit the hook was supposed to block.
+ * repo modules those tests import) and resolves the repo files they open by
+ * path — data files (DATA_EXTENSIONS) and the `.sh`/`.py` sources a suite
+ * DRIVES (MIRROR_EXTENSIONS). Every one so found must be either registered in
+ * `pairs` or listed in NOT_GUARDED / NOT_MIRRORED with a reason — a partition.
+ * Without that the map is a hand-maintained list one new contract test away
+ * from its next gap, and a file whose guard test exists but is unpaired breaks
+ * only in full CI, after the commit the hook was supposed to block.
  *
  * The resolution below runs on acorn's AST and Node's own module resolver, not
  * on regexes over source text: "validate against the actual tokenizer/parser,
@@ -99,8 +100,23 @@ const NOT_GUARDED = {
   "plugin/requirements.txt": "only reader is the ~55s plugin-bundle test",
 };
 
+/**
+ * Scanned SOURCE mirrors (`.sh`/`.py` opened by path) deliberately kept out of
+ * the pair map, with the reason — the MIRROR_EXTENSIONS counterpart of
+ * NOT_GUARDED, held separate so the two kinds of excuse cannot be confused.
+ *
+ * Empty today: every script a suite drives by path is cheap enough to run at
+ * commit time (the slowest, `.github/scripts/auto-resolve/prepare.test.mjs`, is
+ * ~8s — well inside the tolerance the already-paired ~13s
+ * `scripts/version-bump.test.mjs` sets). It exists so the partition assertion
+ * below has something to tell a contributor to do when one is not.
+ *
+ * @type {Record<string, string>}
+ */
+const NOT_MIRRORED = {};
+
 // Extensions of the files the map is FOR: data a test mirrors or validates.
-// Source modules are excluded on purpose — every test imports the module it
+// JS modules are excluded on purpose — every test imports the module it
 // exercises, so pairing those would run most of the suite on every commit, and
 // a module that moves already fails loudly at import resolution.
 const DATA_EXTENSIONS = new Set([
@@ -116,6 +132,29 @@ const DATA_EXTENSIONS = new Set([
   ".yaml",
   ".yml",
 ]);
+
+/**
+ * Extensions of SOURCE files a test reaches BY PATH rather than by import.
+ *
+ * The "source modules need no pair" rationale above is about import resolution:
+ * a `.mjs` that moves or is renamed takes its own suite down at load time, so
+ * the pair would be redundant. A `.sh` or `.py` driven through `execFileSync`
+ * gets none of that. It is read as a string path, and a test that mirrors its
+ * behaviour (`test/hook-timing-shell-parity.test.mjs` runs the shell port of the
+ * hook timer and byte-compares it against the node one) is exactly the cheap
+ * guard the map exists to schedule — but while the scan was keyed on
+ * DATA_EXTENSIONS alone the pair could not even be proposed, and editing
+ * `plugin/scripts/lib/hook-timing.sh` left the hook exiting 0 having run
+ * nothing while full CI went 25 tests red.
+ *
+ * So these join the partition. They keep a SEPARATE exemption map (NOT_MIRRORED)
+ * from the data one: "no test mirrors this script" and "no test validates this
+ * data file" are different excuses and should not share a list.
+ */
+const MIRROR_EXTENSIONS = new Set([".py", ".sh"]);
+
+/** Everything the scan is responsible for accounting for. */
+const SCANNED_EXTENSIONS = new Set([...DATA_EXTENSIONS, ...MIRROR_EXTENSIONS]);
 const MODULE_EXTENSIONS = new Set([".cjs", ".js", ".mjs"]);
 
 // Node types that open a lexical scope. Shadowing has to be honoured or a
@@ -281,6 +320,58 @@ function resolvePath(node, file, scope) {
 
 const mapPath = (path, fn) => (path === null ? null : fn(path));
 
+/**
+ * The repo-root read helper: `const read = (p) => readFileSync(join(root, p))`.
+ *
+ * A test that defines one names its data as a BARE relative string at every call
+ * site (`read("THREAT-MODEL.md")`), which every other arm of `resolvePath`
+ * correctly declines — a literal is not a path expression. So the file dropped
+ * out of the scan and out of the partition with it, and
+ * `test/threat-model-layers.test.mjs` guarded a doc the hook would never
+ * schedule it for.
+ *
+ * Returns the base the single parameter is joined onto, or null. Deliberately
+ * narrow: exactly one parameter, and somewhere in the body a two-argument
+ * `join`/`resolve` whose SECOND argument is that parameter and whose first
+ * resolves to a repo path. A helper that decorates its argument, or joins more
+ * than the one segment, is not recognised and its reads stay unresolved —
+ * precision over recall, as everywhere else in this resolver.
+ *
+ * @param {object} fn arrow/function node
+ * @param {string} file repo-relative path of the module it appears in
+ * @param {object} scope scope the helper is DEFINED in (its parameter is not in it)
+ * @returns {string|null}
+ */
+function rootHelperBase(fn, file, scope) {
+  if (fn.params?.length !== 1 || fn.params[0].type !== "Identifier")
+    return null;
+  const parameter = fn.params[0].name;
+  const search = (node) => {
+    if (node.type === "CallExpression") {
+      const bare = calleeName(node.callee)?.replace(/^path\./, "");
+      const [first, second] = node.arguments;
+      if (
+        (bare === "join" || bare === "resolve") &&
+        node.arguments.length === 2 &&
+        second.type === "Identifier" &&
+        second.name === parameter
+      ) {
+        const base = resolvePath(first, file, scope);
+        if (base !== null) return base;
+      }
+    }
+    for (const value of Object.values(node)) {
+      for (const child of Array.isArray(value) ? value : [value]) {
+        if (!child || typeof child.type !== "string") continue;
+        const found = search(child);
+        if (found !== null) return found;
+      }
+    }
+    return null;
+  };
+  return search(fn.body);
+}
+
 /** Every identifier a binding pattern introduces. */
 function patternNames(node, out = []) {
   if (node.type === "Identifier") out.push(node.name);
@@ -328,9 +419,19 @@ function visit(node, scope, ctx) {
       if (path !== null) ctx.refs.add(path);
       visit(node.init, scope, ctx);
     }
+    // A rebinding always writes all three maps, null included: a name that used
+    // to hold a helper and now holds something else must stop resolving, not
+    // fall through to the stale outer entry.
+    const helper =
+      single &&
+      (node.init.type === "ArrowFunctionExpression" ||
+        node.init.type === "FunctionExpression")
+        ? rootHelperBase(node.init, ctx.file, scope)
+        : null;
     for (const name of names) {
       scope.vars.set(name, path);
       scope.strings.set(name, single ? staticString(node.init, scope) : null);
+      scope.helpers.set(name, helper);
     }
     return;
   }
@@ -339,17 +440,31 @@ function visit(node, scope, ctx) {
       const path = resolvePath(argument, ctx.file, scope);
       if (path !== null) ctx.refs.add(path);
     }
-  if (node.type === "FunctionDeclaration" && node.id)
+  if (node.type === "CallExpression" && node.arguments.length === 1) {
+    const base = lookup(scope, "helpers", calleeName(node.callee) ?? "");
+    const literal = staticString(node.arguments[0], scope);
+    if (base !== null && literal !== null)
+      ctx.refs.add(normalize(join(base, literal)));
+  }
+  if (node.type === "FunctionDeclaration" && node.id) {
     scope.vars.set(node.id.name, null);
+    scope.helpers.set(node.id.name, rootHelperBase(node, ctx.file, scope));
+  }
 
   const inner = SCOPE_NODES.has(node.type)
-    ? { vars: new Map(), strings: new Map(), parent: scope }
+    ? {
+        vars: new Map(),
+        strings: new Map(),
+        helpers: new Map(),
+        parent: scope,
+      }
     : scope;
   if (node.params)
     for (const param of node.params)
       for (const name of patternNames(param)) {
         inner.vars.set(name, null);
         inner.strings.set(name, null);
+        inner.helpers.set(name, null);
       }
 
   for (const value of Object.values(node)) {
@@ -369,6 +484,7 @@ function analyzeModule(file) {
   const result = {
     vars: new Map(),
     strings: new Map(),
+    helpers: new Map(),
     refs: new Set(),
     deps: [],
   };
@@ -380,7 +496,12 @@ function analyzeModule(file) {
     allowHashBang: true,
     allowReturnOutsideFunction: true,
   });
-  const scope = { vars: result.vars, strings: result.strings, parent: null };
+  const scope = {
+    vars: result.vars,
+    strings: result.strings,
+    helpers: result.helpers,
+    parent: null,
+  };
 
   // Imports first, so a binding is resolved wherever the body uses it.
   for (const node of ast.body) {
@@ -418,7 +539,8 @@ function scanGuardedData() {
       seen.add(file);
       const { refs, deps } = analyzeModule(file);
       for (const path of refs) {
-        if (!DATA_EXTENSIONS.has(extname(path)) || !tracked.has(path)) continue;
+        if (!SCANNED_EXTENSIONS.has(extname(path)) || !tracked.has(path))
+          continue;
         if (!readers.has(path)) readers.set(path, new Set());
         readers.get(path).add(test);
       }
@@ -435,7 +557,7 @@ const scanned = scanGuardedData();
 // floor: a path that drops out of the scan drops out of the partition and
 // direction assertions with it, so a resolver regression would quietly narrow
 // all of them at once while staying green.
-const RESOLVED_PATH_COUNT = 31;
+const RESOLVED_PATH_COUNT = 51;
 
 describe("SSOT guard-pair map", () => {
   it("is non-empty and every mapped path exists in the repo", () => {
@@ -555,20 +677,59 @@ describe("guarded-data scan (the map is a checked projection of the tests)", () 
     }
   });
 
-  it("accounts for every scanned data file: pairs and NOT_GUARDED partition it", () => {
+  it("reaches the sources a test drives BY PATH, not only the data it parses", () => {
+    // Non-vacuity for MIRROR_EXTENSIONS and for the repo-root-helper arm of
+    // `resolvePath`. Both were added because a real edit slipped the hook:
+    // touching hook-timing.sh ran no guard while full CI went 25 tests red, and
+    // THREAT-MODEL.md is named only as a bare string handed to a one-argument
+    // `read()` helper, which every other arm correctly declines to resolve.
+    for (const [path, reader] of [
+      [
+        "plugin/scripts/lib/hook-timing.sh",
+        "test/hook-timing-shell-parity.test.mjs",
+      ],
+      [
+        ".github/scripts/auto-resolve/discover.py",
+        ".github/scripts/auto-resolve/discover.test.mjs",
+      ],
+      ["THREAT-MODEL.md", "test/threat-model-layers.test.mjs"],
+    ]) {
+      assert.ok(scanned.has(path), `scan no longer finds ${path}`);
+      assert.ok(
+        scanned.get(path).has(reader),
+        `scan no longer attributes ${path} to ${reader}`,
+      );
+    }
+    // Every mirror extension must still contribute something: a set that
+    // silently stopped matching one of them would narrow the partition below
+    // without changing which named anchors above pass.
+    for (const extension of MIRROR_EXTENSIONS)
+      assert.ok(
+        [...scanned.keys()].some((path) => path.endsWith(extension)),
+        `no ${extension} source is reached any more — MIRROR_EXTENSIONS is decorative`,
+      );
+  });
+
+  it("accounts for every scanned file: pairs, NOT_GUARDED and NOT_MIRRORED partition it", () => {
+    const excused = (path) =>
+      path in pairs || path in NOT_GUARDED || path in NOT_MIRRORED;
     const unaccounted = [...scanned.keys()]
-      .filter((path) => !(path in pairs) && !(path in NOT_GUARDED))
+      .filter((path) => !excused(path))
       .map((path) => `${path} (read by ${[...scanned.get(path)].join(", ")})`);
     assert.deepEqual(
       unaccounted,
       [],
-      "a test reads these data files but nothing pairs them: add each to .hooks/guard-pairs.json (mapped to the test that reads it) or to NOT_GUARDED with a reason",
+      "a test reads these files but nothing pairs them: add each to .hooks/guard-pairs.json (mapped to the test that reads it), or to NOT_GUARDED (data) / NOT_MIRRORED (a .sh/.py source) with a reason",
     );
-    assert.deepEqual(
-      Object.keys(NOT_GUARDED).filter((path) => path in pairs),
-      [],
-      "paths are both paired and NOT_GUARDED",
-    );
+    for (const [name, excuses] of [
+      ["NOT_GUARDED", NOT_GUARDED],
+      ["NOT_MIRRORED", NOT_MIRRORED],
+    ])
+      assert.deepEqual(
+        Object.keys(excuses).filter((path) => path in pairs),
+        [],
+        `paths are both paired and ${name}`,
+      );
   });
 
   it("pairs each scanned data file with a test that actually reads it", () => {
@@ -586,13 +747,18 @@ describe("guarded-data scan (the map is a checked projection of the tests)", () 
     );
   });
 
-  it("has no stale NOT_GUARDED entries", () => {
-    assert.deepEqual(
-      Object.keys(NOT_GUARDED).filter((path) => !scanned.has(path)),
-      [],
-      "NOT_GUARDED lists paths no test reads any more — delete them",
-    );
-    for (const [path, reason] of Object.entries(NOT_GUARDED))
-      assert.ok(reason.length > 10, `NOT_GUARDED[${path}] needs a real reason`);
+  it("has no stale NOT_GUARDED / NOT_MIRRORED entries", () => {
+    for (const [name, excuses] of [
+      ["NOT_GUARDED", NOT_GUARDED],
+      ["NOT_MIRRORED", NOT_MIRRORED],
+    ]) {
+      assert.deepEqual(
+        Object.keys(excuses).filter((path) => !scanned.has(path)),
+        [],
+        `${name} lists paths no test reads any more — delete them`,
+      );
+      for (const [path, reason] of Object.entries(excuses))
+        assert.ok(reason.length > 10, `${name}[${path}] needs a real reason`);
+    }
   });
 });

--- a/test/lint-scope.test.mjs
+++ b/test/lint-scope.test.mjs
@@ -1,0 +1,94 @@
+/**
+ * `pnpm lint` covers the automation layer, not just the library.
+ *
+ * `eslint.config.mjs` used to ignore `.github/**`, `.hooks/**` and `.claude/**`
+ * wholesale on the grounds that "the template's automation scripts carry their
+ * own conventions". The effect was that `pnpm lint` linted ZERO of the ~50 JS
+ * files there — four hook modules that run inside a Claude session, three
+ * CommonJS scripts that run in CI holding a token, and every suite under
+ * `.github/scripts`. Un-ignoring them surfaced five real errors on the first
+ * run (four dead initialisers and a `throw` that dropped its cause).
+ *
+ * An `ignores` entry is one line, so the cheapest way to make a lint failure go
+ * away is to re-add it — and nothing would notice. This asks ESLint itself
+ * whether it would lint each file, so the assertion is about the resolved live
+ * config rather than about the text of it.
+ */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { describe, it } from "node:test";
+import { ESLint } from "eslint";
+
+const REPO_ROOT = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+  encoding: "utf8",
+}).trim();
+
+const tracked = (...pathspecs) =>
+  execFileSync("git", ["ls-files", "--", ...pathspecs], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+  })
+    .split("\n")
+    .filter(Boolean);
+
+const eslint = new ESLint({ cwd: REPO_ROOT });
+
+/** The tracked JS files under the automation directories. */
+const AUTOMATION = tracked(
+  ".github/**.mjs",
+  ".github/**.js",
+  ".github/**.cjs",
+  ".hooks/**.mjs",
+  ".claude/hooks/**.mjs",
+);
+
+describe("lint scope", () => {
+  it("lints every tracked JS file under .github, .hooks and .claude/hooks", async () => {
+    // Non-vacuity: an empty pathspec result would make the loop assert nothing.
+    assert.ok(
+      AUTOMATION.length > 40,
+      `only ${AUTOMATION.length} files matched`,
+    );
+    for (const known of [
+      ".github/scripts/main-health.mjs",
+      ".github/scripts/nightly-fuzz-issue.js",
+      ".hooks/run-guard-pairs.mjs",
+      ".claude/hooks/drop-superseded-ci-events.mjs",
+    ])
+      assert.ok(AUTOMATION.includes(known), `${known} is not tracked`);
+
+    const ignored = [];
+    for (const file of AUTOMATION)
+      if (await eslint.isPathIgnored(file)) ignored.push(file);
+    assert.deepEqual(
+      ignored,
+      [],
+      "eslint.config.mjs ignores these — `pnpm lint` reports them clean without reading them",
+    );
+  });
+
+  it("still applies a real rule set to an automation file", async () => {
+    // isPathIgnored() only proves the file is in scope; a `files:` block that
+    // stopped matching would leave it linted by nothing but the parser, which
+    // reads as green just as convincingly. Lint a snippet AS one of those paths
+    // and require the recommended rules to fire.
+    const [result] = await eslint.lintText(
+      "const unused = 1;\nbadGlobal();\n",
+      {
+        filePath: `${REPO_ROOT}/.github/scripts/lint-scope-probe.mjs`,
+      },
+    );
+    const ruleIds = result.messages.map((m) => m.ruleId).sort();
+    assert.deepEqual(ruleIds, ["no-undef", "no-unused-vars"]);
+  });
+
+  it("does not lint the gitignored worktree copies of the repo", async () => {
+    // The paired negative: `.claude/worktrees/` is a second checkout of this
+    // same tree, so linting it would double every finding at paths that do not
+    // exist on the branch.
+    assert.equal(
+      await eslint.isPathIgnored(".claude/worktrees/agent-x/src/index.mjs"),
+      true,
+    );
+  });
+});

--- a/test/shipped-gates.test.mjs
+++ b/test/shipped-gates.test.mjs
@@ -27,7 +27,12 @@ import { join } from "node:path";
 import { describe, it } from "node:test";
 
 import { expandShards } from "../.github/scripts/expand-shards.mjs";
-import { SCOPES, srcRoots } from "../scripts/coverage.mjs";
+import {
+  assertRatcheted,
+  RATCHET_SLACK,
+  SCOPES,
+  srcRoots,
+} from "../scripts/coverage.mjs";
 import { mutateSpec } from "../scripts/mutate.mjs";
 import {
   hookScope,
@@ -70,6 +75,12 @@ function manifestMjs() {
  * asserted only as `> 0` can be quietly dropped to 1 in a PR that is really
  * about something else, which is precisely the silent weakening this whole
  * change argues against. Raising a floor is equally deliberate: edit both.
+ *
+ * This pins the floor DOWNWARD only. The upward half — a floor left so far
+ * behind the measurement that whole modules could go untested with CI green,
+ * which is exactly what happened while `functions` sat at 72% against a measured
+ * 90% — is enforced at run time by `assertRatcheted` in scripts/coverage.mjs,
+ * because only the coverage run knows the measurement.
  */
 const SRC_FLOORS = {
   lines: 100,
@@ -77,7 +88,7 @@ const SRC_FLOORS = {
   functions: 100,
   statements: 100,
 };
-const HOOK_FLOORS = { lines: 88, branches: 80, functions: 72, statements: 88 };
+const HOOK_FLOORS = { lines: 93, branches: 88, functions: 87, statements: 93 };
 
 /** The hook layer's mutation ratchet, same contract as the coverage floors. */
 const HOOK_SCOPE_BREAK = 30;
@@ -192,6 +203,44 @@ describe("coverage gate covers the shipped set", () => {
       // …then whole-object, so an extra metric cannot sneak in unpinned.
       assert.deepEqual(scope.thresholds, floors);
     }
+  });
+
+  it("fails a floor that has fallen too far behind its measurement", () => {
+    // The ratchet's upward half. Pinned like the floors themselves: widening
+    // the slack retires the check as surely as lowering a floor does, so it
+    // costs a second deliberate edit.
+    assert.equal(RATCHET_SLACK, 6);
+
+    const scope = { name: "probe", thresholds: { lines: 90, functions: 70 } };
+    // Exactly at the limit is still fine; one hundredth past it is not — the
+    // boundary is where an off-by-one would hide.
+    assert.doesNotThrow(() =>
+      assertRatcheted(scope, { lines: 96, functions: 76 }),
+    );
+    assert.throws(
+      () => assertRatcheted(scope, { lines: 96, functions: 76.01 }),
+      /stopped ratcheting[\s\S]*functions: measured 76\.01%, floor 70%/,
+    );
+    // Metrics the summary reports but no floor names (c8 emits `branchesTrue`)
+    // must not be compared against a floor that does not exist.
+    assert.doesNotThrow(() =>
+      assertRatcheted(scope, { lines: 90, functions: 70, branchesTrue: 100 }),
+    );
+    // A floor whose metric the report does not carry gates nothing, so it fails
+    // rather than being skipped — the fail-open this whole script exists to close.
+    assert.throws(
+      () => assertRatcheted(scope, { lines: 100 }),
+      /has a functions floor, but the coverage summary reports no functions/,
+    );
+    // The message has to name BOTH files, or the fix is a scavenger hunt.
+    assert.throws(
+      () => assertRatcheted(scope, { lines: 100, functions: 70 }),
+      (error) => {
+        assert.match(error.message, /scripts\/coverage\.mjs/);
+        assert.match(error.message, /test\/shipped-gates\.test\.mjs/);
+        return true;
+      },
+    );
   });
 
   it("walks a --src root for every directory the shipped set lives in", () => {

--- a/test/test-runner-partition.test.mjs
+++ b/test/test-runner-partition.test.mjs
@@ -230,6 +230,26 @@ describe("test-runner discovery partition", () => {
       assert.ok(!DOT_HOOK_FILES.test(unwanted), `${unwanted} matched the hook`);
   });
 
+  it("checks each derived runner is actually invoked by something", () => {
+    // A claim read from the runner's OWN configuration stays true after nothing
+    // invokes that runner any more: delete the workflow step and
+    // run-script-tests.sh, its pathspec and therefore its claim are all still
+    // there, so its suites run in no job while the partition above stays green.
+    // That is the one-direction gate this file exists to close, one level up.
+    assert.match(
+      WORKFLOWS.map(read).join("\n"),
+      /run-script-tests\.sh/u,
+      "no workflow invokes run-script-tests.sh, so its claim runs nothing",
+    );
+    // `discoveredByDefault` stands in for `pnpm test` reaching `node --test`;
+    // repointing that script would retire the largest claim silently.
+    assert.match(
+      JSON.parse(read("package.json")).scripts.test,
+      /^node scripts\/coverage\.mjs$/u,
+      "`pnpm test` no longer reaches `node --test`, so default discovery claims nothing",
+    );
+  });
+
   it("runs the dot-directory suites rather than merely linting them", () => {
     // `entry: node --test` with pre-commit's default pass_filenames means the
     // matched paths ARE the arguments. Turning that off would hand `node --test`

--- a/test/test-runner-partition.test.mjs
+++ b/test/test-runner-partition.test.mjs
@@ -1,0 +1,289 @@
+/**
+ * Every committed test suite is CLAIMED by a runner that actually executes it.
+ *
+ * `node --test`'s default discovery skips dot-directories. That is not a
+ * hypothetical: planting three always-failing suites — one under `test/`, one
+ * under `.claude/hooks/`, one under `.hooks/` — and running the default
+ * discovery finds exactly the first, and the run goes green with two failing
+ * suites in the tree. `.pre-commit-config.yaml` had even grown an
+ * `exclude: \.test\.mjs$` on its `^\.claude/hooks/.*\.mjs$` lints: the config
+ * anticipated suites in a directory no runner reached.
+ *
+ * The repo answers that for `.github/scripts` (a discovery script), for
+ * `plugin/test` and for the credential-ladder suite (explicit workflow steps),
+ * and now for the dot-hook directories (a pre-commit hook). What nothing did was
+ * check the SET: a suite that lands somewhere none of them look is a file full
+ * of assertions that never run, and it looks exactly like a passing one.
+ *
+ * So this enumerates the runners, derives what each claims FROM ITS OWN
+ * CONFIGURATION (the workflow's `node --test` arguments, the discovery script's
+ * git pathspec, the pre-commit hook's `files:` regex) rather than from a copy
+ * of it here, and asserts the union covers every tracked `*.test.mjs`. Claims
+ * may overlap — `plugin/test/*.test.mjs` is both discovered by `pnpm test` and
+ * named explicitly in the workflow, deliberately — so the assertion is coverage,
+ * not disjointness.
+ */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  globSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+
+const REPO_ROOT = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+  encoding: "utf8",
+}).trim();
+
+const read = (relative) => readFileSync(join(REPO_ROOT, relative), "utf8");
+
+/** Tracked paths matching a git pathspec, repo-relative. */
+const tracked = (...pathspecs) =>
+  execFileSync("git", ["ls-files", "--", ...pathspecs], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+  })
+    .split("\n")
+    .filter(Boolean);
+
+const SUITES = tracked("*.test.mjs");
+
+const WORKFLOWS = tracked(
+  ".github/workflows/*.yaml",
+  ".github/workflows/*.yml",
+);
+
+/**
+ * Whether `path` would be found by `node --test` with no file arguments.
+ *
+ * The rule is Node's, not ours, and `runnerDiscoveryRule` below re-derives it
+ * from a real `node --test` run over a scratch tree — a hardcoded predicate
+ * that Node later changed would silently claim files nothing runs.
+ */
+const discoveredByDefault = (path) =>
+  path.endsWith(".test.mjs") &&
+  !path.split("/").some((segment) => segment.startsWith("."));
+
+/**
+ * The file arguments of every `run: node --test …` step in the workflows.
+ *
+ * Anchored on `run:` so the prose ABOUT `node --test` in node-tests.yaml's
+ * comments (which is where the dot-directory blind spot is explained) is not
+ * mistaken for an invocation.
+ */
+function workflowTestGlobs() {
+  const globs = [];
+  for (const workflow of WORKFLOWS)
+    for (const line of read(workflow).split("\n")) {
+      const run = line.match(/^\s*run:\s*node --test\s+(.*?)\s*$/);
+      if (run) globs.push(...run[1].split(/\s+/));
+    }
+  return globs;
+}
+
+/** The git pathspec the .github/scripts discovery script enumerates. */
+function discoveryPathspec() {
+  const script = read(".github/scripts/run-script-tests.sh");
+  const match = script.match(/git ls-files -- '([^']+)'/);
+  // Fail loud: a rewritten invocation this parser no longer recognises must not
+  // read as "the script claims nothing", which would blame the suites instead.
+  if (!match)
+    throw new Error(
+      "run-script-tests.sh: no `git ls-files -- '<pathspec>'` invocation found",
+    );
+  return match[1];
+}
+
+/**
+ * One local pre-commit hook's body, as a `key: value` map.
+ *
+ * Hand-rolled rather than parsed with a YAML library because the repo has no
+ * YAML dependency (see `pagedWorkflowNames` in .github/scripts/main-health.mjs
+ * for the same trade-off), and deliberately narrow: it takes the lines of one
+ * block-sequence item and throws when the id is absent rather than returning an
+ * empty map that would read as "the hook claims nothing".
+ */
+function precommitHook(id) {
+  const lines = read(".pre-commit-config.yaml").split("\n");
+  const start = lines.findIndex((line) =>
+    new RegExp(`^\\s*- id: ${id}\\s*$`).test(line),
+  );
+  if (start === -1)
+    throw new Error(`.pre-commit-config.yaml: no hook with id ${id}`);
+  const indent = lines[start].match(/^\s*/)[0].length;
+  const body = {};
+  for (const line of lines.slice(start + 1)) {
+    if (/^\s*$/.test(line)) continue;
+    const entry = line.match(/^(\s*)([a-z_]+):\s*(.*?)\s*$/);
+    if (!entry || entry[1].length <= indent) break;
+    body[entry[2]] = entry[3];
+  }
+  return body;
+}
+
+const DOT_HOOK = precommitHook("dot-directory-test-suites");
+const DOT_HOOK_FILES = new RegExp(DOT_HOOK.files);
+
+/** A `claims` predicate over a fixed, eagerly-resolved path list. */
+const memberOf = (paths) => {
+  const set = new Set(paths);
+  return (path) => set.has(path);
+};
+
+/**
+ * Every runner that executes committed suites, and what each one claims.
+ * `claims` is a repo-relative predicate; `where` is what a contributor must edit
+ * to widen it.
+ */
+const RUNNERS = [
+  {
+    name: "pnpm test (node --test default discovery)",
+    where: "package.json scripts.test -> scripts/coverage.mjs",
+    claims: discoveredByDefault,
+  },
+  {
+    // Resolved once: `claims` is called for every suite, and re-shelling out to
+    // git per call turns a set membership test into a hundred subprocesses.
+    name: ".github/scripts/run-script-tests.sh",
+    where: "its git ls-files pathspec",
+    claims: memberOf(tracked(discoveryPathspec())),
+  },
+  {
+    name: "explicit `node --test` workflow steps",
+    where: ".github/workflows/*.yaml",
+    claims: memberOf(
+      workflowTestGlobs().flatMap((pattern) =>
+        globSync(pattern, { cwd: REPO_ROOT }),
+      ),
+    ),
+  },
+  {
+    name: "pre-commit hook dot-directory-test-suites",
+    where: ".pre-commit-config.yaml",
+    claims: (path) => DOT_HOOK_FILES.test(path),
+  },
+];
+
+/** The runners claiming `path`. */
+const claimants = (path) =>
+  RUNNERS.filter((runner) => runner.claims(path)).map((runner) => runner.name);
+
+describe("test-runner discovery partition", () => {
+  it("has a non-empty suite set with a suite in every runner's territory", () => {
+    // Non-vacuity for everything below: an empty SUITES (a broken ls-files, a
+    // pathspec typo) would make the coverage assertion pass over nothing.
+    assert.ok(SUITES.length > 50, `only ${SUITES.length} suites tracked`);
+    for (const known of [
+      "test/guard-pairs.test.mjs",
+      "test/test-runner-partition.test.mjs",
+      ".github/scripts/main-health.test.mjs",
+      ".github/scripts/auto-resolve/lib.test.mjs",
+      ".github/scripts/lib/anthropic-ladder.test.mjs",
+      "plugin/test/plugin-bundle.test.mjs",
+      "scripts/version-bump.test.mjs",
+    ])
+      assert.ok(SUITES.includes(known), `${known} is not a tracked suite`);
+  });
+
+  it("claims every tracked *.test.mjs with at least one runner", () => {
+    const orphans = SUITES.filter((path) => claimants(path).length === 0);
+    assert.deepEqual(
+      orphans,
+      [],
+      "these suites run in NO job — `node --test`'s default discovery skips " +
+        "dot-directories, so a suite there is silently never executed. Register " +
+        "each with a runner: " +
+        RUNNERS.map((r) => `${r.name} (${r.where})`).join("; "),
+    );
+  });
+
+  it("gives every runner something to run", () => {
+    // A runner whose claim set went empty — a glob that stopped matching, a
+    // pathspec that no longer resolves — is the exact failure run-script-tests.sh
+    // exists to fail loud on, and it would leave the assertion above passing
+    // because some OTHER runner happens to cover the same files.
+    for (const runner of RUNNERS.filter(
+      (r) => r.name !== "pre-commit hook dot-directory-test-suites",
+    )) {
+      const claimed = SUITES.filter(runner.claims);
+      assert.ok(claimed.length > 0, `${runner.name} claims no suite`);
+    }
+    // The dot-directory hook legitimately claims nothing TODAY (no suite lives
+    // there yet), so its predicate is proven against fixed inputs instead — the
+    // regex has to work on the day the first such suite lands.
+    for (const wanted of [
+      ".claude/hooks/drop-superseded-ci-events.test.mjs",
+      ".hooks/run-guard-pairs.test.mjs",
+    ])
+      assert.ok(DOT_HOOK_FILES.test(wanted), `${wanted} would not be run`);
+    for (const unwanted of [
+      ".claude/hooks/drop-superseded-ci-events.mjs",
+      "test/guard-pairs.test.mjs",
+      ".github/scripts/main-health.test.mjs",
+    ])
+      assert.ok(!DOT_HOOK_FILES.test(unwanted), `${unwanted} matched the hook`);
+  });
+
+  it("runs the dot-directory suites rather than merely linting them", () => {
+    // `entry: node --test` with pre-commit's default pass_filenames means the
+    // matched paths ARE the arguments. Turning that off would hand `node --test`
+    // no files, which falls back to default discovery — the very blind spot this
+    // hook exists to cover, reported as a pass.
+    assert.equal(DOT_HOOK.entry, "node --test");
+    assert.equal(DOT_HOOK.pass_filenames, undefined);
+    assert.equal(DOT_HOOK.language, "system");
+  });
+
+  it("derives the default-discovery rule from a real `node --test` run", () => {
+    // The one claim with no configuration to read: Node's own discovery. Driven
+    // over a scratch tree so `discoveredByDefault` is checked against the runner
+    // rather than against a memory of its documentation.
+    const scratch = mkdtempSync(join(tmpdir(), "runner-discovery-"));
+    try {
+      const planted = [
+        "visible/a.test.mjs",
+        "nested/deep/b.test.mjs",
+        ".dothooks/c.test.mjs",
+        "outer/.inner/d.test.mjs",
+        "visible/not-a-suite.mjs",
+      ];
+      for (const path of planted) {
+        mkdirSync(join(scratch, dirname(path)), { recursive: true });
+        // Each names itself, so the reporter output identifies exactly which
+        // files the runner reached.
+        writeFileSync(
+          join(scratch, path),
+          `import { test } from "node:test";\ntest(${JSON.stringify(path)}, () => {});\n`,
+        );
+      }
+      // NODE_TEST_CONTEXT is inherited from THIS run and would switch the child
+      // to the v8-serialized child-process protocol, whose output carries none
+      // of these names — the discovery set would read as empty and the equality
+      // below would hold vacuously against an empty expectation.
+      const env = { ...process.env };
+      delete env.NODE_TEST_CONTEXT;
+      const stdout = execFileSync(
+        process.execPath,
+        ["--test", "--test-reporter=tap"],
+        { cwd: scratch, encoding: "utf8", env },
+      );
+      const found = planted.filter((path) => stdout.includes(path));
+      assert.deepEqual(
+        found.sort(),
+        planted.filter(discoveredByDefault).sort(),
+        "node --test's default discovery no longer matches discoveredByDefault",
+      );
+      // Non-vacuity: the equality above would also hold if BOTH sides were
+      // empty, which is what a runner that found nothing looks like.
+      assert.ok(found.length > 0, "node --test discovered nothing at all");
+    } finally {
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Claimed area: `.hooks/guard-pairs.json`, `scripts/coverage.mjs`, `eslint.config.mjs`, `.pre-commit-config.yaml`, `.github/workflows/{ci-failure-notify,fuzz-nightly}.yaml`, `.github/scripts/**`, and the guard suites under `test/`. File-disjoint from PR #278 (detection layer) and PR #279 (fail-open posture).

## Summary

Five findings from the same ten-scope eliminator audit. Every one is a **one-direction gate**: a check that fires when something drops below a line, and is silent when the surface it is supposed to cover grows past it. Each is replaced by a partition assertion — the guarded set ∪ the exempt set must equal the live surface, in both directions.

**1. Guard-pair scanning ignored `.sh`/`.py` sources read by path.** The scan behind `.hooks/guard-pairs.json` accounted only for `DATA_EXTENSIONS`, so a shell script or Python module a suite *drives* was outside the partition entirely. Editing `plugin/scripts/lib/hook-timing.sh` left `node .hooks/run-guard-pairs.mjs` exiting 0 having run nothing, while `test/hook-timing-shell-parity.test.mjs` went 25 tests red in full CI. Adds `MIRROR_EXTENSIONS` with its own `NOT_MIRRORED` exemption map, and teaches `resolvePath` the one-argument repo-root helper idiom (`const read = (p) => readFileSync(join(repoRoot, p))`) that had hidden `THREAT-MODEL.md` from the scan. 19 newly-visible pairs registered; `RESOLVED_PATH_COUNT` 31 → 51. JS modules stay out on purpose: a moved `.mjs` already fails loudly at import resolution, which is what the exclusion was ever about.

**2. A committed test suite could run in no job at all.** `node --test`'s default discovery skips dot-directories, so a `*.test.mjs` under `.claude/hooks/` or `.hooks/` ran **nowhere** — verified by planting always-failing suites there and watching the default run stay green. `.pre-commit-config.yaml` already carried `exclude: \.test\.mjs$` on its `.claude/hooks` lints, anticipating suites in a directory nothing reached. Adds a discovery-partition guard that derives each runner's claim from its own configuration (the workflow's `node --test` arguments, `run-script-tests.sh`'s git pathspec, the pre-commit hook's `files:` regex) and fails when a tracked suite is claimed by none, plus the pre-commit hook that actually runs the dot-directory suites. The default-discovery rule is re-derived from a real `node --test` run over a scratch tree rather than hardcoded.

**3. `pnpm lint` linted 0 of the 52 JS files in the automation layer.** `eslint.config.mjs` ignored `.github/**`, `.hooks/**` and `.claude/**` on the grounds that they "carry their own conventions" — including four hook modules that run inside a Claude session and three CommonJS scripts that run in CI with a token. Un-ignoring them surfaced **five real errors**, all fixed here: four dead initialisers (`no-useless-assignment`) and a `throw` inside a `catch` that dropped its cause (`preserve-caught-error`). Adds a CommonJS block for `.github/scripts/*.js` and a guard that asks ESLint itself whether each automation file is in scope, so a one-line `ignores` entry cannot silently retire the coverage.

**4. The coverage ratchet only ratcheted downward.** c8 fails when a measurement drops below the floor and is silent however far above it climbs, so the hook floor had drifted to 72% functions against a measured 90.15% — room for 47 shipped functions and 608 lines to become entirely untested with CI green, while `CONTRIBUTING.md` said the ratchet "should only ever move up". Adds `assertRatcheted()`: after each report pass, fail when `measured - floor` exceeds `RATCHET_SLACK`, naming both files to edit. Raises the hook floors to ~3 points under the live measurement (93/88/87/93) in the same commit, in `coverage.mjs` and in `shipped-gates`' exact-equality pin, so lowering one still costs two edits.

**5. Post-merge failures that reached nobody.** `ci-failure-notify.yaml` claimed "a ci-truth-serum hook (`check-failure-notifier-coverage`) keeps this list in sync with the tree". No such hook exists — the pinned rev provides 18 `check-*` ids and none references this file. The gap it was credited with closing was live: 22 workflows have a push-to-main or `schedule:` trigger and the roster named 19, so **Mutation tests**, **Pack smoke test** and **Nightly unseeded fuzz** could fail on main indefinitely and page no one. Rosters the two push-to-main workflows, marks the schedule-only fuzz nightly `# failure-notify-exempt:` in its own yaml, corrects the false comment to name what enforces this now, and adds the contract test asserting the partition in both directions.

## Tests / verification

Run on this branch:

- `pnpm test` (full suite + both coverage floors + the new ratchet check) → **rc 0**
- `uv run --extra dev python -m pytest tests/ -q` → **2220 passed, 5 skipped**
- `pnpm lint` → clean, with the automation layer now in scope

Each guard was shown to fail before its fix: the dot-directory suites were proven unreachable by planting failing suites; the guard-pair gap was proven by editing `hook-timing.sh` and watching the runner exit 0 while the parity suite went red.

## Decisions made

- **`RATCHET_SLACK = 6`, not an exactly-pinned floor.** The documented headroom is real: hooks that Claude Code drives as subprocesses execute the committed `plugin/dist` bundle, so those lines are attributed to the bundle and the ratio moves when a file merely grows. 6 absorbs that while still being far smaller than the 18-point gap that accumulated unnoticed, and the failure it raises is a two-line edit, not a debugging session.
- **JS modules stay outside the guard-pair mirror scan.** A moved `.mjs` already fails loudly at import resolution; adding it would be redundant surface.
- **The fuzz nightly is exempt from failure-notify rather than rostered.** It is already routed to a deduped issue, and paging on it would latch main-health's level alert. Marked with a reason in its own yaml so the exemption is visible where the workflow is read.
- **`.claude/worktrees/**` stays ESLint-ignored.** It is a second, gitignored copy of the whole repo; linting it would double every finding and report them at paths that do not exist on the branch.

## Checklist

- [x] Commits follow Conventional Commits; each subject reads as a user-facing release note.
- [x] `pnpm test`, `pnpm lint` pass on this branch.
- [x] Guards are non-vacuous — each was shown failing before its fix.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version left untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_013gUCEpudVMyzHF5K6BLQaw)_