### PR TITLE
fix: green main again after the #279/#280 semantic merge conflict

### DIFF
--- a/.github/scripts/main-health.mjs
+++ b/.github/scripts/main-health.mjs
@@ -38,10 +38,14 @@ import { fileURLToPath } from "node:url";
 // misses this constant fails the guard instead of silently disabling it.
 export const SELF_WORKFLOW_PATH = ".github/workflows/main-health.yaml";
 
-// The SSOT for which workflows are worth paging a human about. Read at runtime
-// so the two alerts cannot drift; a ci-truth-serum pre-commit hook
-// (check-failure-notifier-coverage) already keeps this list honest against the
-// tree, so intersecting against it inherits that maintenance for free.
+// The SSOT for which workflows are worth paging a human about — genuinely one
+// source, read at runtime rather than restated here, so the two alerts cannot
+// drift. This used to credit a ci-truth-serum pre-commit hook
+// (check-failure-notifier-coverage) with keeping the roster honest against the
+// tree; no such hook exists. What actually holds the roster to the tree is
+// test/failure-notify-roster.test.mjs, whose partition assertion requires every
+// push-to-main/`schedule:` workflow to be rostered or exempt in its own yaml —
+// so intersecting against it inherits THAT maintenance, not a phantom hook's.
 export const NOTIFIER_WORKFLOW_PATH =
   ".github/workflows/ci-failure-notify.yaml";
 

--- a/.hooks/guard-pairs.json
+++ b/.hooks/guard-pairs.json
@@ -123,6 +123,9 @@
       "plugin/test/enable-auto-update.test.mjs"
     ],
     "plugin/README.md": ["plugin/test/plugin-manifest.test.mjs"],
+    "plugin/scripts/lib/fail-open.sh": [
+      "plugin/test/fail-open-parity.test.mjs"
+    ],
     "plugin/scripts/lib/hook-timing.sh": [
       "test/hook-timing-shell-parity.test.mjs"
     ],

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -37,14 +37,14 @@ if ! git diff --quiet; then
   fi
 fi
 
-# SSOT guard-test pairing: when a mapped SSOT source is staged, run its cheap
+# Guard-test pairing: when a mapped source is staged, run its cheap
 # paired contract test(s) (map: .hooks/guard-pairs.json) so the data and its
 # guard can only change together — this repo has twice broken main by editing a
 # guarded source without its test. Ahead of the Node-project gate below: the map
 # guards data of any language, so a repo without a package.json still wants it.
 if [[ -f "$git_root/.hooks/guard-pairs.json" ]]; then
   if ! command -v node >/dev/null 2>&1; then
-    gate_die_missing_tool pre-commit node "install Node so the paired SSOT guard tests can run, then retry the commit."
+    gate_die_missing_tool pre-commit node "install Node so the paired guard tests can run, then retry the commit."
   fi
   staged_files=()
   while IFS= read -r line; do staged_files+=("$line"); done < <(git diff --cached --name-only --diff-filter=ACMRD)

--- a/.hooks/run-guard-pairs.mjs
+++ b/.hooks/run-guard-pairs.mjs
@@ -1,11 +1,16 @@
 #!/usr/bin/env node
 /**
- * SSOT guard-test pairing: run the cheap contract test(s) paired with each
- * staged SSOT source (pairs live in .hooks/guard-pairs.json) and exit
- * non-zero if any fails — so "edited the data, forgot its guard test" is
- * caught at commit time instead of as a red main. Invoked by .hooks/pre-commit
- * with the staged paths as argv; only tests whose paired source is staged run,
- * keeping the added latency to ~1s per touched SSOT.
+ * Guard-test pairing: run the cheap contract test(s) paired with each staged
+ * source (pairs live in .hooks/guard-pairs.json) and exit non-zero if any
+ * fails — so "edited the data, forgot its guard test" is caught at commit time
+ * instead of as a red main. Invoked by .hooks/pre-commit with the staged paths
+ * as argv; only tests whose paired source is staged run, keeping the added
+ * latency to ~1s per touched source.
+ *
+ * A pair is a GUARD, not an SSOT — guard-pairs.json's own header says so, and
+ * the distinction is the point: the map does not derive anything, it says "run
+ * this check when that file changes". Calling it an SSOT would launder the very
+ * smell a drift guard exists to expose.
  *
  * A guard test is either a `node --test` file (`*.test.mjs`) or a pytest module
  * (`test_*.py`), dispatched by extension. Both are supported because the map

--- a/.hooks/run-guard-pairs.mjs
+++ b/.hooks/run-guard-pairs.mjs
@@ -40,11 +40,11 @@ if (testsToRun.size === 0) process.exit(0);
 
 const files = [...testsToRun].sort();
 console.error(
-  `pre-commit: staged SSOT source(s) — running paired guard test(s): ${files.join(", ")}`,
+  `pre-commit: staged guarded source(s) — running paired guard test(s): ${files.join(", ")}`,
 );
 
 // One runner invocation per language, each over all of its files, so a commit
-// touching both a JS-guarded and a Python-guarded SSOT pays two process starts
+// touching both a JS-guarded and a Python-guarded source pays two process starts
 // rather than one per test.
 const RUNNERS = [
   {
@@ -64,7 +64,7 @@ const RUNNERS = [
 
 // The runners must PARTITION the guard tests. A path matching none of them
 // would otherwise fall through the loop below and the hook would exit 0 having
-// run nothing — a silent no-op for exactly the SSOT the pair was added to
+// run nothing — a silent no-op for exactly the source the pair was added to
 // protect. test/guard-pairs.test.mjs pins the value domain, but it only runs in
 // CI and when guard-pairs.json itself is staged, so the hook checks here too.
 const unclaimed = files.filter(
@@ -98,7 +98,7 @@ for (const runner of RUNNERS) {
   if (result.error) throw result.error;
   if (result.status !== 0) {
     console.error(
-      "pre-commit: a paired SSOT guard test failed — update the guard test in the SAME commit as its data (see CLAUDE.md, Testing).",
+      "pre-commit: a paired guard test failed — update the guard test in the SAME commit as its data (see CLAUDE.md, Testing).",
     );
     process.exit(result.status ?? 1);
   }

--- a/test/guard-pairs.test.mjs
+++ b/test/guard-pairs.test.mjs
@@ -1,8 +1,8 @@
 /**
- * Contract test for the SSOT guard-pair map (.hooks/guard-pairs.json)
+ * Contract test for the guard-pair map (.hooks/guard-pairs.json)
  * that the pre-commit hook uses to run a source's paired contract test in the
  * same commit as the source. A pair pointing at a moved/renamed file would
- * make the hook a silent no-op for exactly the SSOT it was added to protect,
+ * make the hook a silent no-op for exactly the source it was added to protect,
  * so every path is asserted to exist, and the two pairings that actually broke
  * main are pinned by name (non-vacuity: an emptied map cannot pass).
  *
@@ -93,7 +93,7 @@ const tracked = new Set(listFiles());
 const NOT_GUARDED = {
   // plugin/test/plugin-bundle.test.mjs is the only test that reads these three,
   // and it stages the whole plugin and provisions a Python venv — ~55s on a warm
-  // checkout, against the hook's ~1s-per-touched-SSOT budget. Pairing it would
+  // checkout, against the hook's ~1s-per-touched-source budget. Pairing it would
   // make every plugin edit unbearable at commit time; CI runs it instead.
   "plugin/hooks/hooks.json": "only reader is the ~55s plugin-bundle test",
   "plugin/requirements.in": "only reader is the ~55s plugin-bundle test",
@@ -583,14 +583,14 @@ const scanned = scanGuardedData();
 // all of them at once while staying green.
 const RESOLVED_PATH_COUNT = 53;
 
-describe("SSOT guard-pair map", () => {
+describe("guard-pair map", () => {
   it("is non-empty and every mapped path exists in the repo", () => {
     const entries = Object.entries(pairs);
     assert.ok(entries.length > 0, "pair map must not be empty");
     for (const [source, tests] of entries) {
       assert.ok(
         existsSync(join(repoRoot, source)),
-        `mapped SSOT source does not exist: ${source}`,
+        `mapped source does not exist: ${source}`,
       );
       assert.ok(
         Array.isArray(tests) && tests.length > 0,

--- a/test/guard-pairs.test.mjs
+++ b/test/guard-pairs.test.mjs
@@ -581,7 +581,7 @@ const scanned = scanGuardedData();
 // floor: a path that drops out of the scan drops out of the partition and
 // direction assertions with it, so a resolver regression would quietly narrow
 // all of them at once while staying green.
-const RESOLVED_PATH_COUNT = 52;
+const RESOLVED_PATH_COUNT = 53;
 
 describe("SSOT guard-pair map", () => {
   it("is non-empty and every mapped path exists in the repo", () => {

--- a/tests/test_hook_fail_closed.py
+++ b/tests/test_hook_fail_closed.py
@@ -221,12 +221,12 @@ def test_pre_commit_passes_without_package_json(tmp_path: Path) -> None:
 
 
 # --------------------------------------------------------------------------- #
-# pre-commit: staged SSOT source runs its paired guard test and blocks the
+# pre-commit: a staged guarded source runs its paired guard test and blocks the
 # commit when the guard fails (map: .hooks/guard-pairs.json).
 # --------------------------------------------------------------------------- #
 
 
-def _sandbox_ssot_repo(tmp_path: Path, guard_body: str) -> Path:
+def _sandbox_guarded_repo(tmp_path: Path, guard_body: str) -> Path:
     repo = init_repo(tmp_path)
     binp = repo / "node_modules" / ".bin"
     binp.mkdir(parents=True)
@@ -244,9 +244,9 @@ def _sandbox_ssot_repo(tmp_path: Path, guard_body: str) -> Path:
     return repo
 
 
-def _run_pre_commit_ssot(repo: Path, tmp_path: Path) -> subprocess.CompletedProcess:
+def _run_pre_commit_guarded(repo: Path, tmp_path: Path) -> subprocess.CompletedProcess:
     # node for the guard runner; no pnpm/npm so lint-staged (a stub) runs via
-    # the direct-binary branch, keeping the test about the SSOT guard wiring.
+    # the direct-binary branch, keeping the test about the guard-pair wiring.
     path = curated_path(tmp_path, BASE_TOOLS + ["node"])
     return subprocess.run(
         ["bash", str(REPO_ROOT / ".hooks" / "pre-commit")],
@@ -257,27 +257,27 @@ def _run_pre_commit_ssot(repo: Path, tmp_path: Path) -> subprocess.CompletedProc
     )
 
 
-def test_pre_commit_blocks_when_paired_ssot_guard_fails(tmp_path: Path) -> None:
-    repo = _sandbox_ssot_repo(
+def test_pre_commit_blocks_when_paired_guard_fails(tmp_path: Path) -> None:
+    repo = _sandbox_guarded_repo(
         tmp_path,
         'import { test } from "node:test";\n'
         'import assert from "node:assert";\n'
         'test("guard", () => assert.fail("contract broken"));\n',
     )
-    result = _run_pre_commit_ssot(repo, tmp_path)
+    result = _run_pre_commit_guarded(repo, tmp_path)
     assert result.returncode != 0, (
         "a failing paired guard test must block the commit\n" + result.stderr
     )
-    assert "SSOT guard test failed" in result.stderr
+    assert "paired guard test failed" in result.stderr
 
 
-def test_pre_commit_passes_when_paired_ssot_guard_passes(tmp_path: Path) -> None:
+def test_pre_commit_passes_when_paired_guard_passes(tmp_path: Path) -> None:
     # Positive control: same wiring, green guard — proves the block above comes
     # from the guard's verdict, not from broken plumbing.
-    repo = _sandbox_ssot_repo(
+    repo = _sandbox_guarded_repo(
         tmp_path,
         'import { test } from "node:test";\ntest("guard", () => {});\n',
     )
-    result = _run_pre_commit_ssot(repo, tmp_path)
+    result = _run_pre_commit_guarded(repo, tmp_path)
     assert result.returncode == 0, result.stderr
     assert "running paired guard test" in result.stderr

--- a/tests/test_hook_fail_closed.py
+++ b/tests/test_hook_fail_closed.py
@@ -280,4 +280,9 @@ def test_pre_commit_passes_when_paired_guard_passes(tmp_path: Path) -> None:
     )
     result = _run_pre_commit_guarded(repo, tmp_path)
     assert result.returncode == 0, result.stderr
+    # Both operator-facing strings are pinned, not just the one this rename left
+    # alone: matching only "running paired guard test" would stay green through a
+    # revert of "staged guarded source(s)". ASCII-only on purpose — `text=True`
+    # decodes stderr with the locale codec, so matching the em dash is fragile.
+    assert "staged guarded source(s)" in result.stderr
     assert "running paired guard test" in result.stderr


### PR DESCRIPTION
Claimed area: `.hooks/{guard-pairs.json,pre-commit,run-guard-pairs.mjs}`, `test/guard-pairs.test.mjs`, `tests/test_hook_fail_closed.py`, `.github/scripts/main-health.mjs`.

## main is red

`test/guard-pairs.test.mjs` fails on `main` at 02e5ab8:

```
scan resolved 53 data files, expected 52
a test reads these files but nothing pairs them:
  plugin/scripts/lib/fail-open.sh (read by plugin/test/fail-open-parity.test.mjs)
```

Neither PR was wrong on its own base. #279 added the generated shell lib and its parity test; #280 taught the guarded-data scan to see `.sh`/`.py` sources at all. #279 merged first, so #280's branch never saw the file its new scanner would go on to find. Each was green when it merged; their union is red.

That is the semantic merge conflict `RESOLVED_PATH_COUNT` exists to catch, working exactly as designed — the pin is a hand-maintained number precisely so a new read cannot land unremarked. Registering the pair and bumping 52 → 53 is the whole fix.

## Also in here

**The guard-pair map is not an SSOT, and five places said it was.** It derives nothing: a pair says "run this check when that file changes", which is a guard over two things that must agree. `guard-pairs.json`'s own header already made this exact point —

> These are GUARDS, not an SSOT ... naming it otherwise would launder the very smell a drift guard should expose

— while `.hooks/pre-commit`, `.hooks/run-guard-pairs.mjs`, `test/guard-pairs.test.mjs` and `tests/test_hook_fail_closed.py` all contradicted it, including in the two strings a contributor actually reads at commit time. Renamed to "staged guarded source(s)" and "a paired guard test failed"; the Python test pins those strings so it moves in the same commit.

**A false claim in `main-health.mjs`.** Its roster comment credited a ci-truth-serum pre-commit hook (`check-failure-notifier-coverage`) with keeping the notify list honest against the tree. No such hook exists — #280 established that and corrected the twin comment in `ci-failure-notify.yaml`, but this second copy was missed. Now names what actually enforces it (`test/failure-notify-roster.test.mjs`'s partition). The `SSOT` label on the constant itself is correct and stays: the path is read at runtime, not restated.

## Tests / verification

- `node --test 'test/*.test.mjs'` → **3473 passed, 0 failed** (fails on `main` without this)
- `uv run --extra dev python -m pytest tests/test_hook_fail_closed.py -q` → **9 passed**
- Red-before-green confirmed by stashing: the two failures reproduce on unmodified `main`.

## Decisions made

- **Bumped the pin rather than loosening it to a floor.** A `>=` floor would never break on a merge like this one — and a one-direction gate is the exact genre #280 spent five findings removing.
- **Kept `SSOT` where it is accurate.** `main-health.mjs`'s `NOTIFIER_WORKFLOW_PATH`, `config/review-severities.json`, `lib/shared-names.json` and the `on.push.paths` parse are all read at runtime by their consumers. Only the guard-pair map was mislabelled.

## Lessons Learned

- **What to change:** in `CLAUDE.md`'s Testing section, extend the drift-guard rule to name the two-PR case explicitly — a hand-pinned count or roster in one PR and a scanner widening in another can each be green on their own base and red on the merge, so a PR that widens what a scan resolves should rebase onto the latest default branch before its final CI run rather than trusting a stale base.
- **Where:** `CLAUDE.md`, Testing (next to "SSOT contract tests must change in the same commit as their data").
- **Why:** this repo just lost main to it. Both PRs followed the existing rule correctly; the rule only covers one PR's own diff, not a concurrent one's.
- **What to change:** in `.hooks/guard-pairs.json`'s header (template surface), keep the "these are GUARDS, not an SSOT" sentence — and note that downstream template consumers should grep their own hook/runner/test copies for the mislabel, since it propagated into four files here before anyone read the header.
- **Where:** `.hooks/guard-pairs.json`, `.hooks/run-guard-pairs.mjs`.
- **Why:** a correct definition in one file does not stop four siblings from contradicting it; the naming has to be enforced where the strings are emitted.


---
_Generated by [Claude Code](https://claude.ai/code/session_013gUCEpudVMyzHF5K6BLQaw)_