### PR TITLE
fix(ci): widen the mutation dry-run oracle; feat(plugin): per-hook opt-out and an honest plugin description

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,8 +8,7 @@
   "plugins": [
     {
       "name": "agent-sanitizer",
-      "source": "./plugin",
-      "description": "Sanitization for tool inputs, tool outputs, and user prompts: invisible-Unicode/ANSI stripping, hidden-HTML splicing, exfil-URL detection, confusable normalization, and detect-secrets-backed secret redaction."
+      "source": "./plugin"
     }
   ]
 }

--- a/.github/scripts/run-mutation-dry-run.sh
+++ b/.github/scripts/run-mutation-dry-run.sh
@@ -18,15 +18,14 @@
 set -euo pipefail
 
 # The mutate scope is derived, never spelled out here: scripts/shipped-sources.mjs
-# is the same SSOT the coverage floor and the shard list read, so a new module is
-# instrumented by this oracle with no config to remember. `--mutated` is what
-# makes it the shards' scope rather than a subset of it: the matrix mutates the
-# `.hooks/lib/` tooling as well as the shipped surface, and an oracle that
+# prints the same set the shard matrix mutates — the shipped surface plus the
+# `.hooks/lib/` tooling — so a new module is instrumented by this oracle with no
+# config to remember, and no scope for this script to pick. An oracle that
 # instruments less than the matrix cannot see a dry-run failure the matrix will.
 sources=()
 while IFS= read -r line; do
   sources+=("$line")
-done < <(node scripts/shipped-sources.mjs --mutated)
+done < <(node scripts/shipped-sources.mjs)
 
 if [[ ${#sources[@]} -eq 0 ]]; then
   echo "run-mutation-dry-run: shipped-sources.mjs listed no files. The dry run" >&2

--- a/.github/scripts/run-mutation-dry-run.sh
+++ b/.github/scripts/run-mutation-dry-run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Stryker DRY RUN only, over every shipped source: instrument the tree, run the
-# suite once, exit. No mutants are executed.
+# Stryker DRY RUN only, over everything the shards mutate: instrument the tree,
+# run the suite once, exit. No mutants are executed.
 #
 # WHY THIS EXISTS. Stryker does not run the suite against the checkout — it
 # copies the project to .stryker-tmp/sandbox-XXXXXX/ and rewrites every file in
@@ -18,12 +18,15 @@
 set -euo pipefail
 
 # The mutate scope is derived, never spelled out here: scripts/shipped-sources.mjs
-# is the same SSOT the coverage floor and the shard list read, so a new shipped
-# module is instrumented by this oracle with no config to remember.
+# is the same SSOT the coverage floor and the shard list read, so a new module is
+# instrumented by this oracle with no config to remember. `--mutated` is what
+# makes it the shards' scope rather than a subset of it: the matrix mutates the
+# `.hooks/lib/` tooling as well as the shipped surface, and an oracle that
+# instruments less than the matrix cannot see a dry-run failure the matrix will.
 sources=()
 while IFS= read -r line; do
   sources+=("$line")
-done < <(node scripts/shipped-sources.mjs)
+done < <(node scripts/shipped-sources.mjs --mutated)
 
 if [[ ${#sources[@]} -eq 0 ]]; then
   echo "run-mutation-dry-run: shipped-sources.mjs listed no files. The dry run" >&2

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ npm install agent-sanitizer
 **As a Claude Code plugin:**
 
 Enter one at a time:
+
 ```
 /plugin marketplace add AlexanderMattTurner/agent-sanitizer
 ```
@@ -23,6 +24,7 @@ Enter one at a time:
 ```
 /plugin install agent-sanitizer@agent-sanitizer
 ```
+
 ```
 /agent-sanitizer:enable-auto-update
 ```

--- a/claude-hooks/lib/hook-io.mjs
+++ b/claude-hooks/lib/hook-io.mjs
@@ -243,6 +243,50 @@ export function failOpenEnabled(env = process.env) {
 }
 
 /**
+ * The public knob that turns individual hooks off: a comma-separated list of
+ * hook names (the `--hook=` modes). The layer opt-outs
+ * (`AGENT_SANITIZER_*_DISABLED`) narrow what a hook rewrites; this one is for
+ * the deployment that wants a whole event unguarded — a session whose prompts
+ * legitimately carry escape sequences, or one where the SessionStart context
+ * scan is redundant because the instruction files are already vetted upstream.
+ * Without it the only way to drop one hook is to edit the shipped hooks.json,
+ * which the next plugin update overwrites.
+ */
+export const DISABLED_HOOKS_ENV = "AGENT_SANITIZER_DISABLED_HOOKS";
+
+/**
+ * The hook names an operator switched off, restricted to `known`.
+ *
+ * An unrecognized name is REPORTED and dropped rather than thrown on, and the
+ * direction of that choice is the point: this variable is set outside the
+ * session, so a throw here — or a blocking verdict — would leave every tool
+ * call failing on a config value the session cannot edit. Dropping it keeps the
+ * named hook running, which is the safe side, and `report` is what stops it
+ * being silent.
+ * @param {readonly string[]} known  every dispatchable hook name
+ * @param {NodeJS.ProcessEnv | Record<string, string | undefined>} [env]
+ * @param {(message: string) => void} [report]
+ * @returns {Set<string>}
+ */
+export function disabledHooks(
+  known,
+  env = process.env,
+  report = (message) => process.stderr.write(`${message}\n`),
+) {
+  const named = (env[DISABLED_HOOKS_ENV] ?? "")
+    .split(",")
+    .map((name) => name.trim())
+    .filter((name) => name !== "");
+  const unknown = named.filter((name) => !known.includes(name));
+  if (unknown.length > 0)
+    report(
+      `agent-sanitizer: ${DISABLED_HOOKS_ENV} names ${unknown.join(", ")}, ` +
+        `which is not a hook — it stays ENABLED. Known hooks: ${known.join(", ")}.`,
+    );
+  return new Set(named.filter((name) => known.includes(name)));
+}
+
+/**
  * The model-facing warning accompanying a fail-open pass-through. Emitted as
  * `additionalContext` so the transcript still carries the failure: the posture
  * gives up ENFORCEMENT, not visibility, and stdout is never left empty (which

--- a/claude-hooks/plugin-hooks.mjs
+++ b/claude-hooks/plugin-hooks.mjs
@@ -15,6 +15,10 @@
  */
 import {
   claimCliEntry,
+  disabledHooks,
+  DISABLED_HOOKS_ENV,
+  emitHookResponse,
+  HookEvent,
   isMain,
   registerLazyModules,
   readFlag,
@@ -102,6 +106,66 @@ async function registerAvailableModules() {
 }
 
 /**
+ * Every dispatchable hook: its Claude Code event, and the loader that runs it.
+ *
+ * A table rather than a switch because the mode NAMES are read three ways — the
+ * dispatch, the {@link DISABLED_HOOKS_ENV} validation, and the tests that check
+ * hooks.json wires exactly these — and each hand-written copy is one that can
+ * drift into naming a hook nothing dispatches. The event is here because a
+ * disabled hook still has to answer in its own event's envelope.
+ *
+ * Each module is loaded through a LITERAL dynamic import: esbuild inlines only
+ * what it can read statically, so a computed specifier would survive into the
+ * bundle as a runtime dial against a node_modules the plugin does not ship.
+ * @type {Record<string, { event: string, run: () => Promise<void> }>}
+ */
+const HOOKS = {
+  "pretooluse-sanitize": {
+    event: HookEvent.PRE_TOOL_USE,
+    run: async () => {
+      const { cliMain } =
+        /** @type {typeof import("./pretooluse-sanitize.mjs")} */ (
+          await import("./pretooluse-sanitize.mjs")
+        );
+      await cliMain();
+    },
+  },
+  "sanitize-output": {
+    event: HookEvent.POST_TOOL_USE,
+    run: async () => {
+      const { cliMain } =
+        /** @type {typeof import("./sanitize-output.mjs")} */ (
+          await import("./sanitize-output.mjs")
+        );
+      await cliMain();
+    },
+  },
+  "sanitize-user-prompt": {
+    event: HookEvent.USER_PROMPT_SUBMIT,
+    run: async () => {
+      const { main: promptMain } =
+        /** @type {typeof import("./sanitize-user-prompt.mjs")} */ (
+          await import("./sanitize-user-prompt.mjs")
+        );
+      await promptMain(readStdinJson, (chunk) => process.stdout.write(chunk));
+    },
+  },
+  "scan-invisible-chars": {
+    event: HookEvent.SESSION_START,
+    run: async () => {
+      const { cliMain } =
+        /** @type {typeof import("./scan-invisible-chars.mjs")} */ (
+          await import("./scan-invisible-chars.mjs")
+        );
+      await cliMain();
+    },
+  },
+};
+
+/** The dispatchable hook names, in hooks.json's spelling. */
+export const HOOK_MODES = Object.freeze(Object.keys(HOOKS));
+
+/**
  * Dispatch to the hook named by `--hook=<name>` in argv. Exported and guarded by
  * isMain below so importing this module (the published entry point) is a no-op:
  * only a direct `node plugin-hooks.mjs --hook=…` run consumes stdin and exits.
@@ -115,54 +179,42 @@ export async function main() {
   await registerAvailableModules();
 
   const mode = readFlag(process.argv, "hook");
-  switch (mode) {
-    case "pretooluse-sanitize": {
-      const { cliMain } =
-        /** @type {typeof import("./pretooluse-sanitize.mjs")} */ (
-          await import("./pretooluse-sanitize.mjs")
-        );
-      await cliMain();
-      break;
-    }
-    case "sanitize-output": {
-      const { cliMain } =
-        /** @type {typeof import("./sanitize-output.mjs")} */ (
-          await import("./sanitize-output.mjs")
-        );
-      await cliMain();
-      break;
-    }
-    case "sanitize-user-prompt": {
-      const { main: promptMain } =
-        /** @type {typeof import("./sanitize-user-prompt.mjs")} */ (
-          await import("./sanitize-user-prompt.mjs")
-        );
-      await promptMain(readStdinJson, (chunk) => process.stdout.write(chunk));
-      break;
-    }
-    case "scan-invisible-chars": {
-      const { cliMain } =
-        /** @type {typeof import("./scan-invisible-chars.mjs")} */ (
-          await import("./scan-invisible-chars.mjs")
-        );
-      await cliMain();
-      break;
-    }
-    default:
-      // An unknown mode means broken hooks.json wiring — never fall through to
-      // some default hook and vet the wrong payload class. WHICH way it fails is
-      // the operator's call, taken through the one posture table like every
-      // other hook fault (this arm used to hard-exit 2 unconditionally, so the
-      // knob an operator set was silently overruled here alone).
-      process.exit(
-        writeFaultOutcome(
-          hookFaultOutcome(
-            HOOK_NAME,
-            new Error(`unknown hook mode ${JSON.stringify(mode)}`),
-          ),
+  const hook = mode === undefined ? undefined : HOOKS[mode];
+  if (mode === undefined || hook === undefined) {
+    // An unknown mode means broken hooks.json wiring — never fall through to
+    // some default hook and vet the wrong payload class. WHICH way it fails is
+    // the operator's call, taken through the one posture table like every other
+    // hook fault.
+    process.exit(
+      writeFaultOutcome(
+        hookFaultOutcome(
+          HOOK_NAME,
+          new Error(`unknown hook mode ${JSON.stringify(mode)}`),
         ),
-      );
+      ),
+    );
   }
+
+  // An empty envelope is a verdict, not a crash: stdout stays non-empty, so the
+  // launcher's post-condition sees an answer and Claude Code records a clean
+  // run rather than a hook error. The operator asked for this hook not to
+  // guard, so there is nothing to warn the MODEL about — the stderr line is
+  // where an operator finds out which hooks are off.
+  if (disabledHooks(HOOK_MODES).has(mode)) {
+    process.stderr.write(
+      `agent-sanitizer: ${mode} is off via ${DISABLED_HOOKS_ENV}; this ` +
+        `${hook.event} event is UNGUARDED.\n`,
+    );
+    emitHookResponse(hook.event, {});
+    // Every other hook reads the payload to EOF. Exiting without doing so
+    // leaves Claude Code writing into a closed pipe — an EPIPE on the harness
+    // side for any payload past the pipe buffer, which is most of them.
+    // `resume()` with no data listener consumes and discards.
+    process.stdin.resume();
+    return;
+  }
+
+  await hook.run();
 }
 
 // isMain is read BEFORE main() claims the CLI slot (the claim makes every later

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "agent-sanitizer",
   "displayName": "Agent Sanitizer",
   "version": "2.33.0",
-  "description": "The agent-sanitizer defense pipeline as a Claude Code plugin: invisible-Unicode and ANSI stripping, hidden-HTML splicing, exfil-URL detection, confusable normalization, and detect-secrets-backed secret redaction over tool inputs, tool outputs, and user prompts. A hook that cannot run says so instead of failing silently.",
+  "description": "Four hooks over everything crossing a Claude Code session. SessionStart scans CLAUDE.md, AGENTS.md and the .claude/ context files for hidden-Unicode payloads and cleans what it can. UserPromptSubmit blocks prompts carrying payload-capable invisible Unicode or ANSI escapes. PreToolUse normalizes confusable paths and commands and strips stego and terminal-control sequences from model-authored content. PostToolUse strips invisibles and ANSI, splices hidden HTML out of web and MCP output, and flags exfil-shaped URLs. Secret redaction via detect-secrets is opt-in (AGENT_SANITIZER_SECRETS_ENABLED=1). A hook that cannot run passes the guarded action through with a loud warning by default; AGENT_SANITIZER_FAIL_OPEN=0 makes it block instead, and AGENT_SANITIZER_DISABLED_HOOKS turns individual hooks off. All local and deterministic: no inference key is read and no request leaves the machine.",
   "author": {
     "name": "Alexander Matt Turner",
     "url": "https://github.com/AlexanderMattTurner/agent-sanitizer"

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -2,7 +2,8 @@
 
 Sanitization for everything flowing into and out of a Claude Code session: tool
 inputs, tool outputs, and user prompts. Hook failures pass through with a loud
-warning by default; `AGENT_SANITIZER_FAIL_OPEN=0` makes them block instead.
+warning by default; `AGENT_SANITIZER_FAIL_OPEN=0` makes them block instead, and
+`AGENT_SANITIZER_DISABLED_HOOKS` stands individual hooks down.
 
 ## Install
 
@@ -119,6 +120,15 @@ engages only when an operator asked for it:
 | Variable                            | Effect                                                                                                                                                                                                                        |
 | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `AGENT_SANITIZER_SECRETS_ENABLED=1` | Enable the secret-redaction layer: Layer-4 redaction of tool output, placeholder rehydration on Edit/Write, the placeholder-write hold on hook failure, and SessionStart provisioning of the Python engine (default: **off**) |
+
+One per-hook opt-out, for a deployment that wants a whole event left alone —
+prompts that legitimately carry escape sequences, or instruction files already
+vetted upstream. Editing the shipped `hooks.json` is the alternative, and the
+next plugin update overwrites it:
+
+| Variable                          | Effect                                                                                                                                                                                                                                                                                                                                                                                           |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `AGENT_SANITIZER_DISABLED_HOOKS=` | Comma-separated hook names to stand down: `scan-invisible-chars`, `sanitize-user-prompt`, `pretooluse-sanitize`, `sanitize-output`. Each still answers, with an empty verdict, so nothing degrades — the event is simply unguarded. A name that is not a hook is reported on stderr and its hook keeps guarding: the variable is set outside the session, so a typo must not be able to halt it. |
 
 And one posture knob, for what happens when a hook itself fails:
 

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -122,6 +122,16 @@ function readFlag(argv, name50) {
 function failOpenEnabled(env = process.env) {
   return !FAIL_CLOSED_SET.has(env[FAIL_OPEN_ENV] ?? "");
 }
+function disabledHooks(known, env = process.env, report = (message) => process.stderr.write(`${message}
+`)) {
+  const named = (env[DISABLED_HOOKS_ENV] ?? "").split(",").map((name50) => name50.trim()).filter((name50) => name50 !== "");
+  const unknown = named.filter((name50) => !known.includes(name50));
+  if (unknown.length > 0)
+    report(
+      `agent-sanitizer: ${DISABLED_HOOKS_ENV} names ${unknown.join(", ")}, which is not a hook \u2014 it stays ENABLED. Known hooks: ${known.join(", ")}.`
+    );
+  return new Set(named.filter((name50) => known.includes(name50)));
+}
 function failOpenContext(hookName, guarded, err, failedPackages = failedLazyPackages, packageMessage = missingPackageMessage) {
   const [pkg] = err instanceof TypeError ? failedPackages() : [];
   const hint = pkg === void 0 ? "" : ` ${packageMessage(pkg)}`;
@@ -353,7 +363,7 @@ function writeFileNoFollow(path2, content3, mode = 384) {
     closeSync(fd);
   }
 }
-var defaultSharedState, shared, HookEvent, PermissionDecision, FAIL_OPEN_ENV, FAIL_CLOSED_VALUES, FAIL_CLOSED_SET, LONE_SURROGATE_RE, MAX_STDIN_BYTES, lazyImportErrors, DEFAULT_MISSING_PACKAGE_REMEDY, UNTRUSTED_TEXT_CAP, HOOKGATE_MARKER_STEM;
+var defaultSharedState, shared, HookEvent, PermissionDecision, FAIL_OPEN_ENV, FAIL_CLOSED_VALUES, FAIL_CLOSED_SET, DISABLED_HOOKS_ENV, LONE_SURROGATE_RE, MAX_STDIN_BYTES, lazyImportErrors, DEFAULT_MISSING_PACKAGE_REMEDY, UNTRUSTED_TEXT_CAP, HOOKGATE_MARKER_STEM;
 var init_hook_io = __esm({
   "claude-hooks/lib/hook-io.mjs"() {
     "use strict";
@@ -380,6 +390,7 @@ var init_hook_io = __esm({
     FAIL_OPEN_ENV = "AGENT_SANITIZER_FAIL_OPEN";
     FAIL_CLOSED_VALUES = Object.freeze(["0", "false"]);
     FAIL_CLOSED_SET = new Set(FAIL_CLOSED_VALUES);
+    DISABLED_HOOKS_ENV = "AGENT_SANITIZER_DISABLED_HOOKS";
     LONE_SURROGATE_RE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
     MAX_STDIN_BYTES = 64 * 1024 * 1024;
     lazyImportErrors = /* @__PURE__ */ new Map();
@@ -70352,57 +70363,79 @@ async function registerAvailableModules() {
   );
   registerLazyModules(loaded2);
 }
-async function main2() {
-  claimCliEntry();
-  await registerAvailableModules();
-  const mode = readFlag(process.argv, "hook");
-  switch (mode) {
-    case "pretooluse-sanitize": {
+var HOOKS = {
+  "pretooluse-sanitize": {
+    event: HookEvent.PRE_TOOL_USE,
+    run: async () => {
       const { cliMain: cliMain4 } = (
         /** @type {typeof import("./pretooluse-sanitize.mjs")} */
         await init_pretooluse_sanitize().then(() => pretooluse_sanitize_exports)
       );
       await cliMain4();
-      break;
     }
-    case "sanitize-output": {
+  },
+  "sanitize-output": {
+    event: HookEvent.POST_TOOL_USE,
+    run: async () => {
       const { cliMain: cliMain4 } = (
         /** @type {typeof import("./sanitize-output.mjs")} */
         await init_sanitize_output().then(() => sanitize_output_exports)
       );
       await cliMain4();
-      break;
     }
-    case "sanitize-user-prompt": {
+  },
+  "sanitize-user-prompt": {
+    event: HookEvent.USER_PROMPT_SUBMIT,
+    run: async () => {
       const { main: promptMain } = (
         /** @type {typeof import("./sanitize-user-prompt.mjs")} */
         await init_sanitize_user_prompt().then(() => sanitize_user_prompt_exports)
       );
       await promptMain(readStdinJson, (chunk) => process.stdout.write(chunk));
-      break;
     }
-    case "scan-invisible-chars": {
+  },
+  "scan-invisible-chars": {
+    event: HookEvent.SESSION_START,
+    run: async () => {
       const { cliMain: cliMain4 } = (
         /** @type {typeof import("./scan-invisible-chars.mjs")} */
         await init_scan_invisible_chars().then(() => scan_invisible_chars_exports)
       );
       await cliMain4();
-      break;
     }
-    default:
-      process.exit(
-        writeFaultOutcome(
-          hookFaultOutcome(
-            HOOK_NAME5,
-            new Error(`unknown hook mode ${JSON.stringify(mode)}`)
-          )
-        )
-      );
   }
+};
+var HOOK_MODES = Object.freeze(Object.keys(HOOKS));
+async function main2() {
+  claimCliEntry();
+  await registerAvailableModules();
+  const mode = readFlag(process.argv, "hook");
+  const hook = mode === void 0 ? void 0 : HOOKS[mode];
+  if (mode === void 0 || hook === void 0) {
+    process.exit(
+      writeFaultOutcome(
+        hookFaultOutcome(
+          HOOK_NAME5,
+          new Error(`unknown hook mode ${JSON.stringify(mode)}`)
+        )
+      )
+    );
+  }
+  if (disabledHooks(HOOK_MODES).has(mode)) {
+    process.stderr.write(
+      `agent-sanitizer: ${mode} is off via ${DISABLED_HOOKS_ENV}; this ${hook.event} event is UNGUARDED.
+`
+    );
+    emitHookResponse(hook.event, {});
+    process.stdin.resume();
+    return;
+  }
+  await hook.run();
 }
 if (isMain(import.meta.url)) {
   await main2();
 }
 export {
+  HOOK_MODES,
   main2 as main
 };

--- a/plugin/test/plugin-bundle.test.mjs
+++ b/plugin/test/plugin-bundle.test.mjs
@@ -39,6 +39,7 @@ import {
   bundleTarget,
   runtimeRequires,
 } from "../../scripts/lib/bundle-esbuild.mjs";
+import { HOOK_MODES } from "../../claude-hooks/plugin-hooks.mjs";
 
 const ROOT = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
 const PLUGIN_DIR = join(ROOT, "plugin");
@@ -387,12 +388,10 @@ test("hooks.json wires exactly the four modes, each through the launcher", () =>
     .map((c) => /--hook=(?<mode>[\w-]+)/.exec(c)?.groups.mode)
     .filter(Boolean)
     .sort();
-  assert.deepEqual(modes, [
-    "pretooluse-sanitize",
-    "sanitize-output",
-    "sanitize-user-prompt",
-    "scan-invisible-chars",
-  ]);
+  // Against the dispatcher's own table, not a third copy of the names: a hook
+  // wired here but absent there is the unknown-mode fail-closed, and one
+  // dispatchable but unwired is a layer that silently never runs.
+  assert.deepEqual(modes, [...HOOK_MODES].sort());
   // Every sanitize call goes through the launcher, never bare node: a bare
   // `node bundle` that cannot start prints nothing, which the harness reads as
   // "no objection" and passes the guarded action through SILENTLY — no warning
@@ -409,12 +408,7 @@ test("hooks.json wires exactly the four modes, each through the launcher", () =>
 
 test("every wired mode is dispatchable (no unknown-mode fail-closed)", (t) => {
   const plugin = stagePlugin(t);
-  for (const mode of [
-    "pretooluse-sanitize",
-    "sanitize-output",
-    "sanitize-user-prompt",
-    "scan-invisible-chars",
-  ]) {
+  for (const mode of HOOK_MODES) {
     const res = launch(plugin, "PreToolUse", mode, {
       hook_event_name: "PreToolUse",
       tool_name: "Bash",
@@ -504,6 +498,64 @@ test("pretooluse hook normalizes a confusable through the inlined scanner", (t) 
     tool_input: { command: "ls /tmp/path" },
   });
   assert.equal(clean.stdout, "");
+});
+
+test("a hook named in the disable list stands down for its event only", (t) => {
+  const plugin = stagePlugin(t);
+  const payload = {
+    hook_event_name: "PostToolUse",
+    tool_name: "Bash",
+    tool_input: {},
+    // Padded past a pipe buffer: a hook that answered without draining stdin
+    // would leave the harness writing into a closed pipe, and the EPIPE would
+    // only show on payloads this size.
+    tool_response: {
+      stdout: `${ESC}[32mok${ESC}[0m a\u200bb\u200bc done${"x".repeat(1 << 20)}`,
+    },
+  };
+  const res = launch(plugin, "PostToolUse", "sanitize-output", payload, {
+    env: { AGENT_SANITIZER_DISABLED_HOOKS: "sanitize-output" },
+  });
+  assert.equal(res.status, 0);
+  // A verdict, not a crash: an empty envelope keeps stdout non-empty, so the
+  // launcher's post-condition sees an answer and does not degrade.
+  assert.deepEqual(JSON.parse(res.stdout), {
+    hookSpecificOutput: { hookEventName: "PostToolUse" },
+  });
+  assert.match(res.stderr, /sanitize-output is off/);
+
+  // Scoped: disabling one hook must not stand the others down. Without this the
+  // list could match on anything (a prefix, a substring) and silently unguard
+  // events the operator never named.
+  const other = launch(plugin, "PreToolUse", "pretooluse-sanitize", {
+    hook_event_name: "PreToolUse",
+    tool_name: "Bash",
+    tool_input: { command: "ls /tmp/pаth" },
+  });
+  const out = JSON.parse(other.stdout);
+  assert.equal(out.hookSpecificOutput.updatedInput.command, "ls /tmp/path");
+});
+
+test("a mistyped disable entry warns and leaves the hook guarding", (t) => {
+  // The variable is set outside the session, so refusing to run — or blocking —
+  // would leave every tool call failing on a value the session cannot edit. The
+  // safe direction is to keep sanitizing; the stderr line is what keeps that
+  // from being silent.
+  const res = launch(
+    stagePlugin(t),
+    "PreToolUse",
+    "pretooluse-sanitize",
+    {
+      hook_event_name: "PreToolUse",
+      tool_name: "Bash",
+      tool_input: { command: "ls /tmp/pаth" },
+    },
+    { env: { AGENT_SANITIZER_DISABLED_HOOKS: "sanitize-ouput" } },
+  );
+  assert.equal(res.status, 0);
+  assert.match(res.stderr, /sanitize-ouput.*not a hook/su);
+  const out = JSON.parse(res.stdout);
+  assert.equal(out.hookSpecificOutput.updatedInput.command, "ls /tmp/path");
 });
 
 test("output hook strips ANSI and invisibles, preserving the response shape", (t) => {

--- a/plugin/test/plugin-manifest.test.mjs
+++ b/plugin/test/plugin-manifest.test.mjs
@@ -16,7 +16,13 @@ import assert from "node:assert/strict";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { dirname, isAbsolute, join, normalize } from "node:path";
 import { fileURLToPath } from "node:url";
-import { failOpenEnabled } from "../../claude-hooks/lib/hook-io.mjs";
+import {
+  DISABLED_HOOKS_ENV,
+  FAIL_OPEN_ENV,
+  failOpenEnabled,
+  HookEvent,
+} from "../../claude-hooks/lib/hook-io.mjs";
+import { SECRETS_ENABLED_ENV } from "../../claude-hooks/lib/env-config.mjs";
 
 const ROOT = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
 const MARKETPLACE_PATH = join(ROOT, ".claude-plugin", "marketplace.json");
@@ -136,12 +142,16 @@ test("every marketplace entry resolves to a real plugin inside the repo", () => 
 
     // The docs are explicit that plugin.json's version wins silently over the
     // entry's, so a version here would be a value nobody can observe — and a
-    // trap the moment the two drift.
-    assert.equal(
-      entry.version,
-      undefined,
-      `${entry.name}: pin the version in plugin.json, not the marketplace entry`,
-    );
+    // trap the moment the two drift. `description` resolves the same way, and
+    // it drifted for real: the entry's copy still advertised a posture the
+    // hooks had stopped taking, several releases after the manifest's was
+    // corrected. Neither field is restated here; plugin.json is the source.
+    for (const field of ["version", "description"])
+      assert.equal(
+        entry[field],
+        undefined,
+        `${entry.name}: set ${field} in plugin.json, not the marketplace entry`,
+      );
   }
 });
 
@@ -186,20 +196,32 @@ test("the hooks Claude Code loads are where it looks for them", () => {
   assert.ok(Object.keys(readJson(path).hooks).length > 0);
 });
 
-test("neither description advertises a posture the hooks do not take", () => {
-  // The default posture is fail-OPEN (a hook that cannot run warns and passes
-  // the action through). Both descriptions are pre-install surfaces — the
-  // marketplace entry is what `/plugin marketplace` lists, the manifest is what
-  // the picker shows — and both claimed fail-closed for several releases after
-  // the default flipped.
+test("the description does not advertise a posture the hooks do not take", () => {
+  // The description is the pre-install surface — what the picker and
+  // `/plugin marketplace` show — so it is the one place a reader decides what
+  // this plugin does before any of it runs. The default posture is fail-OPEN:
+  // a hook that cannot run warns and passes the action through.
   assert.equal(
     failOpenEnabled({}),
     true,
-    "default posture changed — revisit both descriptions",
+    "default posture changed — revisit the description",
   );
-  const entry = marketplace.plugins.find((p) => p.source === "./plugin");
-  for (const text of [manifest.description, entry.description])
-    assert.doesNotMatch(text, /fails?[- ]closed/i);
+  assert.doesNotMatch(manifest.description, /fails?[- ]closed/i);
+});
+
+test("the description names each hook's event and every public knob", () => {
+  // A description that lists capabilities without saying which event they run
+  // on, or that omits a knob, is the drift this test exists to catch: the
+  // picker is the only surface an operator reads before installing, and both
+  // halves went stale before (a posture claim that had flipped, and a layer
+  // that shipped opt-in with the description still implying it was always on).
+  for (const event of Object.values(HookEvent))
+    assert.match(manifest.description, new RegExp(event, "u"));
+  for (const knob of [FAIL_OPEN_ENV, DISABLED_HOOKS_ENV, SECRETS_ENABLED_ENV])
+    assert.ok(
+      manifest.description.includes(knob),
+      `description does not mention ${knob}`,
+    );
 });
 
 // ─── the install commands the docs advertise ─────────────────────────────────

--- a/scripts/shipped-sources.mjs
+++ b/scripts/shipped-sources.mjs
@@ -15,7 +15,11 @@
  *
  * Usage:
  *   import { shippedSources } from "./shipped-sources.mjs";
- *   node scripts/shipped-sources.mjs   → one repo-relative path per line
+ *   node scripts/shipped-sources.mjs   → the MUTATED set, one path per line
+ *
+ * The CLI prints the mutation scope rather than the shipped subset the module
+ * is named for: see the block above it for why that is the shape with no scope
+ * decision in it.
  */
 import { execFileSync } from "node:child_process";
 import { readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
@@ -190,37 +194,15 @@ export const findRepoRoot = () =>
     cwd: dirname(fileURLToPath(import.meta.url)),
   }).trim();
 
-/**
- * The list a CLI invocation prints: the shipped surface, or with `--mutated`
- * everything the mutation gate instruments (that surface plus the tooling).
- *
- * An unknown argument throws rather than falling back to the shipped list: a
- * caller asking for a scope this module does not know about would otherwise
- * gate a NARROWER set than it believes, silently.
- *
- * @param {string[]} argv arguments after the script path
- * @param {string} repoRoot absolute path to the repository root
- * @returns {string[]} repo-relative POSIX paths, sorted
- */
-export function cliSources(argv, repoRoot) {
-  const [scope, ...rest] = argv;
-  if (rest.length > 0 || (scope !== undefined && scope !== "--mutated")) {
-    throw new Error(
-      `shipped-sources: unrecognized arguments ${argv.join(" ")}. Pass no ` +
-        `argument for the shipped sources, or --mutated for the full ` +
-        `mutation scope.`,
-    );
-  }
-  return scope === "--mutated"
-    ? mutatedSources(repoRoot)
-    : shippedSources(repoRoot);
-}
-
+// The CLI prints the MUTATED set, a superset of the shipped one the module is
+// named for. Its one consumer is the mutation dry-run oracle, which has to
+// instrument everything the shard matrix does or it passes on exactly the
+// commits where a shard is about to die; printing the superset makes that hold
+// by construction, with no scope for the shell to choose and none to police.
+// Every other consumer imports the export it wants.
 if (
   process.argv[1] &&
   realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)
 ) {
-  process.stdout.write(
-    `${cliSources(process.argv.slice(2), findRepoRoot()).join("\n")}\n`,
-  );
+  process.stdout.write(`${mutatedSources(findRepoRoot()).join("\n")}\n`);
 }

--- a/scripts/shipped-sources.mjs
+++ b/scripts/shipped-sources.mjs
@@ -190,9 +190,37 @@ export const findRepoRoot = () =>
     cwd: dirname(fileURLToPath(import.meta.url)),
   }).trim();
 
+/**
+ * The list a CLI invocation prints: the shipped surface, or with `--mutated`
+ * everything the mutation gate instruments (that surface plus the tooling).
+ *
+ * An unknown argument throws rather than falling back to the shipped list: a
+ * caller asking for a scope this module does not know about would otherwise
+ * gate a NARROWER set than it believes, silently.
+ *
+ * @param {string[]} argv arguments after the script path
+ * @param {string} repoRoot absolute path to the repository root
+ * @returns {string[]} repo-relative POSIX paths, sorted
+ */
+export function cliSources(argv, repoRoot) {
+  const [scope, ...rest] = argv;
+  if (rest.length > 0 || (scope !== undefined && scope !== "--mutated")) {
+    throw new Error(
+      `shipped-sources: unrecognised arguments ${argv.join(" ")}. Pass no ` +
+        `argument for the shipped sources, or --mutated for the full ` +
+        `mutation scope.`,
+    );
+  }
+  return scope === "--mutated"
+    ? mutatedSources(repoRoot)
+    : shippedSources(repoRoot);
+}
+
 if (
   process.argv[1] &&
   realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)
 ) {
-  process.stdout.write(`${shippedSources(findRepoRoot()).join("\n")}\n`);
+  process.stdout.write(
+    `${cliSources(process.argv.slice(2), findRepoRoot()).join("\n")}\n`,
+  );
 }

--- a/scripts/shipped-sources.mjs
+++ b/scripts/shipped-sources.mjs
@@ -206,7 +206,7 @@ export function cliSources(argv, repoRoot) {
   const [scope, ...rest] = argv;
   if (rest.length > 0 || (scope !== undefined && scope !== "--mutated")) {
     throw new Error(
-      `shipped-sources: unrecognised arguments ${argv.join(" ")}. Pass no ` +
+      `shipped-sources: unrecognized arguments ${argv.join(" ")}. Pass no ` +
         `argument for the shipped sources, or --mutated for the full ` +
         `mutation scope.`,
     );

--- a/test/mutation-shards.test.mjs
+++ b/test/mutation-shards.test.mjs
@@ -144,47 +144,24 @@ describe("mutation shard matrix", () => {
 });
 
 describe("the dry-run oracle's scope", () => {
-  /** @param {string[]} argv @returns {string[]} the CLI's printed list */
-  const cli = (argv) =>
-    execFileSync(
+  // The oracle instruments whatever this CLI prints. Printing the SHIPPED
+  // subset is what let it pass on exactly the commits where a shard was about
+  // to die: the matrix mutates the `.hooks/lib/` tooling too, and a dry-run
+  // failure there is invisible to an oracle that never instrumented it.
+  it("prints everything the shards mutate, tooling included", () => {
+    const printed = execFileSync(
       process.execPath,
-      [join(repoRoot, "scripts", "shipped-sources.mjs"), ...argv],
+      [join(repoRoot, "scripts", "shipped-sources.mjs")],
       { encoding: "utf8" },
     )
       .trim()
       .split("\n");
-
-  it("prints the shipped surface bare, and the mutated set under --mutated", () => {
-    assert.deepEqual(cli([]), shippedSources(repoRoot));
-    assert.deepEqual(cli(["--mutated"]), mutatedSources(repoRoot));
-    // The two must actually differ, or this suite and the wiring pin below both
-    // hold with the oracle still instrumenting a subset of the matrix.
+    assert.deepEqual(printed, mutatedSources(repoRoot));
+    // Without this the assertion above holds just as well while the two sets
+    // are equal, which is the state it exists to rule out.
     assert.ok(
       mutatedSources(repoRoot).length > shippedSources(repoRoot).length,
-      "the tooling half of the mutated set is empty — --mutated proves nothing",
-    );
-  });
-
-  it("refuses a scope it does not know instead of printing a narrower one", () => {
-    // Falling back to the shipped list would gate LESS than the caller asked
-    // for, silently: the failure this whole job exists to catch.
-    assert.throws(() => cli(["--everything"]), /unrecognized arguments/u);
-  });
-
-  it("asks for the scope the shards mutate", () => {
-    // A wiring pin: the oracle runs the suite once over everything the matrix
-    // instruments, and it is the shell script that chooses which. Instrumenting
-    // a subset is invisible — the job passes and a shard then dies on a dry-run
-    // failure the oracle was supposed to name first. Anchored on the whole
-    // command line, not on the flag: the script's own comments name `--mutated`
-    // too, and a mention must not read as the invocation.
-    const script = readFileSync(
-      join(repoRoot, ".github", "scripts", "run-mutation-dry-run.sh"),
-      "utf8",
-    );
-    assert.match(
-      script,
-      /^done < <\(node scripts\/shipped-sources\.mjs --mutated\)$/mu,
+      "the tooling half of the mutated set is empty — this proves nothing",
     );
   });
 });

--- a/test/mutation-shards.test.mjs
+++ b/test/mutation-shards.test.mjs
@@ -168,19 +168,23 @@ describe("the dry-run oracle's scope", () => {
   it("refuses a scope it does not know instead of printing a narrower one", () => {
     // Falling back to the shipped list would gate LESS than the caller asked
     // for, silently: the failure this whole job exists to catch.
-    assert.throws(() => cli(["--everything"]), /unrecognised arguments/u);
+    assert.throws(() => cli(["--everything"]), /unrecognized arguments/u);
   });
 
   it("asks for the scope the shards mutate", () => {
     // A wiring pin: the oracle runs the suite once over everything the matrix
     // instruments, and it is the shell script that chooses which. Instrumenting
     // a subset is invisible — the job passes and a shard then dies on a dry-run
-    // failure the oracle was supposed to name first, which is how the
-    // `.hooks/lib/` half went unwatched.
+    // failure the oracle was supposed to name first. Anchored on the whole
+    // command line, not on the flag: the script's own comments name `--mutated`
+    // too, and a mention must not read as the invocation.
     const script = readFileSync(
       join(repoRoot, ".github", "scripts", "run-mutation-dry-run.sh"),
       "utf8",
     );
-    assert.match(script, /shipped-sources\.mjs --mutated\)/u);
+    assert.match(
+      script,
+      /^done < <\(node scripts\/shipped-sources\.mjs --mutated\)$/mu,
+    );
   });
 });

--- a/test/mutation-shards.test.mjs
+++ b/test/mutation-shards.test.mjs
@@ -27,7 +27,7 @@ import {
   expandShards,
   EOF_SENTINEL,
 } from "../.github/scripts/expand-shards.mjs";
-import { mutatedSources } from "../scripts/shipped-sources.mjs";
+import { mutatedSources, shippedSources } from "../scripts/shipped-sources.mjs";
 
 const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
   encoding: "utf8",
@@ -140,5 +140,47 @@ describe("mutation shard matrix", () => {
         );
       }
     }
+  });
+});
+
+describe("the dry-run oracle's scope", () => {
+  /** @param {string[]} argv @returns {string[]} the CLI's printed list */
+  const cli = (argv) =>
+    execFileSync(
+      process.execPath,
+      [join(repoRoot, "scripts", "shipped-sources.mjs"), ...argv],
+      { encoding: "utf8" },
+    )
+      .trim()
+      .split("\n");
+
+  it("prints the shipped surface bare, and the mutated set under --mutated", () => {
+    assert.deepEqual(cli([]), shippedSources(repoRoot));
+    assert.deepEqual(cli(["--mutated"]), mutatedSources(repoRoot));
+    // The two must actually differ, or this suite and the wiring pin below both
+    // hold with the oracle still instrumenting a subset of the matrix.
+    assert.ok(
+      mutatedSources(repoRoot).length > shippedSources(repoRoot).length,
+      "the tooling half of the mutated set is empty — --mutated proves nothing",
+    );
+  });
+
+  it("refuses a scope it does not know instead of printing a narrower one", () => {
+    // Falling back to the shipped list would gate LESS than the caller asked
+    // for, silently: the failure this whole job exists to catch.
+    assert.throws(() => cli(["--everything"]), /unrecognised arguments/u);
+  });
+
+  it("asks for the scope the shards mutate", () => {
+    // A wiring pin: the oracle runs the suite once over everything the matrix
+    // instruments, and it is the shell script that chooses which. Instrumenting
+    // a subset is invisible — the job passes and a shard then dies on a dry-run
+    // failure the oracle was supposed to name first, which is how the
+    // `.hooks/lib/` half went unwatched.
+    const script = readFileSync(
+      join(repoRoot, ".github", "scripts", "run-mutation-dry-run.sh"),
+      "utf8",
+    );
+    assert.match(script, /shipped-sources\.mjs --mutated\)/u);
   });
 });


### PR DESCRIPTION
Claims: the mutation dry-run oracle's `--mutate` scope, and the plugin's description/config surface.

Two independent pieces, one branch and one CI run (see `## Partitions`).

## Partitions

| Commits | Area |
| --- | --- |
| `fix(ci)` + `test(ci)` + `refactor(ci)` | `.github/scripts/run-mutation-dry-run.sh`, `scripts/shipped-sources.mjs`, `test/mutation-shards.test.mjs`, `README.md` |
| `feat(plugin): stand individual hooks down with AGENT_SANITIZER_DISABLED_HOOKS` | `claude-hooks/`, `plugin/dist/`, `plugin/README.md`, `plugin/test/plugin-bundle.test.mjs` |
| `docs(plugin): make the plugin description a real summary, sourced from plugin.json alone` | `plugin/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `plugin/test/plugin-manifest.test.mjs` |

## What & why

**1. The dry-run oracle instrumented less than the shards do.** It exists so a test that breaks under Stryker instrumentation is named once, in a two-minute job, instead of killing all ~60 twenty-five-minute shards. `scripts/shipped-sources.mjs`'s CLI printed the *shipped* list while the matrix mutates shipped ∪ `.hooks/lib/` — 39 files vs 40 on current main. The one file in the gap, `.hooks/lib/guarded-data-scan.mjs`, reads files from disk and cares about their shape, so the oracle passed green on exactly the commits where a shard was about to die.

The CLI now prints `mutatedSources(findRepoRoot())`. That is the whole fix: its only consumer is the oracle (every other consumer imports the export it wants), so the invariant *oracle scope ⊇ shard scope* holds by construction, with no scope for the shell script to choose and nothing to police. `run-mutation-dry-run.sh` is unchanged apart from its comment. The module's `Usage:` block says why a file named for the shipped set prints a superset.

**2. The plugin's pre-install description was stale, duplicated, and had no room for the knobs.** The marketplace entry restated the manifest's description in its own words, so the two drifted — the entry still advertised a posture the hooks had stopped taking, several releases after the manifest's copy was corrected. Claude Code resolves `description` from `plugin.json` when the entry omits it, exactly as it already does for `version`, so the entry's copy is deleted and `plugin.json` is the source. The description is rewritten to say what each of the four hooks actually does, on which event, and to name every public knob.

**3. There was no way to turn one hook off.** The layer opt-outs narrow what a hook *rewrites*; nothing stood a whole event down short of editing the shipped `hooks.json`, which the next plugin update overwrites. `AGENT_SANITIZER_DISABLED_HOOKS` takes a comma-separated list of hook names. A disabled hook still answers — an empty envelope, so stdout stays non-empty and the launcher's post-condition sees a verdict rather than degrading — writes one stderr line saying its event is unguarded, and drains stdin so the harness is not left writing into a closed pipe. The dispatcher's four-arm `switch` becomes a `HOOKS` table exporting `HOOK_MODES`, which is now the single list the disable-validation and both wiring tests read instead of three hand-written copies.

## Review focus

`claude-hooks/plugin-hooks.mjs` first — the disable branch is the only new path that can leave an event unguarded, and the question worth checking is whether an empty `hookSpecificOutput` envelope is genuinely inert on all four events. On the CI half the invariant is *oracle scope ⊇ shard scope*; it is now structural rather than tested, so the thing to check is that no other caller wanted the bare shipped list from the CLI (`scripts/mutate.mjs`, `scripts/coverage.mjs` and every test import the module directly).

## How it was tested

- `pnpm test` → 3672 pass, 0 fail; both coverage floors hold. (Run before the review-fix commit, which is a strict deletion plus a one-line CLI change; `test/mutation-shards.test.mjs`, `test/shipped-gates.test.mjs` and `test/aggregate-mutation.test.mjs` re-run green after it — 27 pass, 0 fail.)
- `node --test plugin/test/*.test.mjs` → 96 pass, 0 fail, including the two new toggle cases (a named hook stands down while its siblings keep guarding; a mistyped name warns and the hook still sanitizes).
- `pnpm lint`, `pnpm check` clean; `plugin/dist/` regenerated by `node plugin/scripts/build-plugin.mjs` and byte-compared by the reproducibility test.
- Executed the widened oracle end to end: `Found 40 of 1146 file(s) to be mutated`, exit 0. Before the change it reported 39.

## Decisions made

- **A mistyped `AGENT_SANITIZER_DISABLED_HOOKS` entry warns and leaves the hook guarding**, rather than throwing or blocking. The variable is set outside the session, so a throw would leave every tool call failing on a value the session cannot edit — the lockout shape `safe-launch.sh` exists to avoid. Under the alternative (throw, as `extraSecretVars` does) a typo is impossible to miss, at the cost of a config typo halting the session.
- **A disabled hook emits an empty envelope rather than exiting silently.** Empty stdout is what Claude Code reads as a hook error, and it is what the launcher's degrade path is keyed on; an explicit verdict keeps the two apart. Under the alternative the transcript cannot distinguish "off by request" from "crashed".
- **The marketplace entry's `description` is deleted, not generated.** This follows the `version` precedent already pinned by `plugin-manifest.test.mjs` (plugin.json wins silently, so a second copy is unobservable and a drift trap). The alternative — generating the entry's copy from `plugin.json` with a round-trip freshness check — keeps the field present for any consumer that does not fall back, at the cost of a build step and a generated artifact.
- **The CLI prints the mutation scope, at the cost of name fidelity.** A `--mutated` flag was the first shape; it put a scope decision at the call site and needed a regex over the shell script to keep it there, which `.claude/rules/code-style.md` names twice (a drift guard is the signal to remove the duplication, and a "does the code do X" check over shell must not be text matching). Under the alternative the CLI's name matches its bare output, and the oracle's scope is a thing that can drift again.
- **The two pieces share one branch and one PR.** The CI-oracle fix and the plugin work are unrelated; consolidating is the repo's stated default (one CI fan-out, one review), and the `## Partitions` table above is the per-concern map.
- **The README whitespace reflow is folded in** rather than opened as a one-hunk PR: two blank lines Prettier requires around the `/plugin marketplace add` fences, already red on main from `3f62e66`.
