### PR TITLE
fix(ci): close a mutation-gate fail-open, make the script suites runnable, and mutate .hooks/lib

### DIFF
--- a/.github/mutation-shards.json
+++ b/.github/mutation-shards.json
@@ -29,7 +29,8 @@
       "id": "hook-scan-invisible",
       "file": "claude-hooks/scan-invisible-chars.mjs"
     },
-    { "id": "cli", "file": "bin/sanitize-cli.mjs" }
+    { "id": "cli", "file": "bin/sanitize-cli.mjs" },
+    { "id": "guarded-data-scan", "file": ".hooks/lib/guarded-data-scan.mjs" }
   ],
   "groups": [
     {
@@ -61,5 +62,6 @@
       "mutate": "claude-hooks/lib/placeholder-grammar.mjs,claude-hooks/lib/secret-drop-guard.mjs"
     }
   ],
-  "hookScopeBreak": 30
+  "hookScopeBreak": 30,
+  "toolingScopeBreak": 1
 }

--- a/.github/scripts/aggregate-mutation.mjs
+++ b/.github/scripts/aggregate-mutation.mjs
@@ -101,9 +101,19 @@ const relativize = (report, path) => {
     : posixPath;
 };
 
-/** Path prefixes that separate the three gated scopes (see the file header). */
+/**
+ * Path prefixes that separate the three gated scopes (see the file header).
+ *
+ * Every scope NAMES what it claims — none of them is "everything else". A
+ * catch-all would partition every possible string by construction, so a
+ * directory that later joins the mutated set would silently inherit whichever
+ * ratchet the negation covered, scored against a floor it was never measured
+ * against. Named prefixes make such a path claimed by nobody, which
+ * `test/aggregate-mutation.test.mjs` fails on at test time.
+ */
 const SRC_PREFIX = "src/";
 const TOOLING_PREFIX = ".hooks/lib/";
+const HOOK_PREFIXES = ["claude-hooks/", "bin/"];
 
 /**
  * Deduplicate mutants across shard reports by identity and tally the score.
@@ -199,7 +209,7 @@ export const gatedScopes = ({
   {
     name: "claude-hooks + bin",
     inScope: (/** @type {string} */ f) =>
-      !f.startsWith(SRC_PREFIX) && !f.startsWith(TOOLING_PREFIX),
+      HOOK_PREFIXES.some((prefix) => f.startsWith(prefix)),
     threshold: hookScopeBreak,
   },
   {

--- a/.github/scripts/aggregate-mutation.mjs
+++ b/.github/scripts/aggregate-mutation.mjs
@@ -9,15 +9,21 @@
  * per-mutant verdicts across every shard's `mutation.json` and computes the same
  * mutation score Stryker would — once per gated SCOPE.
  *
- * There are two scopes because the shipped surface is two populations with very
+ * There are three scopes because the mutated set is three populations with very
  * different histories: `src/` has been mutated (and hardened) for months and
  * keeps `stryker.conf.json`'s `thresholds.break`, while the Claude-hook layer
  * and the CLI were outside the gate entirely until they were added to the shard
  * matrix and carry their own ratchet (`hookScopeBreak` in
  * `.github/mutation-shards.json`). Scoring them as one blended number would let
  * the newly-added files quietly pull the library's long-standing floor down.
- * Each scope's threshold is applied independently; either one failing fails the
+ * Each scope's threshold is applied independently; any one failing fails the
  * build.
+ *
+ * The third scope is `.hooks/lib/`: repo tooling that ships to nobody, so the
+ * manifest-derived shipped set cannot see it, but that has a node suite
+ * (`test/guard-pairs.test.mjs`) exercising it and real consequences when it
+ * silently stops resolving — the pre-commit guard-pair map is derived there, and
+ * a resolver arm that quietly breaks means guards stop running with no red.
  *
  * `hookScopeBreak` is a RATCHET set below the first measurement (a local
  * unsharded run over `claude-hooks/lib/*.mjs` + `bin/sanitize-cli.mjs` scored
@@ -25,6 +31,12 @@
  * had never been mutated when it was chosen. Raise it as the real number lands
  * in the job summary; never lower it, and never lower `thresholds.break`
  * because the hook scope is behind.
+ *
+ * `toolingScopeBreak` is the same kind of ratchet with NO measurement behind it
+ * yet — it starts at 1, which is not a quality bar but a liveness one: the
+ * empty-scope check below still fails the build if no shard mutates the scope.
+ * The first CI run prints the real score in the job summary; raise it to just
+ * under that number then.
  *
  * Usage: node aggregate-mutation.mjs <reports-dir>
  * Exits non-zero when the score is under threshold or when no reports are found
@@ -89,8 +101,9 @@ const relativize = (report, path) => {
     : posixPath;
 };
 
-/** Path prefix that separates the two gated scopes (see the file header). */
+/** Path prefixes that separate the three gated scopes (see the file header). */
 const SRC_PREFIX = "src/";
+const TOOLING_PREFIX = ".hooks/lib/";
 
 /**
  * Deduplicate mutants across shard reports by identity and tally the score.
@@ -161,6 +174,41 @@ export function tallyMutants(reports, inScope = () => true) {
   };
 }
 
+/**
+ * The gated scopes, in report order.
+ *
+ * Exported so the partition itself is testable: the three predicates must
+ * assign every mutated path to exactly one scope. A path claimed twice is
+ * double-gated (and the stricter floor applied to files it was never meant
+ * for); a path claimed by none is silently ungated, which is the failure the
+ * whole per-scope split exists to prevent.
+ *
+ * @param {{breakThreshold: number, hookScopeBreak: number, toolingScopeBreak: number}} thresholds
+ * @returns {{name: string, inScope: (f: string) => boolean, threshold: number}[]}
+ */
+export const gatedScopes = ({
+  breakThreshold,
+  hookScopeBreak,
+  toolingScopeBreak,
+}) => [
+  {
+    name: "src (library)",
+    inScope: (/** @type {string} */ f) => f.startsWith(SRC_PREFIX),
+    threshold: breakThreshold,
+  },
+  {
+    name: "claude-hooks + bin",
+    inScope: (/** @type {string} */ f) =>
+      !f.startsWith(SRC_PREFIX) && !f.startsWith(TOOLING_PREFIX),
+    threshold: hookScopeBreak,
+  },
+  {
+    name: ".hooks/lib (repo tooling)",
+    inScope: (/** @type {string} */ f) => f.startsWith(TOOLING_PREFIX),
+    threshold: toolingScopeBreak,
+  },
+];
+
 function main(reportsDir) {
   const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
   const strykerConf = JSON.parse(
@@ -181,19 +229,18 @@ function main(reportsDir) {
       `.github/mutation-shards.json hookScopeBreak must be a positive number, got ${JSON.stringify(hookScopeBreak)}`,
     );
   }
+  const toolingScopeBreak = shardConf.toolingScopeBreak;
+  if (typeof toolingScopeBreak !== "number" || toolingScopeBreak <= 0) {
+    throw new Error(
+      `.github/mutation-shards.json toolingScopeBreak must be a positive number, got ${JSON.stringify(toolingScopeBreak)}`,
+    );
+  }
 
-  const scopes = [
-    {
-      name: "src (library)",
-      inScope: (/** @type {string} */ f) => f.startsWith(SRC_PREFIX),
-      threshold: breakThreshold,
-    },
-    {
-      name: "claude-hooks + bin",
-      inScope: (/** @type {string} */ f) => !f.startsWith(SRC_PREFIX),
-      threshold: hookScopeBreak,
-    },
-  ];
+  const scopes = gatedScopes({
+    breakThreshold,
+    hookScopeBreak,
+    toolingScopeBreak,
+  });
 
   const reportFiles = readdirSync(reportsDir, { recursive: true })
     .map((entry) => join(reportsDir, entry.toString()))

--- a/.github/scripts/mutation-changed.sh
+++ b/.github/scripts/mutation-changed.sh
@@ -53,6 +53,11 @@ extract_push_paths() {
       print line
       next
     }
+    # A comment or blank line inside the block is not the end of it. Ending on
+    # one silently DROPPED every entry below it, so a PR touching only those
+    # files was classified irrelevant and skipped the whole mutation gate — a
+    # fail-open a reviewer would never see, triggered by adding a comment.
+    in_paths && /^[[:space:]]*(#|$)/ { next }
     in_paths { in_paths = 0 }
   ' "$workflow"
 }

--- a/.github/scripts/run-script-tests.sh
+++ b/.github/scripts/run-script-tests.sh
@@ -16,6 +16,20 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
+# Three of the discovered suites load scripts that `import … from
+# "agent-sanitizer"`, and `.github/scripts/package.json` ends the package scope
+# there, so Node's self-reference never resolves the name — the import needs
+# .github/scripts/node_modules, which install-sanitizer.sh provisions. The
+# workflow runs that script in its own step; a developer running this one from a
+# fresh clone does not, and got 75 failures whose only message was a raw
+# ERR_MODULE_NOT_FOUND stack. Provisioning here when it is missing makes the
+# documented entry point work anywhere, and is a no-op in CI (the step already
+# ran, so the package is present).
+if [[ ! -d .github/scripts/node_modules/agent-sanitizer ]]; then
+  echo "run-script-tests: installing the input sanitizer the review scripts import" >&2
+  bash .github/scripts/install-sanitizer.sh
+fi
+
 suites=()
 while IFS= read -r suite; do
   suites+=("$suite")

--- a/.github/workflows/mutation.yaml
+++ b/.github/workflows/mutation.yaml
@@ -7,6 +7,10 @@ on:
       - "src/**/*.mjs"
       - "claude-hooks/**/*.mjs"
       - "bin/**/*.mjs"
+      # Repo tooling that is mutation-gated as its own scope (see
+      # aggregate-mutation.mjs); derived by scripts/shipped-sources.mjs from the
+      # directory, so a new module here joins the gate and must join this gate too.
+      - ".hooks/lib/**/*.mjs"
       - "test/**/*.mjs"
       - "scripts/shipped-sources.mjs"
       - "scripts/mutate.mjs"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,13 @@ a new module and `test/shipped-gates.test.mjs` fails until it is in both gates.
 `src/` is held at 100%; `claude-hooks/` and `bin/` carry a separate, lower
 ratchet that should only ever move up.
 
+The mutation gate additionally covers `.hooks/lib/`, which ships to nobody but
+derives the pre-commit guard-pair map — a resolver arm that quietly stops
+resolving there means guard tests stop running with nothing red. That scope is
+derived from the directory, so a new module in it joins the gate on commit and
+`test/shipped-gates.test.mjs` fails until `.github/mutation-shards.json` names
+it. It carries its own ratchet (`toolingScopeBreak`), same move-up-only rule.
+
 Run the tests, lint, type-check, and formatter before pushing. The git hooks
 under `.hooks/` also enforce formatting and commit conventions on commit.
 

--- a/scripts/mutate.mjs
+++ b/scripts/mutate.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 /**
- * Run Stryker over every shipped `.mjs`, unsharded (the local `pnpm
- * test:mutation` entry point).
+ * Run Stryker over every mutated `.mjs` — the shipped surface plus the
+ * `.hooks/lib/` tooling — unsharded (the local `pnpm test:mutation` entry
+ * point).
  *
  * `stryker.conf.json` deliberately carries NO `mutate` key. It used to say
  * `src/*.mjs`, which silently excluded the entire Claude-hook layer and the
@@ -19,11 +20,11 @@ import { realpathSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { findRepoRoot, shippedSources } from "./shipped-sources.mjs";
+import { findRepoRoot, mutatedSources } from "./shipped-sources.mjs";
 
-/** The Stryker `--mutate` spec covering the whole shipped surface.
+/** The Stryker `--mutate` spec covering the whole mutated surface.
  * @param {string} repoRoot @returns {string} */
-export const mutateSpec = (repoRoot) => shippedSources(repoRoot).join(",");
+export const mutateSpec = (repoRoot) => mutatedSources(repoRoot).join(",");
 
 // Importable without side effects: the contract test asserts what this wrapper
 // would pass, and must not launch a multi-hour mutation run to do it.

--- a/scripts/shipped-sources.mjs
+++ b/scripts/shipped-sources.mjs
@@ -55,7 +55,14 @@ export const TOOLING_SCOPE = ".hooks/lib/";
  * @returns {string[]} repo-relative POSIX paths, sorted
  */
 export const toolingSources = (repoRoot) =>
-  readdirSync(join(repoRoot, TOOLING_SCOPE))
+  // RECURSIVE, matching both the docstring and `mutation.yaml`'s
+  // `.hooks/lib/**/*.mjs` trigger. A shallow read would leave a module at
+  // `.hooks/lib/sub/x.mjs` out of the mutated set — so no shard would name it,
+  // the contract test (tooling ⊆ mutated) would stay green, and the gate would
+  // run over a file it never mutates. That is the silent ungating this scope
+  // exists to close. `replace(/\\/g, "/")` keeps the entries POSIX on Windows.
+  readdirSync(join(repoRoot, TOOLING_SCOPE), { recursive: true })
+    .map((entry) => entry.toString().replace(/\\/g, "/"))
     .filter((name) => name.endsWith(".mjs"))
     .map((name) => posix.join(TOOLING_SCOPE, name))
     .sort();

--- a/scripts/shipped-sources.mjs
+++ b/scripts/shipped-sources.mjs
@@ -26,6 +26,55 @@ import { fileURLToPath } from "node:url";
 export const SRC_SCOPE = "src/";
 
 /**
+ * Repo TOOLING that is mutation-gated despite shipping to nobody.
+ *
+ * `.hooks/lib/` holds the modules the pre-commit hook derives its guard-pair
+ * map with. Nothing there is published, so `shippedSources` — which reads the
+ * package manifest — cannot see it, and it was outside every gate: a resolver
+ * arm could stop resolving and the only signal would be guards quietly not
+ * running. It has a node suite that exercises it (`test/guard-pairs.test.mjs`),
+ * which is the whole precondition for mutating something.
+ *
+ * DIRECTORY-scoped, not repo-wide, and deliberately: `.hooks/run-guard-pairs.mjs`
+ * one level up is covered only by `tests/test_hook_fail_closed.py`, and Stryker
+ * runs the tap runner over `test/**` — pytest never executes, so every mutant
+ * there would survive by construction and the score would measure the runner
+ * rather than the tests.
+ */
+export const TOOLING_SCOPE = ".hooks/lib/";
+
+/**
+ * Every `.mjs` under `TOOLING_SCOPE`, derived from the directory.
+ *
+ * Derived rather than listed for the same reason the shipped set is: a new
+ * module here joins the mutation gate the moment it is committed, and
+ * `test/shipped-gates.test.mjs` fails the build if the shard matrix has not
+ * been taught about it.
+ *
+ * @param {string} repoRoot absolute path to the repository root
+ * @returns {string[]} repo-relative POSIX paths, sorted
+ */
+export const toolingSources = (repoRoot) =>
+  readdirSync(join(repoRoot, TOOLING_SCOPE))
+    .filter((name) => name.endsWith(".mjs"))
+    .map((name) => posix.join(TOOLING_SCOPE, name))
+    .sort();
+
+/**
+ * Everything the mutation gate mutates: the shipped surface plus the tooling.
+ *
+ * De-duplicated because the two halves are only disjoint by convention — a
+ * `.hooks/lib/*.mjs` added to the manifest would otherwise appear twice and the
+ * shard contract test would fail on a set-vs-list mismatch instead of on the
+ * real problem, which `test/shipped-gates.test.mjs` asserts directly.
+ *
+ * @param {string} repoRoot @returns {string[]} */
+export const mutatedSources = (repoRoot) =>
+  [
+    ...new Set([...shippedSources(repoRoot), ...toolingSources(repoRoot)]),
+  ].sort();
+
+/**
  * Resolve one `files` entry into the `.mjs` paths it publishes.
  *
  * Only the two shapes the manifest actually uses are understood — a literal

--- a/test/aggregate-mutation.test.mjs
+++ b/test/aggregate-mutation.test.mjs
@@ -151,6 +151,38 @@ describe("tallyMutants", () => {
     assert.equal(tallyMutants(reports).score, 75);
   });
 
+  it("scopes absolute report paths by relativizing against projectRoot", () => {
+    // Stryker keys `files` relative to projectRoot, but the field is optional
+    // and an absolute key must not silently land in the wrong scope (or dedup
+    // against nothing when a sibling shard emitted the relative form).
+    const relative = multiFileReport({ "src/a.mjs": [mutant("Killed", 5)] });
+    const absolute = multiFileReport(
+      { "/build/repo/src/a.mjs": [mutant("Survived", 5)] },
+      "/build/repo",
+    );
+    const isSrc = (/** @type {string} */ f) => f.startsWith("src/");
+    const scoped = tallyMutants([relative, absolute], isSrc);
+    assert.equal(scoped.total, 1, "both keys name the same mutant");
+    assert.equal(scoped.score, 100);
+    assert.equal(
+      tallyMutants([absolute], (f) => !isSrc(f)).total,
+      0,
+      "an absolute src/ path must not fall into the hook scope",
+    );
+  });
+
+  it("scores 0 when no mutant produced a scorable verdict", () => {
+    // Only errored/ignored mutants: scored denominator is 0, guard the div.
+    const { score, detected, undetected } = tallyMutants([
+      report(mutant("RuntimeError"), mutant("Ignored")),
+    ]);
+    assert.equal(detected, 0);
+    assert.equal(undetected, 0);
+    assert.equal(score, 0);
+  });
+});
+
+describe("gatedScopes", () => {
   it("partitions every mutated file into exactly one gated scope", () => {
     // Each scope applies its own break threshold to whatever it claims. A file
     // claimed twice is gated twice — the library's floor applied to tooling it
@@ -184,35 +216,5 @@ describe("tallyMutants", () => {
         files.some((file) => scope.inScope(file)),
         `scope "${scope.name}" claims no mutated file`,
       );
-  });
-
-  it("scopes absolute report paths by relativizing against projectRoot", () => {
-    // Stryker keys `files` relative to projectRoot, but the field is optional
-    // and an absolute key must not silently land in the wrong scope (or dedup
-    // against nothing when a sibling shard emitted the relative form).
-    const relative = multiFileReport({ "src/a.mjs": [mutant("Killed", 5)] });
-    const absolute = multiFileReport(
-      { "/build/repo/src/a.mjs": [mutant("Survived", 5)] },
-      "/build/repo",
-    );
-    const isSrc = (/** @type {string} */ f) => f.startsWith("src/");
-    const scoped = tallyMutants([relative, absolute], isSrc);
-    assert.equal(scoped.total, 1, "both keys name the same mutant");
-    assert.equal(scoped.score, 100);
-    assert.equal(
-      tallyMutants([absolute], (f) => !isSrc(f)).total,
-      0,
-      "an absolute src/ path must not fall into the hook scope",
-    );
-  });
-
-  it("scores 0 when no mutant produced a scorable verdict", () => {
-    // Only errored/ignored mutants: scored denominator is 0, guard the div.
-    const { score, detected, undetected } = tallyMutants([
-      report(mutant("RuntimeError"), mutant("Ignored")),
-    ]);
-    assert.equal(detected, 0);
-    assert.equal(undetected, 0);
-    assert.equal(score, 0);
   });
 });

--- a/test/aggregate-mutation.test.mjs
+++ b/test/aggregate-mutation.test.mjs
@@ -14,9 +14,14 @@
  * over the real 28 shard reports is exercised by running the script in CI.
  */
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { describe, it } from "node:test";
 
-import { tallyMutants } from "../.github/scripts/aggregate-mutation.mjs";
+import {
+  gatedScopes,
+  tallyMutants,
+} from "../.github/scripts/aggregate-mutation.mjs";
+import { mutatedSources } from "../scripts/shipped-sources.mjs";
 
 /** Build a mutant with a distinct-by-default location so tests opt IN to
  * collisions by passing the same `loc`, rather than colliding by accident. */
@@ -144,6 +149,41 @@ describe("tallyMutants", () => {
     assert.equal(tallyMutants(reports, (f) => !isSrc(f)).score, 50);
     // Unfiltered, the hook layer's miss would show up as a 75% library score.
     assert.equal(tallyMutants(reports).score, 75);
+  });
+
+  it("partitions every mutated file into exactly one gated scope", () => {
+    // Each scope applies its own break threshold to whatever it claims. A file
+    // claimed twice is gated twice — the library's floor applied to tooling it
+    // was never measured against — and a file claimed by nothing is scored by
+    // no threshold at all, which is the silent ungating the split exists to
+    // prevent. Run over the LIVE mutated set, so a new directory that fits none
+    // of the prefixes fails here rather than at the next aggregate run.
+    const scopes = gatedScopes({
+      breakThreshold: 83,
+      hookScopeBreak: 30,
+      toolingScopeBreak: 1,
+    });
+    const files = mutatedSources(
+      execFileSync("git", ["rev-parse", "--show-toplevel"], {
+        encoding: "utf8",
+      }).trim(),
+    );
+    assert.ok(files.length > 0, "the mutated set must not be empty");
+    for (const file of files) {
+      const claimed = scopes.filter((scope) => scope.inScope(file));
+      assert.equal(
+        claimed.length,
+        1,
+        `${file} is claimed by ${claimed.length} scope(s): ${claimed.map((s) => s.name).join(", ") || "none"}`,
+      );
+    }
+    // Every scope must claim something, or its threshold gates an empty set —
+    // the vacuous pass the aggregator's own empty-scope check also refuses.
+    for (const scope of scopes)
+      assert.ok(
+        files.some((file) => scope.inScope(file)),
+        `scope "${scope.name}" claims no mutated file`,
+      );
   });
 
   it("scopes absolute report paths by relativizing against projectRoot", () => {

--- a/test/guard-pairs.test.mjs
+++ b/test/guard-pairs.test.mjs
@@ -28,12 +28,25 @@ import { describe, it } from "node:test";
 import {
   MODULE_EXTENSIONS,
   expandPathspec,
-  repoRoot,
   scanGuardedData,
   scanJsGuards,
   scanPythonGuards,
   tracked,
 } from "../.hooks/lib/guarded-data-scan.mjs";
+
+/**
+ * The repo root, resolved HERE rather than imported from the module under test.
+ *
+ * Two reasons, and the second is why it is not the scanner's `repoRoot` export.
+ * A test should not take its ground truth from the thing it is testing. And the
+ * self-read pin below asserts that the scan resolves THIS file's
+ * `join(repoRoot, ".hooks", "guard-pairs.json")` — with `repoRoot` imported,
+ * that resolution runs through the scanner's own source, so Stryker's
+ * instrumentation of the scanner (which turns its `".."` literals into
+ * conditional expressions the resolver correctly declines) broke the pin and
+ * failed the mutation run's dry run before a single mutant was applied.
+ */
+const repoRoot = join(import.meta.dirname, "..");
 
 const { pairs, tooSlowForCommit } = JSON.parse(
   readFileSync(join(repoRoot, ".hooks", "guard-pairs.json"), "utf8"),

--- a/test/mutation-shards.test.mjs
+++ b/test/mutation-shards.test.mjs
@@ -10,10 +10,11 @@
  * open over uncovered code.
  *
  * This guards both holes against the EXPANDED matrix (what CI actually runs):
- * every shipped `.mjs` is covered exactly once, and each split file's slices
- * tile [1, EOF) with no gap or overlap, ending open. The shipped set comes from
- * `scripts/shipped-sources.mjs` (the package manifest), not from a `readdir` of
- * `src/` — reading only `src/` is what let the whole `claude-hooks/` layer sit
+ * every mutated `.mjs` is covered exactly once, and each split file's slices
+ * tile [1, EOF) with no gap or overlap, ending open. The mutated set comes from
+ * `scripts/shipped-sources.mjs` — the package manifest for the shipped half and
+ * the `.hooks/lib/` directory for the tooling half — not from a `readdir` of
+ * `src/`; reading only `src/` is what let the whole `claude-hooks/` layer sit
  * outside the gate while this test stayed green.
  */
 import { execFileSync } from "node:child_process";
@@ -26,7 +27,7 @@ import {
   expandShards,
   EOF_SENTINEL,
 } from "../.github/scripts/expand-shards.mjs";
-import { shippedSources } from "../scripts/shipped-sources.mjs";
+import { mutatedSources } from "../scripts/shipped-sources.mjs";
 
 const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
   encoding: "utf8",
@@ -61,8 +62,8 @@ describe("mutation shard matrix", () => {
     );
   });
 
-  it("covers exactly the .mjs files the package ships", () => {
-    const onDisk = shippedSources(repoRoot);
+  it("covers exactly the .mjs files the gate mutates", () => {
+    const onDisk = mutatedSources(repoRoot);
 
     const inShards = [
       ...new Set(
@@ -73,7 +74,7 @@ describe("mutation shard matrix", () => {
     assert.deepEqual(
       inShards,
       onDisk,
-      "shard file set must equal the shipped .mjs set (add a `split` entry or `group` when a published file is added/removed)",
+      "shard file set must equal the mutated .mjs set (add a `split` entry or `group` when a published file or a .hooks/lib module is added/removed)",
     );
   });
 

--- a/test/shipped-gates.test.mjs
+++ b/test/shipped-gates.test.mjs
@@ -36,8 +36,11 @@ import {
 import { mutateSpec } from "../scripts/mutate.mjs";
 import {
   hookScope,
+  mutatedSources,
   shippedSources,
   srcScope,
+  TOOLING_SCOPE,
+  toolingSources,
 } from "../scripts/shipped-sources.mjs";
 
 const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
@@ -45,6 +48,7 @@ const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
 }).trim();
 
 const shipped = shippedSources(repoRoot);
+const mutated = mutatedSources(repoRoot);
 const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
 
 /** Every `.mjs` the manifest names, read straight off `package.json` rather
@@ -92,6 +96,17 @@ const HOOK_FLOORS = { lines: 93, branches: 88, functions: 87, statements: 93 };
 
 /** The hook layer's mutation ratchet, same contract as the coverage floors. */
 const HOOK_SCOPE_BREAK = 30;
+
+/**
+ * The `.hooks/lib` tooling's mutation ratchet.
+ *
+ * 1 is a LIVENESS bar, not a quality one: the scope has never been measured (it
+ * joins the gate in the same change that adds this), and the aggregator refuses
+ * a scope that scored no mutants, so a threshold of 1 still fails a matrix that
+ * stopped mutating it. Raise this and `toolingScopeBreak` together once the
+ * first CI run reports the real score.
+ */
+const TOOLING_SCOPE_BREAK = 1;
 
 /** Parse "src/a.mjs:1-50,src/b.mjs" into [{file, ranged}, ...]. */
 const parseMutate = (mutate) =>
@@ -274,15 +289,15 @@ describe("coverage gate covers the shipped set", () => {
   });
 });
 
-describe("mutation gate covers the shipped set", () => {
+describe("mutation gate covers the mutated set", () => {
   const shards = expandShards(repoRoot);
   const entries = shards.flatMap((shard) => parseMutate(shard.mutate));
 
-  it("puts every shipped file in the shard matrix, whole files exactly once", () => {
+  it("puts every mutated file in the shard matrix, whole files exactly once", () => {
     assert.deepEqual(
       [...new Set(entries.map((e) => e.file))].sort(),
-      shipped,
-      "shard file set must equal the shipped set (add a `split` entry or `group` in .github/mutation-shards.json)",
+      mutated,
+      "shard file set must equal the mutated set (add a `split` entry or `group` in .github/mutation-shards.json)",
     );
 
     // A split file is deliberately spread over several line-ranged shards (the
@@ -297,8 +312,31 @@ describe("mutation gate covers the shipped set", () => {
       assert.equal(count, 1, `${file} appears in ${count} whole-file shards`);
   });
 
-  it("passes the whole shipped set to an unsharded run", () => {
-    assert.deepEqual(mutateSpec(repoRoot).split(","), shipped);
+  it("passes the whole mutated set to an unsharded run", () => {
+    assert.deepEqual(mutateSpec(repoRoot).split(","), mutated);
+  });
+
+  it("mutates the .hooks/lib tooling, derived from the directory", () => {
+    // The tooling half is not in the manifest, so nothing else in this file
+    // would notice it vanishing from the gate. Both halves are asserted
+    // non-empty: an empty `toolingSources` would make the equality above hold
+    // against a shard matrix that had also dropped it.
+    const tooling = toolingSources(repoRoot);
+    assert.ok(
+      tooling.includes(`${TOOLING_SCOPE}guarded-data-scan.mjs`),
+      `expected the guard-pair scanner in the tooling scope, got ${tooling.join(", ") || "nothing"}`,
+    );
+    for (const file of tooling)
+      assert.ok(
+        mutated.includes(file),
+        `${file} is in the tooling scope but not in the mutated set`,
+      );
+    // Disjoint by construction; an overlap would double-count in the aggregate,
+    // whose scopes partition on the same two prefixes.
+    assert.deepEqual(
+      shipped.filter((file) => file.startsWith(TOOLING_SCOPE)),
+      [],
+    );
   });
 
   it("keeps `mutate` out of stryker.conf.json so it cannot go stale", () => {
@@ -312,7 +350,7 @@ describe("mutation gate covers the shipped set", () => {
     assert.equal(conf.mutate, undefined);
   });
 
-  it("gates the hook scope on its own explicit, non-zero break threshold", () => {
+  it("gates the hook and tooling scopes on their own explicit, non-zero break thresholds", () => {
     const shardConf = JSON.parse(
       readFileSync(join(repoRoot, ".github", "mutation-shards.json"), "utf8"),
     );
@@ -322,6 +360,10 @@ describe("mutation gate covers the shipped set", () => {
     assert.ok(
       shardConf.hookScopeBreak >= HOOK_SCOPE_BREAK,
       `hookScopeBreak is a ratchet: it may rise above ${HOOK_SCOPE_BREAK} (raise HOOK_SCOPE_BREAK with it) but never fall, got ${shardConf.hookScopeBreak}`,
+    );
+    assert.ok(
+      shardConf.toolingScopeBreak >= TOOLING_SCOPE_BREAK,
+      `toolingScopeBreak is a ratchet: it may rise above ${TOOLING_SCOPE_BREAK} (raise TOOLING_SCOPE_BREAK with it) but never fall, got ${shardConf.toolingScopeBreak}`,
     );
     // src/ keeps its own long-standing floor; the hook ratchet must never be
     // used as an excuse to lower it.

--- a/tests/test_mutation_changed.py
+++ b/tests/test_mutation_changed.py
@@ -116,6 +116,34 @@ def test_every_push_path_glob_matches_itself(tmp_path: Path) -> None:
         )
 
 
+def test_a_comment_inside_the_paths_block_does_not_truncate_it(
+    tmp_path: Path,
+) -> None:
+    """A comment between entries must not end the parse.
+
+    The parser used to treat any non-entry line as the end of the block, so a
+    comment silently dropped every path below it — and the failure mode is a
+    clean exit 1, which the workflow reads as "nothing relevant, skip". Pinned
+    on a synthetic workflow rather than on the live one having a comment, so
+    removing that comment cannot quietly retire this case.
+    """
+    workflow = (
+        "name: Mutation tests\n"
+        "on:\n"
+        "  push:\n"
+        "    paths:\n"
+        '      - "src/**/*.mjs"\n'
+        "      # a comment, and a blank line, in the middle of the list\n"
+        "\n"
+        '      - "below-the-comment.mjs"\n'
+        "  pull_request:\n"
+        "jobs: {}\n"
+    )
+    repo = make_sandbox(tmp_path, workflow)
+    result = run_script(repo, "below-the-comment.mjs")
+    assert result.returncode == 0, (result.returncode, result.stderr)
+
+
 def test_zero_parsed_paths_fails_loudly(tmp_path: Path) -> None:
     """A workflow whose paths block the parser cannot find is exit >= 2 (fail
     the job), never exit 1 (which the workflow reads as a clean skip)."""


### PR DESCRIPTION
Claims: `.github/scripts/mutation-changed.sh`, `.github/scripts/run-script-tests.sh`, and the mutation-scope plumbing (`scripts/shipped-sources.mjs`, `.github/mutation-shards.json`, `aggregate-mutation.mjs`).

## Summary

Three fixes, found while asking whether the guard-pair scanner merged in #284 was covered by anything.

**1. A comment in `mutation.yaml`'s `on.push.paths` silently disabled the mutation gate.** `mutation-changed.sh` parses that list out of the workflow (it is the SSOT for "is this PR mutation-relevant"), and its awk treated *any* non-entry line inside the block as the end of it. A comment therefore dropped every path below it, and a PR touching only those files was classified irrelevant — exit 1, which the workflow reads as a clean skip. The failure is invisible in review: the workflow still looks correct, the gate just stops running. Found by adding a comment to that list in this very PR and watching four existing tests go red.

**2. `bash .github/scripts/run-script-tests.sh` did not work from a fresh clone.** Three of the discovered suites load scripts that `import … from "agent-sanitizer"`, and `.github/scripts/package.json` (which exists so the three `.js` files there are CJS under a `"type": "module"` root) ends the package scope, so Node's self-reference never resolves the name. The workflow installs the package in a separate step; a developer running the script got 75 failures whose only message was a raw `ERR_MODULE_NOT_FOUND` stack. The script now provisions it when missing — a no-op in CI, where the step already ran.

**3. `.hooks/lib/` is now a mutation-gated scope.** The guard-pair scanner derives what the pre-commit hook runs; a resolver arm that quietly stops resolving means guard tests stop running with *nothing red*. It ships to nobody, so the manifest-derived mutated set could not see it. It is now its own scope, derived from the directory rather than listed, with the shard matrix asserted to cover it.

## Changes

- `.github/scripts/mutation-changed.sh` — skip comment/blank lines inside the `paths` block instead of ending the parse there.
- `.github/scripts/run-script-tests.sh` — run `install-sanitizer.sh` when `.github/scripts/node_modules/agent-sanitizer` is absent.
- `scripts/shipped-sources.mjs` — add `TOOLING_SCOPE` (`.hooks/lib/`), `toolingSources()` (derived from the directory), and `mutatedSources()` = shipped ∪ tooling.
- `scripts/mutate.mjs` — the unsharded `--mutate` spec is now the mutated set.
- `.github/mutation-shards.json` — split entry for the scanner; `toolingScopeBreak: 1`.
- `.github/scripts/aggregate-mutation.mjs` — extract the scope list to an exported `gatedScopes()` and add the third scope with its own threshold.
- `.github/workflows/mutation.yaml` — `.hooks/lib/**/*.mjs` in `on.push.paths`.
- `CONTRIBUTING.md` — document the tooling scope.

## Decisions made

- **The tooling scope is `.hooks/lib/`, not `.hooks/`.** `.hooks/run-guard-pairs.mjs` one level up is covered only by `tests/test_hook_fail_closed.py`, and Stryker runs the tap runner over `test/**` — pytest never executes, so every mutant there would survive by construction and the score would measure the runner rather than the tests. Under the alternative (whole-directory scope) the number would be meaningless and the threshold would have to be ~0.
- **`toolingScopeBreak` starts at 1, with no measurement behind it.** Local Stryker runs are off the table for this session, so there is no first number to ratchet from. 1 is a *liveness* bar rather than a quality one — the aggregator already refuses a scope that scored no mutants, so a matrix that stopped mutating the scope still fails the build. The first CI run prints the real score in the job summary; raise `toolingScopeBreak` and `TOOLING_SCOPE_BREAK` together then. Under the alternative (guess a number), a wrong guess either gates nothing or reds the branch on an unmeasured floor.
- **`TOOLING_PREFIX` is duplicated in `aggregate-mutation.mjs` rather than imported** from `scripts/shipped-sources.mjs`, matching the existing `SRC_PREFIX` precedent. Drift is covered rather than prevented: the new partition test runs `gatedScopes()` over the live `mutatedSources()`, so a prefix that drifts leaves a file claimed by two scopes or a scope claiming none, and both fail.
- **Both existing shard contract tests were updated** (`test/shipped-gates.test.mjs` and `test/mutation-shards.test.mjs` assert the same thing). Consolidating them is out of scope here.

## Tests / verification

- `tests/test_mutation_changed.py` — new `test_a_comment_inside_the_paths_block_does_not_truncate_it`, pinned on a synthetic workflow so removing the live comment cannot retire the case. Reverting the awk fix fails it plus four existing cases.
- `test/aggregate-mutation.test.mjs` — new partition test: every file in the live mutated set is claimed by exactly one scope, and every scope claims something.
- `test/shipped-gates.test.mjs` — shard matrix must equal the mutated set; the tooling scope must contain the scanner and be disjoint from the shipped set; `toolingScopeBreak` ratchet.
- `bash .github/scripts/run-script-tests.sh` from a state with no `.github/scripts/node_modules`: 387 pass (was 75 failures).
- Full sweep green: `node --test "test/**/*.test.mjs"` 3476 pass, `pytest tests` 2429 pass, `pnpm lint`, `pnpm check`, `prettier --check .`.

## Checklist

- [x] Commits follow Conventional Commits; each subject reads as a user-facing release note.
- [x] `pnpm test`, `pnpm lint`, and `pnpm check` pass locally.
- [x] New or changed detectors have negative tests — n/a, no detector changes.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version left untouched.

## Lessons Learned

- **`.github/scripts/mutation-changed.sh` (template file): a block parser that ends on "any line that is not an entry" fails open.** The awk that extracts `on.push.paths` treated a comment as the end of the list, silently dropping every path below it — and the resulting exit 1 reads as "nothing relevant, skip" rather than as an error. Any template script that parses a YAML block by shape should skip comment and blank lines explicitly and end only on a real dedent, with a test that puts a comment mid-block.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BEZNzGcSWZJHviwmkjAcbW)_