### PR TITLE
refactor(gates): derive the mutation scopes and shard membership from the shipped-sources SSOT

### DIFF
--- a/.github/mutation-shards.json
+++ b/.github/mutation-shards.json
@@ -32,36 +32,7 @@
     { "id": "cli", "file": "bin/sanitize-cli.mjs" },
     { "id": "guarded-data-scan", "file": ".hooks/lib/guarded-data-scan.mjs" }
   ],
-  "groups": [
-    {
-      "id": "index-prompt-gates",
-      "mutate": "src/index.mjs,src/prompt.mjs,src/gates.mjs,src/cf-charset.mjs,src/warnings.mjs,src/severity.mjs,src/claude-context.mjs"
-    },
-    {
-      "id": "credential-names",
-      "mutate": "src/credential-names.mjs"
-    },
-    {
-      "id": "hook-entrypoints",
-      "mutate": "claude-hooks/sanitize-user-prompt.mjs,claude-hooks/plugin-hooks.mjs"
-    },
-    {
-      "id": "hook-lib-posture",
-      "mutate": "claude-hooks/lib/hook-fault.mjs,claude-hooks/lib/hook-timing.mjs,claude-hooks/lib/layer-pipeline.mjs"
-    },
-    {
-      "id": "hook-lib-config",
-      "mutate": "claude-hooks/lib/authored-content.mjs,claude-hooks/lib/control-plane.mjs,claude-hooks/lib/env-config.mjs"
-    },
-    {
-      "id": "hook-lib-report",
-      "mutate": "claude-hooks/lib/invisible-alert.mjs,claude-hooks/lib/reveal.mjs,claude-hooks/lib/secret-annotate.mjs,claude-hooks/lib/trace.mjs"
-    },
-    {
-      "id": "hook-lib-guards",
-      "mutate": "claude-hooks/lib/placeholder-grammar.mjs,claude-hooks/lib/secret-drop-guard.mjs"
-    }
-  ],
+  "groupCount": 7,
   "hookScopeBreak": 30,
   "toolingScopeBreak": 1
 }

--- a/.github/scripts/aggregate-mutation.mjs
+++ b/.github/scripts/aggregate-mutation.mjs
@@ -187,10 +187,7 @@ export function tallyMutants(reports, inScope = () => true) {
  *
  * The prefixes come from `scripts/shipped-sources.mjs`, which builds the
  * coverage scopes from the same constants, so the two splits are one definition
- * and neither can drift from the other. None of them is "everything else": a
- * directory that later joins the mutated set is therefore claimed by nobody and
- * fails `test/aggregate-mutation.test.mjs` rather than silently inheriting a
- * ratchet it was never measured against.
+ * and neither can drift from the other.
  *
  * @param {{breakThreshold: number, hookScopeBreak: number, toolingScopeBreak: number}} thresholds
  * @returns {{name: string, inScope: (f: string) => boolean, threshold: number}[]}

--- a/.github/scripts/aggregate-mutation.mjs
+++ b/.github/scripts/aggregate-mutation.mjs
@@ -51,6 +51,12 @@ import {
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  HOOK_SCOPE_PREFIXES,
+  SRC_SCOPE,
+  TOOLING_SCOPE,
+} from "../../scripts/shipped-sources.mjs";
+
 import { expandShards } from "./expand-shards.mjs";
 
 // Detected mutants are caught by the suite; undetected slip through. Mutants
@@ -100,20 +106,6 @@ const relativize = (report, path) => {
     ? posixPath.slice(root.length + 1)
     : posixPath;
 };
-
-/**
- * Path prefixes that separate the three gated scopes (see the file header).
- *
- * Every scope NAMES what it claims — none of them is "everything else". A
- * catch-all would partition every possible string by construction, so a
- * directory that later joins the mutated set would silently inherit whichever
- * ratchet the negation covered, scored against a floor it was never measured
- * against. Named prefixes make such a path claimed by nobody, which
- * `test/aggregate-mutation.test.mjs` fails on at test time.
- */
-const SRC_PREFIX = "src/";
-const TOOLING_PREFIX = ".hooks/lib/";
-const HOOK_PREFIXES = ["claude-hooks/", "bin/"];
 
 /**
  * Deduplicate mutants across shard reports by identity and tally the score.
@@ -193,6 +185,13 @@ export function tallyMutants(reports, inScope = () => true) {
  * for); a path claimed by none is silently ungated, which is the failure the
  * whole per-scope split exists to prevent.
  *
+ * The prefixes come from `scripts/shipped-sources.mjs`, which derives the
+ * coverage scopes from the same three constants: the mutation split and the
+ * coverage split are one definition, so neither can drift from the other.
+ * Every scope NAMES what it claims — none is "everything else", so a directory
+ * that later joins the mutated set is claimed by nobody and fails the partition
+ * test rather than inheriting a ratchet it was never measured against.
+ *
  * @param {{breakThreshold: number, hookScopeBreak: number, toolingScopeBreak: number}} thresholds
  * @returns {{name: string, inScope: (f: string) => boolean, threshold: number}[]}
  */
@@ -203,18 +202,18 @@ export const gatedScopes = ({
 }) => [
   {
     name: "src (library)",
-    inScope: (/** @type {string} */ f) => f.startsWith(SRC_PREFIX),
+    inScope: (/** @type {string} */ f) => f.startsWith(SRC_SCOPE),
     threshold: breakThreshold,
   },
   {
     name: "claude-hooks + bin",
     inScope: (/** @type {string} */ f) =>
-      HOOK_PREFIXES.some((prefix) => f.startsWith(prefix)),
+      HOOK_SCOPE_PREFIXES.some((prefix) => f.startsWith(prefix)),
     threshold: hookScopeBreak,
   },
   {
     name: ".hooks/lib (repo tooling)",
-    inScope: (/** @type {string} */ f) => f.startsWith(TOOLING_PREFIX),
+    inScope: (/** @type {string} */ f) => f.startsWith(TOOLING_SCOPE),
     threshold: toolingScopeBreak,
   },
 ];

--- a/.github/scripts/aggregate-mutation.mjs
+++ b/.github/scripts/aggregate-mutation.mjs
@@ -185,12 +185,12 @@ export function tallyMutants(reports, inScope = () => true) {
  * for); a path claimed by none is silently ungated, which is the failure the
  * whole per-scope split exists to prevent.
  *
- * The prefixes come from `scripts/shipped-sources.mjs`, which derives the
- * coverage scopes from the same three constants: the mutation split and the
- * coverage split are one definition, so neither can drift from the other.
- * Every scope NAMES what it claims — none is "everything else", so a directory
- * that later joins the mutated set is claimed by nobody and fails the partition
- * test rather than inheriting a ratchet it was never measured against.
+ * The prefixes come from `scripts/shipped-sources.mjs`, which builds the
+ * coverage scopes from the same constants, so the two splits are one definition
+ * and neither can drift from the other. None of them is "everything else": a
+ * directory that later joins the mutated set is therefore claimed by nobody and
+ * fails `test/aggregate-mutation.test.mjs` rather than silently inheriting a
+ * ratchet it was never measured against.
  *
  * @param {{breakThreshold: number, hookScopeBreak: number, toolingScopeBreak: number}} thresholds
  * @returns {{name: string, inScope: (f: string) => boolean, threshold: number}[]}

--- a/.github/scripts/expand-shards.mjs
+++ b/.github/scripts/expand-shards.mjs
@@ -2,12 +2,15 @@
 /**
  * Expand the declarative mutation-shard config into a concrete shard matrix.
  *
- * `.github/mutation-shards.json` declares WHICH files to mutate, not the exact
- * line ranges: big files listed under `split` are chunked into `splitEvery`-line
- * slices computed from the file's CURRENT length, and every entry under `groups`
- * is a hand-balanced whole-file (or multi-file) shard. Deriving the ranges at CI
- * time means a growing file automatically gets more shards — no hand re-tiling,
- * and no shard can silently drift past the file's end.
+ * `.github/mutation-shards.json` declares only what a human must decide: which
+ * big files are worth chunking into `splitEvery`-line slices, and how many
+ * whole-file shards to spread everything else over. WHICH files get mutated is
+ * `scripts/shipped-sources.mjs`'s answer, so a newly published module or a new
+ * `.hooks/lib` one joins the matrix the moment it is committed — no config to
+ * remember, and no hand-listed second copy of the mutated set to drift from it.
+ *
+ * Slice ranges are computed from each file's CURRENT length, so a growing file
+ * gets more shards on its own and no shard drifts past the file's end.
  *
  * Both the workflow (to build the job matrix) and aggregate-mutation.mjs (to
  * demand one report per shard) call this on the same checkout, so the shard set
@@ -19,10 +22,45 @@ import { readFileSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { mutatedSources } from "../../scripts/shipped-sources.mjs";
+
 // The open-ended sentinel the last slice of a split file uses so lines beyond
 // the computed boundary (e.g. appended between checkout and Stryker's read) are
 // still mutated. Mirrors Stryker's `file:start-end` --mutate syntax.
 export const EOF_SENTINEL = 99999;
+
+/** @param {string} repoRoot @param {string} file @returns {number} */
+const lineCount = (repoRoot, file) =>
+  readFileSync(join(repoRoot, file), "utf8").split("\n").length;
+
+/**
+ * Spread `files` over `binCount` shards, longest file first into the smallest
+ * shard so far.
+ *
+ * Balanced by LINE COUNT, not file count: a shard's runtime tracks the mutants
+ * in it, so an even split by count puts the whole long tail on one runner.
+ * Ties break on path, keeping the matrix a pure function of the tree — the
+ * workflow and the aggregator expand it separately and must agree exactly.
+ *
+ * @param {{file: string, lines: number}[]} files
+ * @param {number} binCount
+ * @returns {string[][]} one sorted path list per shard
+ */
+function balance(files, binCount) {
+  const bins = Array.from({ length: binCount }, () => ({
+    lines: 0,
+    files: /** @type {string[]} */ ([]),
+  }));
+  const byLinesDesc = [...files].sort(
+    (a, b) => b.lines - a.lines || a.file.localeCompare(b.file),
+  );
+  for (const { file, lines } of byLinesDesc) {
+    const target = bins.reduce((a, b) => (b.lines < a.lines ? b : a));
+    target.lines += lines;
+    target.files.push(file);
+  }
+  return bins.map((bin) => bin.files.sort());
+}
 
 /**
  * @param {string} repoRoot absolute path to the repository root
@@ -32,19 +70,37 @@ export function expandShards(repoRoot) {
   const config = JSON.parse(
     readFileSync(join(repoRoot, ".github", "mutation-shards.json"), "utf8"),
   );
-  const { splitEvery } = config;
+  const { splitEvery, groupCount } = config;
   if (!Number.isInteger(splitEvery) || splitEvery <= 0) {
     throw new Error(
       `mutation-shards.json splitEvery must be a positive integer, got ${JSON.stringify(splitEvery)}`,
     );
   }
+  if (!Number.isInteger(groupCount) || groupCount <= 0) {
+    throw new Error(
+      `mutation-shards.json groupCount must be a positive integer, got ${JSON.stringify(groupCount)}`,
+    );
+  }
+
+  const mutated = mutatedSources(repoRoot);
+  const splitFiles = (config.split ?? []).map((entry) => entry.file);
+  // A `split` entry outside the mutated set is a stale path: its shard mutates
+  // a file no scope scores, while the file it was renamed from silently falls
+  // into the groups below and is mutated twice.
+  const stale = splitFiles.filter((file) => !mutated.includes(file));
+  if (stale.length > 0) {
+    throw new Error(
+      `mutation-shards.json splits ${stale.join(", ")}, which the mutated set ` +
+        `does not contain. Point the split entry at the file's current path.`,
+    );
+  }
 
   const shards = [];
   for (const { id, file } of config.split ?? []) {
-    const lineCount = readFileSync(join(repoRoot, file), "utf8").split(
-      "\n",
-    ).length;
-    const chunks = Math.max(1, Math.ceil(lineCount / splitEvery));
+    const chunks = Math.max(
+      1,
+      Math.ceil(lineCount(repoRoot, file) / splitEvery),
+    );
     for (let i = 0; i < chunks; i++) {
       const start = i * splitEvery + 1;
       // The last chunk ends open so the tail is always covered even if the file
@@ -53,9 +109,24 @@ export function expandShards(repoRoot) {
       shards.push({ id: `${id}-${i + 1}`, mutate: `${file}:${start}-${end}` });
     }
   }
-  for (const group of config.groups ?? []) {
-    shards.push({ id: group.id, mutate: group.mutate });
+
+  const grouped = mutated.filter((file) => !splitFiles.includes(file));
+  // An empty shard is still a matrix job the aggregator demands a report from,
+  // and it scores nothing while looking like coverage.
+  if (grouped.length < groupCount) {
+    throw new Error(
+      `mutation-shards.json groupCount is ${groupCount} but only ` +
+        `${grouped.length} mutated file(s) remain after the split entries, so ` +
+        `at least one shard would mutate nothing. Lower groupCount.`,
+    );
   }
+  const bins = balance(
+    grouped.map((file) => ({ file, lines: lineCount(repoRoot, file) })),
+    groupCount,
+  );
+  bins.forEach((files, i) =>
+    shards.push({ id: `group-${i + 1}`, mutate: files.join(",") }),
+  );
   return shards;
 }
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,17 +24,20 @@ pnpm format    # prettier --write .
 The coverage and mutation gates are scoped to what the package **ships**:
 `scripts/shipped-sources.mjs` resolves `package.json`'s `files` + `exports` +
 `bin` into the checked `.mjs` set, and `scripts/coverage.mjs`,
-`scripts/mutate.mjs` and `.github/mutation-shards.json` all consume it. Publish
-a new module and `test/shipped-gates.test.mjs` fails until it is in both gates.
-`src/` is held at 100%; `claude-hooks/` and `bin/` carry a separate, lower
-ratchet that should only ever move up.
+`scripts/mutate.mjs` and `.github/scripts/expand-shards.mjs` all consume it.
+Publish a new module and it joins both gates on commit — the shard matrix is
+derived, not listed, so there is nothing to add to `.github/mutation-shards.json`
+(which declares only which big files to chunk and how many whole-file shards to
+spread the rest over). A module published outside every named scope prefix fails
+`test/shipped-gates.test.mjs` instead of silently inheriting another scope's
+floors. `src/` is held at 100%; `claude-hooks/` and `bin/` carry a separate,
+lower ratchet that should only ever move up.
 
 The mutation gate additionally covers `.hooks/lib/`, which ships to nobody but
 derives the pre-commit guard-pair map — a resolver arm that quietly stops
 resolving there means guard tests stop running with nothing red. That scope is
-derived from the directory, so a new module in it joins the gate on commit and
-`test/shipped-gates.test.mjs` fails until `.github/mutation-shards.json` names
-it. It carries its own ratchet (`toolingScopeBreak`), same move-up-only rule.
+derived from the directory, so a new module in it joins the gate on commit. It
+carries its own ratchet (`toolingScopeBreak`), same move-up-only rule.
 
 Run the tests, lint, type-check, and formatter before pushing. The git hooks
 under `.hooks/` also enforce formatting and commit conventions on commit.

--- a/scripts/shipped-sources.mjs
+++ b/scripts/shipped-sources.mjs
@@ -177,13 +177,13 @@ export const srcScope = (repoRoot) =>
 /**
  * The shipped prefixes outside `src/`: the Claude-hook layer and the CLI.
  *
- * NAMED rather than expressed as "not `src/`", so that this module and
- * `.github/scripts/aggregate-mutation.mjs`'s mutation scopes share one
- * definition of the split instead of two that must be kept agreeing. A negation
- * would also claim every future top-level shipped directory by construction,
- * silently applying floors and a mutation ratchet measured on other files;
- * naming the prefixes leaves such a path claimed by nobody, which `hookScope`
- * throws on below.
+ * The scope NAMES what it claims, and `.github/scripts/aggregate-mutation.mjs`
+ * builds its mutation scopes from this same constant, so the coverage split and
+ * the mutation split cannot disagree. A `!startsWith(SRC_SCOPE)` catch-all would
+ * claim every future top-level shipped directory by construction, applying
+ * coverage floors and a mutation ratchet measured on files it has nothing to do
+ * with; naming the prefixes leaves such a path claimed by nobody, which
+ * `hookScope` refuses to return silently.
  */
 export const HOOK_SCOPE_PREFIXES = ["claude-hooks/", "bin/"];
 

--- a/scripts/shipped-sources.mjs
+++ b/scripts/shipped-sources.mjs
@@ -174,10 +174,37 @@ export function shippedSources(repoRoot) {
 export const srcScope = (repoRoot) =>
   shippedSources(repoRoot).filter((f) => f.startsWith(SRC_SCOPE));
 
-/** The shipped sources outside `src/`: the Claude-hook layer and the CLI.
+/**
+ * The shipped prefixes outside `src/`: the Claude-hook layer and the CLI.
+ *
+ * NAMED rather than expressed as "not `src/`", so that this module and
+ * `.github/scripts/aggregate-mutation.mjs`'s mutation scopes share one
+ * definition of the split instead of two that must be kept agreeing. A negation
+ * would also claim every future top-level shipped directory by construction,
+ * silently applying floors and a mutation ratchet measured on other files;
+ * naming the prefixes leaves such a path claimed by nobody, which `hookScope`
+ * throws on below.
+ */
+export const HOOK_SCOPE_PREFIXES = ["claude-hooks/", "bin/"];
+
+/** The shipped sources under `HOOK_SCOPE_PREFIXES`.
  * @param {string} repoRoot @returns {string[]} */
-export const hookScope = (repoRoot) =>
-  shippedSources(repoRoot).filter((f) => !f.startsWith(SRC_SCOPE));
+export const hookScope = (repoRoot) => {
+  const shipped = shippedSources(repoRoot);
+  const claimed = (/** @type {string} */ f) =>
+    f.startsWith(SRC_SCOPE) || HOOK_SCOPE_PREFIXES.some((p) => f.startsWith(p));
+  const unclaimed = shipped.filter((f) => !claimed(f));
+  if (unclaimed.length > 0) {
+    throw new Error(
+      `shipped-sources: shipped but in no gated scope: ${unclaimed.join(", ")}. ` +
+        `Add the prefix to HOOK_SCOPE_PREFIXES so these files get a coverage ` +
+        `floor and a mutation ratchet rather than none.`,
+    );
+  }
+  return shipped.filter((f) =>
+    HOOK_SCOPE_PREFIXES.some((p) => f.startsWith(p)),
+  );
+};
 
 /** Repo root, resolved from git so this works from any cwd. */
 export const findRepoRoot = () =>

--- a/test/aggregate-mutation.test.mjs
+++ b/test/aggregate-mutation.test.mjs
@@ -190,10 +190,14 @@ describe("gatedScopes", () => {
     // no threshold at all, which is the silent ungating the split exists to
     // prevent. Run over the LIVE mutated set, so a new directory that fits none
     // of the prefixes fails here rather than at the next aggregate run.
+    // Distinct sentinels, not the live ratchet values: the partition depends on
+    // the prefixes alone, so real numbers here would read as a second pin of
+    // floors that `test/shipped-gates.test.mjs` already owns, and raising a
+    // ratchet would look like drift against a test that never cared.
     const scopes = gatedScopes({
-      breakThreshold: 83,
-      hookScopeBreak: 30,
-      toolingScopeBreak: 1,
+      breakThreshold: 11,
+      hookScopeBreak: 22,
+      toolingScopeBreak: 33,
     });
     const files = mutatedSources(
       execFileSync("git", ["rev-parse", "--show-toplevel"], {

--- a/test/mutation-shards.test.mjs
+++ b/test/mutation-shards.test.mjs
@@ -27,7 +27,6 @@ import {
   expandShards,
   EOF_SENTINEL,
 } from "../.github/scripts/expand-shards.mjs";
-import { mutatedSources } from "../scripts/shipped-sources.mjs";
 
 const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
   encoding: "utf8",
@@ -59,22 +58,6 @@ describe("mutation shard matrix", () => {
       new Set(ids).size,
       ids.length,
       "shard ids must be unique (they key the per-shard incremental cache and artifact name)",
-    );
-  });
-
-  it("covers exactly the .mjs files the gate mutates", () => {
-    const onDisk = mutatedSources(repoRoot);
-
-    const inShards = [
-      ...new Set(
-        shards.flatMap((s) => parseMutate(s.mutate).map((e) => e.file)),
-      ),
-    ].sort();
-
-    assert.deepEqual(
-      inShards,
-      onDisk,
-      "shard file set must equal the mutated .mjs set (add a `split` entry or `group` when a published file or a .hooks/lib module is added/removed)",
     );
   });
 

--- a/test/mutation-shards.test.mjs
+++ b/test/mutation-shards.test.mjs
@@ -1,13 +1,13 @@
 /**
  * Contract test for the sharded mutation-testing matrix.
  *
- * `.github/mutation-shards.json` declares which files to mutate: big files under
- * `split` are chunked into `splitEvery`-line slices, the rest are hand-balanced
- * whole-file `groups`. `.github/scripts/expand-shards.mjs` turns that into the
- * concrete matrix at CI time from each file's real length. The sharded workflow
- * enumerates files explicitly — so a newly shipped file, or a hole in a split
- * file's slices, would be mutated by nobody and the gate would silently fail
- * open over uncovered code.
+ * `.github/mutation-shards.json` declares which big files to chunk into
+ * `splitEvery`-line slices and how many whole-file shards to spread the rest
+ * over; `.github/scripts/expand-shards.mjs` derives the membership from
+ * `scripts/shipped-sources.mjs` and the ranges from each file's real length.
+ * The sharded workflow enumerates files explicitly — so a newly shipped file,
+ * or a hole in a split file's slices, would be mutated by nobody and the gate
+ * would silently fail open over uncovered code.
  *
  * This guards both holes against the EXPANDED matrix (what CI actually runs):
  * every mutated `.mjs` is covered exactly once, and each split file's slices
@@ -18,7 +18,14 @@
  * outside the gate while this test stayed green.
  */
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
@@ -36,6 +43,43 @@ const config = JSON.parse(
   readFileSync(join(repoRoot, ".github", "mutation-shards.json"), "utf8"),
 );
 const shards = expandShards(repoRoot);
+
+/**
+ * A throwaway repo the expander can be driven over end to end.
+ *
+ * `src/*.mjs` is what the scratch manifest packs and `.hooks/lib` is read
+ * straight off disk, so `mutatedSources` resolves for real — the derivation
+ * under test is the live one, not a stand-in.
+ *
+ * @param {{split?: {id: string, file: string}[], groupCount?: number,
+ *   src?: Record<string, number>, tooling?: Record<string, number>,
+ *   packs?: string[]}} spec file names mapped to their line counts
+ * @returns {string} the scratch repo root
+ */
+function scratchRepo({
+  split = [],
+  groupCount = 2,
+  src = {},
+  tooling = {},
+  packs = ["src/*.mjs"],
+}) {
+  const root = mkdtempSync(join(tmpdir(), "mutation-shards-"));
+  mkdirSync(join(root, ".github"));
+  mkdirSync(join(root, "src"));
+  mkdirSync(join(root, ".hooks", "lib"), { recursive: true });
+  const write = (dir, files) => {
+    for (const [name, lines] of Object.entries(files))
+      writeFileSync(join(root, dir, name), "const x = 1;\n".repeat(lines));
+  };
+  write("src", src);
+  write(join(".hooks", "lib"), tooling);
+  writeFileSync(join(root, "package.json"), JSON.stringify({ files: packs }));
+  writeFileSync(
+    join(root, ".github", "mutation-shards.json"),
+    JSON.stringify({ splitEvery: 300, split, groupCount }),
+  );
+  return root;
+}
 
 /** Parse "src/a.mjs:1-50,src/b.mjs" into [{file, start?, end?}, ...]. */
 const parseMutate = (mutate) =>
@@ -107,6 +151,110 @@ describe("mutation shard matrix", () => {
           range.start <= lineCount,
           `${file}: slice start ${range.start} is past the file's real line count (${lineCount})`,
         );
+      }
+    }
+  });
+
+  it("puts a newly mutated file in a shard with no config edit", () => {
+    // The whole point of deriving membership: adding a module used to mean
+    // hand-typing it into `groups`, and forgetting to left it mutated by
+    // nobody while every other check stayed green.
+    const root = scratchRepo({ src: { "a.mjs": 5, "b.mjs": 5 } });
+    try {
+      const configPath = join(root, ".github", "mutation-shards.json");
+      const before = readFileSync(configPath, "utf8");
+      assert.deepEqual(
+        expandShards(root)
+          .flatMap((s) => parseMutate(s.mutate))
+          .map((e) => e.file)
+          .sort(),
+        ["src/a.mjs", "src/b.mjs"],
+      );
+
+      writeFileSync(join(root, "src", "c.mjs"), "const x = 1;\n");
+      const files = expandShards(root)
+        .flatMap((s) => parseMutate(s.mutate))
+        .map((e) => e.file);
+      assert.deepEqual(files.sort(), ["src/a.mjs", "src/b.mjs", "src/c.mjs"]);
+      assert.equal(
+        files.filter((f) => f === "src/c.mjs").length,
+        1,
+        "the new file must land in exactly one shard",
+      );
+      assert.equal(readFileSync(configPath, "utf8"), before);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("balances the group shards by line count, not file count", () => {
+    // The heavy file is LAST in path order on purpose: assigning in path order
+    // hands it to a shard that already holds a small file, so one runner does
+    // ~900 lines plus change while the other does 3. Longest-first is what
+    // isolates it. A shard's runtime tracks the mutants in it, not the paths.
+    const root = scratchRepo({
+      groupCount: 2,
+      src: { "a1.mjs": 3, "a2.mjs": 3, "zbig.mjs": 900 },
+    });
+    try {
+      const groups = expandShards(root).map((s) => s.mutate);
+      assert.deepEqual(groups, ["src/zbig.mjs", "src/a1.mjs,src/a2.mjs"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses a split entry the mutated set does not contain", () => {
+    // A rename that updates the file but not the split entry: the stale shard
+    // mutates an unscored path while the real file falls into the groups.
+    const root = scratchRepo({
+      packs: ["src/a.mjs"],
+      src: { "a.mjs": 5, "unpacked.mjs": 5 },
+      split: [{ id: "stale", file: "src/unpacked.mjs" }],
+    });
+    try {
+      assert.throws(
+        () => expandShards(root),
+        /splits src\/unpacked\.mjs, which the mutated set does not contain/,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses a groupCount that would leave a shard mutating nothing", () => {
+    const root = scratchRepo({
+      groupCount: 3,
+      src: { "a.mjs": 5, "b.mjs": 5 },
+    });
+    try {
+      assert.throws(
+        () => expandShards(root),
+        /groupCount is 3 but only 2 mutated file\(s\) remain/,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses a groupCount that is not a positive integer", () => {
+    // The config is rewritten rather than passed through `scratchRepo`, so the
+    // MISSING-key case really is missing: a helper default would silently
+    // supply the very value under test.
+    for (const groupCount of [0, -1, 2.5, "7", null, undefined]) {
+      const root = scratchRepo({ src: { "a.mjs": 5, "b.mjs": 5 } });
+      try {
+        writeFileSync(
+          join(root, ".github", "mutation-shards.json"),
+          JSON.stringify({ splitEvery: 300, split: [], groupCount }),
+        );
+        assert.throws(
+          () => expandShards(root),
+          /groupCount must be a positive integer/,
+          `groupCount ${JSON.stringify(groupCount)} must be refused`,
+        );
+      } finally {
+        rmSync(root, { recursive: true, force: true });
       }
     }
   });

--- a/test/shipped-gates.test.mjs
+++ b/test/shipped-gates.test.mjs
@@ -326,7 +326,7 @@ describe("mutation gate covers the mutated set", () => {
     assert.deepEqual(
       [...new Set(entries.map((e) => e.file))].sort(),
       mutated,
-      "shard file set must equal the mutated set (add a `split` entry or `group` in .github/mutation-shards.json)",
+      "the expanded shard matrix must cover exactly the mutated set — expand-shards.mjs derives it, so a mismatch is a bug in that derivation, not a missing config entry",
     );
 
     // A split file is deliberately spread over several line-ranged shards (the

--- a/test/shipped-gates.test.mjs
+++ b/test/shipped-gates.test.mjs
@@ -170,6 +170,35 @@ describe("shipped sources", () => {
       rmSync(scratch, { recursive: true, force: true });
     }
   });
+
+  it("throws on a shipped file that falls in no gated scope", () => {
+    // `hookScope` names its prefixes so an unclaimed path is refused rather
+    // than swept under the hook layer's floors and mutation ratchet. At this
+    // head every shipped file is claimed, so only a synthetic manifest can
+    // reach the branch — without this the guard could be deleted green.
+    const scratch = mkdtempSync(join(tmpdir(), "shipped-scope-"));
+    try {
+      mkdirSync(join(scratch, "lib"));
+      writeFileSync(join(scratch, "lib", "a.mjs"), "");
+      writeFileSync(
+        join(scratch, "package.json"),
+        JSON.stringify({ files: ["lib/*.mjs"] }),
+      );
+      // The offending path must be NAMED: an error that only says "some file"
+      // leaves the reader diffing the shipped set by hand.
+      assert.throws(() => hookScope(scratch), /in no gated scope: lib\/a\.mjs/);
+
+      mkdirSync(join(scratch, "bin"));
+      writeFileSync(join(scratch, "bin", "cli.mjs"), "");
+      writeFileSync(
+        join(scratch, "package.json"),
+        JSON.stringify({ files: ["bin/*.mjs"] }),
+      );
+      assert.deepEqual(hookScope(scratch), ["bin/cli.mjs"]);
+    } finally {
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("coverage gate covers the shipped set", () => {


### PR DESCRIPTION
Claims: the gated-scope prefixes and the mutation shard matrix.

## What & why

Delete the two remaining hand-maintained copies of the mutated file set, so both are derived from `scripts/shipped-sources.mjs`:

1. **The gated-scope prefixes.** `.github/scripts/aggregate-mutation.mjs` redeclared `src/`, `.hooks/lib/` and `["claude-hooks/", "bin/"]` locally; it now imports `SRC_SCOPE`, `TOOLING_SCOPE` and the new `HOOK_SCOPE_PREFIXES`. `hookScope()` was `!startsWith("src/")` — a second, independent definition of the same scope that could disagree with the aggregator without either test noticing, and a catch-all that would silently sweep any future top-level shipped directory into coverage floors and a mutation ratchet measured on other files. It now names its prefixes and throws, naming the file, when a shipped path falls in no scope.

2. **The shard membership.** `.github/mutation-shards.json` re-typed every mutated file under `groups` — a full second copy of the derived set, kept honest by a contract test rather than by construction. `expand-shards.mjs` now computes it: everything mutated that no `split` entry claims, spread over `groupCount` shards longest-file-first so a shard's line budget stays even. Adding a shipped module or a `.hooks/lib` one needs no config edit at all; the config keeps only the two things a human decides (which big files are worth chunking, how many whole-file shards to use).

Deriving membership also let two silent failures become loud: a `split` entry naming a file outside the mutated set (a rename that would mutate a stale path while the real file falls into the groups and gets mutated twice), and a `groupCount` larger than the files left to fill it (a shard that mutates nothing while looking like coverage).

Neither gate's file set changes: the shipped set is exactly `src/` ∪ `claude-hooks/` ∪ `bin/`, and the expanded matrix is still 66 shards over the same files.

## Review focus

Read `.github/scripts/expand-shards.mjs` first — it is the only file with new logic, and `balance()` is the part I'd most like scrutinised: it must be a pure function of the tree because the workflow and the aggregator expand the matrix separately and a disagreement means the gate scores a subset. Ties break on path for exactly that reason.

Then `scripts/shipped-sources.mjs:177-206` (`HOOK_SCOPE_PREFIXES` + the `hookScope` throw). The cross-file invariant no single screen shows: `gatedScopes()` in the aggregator and `srcScope()`/`hookScope()` in the SSOT must each partition their file set, and both now do it from the same three constants — asserted from opposite ends by `partitions every mutated file into exactly one gated scope` and `partitions every shipped file into exactly one scope`.

Breaking change for CI, not for consumers: whole-file shard ids are now positional (`group-1`…`group-7`) instead of hand-named, so the first run after this lands rebuilds those shards' incremental caches.

## How it was tested

Every new guard was shown failing on its own perturbation before being trusted:

| perturbation | goes red |
| --- | --- |
| drop `"bin/"` from `HOOK_SCOPE_PREFIXES` | `bin/sanitize-cli.mjs is claimed by 0 scope(s)` + the `hookScope` throw (3 failures) |
| `TOOLING_SCOPE` → `.hooks/libx/` | `partitions every mutated file into exactly one gated scope` |
| delete the `if` block in `hookScope` | `throws on a shipped file that falls in no gated scope` |
| `grouped.slice(1)` in the expander | `puts a newly mutated file in a shard…` + `puts every mutated file in the shard matrix…` |
| remove the stale-split check | `refuses a split entry the mutated set does not contain` |
| remove the empty-bin check | `refuses a groupCount that would leave a shard mutating nothing` |
| assign in path order instead of longest-first | `balances the group shards by line count, not file count` |

The new expander tests drive the real `mutatedSources` over a scratch repo (its own `package.json`, `src/`, `.hooks/lib/`), not a stub.

Green at this head: `pnpm test` (3648 tests), `bash .github/scripts/run-script-tests.sh` (387), `uv run pytest -q` (2472 passed, 5 skipped), `pnpm lint`, `pnpm check`, `prettier --check .`. Stryker is not run locally; the mutation gate runs in CI.

## Decisions made

- **Group shards are balanced by line count, not hand-tuned.** The old `groups` were hand-balanced for runtime; longest-file-first bin packing approximates that from the tree. Under the alternative (declaring per-group membership to keep the tuning) the duplication comes straight back.
- **Positional group ids.** Descriptive ids can't be derived, and deriving one from the member paths would rename the shard — and invalidate its cache — every time membership shifts. Positional ids cost one cache rebuild now instead of on every future change.
- **`hookScope()` throws on an unclaimed shipped file** rather than returning it: returning it would put an unmeasured directory under the hook layer's floors, the silent inheritance this change removes.
- **The check lives inside `hookScope()`**, not in a separate exported validator, so no caller has to remember it. Cost: `srcScope()`-only callers don't get it.
