### PR TITLE
perf(invisible): stop scanning prompts with a regex per code point

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ npm install agent-sanitizer
 **As a Claude Code plugin:**
 
 Enter one at a time:
+
 ```
 /plugin marketplace add AlexanderMattTurner/agent-sanitizer
 ```
@@ -23,6 +24,7 @@ Enter one at a time:
 ```
 /plugin install agent-sanitizer@agent-sanitizer
 ```
+
 ```
 /agent-sanitizer:enable-auto-update
 ```

--- a/src/invisible.mjs
+++ b/src/invisible.mjs
@@ -468,13 +468,38 @@ function isHangul(ch) {
   return HANGUL_RE.test(ch);
 }
 
-// Non-global single-char classifiers (CHECKS carry `g`, whose lastIndex is
-// stateful across `.test`). carveStrip uses these to attribute each removed
-// char to its CHECKS category so `found` names exactly what was stripped.
-const CHECK_ONE = CHECKS.map(
-  ([code, re]) =>
-    /** @type {[string, RegExp]} */ ([code, new RegExp(re.source, "u")]),
-);
+// code point -> CHECKS category, projected from the SAME three code-point sets
+// the CHECKS regexes are built from, in CHECKS order so a code point in two sets
+// gets the category the regexes would report first. Every CHECKS class holds
+// single code points under the `u` flag, so a lookup and a `.test` answer
+// identically; test/invisible-fast-path.test.mjs pins that over the whole
+// code-point space, because a code point dropped here is one the scatter gate
+// stops counting. A lookup rather than the regexes because this runs once per
+// code point of every prompt and tool output.
+/** @type {Map<number, string>} */
+const TRACKED_INVISIBLE = new Map();
+for (const [code, codepoints] of /** @type {[string, Iterable<number>][]} */ ([
+  [CATEGORY.CF, CF_CODEPOINTS],
+  [CATEGORY.VARIATION_SELECTORS, [...VS].map((ch) => ch.codePointAt(0))],
+  [CATEGORY.BLANK_FILLERS, [...BLANK_NON_CF].map((ch) => ch.codePointAt(0))],
+]))
+  for (const cp of codepoints)
+    if (!TRACKED_INVISIBLE.has(cp)) TRACKED_INVISIBLE.set(cp, code);
+
+// No tracked code point sits below this, so ASCII and Latin-1 text answers the
+// classifier without touching the map at all.
+const MIN_TRACKED_CP = Math.min(...TRACKED_INVISIBLE.keys());
+
+/**
+ * The CHECKS category code (a CATEGORY value) a code point belongs to, or null
+ * when it is not payload-capable (an ordinary visible character).
+ * @param {number} cp
+ * @returns {string | null}
+ */
+function classifyCp(cp) {
+  if (cp < MIN_TRACKED_CP) return null;
+  return TRACKED_INVISIBLE.get(cp) ?? null;
+}
 
 /**
  * The CHECKS category code (a CATEGORY value) a single code point belongs to,
@@ -483,8 +508,44 @@ const CHECK_ONE = CHECKS.map(
  * @returns {string | null}
  */
 function classify(ch) {
-  for (const [code, re] of CHECK_ONE) if (re.test(ch)) return code;
-  return null;
+  return classifyCp(/** @type {number} */ (ch.codePointAt(0)));
+}
+
+/**
+ * True when `text` holds at least one code point {@link classify} calls
+ * invisible. Walks UTF-16 units directly rather than iterating code-point
+ * strings, so a clean multi-MB paste is answered without allocating one string
+ * per character; surrogates are paired exactly as the String iterator pairs
+ * them, an unpaired one classifying as the lone surrogate it is.
+ * @param {string} text
+ * @returns {boolean}
+ */
+function hasInvisibleCodePoint(text) {
+  for (let i = 0; i < text.length; i++) {
+    let cp = text.charCodeAt(i);
+    if (cp >= 0xd800 && cp <= 0xdbff && i + 1 < text.length) {
+      const low = text.charCodeAt(i + 1);
+      if (low >= 0xdc00 && low <= 0xdfff) {
+        cp = (cp - 0xd800) * 0x400 + (low - 0xdc00) + 0x10000;
+        i++;
+      }
+    }
+    if (classifyCp(cp) !== null) return true;
+  }
+  return false;
+}
+
+/**
+ * The number of code points in `text`, counted by the String iterator itself —
+ * the same unit `Array.from(text).length` measures, without the array.
+ * @param {string} text
+ * @returns {number}
+ */
+function codePointLength(text) {
+  let n = 0;
+  const iterator = text[Symbol.iterator]();
+  while (!iterator.next().done) n++;
+  return n;
 }
 
 /** A cursive-joining letter: Joining_Type dual, right, or left. (C is a join
@@ -621,18 +682,36 @@ function isEmojiPresentationSelector(cps, i) {
  * @returns {{ codes: (string|null)[], kind: (string|null)[], payloadInvis: number, visibleLen: number }}
  */
 function analyzeCarve(cps) {
-  const codes = cps.map(classify);
-  const tagKeep = markTagSequences(cps);
-  const kind = cps.map((_, i) => {
-    if (codes[i] === null) return null;
-    if (tagKeep[i]) return "tag";
-    if (isPreservedJoiner(cps, i)) return "joiner";
-    if (isEmojiPresentationSelector(cps, i)) return "emojivs";
-    if (isStandardizedVariationSelector(cps, i)) return "stdvs";
-    if (isIdeographicVariationSelector(cps, i)) return "ivs";
-    if (isPreservedBlankFiller(cps, i)) return "blank";
-    return null;
-  });
+  const codes = new Array(cps.length);
+  // Indices of the invisibles, so every pass below is O(invisibles) rather than
+  // O(length): in ordinary text they are a vanishing fraction of a paste, and a
+  // full-length pass per preserve rule is what made the analysis linear in the
+  // WHOLE prompt several times over.
+  const invisible = [];
+  let visibleLen = 0;
+  let hasTagBase = false;
+  for (let i = 0; i < cps.length; i++) {
+    const code = classify(cps[i]);
+    codes[i] = code;
+    if (code !== null) {
+      invisible.push(i);
+      continue;
+    }
+    visibleLen++;
+    hasTagBase ||= cps[i].codePointAt(0) === TAG_BASE;
+  }
+  // A tag sequence is preservable only when it opens on a TAG_BASE pictograph,
+  // so with no base in the text markTagSequences returns all-false.
+  const tagKeep = hasTagBase ? markTagSequences(cps) : null;
+  const kind = new Array(cps.length).fill(null);
+  for (const i of invisible) {
+    if (tagKeep !== null && tagKeep[i]) kind[i] = "tag";
+    else if (isPreservedJoiner(cps, i)) kind[i] = "joiner";
+    else if (isEmojiPresentationSelector(cps, i)) kind[i] = "emojivs";
+    else if (isStandardizedVariationSelector(cps, i)) kind[i] = "stdvs";
+    else if (isIdeographicVariationSelector(cps, i)) kind[i] = "ivs";
+    else if (isPreservedBlankFiller(cps, i)) kind[i] = "blank";
+  }
   // Blank fillers are budgeted here, document-wide and all-or-nothing, against
   // the visible anchor-script text rather than against the joiner/selector
   // counter in carveStrip (see PRESERVED_BLANK_PER_ANCHOR for why the two
@@ -647,13 +726,13 @@ function analyzeCarve(cps) {
   // `⠃⠀⠃⠀…` alternation of 200 Braille blanks. The anchor scan is skipped below
   // the floor: it costs a script regex per visible character, and analyzeCarve
   // runs on every prompt and tool output.
-  const blankScript = kind.map((k, i) =>
-    k !== "blank"
-      ? null
-      : cps[i].codePointAt(0) === BRAILLE_BLANK
-        ? "braille"
-        : "hangul",
-  );
+  /** @type {Record<string, number[]>} */
+  const blankIndices = { braille: [], hangul: [] };
+  for (const i of invisible)
+    if (kind[i] === "blank")
+      blankIndices[
+        cps[i].codePointAt(0) === BRAILLE_BLANK ? "braille" : "hangul"
+      ].push(i);
   for (const [
     script,
     isAnchor,
@@ -661,22 +740,17 @@ function analyzeCarve(cps) {
     ["braille", isBrailleCell],
     ["hangul", isHangul],
   ])) {
-    const blanks = blankScript.filter((s) => s === script).length;
-    if (blanks <= TOTAL_PRESERVED_BLANK_BUDGET) continue;
+    const indices = blankIndices[script];
+    if (indices.length <= TOTAL_PRESERVED_BLANK_BUDGET) continue;
     const anchors = cps.reduce(
       (n, ch, i) => n + (codes[i] === null && isAnchor(ch) ? 1 : 0),
       0,
     );
-    if (blanks > Math.floor(anchors / PRESERVED_BLANK_PER_ANCHOR))
-      for (let i = 0; i < kind.length; i++)
-        if (blankScript[i] === script) kind[i] = null;
+    if (indices.length > Math.floor(anchors / PRESERVED_BLANK_PER_ANCHOR))
+      for (const i of indices) kind[i] = null;
   }
   let payloadInvis = 0;
-  let visibleLen = 0;
-  for (let i = 0; i < cps.length; i++) {
-    if (codes[i] === null) visibleLen++;
-    else if (kind[i] === null) payloadInvis++;
-  }
+  for (const i of invisible) if (kind[i] === null) payloadInvis++;
   return { codes, kind, payloadInvis, visibleLen };
 }
 
@@ -690,6 +764,12 @@ function analyzeCarve(cps) {
  * @returns {number}
  */
 export function countPayloadInvisible(text) {
+  // Payload is a SUBSET of the invisibles (analyzeCarve counts only positions
+  // classify marks invisible), so a text with none has a payload count of zero
+  // and needs neither the code-point array nor the carve analysis. This reads
+  // every code point — it is a necessary condition checked in full, not a scan
+  // bound an attacker could paste past.
+  if (!hasInvisibleCodePoint(text)) return 0;
   return analyzeCarve(Array.from(text)).payloadInvis;
 }
 
@@ -853,7 +933,7 @@ function clusterEnds(body) {
   const ends = [];
   let end = 0;
   for (const { segment } of GRAPHEME_SEGMENTER.segment(body)) {
-    end += Array.from(segment).length;
+    end += codePointLength(segment);
     ends.push(end);
   }
   return ends;
@@ -1067,6 +1147,13 @@ export function payloadInvisibleView(text) {
  * @returns {string | null}
  */
 export function payloadLongRunSample(text) {
+  // The view is code-point-for-code-point with `text` and only ever REPLACES an
+  // invisible with a space, so a run in the view is a run in `text`: no long run
+  // in the raw text means none in the view. This hides no payload — the bulk
+  // regex reads the whole text, and a run it finds still goes through the full
+  // carve analysis below to decide what of it is really payload.
+  LONG_RUN_RE.lastIndex = 0;
+  if (!LONG_RUN_RE.test(text)) return null;
   LONG_RUN_RE.lastIndex = 0;
   return payloadInvisibleView(text).match(LONG_RUN_RE)?.[0] ?? null;
 }
@@ -1093,11 +1180,13 @@ export function payloadLongRunSample(text) {
  */
 export function countEffectiveInvisible(text) {
   const payload = countPayloadInvisible(text);
-  const surplusPreservedJoiners = Math.max(
-    0,
-    [...text].length - [...stripInvisible(text)].length - payload,
-  );
-  return payload + surplusPreservedJoiners;
+  const stripped = stripInvisible(text);
+  // Two identical strings differ by zero code points, so the common clean paste
+  // skips both counting passes; codePointLength is the String iterator's count,
+  // the same unit `[...text].length` measures, without the array.
+  const removed =
+    stripped === text ? 0 : codePointLength(text) - codePointLength(stripped);
+  return payload + Math.max(0, removed - payload);
 }
 
 /**

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -4,7 +4,7 @@
   "plugins": ["@stryker-mutator/tap-runner"],
   "testRunner": "tap",
   "tap": {
-    "testFiles": ["test/**/*.test.mjs", "!test/prompt-latency.test.mjs"],
+    "testFiles": ["test/**/*.test.mjs"],
     "nodeArgs": ["--test-reporter=tap"]
   },
   "coverageAnalysis": "perTest",

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -4,7 +4,7 @@
   "plugins": ["@stryker-mutator/tap-runner"],
   "testRunner": "tap",
   "tap": {
-    "testFiles": ["test/**/*.test.mjs"],
+    "testFiles": ["test/**/*.test.mjs", "!test/prompt-latency.test.mjs"],
     "nodeArgs": ["--test-reporter=tap"]
   },
   "coverageAnalysis": "perTest",

--- a/test/invisible-fast-path.test.mjs
+++ b/test/invisible-fast-path.test.mjs
@@ -1,0 +1,272 @@
+/**
+ * The counting entry points short-circuit before the per-code-point carve
+ * analysis (see countPayloadInvisible / payloadLongRunSample /
+ * countEffectiveInvisible). Each short-circuit is only sound if it agrees with
+ * the analysis EXACTLY — these feed the prompt gate's block decision, so a count
+ * that is merely close is a bypass. Every test here pins a fast path against the
+ * slow definition it replaced, expressed in exported API:
+ *
+ *   countPayloadInvisible(t)   == payload code points in payloadInvisibleView(t)
+ *   payloadLongRunSample(t)    == payloadInvisibleView(t).match(LONG_RUN_RE)
+ *   countEffectiveInvisible(t) == payload + max(0, cpLen(t) - cpLen(strip(t)) - payload)
+ *
+ * payloadInvisibleView walks the whole code-point array with no short-circuit,
+ * so it is the independent reference, not a restatement.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fc from "fast-check";
+import { CF_CODEPOINTS } from "../src/cf-charset.mjs";
+import {
+  BLANK_NON_CF,
+  CHECKS,
+  LONG_RUN_RE,
+  STRIP,
+  VS,
+  countEffectiveInvisible,
+  countPayloadInvisible,
+  payloadInvisibleView,
+  payloadLongRunSample,
+  stripInvisible,
+} from "../src/invisible.mjs";
+
+const cp = (n) => String.fromCodePoint(n);
+const ZWNJ = cp(0x200c);
+const ZWJ = cp(0x200d);
+const VS16 = cp(0xfe0f);
+const BOM = cp(0xfeff);
+const TAG = (s) => [...s].map((c) => cp(0xe0000 + c.charCodeAt(0))).join("");
+
+// Non-global twin of STRIP: `g` makes `.test` stateful across calls.
+const STRIP_ONE = new RegExp(STRIP.source, "u");
+
+/** The slow-path payload count: what the carve analysis left unmasked. */
+const referencePayload = (text) =>
+  [...payloadInvisibleView(text)].filter((ch) => STRIP_ONE.test(ch)).length;
+
+/** The pre-short-circuit definitions of the two derived entry points. */
+const referenceLongRun = (text) =>
+  payloadInvisibleView(text).match(new RegExp(LONG_RUN_RE.source, "gu"))?.[0] ??
+  null;
+const referenceEffective = (text) => {
+  const payload = referencePayload(text);
+  const surplus = Math.max(
+    0,
+    [...text].length - [...stripInvisible(text)].length - payload,
+  );
+  return payload + surplus;
+};
+
+// Adversarial and legitimate shapes a homogeneous benchmark string misses: a
+// prompt that is mostly joiners, one that is mostly variation selectors, emoji
+// ZWJ sequences carrying VS16, joiner-dense multilingual prose, lone surrogates,
+// and a leading BOM (preserved by the strip but counted as payload, so the
+// surplus term goes negative and must clamp).
+const SHAPES = {
+  empty: "",
+  ascii: "The quick brown fox jumps over the lazy dog.",
+  "mostly-zwnj": ZWNJ.repeat(200),
+  "mostly-zwj": ZWJ.repeat(200),
+  "mostly-joiners-alternating": (ZWJ + ZWNJ).repeat(120),
+  "mostly-joiners-cursive": "ب" + (ZWNJ + "ب").repeat(200),
+  "mostly-variation-selectors": VS16.repeat(200),
+  "mostly-ivs": ("漢" + cp(0xe0100)).repeat(120),
+  "mostly-stdvs": ("㐂" + cp(0xfe00)).repeat(120),
+  "persian-prose": "می" + ZWNJ + "خواهم چند کتاب بخرم",
+  "devanagari-conjunct": ("क्" + ZWJ + "ष").repeat(30),
+  "emoji-zwj-vs16": ("\u{1F3F3}" + VS16 + ZWJ + "\u{1F308}").repeat(30),
+  family:
+    "\u{1F468}" + ZWJ + "\u{1F469}" + ZWJ + "\u{1F467}" + ZWJ + "\u{1F466}",
+  keycap: "1" + VS16 + cp(0x20e3),
+  "flag-tag-registered": "\u{1F3F4}" + TAG("gbeng") + cp(0xe007f),
+  "flag-tag-unterminated": "\u{1F3F4}" + TAG("gbeng"),
+  "lone-high-surrogate": "a\uD800" + ZWJ + "b",
+  "lone-low-surrogate": "a\uDC00" + VS16 + "b",
+  "surrogate-pair-split": "\uD83C" + ZWJ + "\uDF08",
+  "leading-bom": BOM + "hello world",
+  "bom-only": BOM,
+  "interior-bom": "ab" + BOM + "cd",
+  "braille-blanks": "⠃⠀".repeat(150),
+  "hangul-fillers": ("가" + cp(0x3164)).repeat(150),
+  "long-run": "text" + cp(0x200b).repeat(40) + "more",
+  "scattered-under-threshold": "a" + (cp(0x00ad) + "a").repeat(9),
+  "scattered-over-threshold": "a" + (cp(0x00ad) + "a").repeat(40),
+};
+
+// What each shape counted BEFORE the counting entry points were made to skip
+// the code-point array: [countPayloadInvisible, countEffectiveInvisible,
+// code-point length of payloadLongRunSample, or null for no run]. The
+// equivalence tests below tie the fast paths to the carve analysis, but they
+// share that analysis with their own reference, so only a recording pins the
+// analysis itself — a preserve arm that starts calling a joiner payload (or
+// stops) moves both sides equally and is invisible to them. These numbers are
+// the gate's behaviour: change one only with a decision to change what blocks.
+const BASELINE = {
+  empty: [0, 0, null],
+  ascii: [0, 0, null],
+  "mostly-zwnj": [200, 200, 200],
+  "mostly-zwj": [200, 200, 200],
+  "mostly-joiners-alternating": [240, 240, 240],
+  "mostly-joiners-cursive": [0, 192, null],
+  "mostly-variation-selectors": [200, 200, 200],
+  "mostly-ivs": [0, 112, null],
+  "mostly-stdvs": [120, 120, null],
+  "persian-prose": [0, 0, null],
+  "devanagari-conjunct": [0, 14, null],
+  "emoji-zwj-vs16": [0, 44, null],
+  family: [0, 0, null],
+  keycap: [0, 0, null],
+  "flag-tag-registered": [0, 0, null],
+  "flag-tag-unterminated": [5, 5, null],
+  "lone-high-surrogate": [1, 1, null],
+  "lone-low-surrogate": [1, 1, null],
+  "surrogate-pair-split": [1, 2, null],
+  "leading-bom": [1, 1, null],
+  "bom-only": [1, 1, null],
+  "interior-bom": [1, 1, null],
+  "braille-blanks": [150, 150, null],
+  "hangul-fillers": [150, 150, null],
+  "long-run": [40, 40, 40],
+  "scattered-under-threshold": [9, 9, null],
+  "scattered-over-threshold": [40, 40, null],
+};
+
+describe("the counts each shape has always produced", () => {
+  it("every shape is recorded", () =>
+    assert.deepEqual(Object.keys(BASELINE), Object.keys(SHAPES)));
+
+  for (const [name, text] of Object.entries(SHAPES))
+    it(name, () => {
+      const sample = payloadLongRunSample(text);
+      assert.deepEqual(
+        [
+          countPayloadInvisible(text),
+          countEffectiveInvisible(text),
+          sample === null ? null : [...sample].length,
+        ],
+        BASELINE[name],
+      );
+    });
+});
+
+describe("counting fast paths agree exactly with the carve analysis", () => {
+  for (const [name, text] of Object.entries(SHAPES)) {
+    it(`${name}: countPayloadInvisible`, () =>
+      assert.equal(countPayloadInvisible(text), referencePayload(text)));
+    it(`${name}: payloadLongRunSample`, () =>
+      assert.equal(payloadLongRunSample(text), referenceLongRun(text)));
+    it(`${name}: countEffectiveInvisible`, () =>
+      assert.equal(countEffectiveInvisible(text), referenceEffective(text)));
+  }
+
+  // Positive controls: without these the cases above could all pass on inputs
+  // that never reach a preserve arm, a long run, or the surplus term at all.
+  it("the shapes exercise both verdicts of every fast path", () => {
+    const counts = Object.values(SHAPES).map(countPayloadInvisible);
+    assert.ok(
+      counts.some((n) => n === 0) && counts.some((n) => n > 0),
+      "need both a zero and a non-zero payload count",
+    );
+    const runs = Object.values(SHAPES).map(payloadLongRunSample);
+    assert.ok(
+      runs.some((r) => r === null) && runs.some((r) => r !== null),
+      "need both a long-run hit and a miss",
+    );
+    assert.ok(
+      Object.values(SHAPES).some(
+        (t) => countEffectiveInvisible(t) > countPayloadInvisible(t),
+      ),
+      "need a text whose over-budget joiner surplus is non-zero",
+    );
+    assert.equal(countPayloadInvisible(BOM), 1);
+    assert.equal(
+      countEffectiveInvisible(BOM),
+      1,
+      "a leading BOM is preserved by the strip, so the surplus term must clamp at 0",
+    );
+  });
+});
+
+describe("property: no input separates a fast path from the analysis", () => {
+  // Weighted toward the code points that drive the carve-out, so a random draw
+  // lands on joiner/selector/tag/blank contexts instead of inert Latin text.
+  const NOTABLE = [
+    0x200b, 0x200c, 0x200d, 0x200e, 0x2060, 0xfeff, 0x00ad, 0xfe00, 0xfe0e,
+    0xfe0f, 0x180b, 0x180e, 0x2800, 0x3164, 0x115f, 0x034f, 0x17b4, 0xe0100,
+    0xe0020, 0xe0067, 0xe007f, 0x1f3f4, 0x1f468, 0x1f308, 0x20e3, 0x0628,
+    0x0915, 0x094d, 0x6f22, 0x3402, 0xac00, 0x2803, 0xd800, 0xdc00, 0x0041,
+    0x0020,
+  ].map((n) => String.fromCodePoint(n));
+  const arbText = fc
+    .array(
+      fc.oneof(
+        { weight: 8, arbitrary: fc.constantFrom(...NOTABLE) },
+        { weight: 1, arbitrary: fc.string({ minLength: 1, maxLength: 3 }) },
+        {
+          weight: 1,
+          arbitrary: fc.string({ unit: "binary", minLength: 1, maxLength: 3 }),
+        },
+      ),
+      { maxLength: 60 },
+    )
+    .map((chars) => chars.join(""));
+
+  it("countPayloadInvisible", () =>
+    fc.assert(
+      fc.property(arbText, (text) =>
+        assert.equal(countPayloadInvisible(text), referencePayload(text)),
+      ),
+      { numRuns: 2000 },
+    ));
+
+  it("payloadLongRunSample", () =>
+    fc.assert(
+      fc.property(arbText, (text) =>
+        assert.equal(payloadLongRunSample(text), referenceLongRun(text)),
+      ),
+      { numRuns: 2000 },
+    ));
+
+  it("countEffectiveInvisible", () =>
+    fc.assert(
+      fc.property(arbText, (text) =>
+        assert.equal(countEffectiveInvisible(text), referenceEffective(text)),
+      ),
+      { numRuns: 2000 },
+    ));
+});
+
+describe("the code-point lookup classifies exactly what the CHECKS regexes match", () => {
+  // The classifier behind the carve analysis is a lookup built from the same
+  // three code-point sets as the CHECKS regexes. A code point dropped in that
+  // projection is one the scatter gate stops counting, so the agreement is
+  // checked over the WHOLE code-point space, not a sample. A lone code point has
+  // no neighbours, so no preserve arm can fire and the payload count is exactly
+  // 1 whenever the classifier calls it invisible.
+  const oneShot = CHECKS.map(([, re]) => new RegExp(re.source, "u"));
+  const matchesChecks = (ch) => oneShot.some((re) => re.test(ch));
+  // The three sets both the regexes and the lookup are built from. Pinning the
+  // scan's hit count to their union is the non-vacuity control: it fails if a
+  // regex class silently covers more or fewer code points than its own set
+  // (a stray range in a class source), and it moves with the sets.
+  const tracked = new Set([
+    ...CF_CODEPOINTS,
+    ...[...VS].map((ch) => ch.codePointAt(0)),
+    ...[...BLANK_NON_CF].map((ch) => ch.codePointAt(0)),
+  ]);
+
+  it("agrees on every code point in U+0000..U+10FFFF", () => {
+    let invisible = 0;
+    for (let n = 0; n <= 0x10ffff; n++) {
+      const ch = String.fromCodePoint(n);
+      const expected = matchesChecks(ch) ? 1 : 0;
+      invisible += expected;
+      const actual = countPayloadInvisible(ch);
+      if (actual !== expected)
+        assert.fail(
+          `U+${n.toString(16).toUpperCase()}: expected ${expected}, got ${actual}`,
+        );
+    }
+    assert.equal(invisible, tracked.size);
+  });
+});

--- a/test/prompt-latency.test.mjs
+++ b/test/prompt-latency.test.mjs
@@ -7,12 +7,6 @@
  * the correctness suites are indifferent to it, which is how a per-code-point
  * RegExp scan sat in the carve analysis charging ~250 ms per megabyte.
  *
- * `stryker.conf.json` excludes this file from `tap.testFiles`: the mutation run
- * instruments every source file and runs four workers at once, which blows the
- * clean-prompt budget in Stryker's own dry run and aborts the whole gate — and a
- * suite that re-times four seconds of prompts per mutant would cost more than
- * every other suite combined while killing nothing a behavioural test does not.
- *
  * Every budget is a RATIO against a calibration measured in this same process:
  * one code-point-by-code-point pass over a fixed 256 KB prompt, which is the
  * cheapest full read of a prompt anything here can do. Machine speed, CPU
@@ -29,6 +23,24 @@ import { classifyPrompt } from "../src/prompt.mjs";
 const { claudeAdapter } = await import("agent-control-plane-core/claude");
 const { judgeSanitizeUserPrompt } =
   await import("../claude-hooks/sanitize-user-prompt.mjs");
+
+/**
+ * Why the ratios cannot be read under Stryker.
+ *
+ * A mutation run rewrites every source file so each expression sits behind a
+ * per-mutant branch, and it runs four workers at once — the code under test
+ * slows several-fold while this file's calibration, which Stryker does not
+ * instrument, does not. The clean-prompt budget is the tightest here, so it goes
+ * red first, and Stryker aborts every shard whose initial dry run is red. The
+ * gate says so and stands down rather than reporting a regression it cannot see.
+ *
+ * `STRYKER_NAMESPACE` is set on every test process the tap runner spawns (see
+ * `@stryker-mutator/tap-runner`'s `runFile`), in both the dry run and the mutant
+ * runs; nothing else in this repo sets it.
+ */
+const MUTATION_RUN = process.env.STRYKER_NAMESPACE
+  ? "Stryker instruments the code under test but not this file's calibration, so the ratios measure the instrumentation"
+  : null;
 
 const KB = 1024;
 const SMALL = 32 * KB;
@@ -133,6 +145,7 @@ function unitsFor(fn) {
 const timing = { unit: 0, large: {}, small: {}, units: {} };
 
 before(() => {
+  if (MUTATION_RUN) return;
   timing.unit = calibrate();
   for (const [name, generate] of Object.entries(SHAPES)) {
     const large = generate(LARGE);
@@ -144,8 +157,19 @@ before(() => {
   }
 });
 
+/** An `it` whose verdict rests on the timings, and so has none under Stryker.
+ * @param {string} name @param {(t: import("node:test").TestContext) => void} fn */
+const timed = (name, fn) =>
+  it(name, (t) => {
+    if (MUTATION_RUN) {
+      t.skip(MUTATION_RUN);
+      return;
+    }
+    fn(t);
+  });
+
 describe("prompt-submit latency", () => {
-  it("the calibration is a measurement, not timer noise", () => {
+  timed("the calibration is a measurement, not timer noise", () => {
     // Every ratio below divides by this. A machine that materializes 256 KB in
     // under a third of a millisecond is not one these gates can speak about, so
     // say so loudly rather than passing on a division by noise.
@@ -156,7 +180,7 @@ describe("prompt-submit latency", () => {
   });
 
   for (const name of Object.keys(SHAPES))
-    it(`${name}: a 256 KB prompt stays inside its budget`, () => {
+    timed(`${name}: a 256 KB prompt stays inside its budget`, () => {
       assert.ok(
         timing.units[name] <= BUDGET[name],
         `${name} classified in ${timing.units[name].toFixed(1)} units (${timing.large[name].toFixed(1)}ms), budget ${BUDGET[name]}`,
@@ -164,7 +188,7 @@ describe("prompt-submit latency", () => {
     });
 
   for (const name of Object.keys(SHAPES))
-    it(`${name}: cost grows with prompt length, not faster`, (t) => {
+    timed(`${name}: cost grows with prompt length, not faster`, (t) => {
       if (timing.small[name] < SCALABLE_FLOOR_MS) {
         t.skip(
           `${timing.small[name].toFixed(2)}ms at 32 KB is below the ${SCALABLE_FLOOR_MS}ms noise floor`,
@@ -178,19 +202,22 @@ describe("prompt-submit latency", () => {
       );
     });
 
-  it("enough shapes clear the noise floor for the scaling gate to mean something", () => {
-    // Without this the scaling gate could silently degrade to zero shapes on a
-    // fast machine and still report green.
-    const scalable = Object.keys(SHAPES).filter(
-      (name) => timing.small[name] >= SCALABLE_FLOOR_MS,
-    );
-    assert.ok(
-      scalable.length >= 4,
-      `only ${scalable.length} shapes were timeable at 32 KB: ${scalable.join(", ")}`,
-    );
-  });
+  timed(
+    "enough shapes clear the noise floor for the scaling gate to mean something",
+    () => {
+      // Without this the scaling gate could silently degrade to zero shapes on a
+      // fast machine and still report green.
+      const scalable = Object.keys(SHAPES).filter(
+        (name) => timing.small[name] >= SCALABLE_FLOOR_MS,
+      );
+      assert.ok(
+        scalable.length >= 4,
+        `only ${scalable.length} shapes were timeable at 32 KB: ${scalable.join(", ")}`,
+      );
+    },
+  );
 
-  it("the shapes really do split into cheap and carve-path prompts", () => {
+  timed("the shapes really do split into cheap and carve-path prompts", () => {
     // A positive control on the budget table: if every shape were answered by
     // the bulk regex passes, the carve-path budgets would be gating nothing and
     // could be tightened to CLEAN_BUDGET. This fails when a shape stops driving
@@ -204,20 +231,23 @@ describe("prompt-submit latency", () => {
       );
   });
 
-  it("the hook entry carries the same budget as the classifier it wraps", () => {
-    // The gate the user actually waits on is the hook, not the library
-    // function. Judging adds only constant work, so a clean paste through
-    // judgeSanitizeUserPrompt must stay inside the same clean budget — this is
-    // what fails if the cost ever moves into the hook's own wrapper.
-    const prompt = SHAPES["ascii-prose"](LARGE);
-    const event = claudeAdapter.parse({
-      hook_event_name: "UserPromptSubmit",
-      prompt,
-    });
-    const { cost, units } = unitsFor(() => judgeSanitizeUserPrompt(event));
-    assert.ok(
-      units <= CLEAN_BUDGET,
-      `the hook judged a clean 256 KB prompt in ${units.toFixed(1)} units (${cost.toFixed(1)}ms), budget ${CLEAN_BUDGET}`,
-    );
-  });
+  timed(
+    "the hook entry carries the same budget as the classifier it wraps",
+    () => {
+      // The gate the user actually waits on is the hook, not the library
+      // function. Judging adds only constant work, so a clean paste through
+      // judgeSanitizeUserPrompt must stay inside the same clean budget — this is
+      // what fails if the cost ever moves into the hook's own wrapper.
+      const prompt = SHAPES["ascii-prose"](LARGE);
+      const event = claudeAdapter.parse({
+        hook_event_name: "UserPromptSubmit",
+        prompt,
+      });
+      const { cost, units } = unitsFor(() => judgeSanitizeUserPrompt(event));
+      assert.ok(
+        units <= CLEAN_BUDGET,
+        `the hook judged a clean 256 KB prompt in ${units.toFixed(1)} units (${cost.toFixed(1)}ms), budget ${CLEAN_BUDGET}`,
+      );
+    },
+  );
 });

--- a/test/prompt-latency.test.mjs
+++ b/test/prompt-latency.test.mjs
@@ -1,0 +1,218 @@
+/**
+ * Latency gates for the UserPromptSubmit path.
+ *
+ * classifyPrompt runs inside the prompt-submit hook and BLOCKS submission, so
+ * its cost is dead wait the user pays before the prompt is sent. A regression
+ * there is invisible from the inside — it reads as "the agent is slow" — and
+ * the correctness suites are indifferent to it, which is how a per-code-point
+ * RegExp scan sat in the carve analysis charging ~250 ms per megabyte.
+ *
+ * Every budget is a RATIO against a calibration measured in this same process:
+ * one code-point-by-code-point pass over a fixed 256 KB prompt, which is the
+ * cheapest full read of a prompt anything here can do. Machine speed, CPU
+ * contention and the coverage instrumentation scale both sides, so the ratios
+ * survive a loaded CI runner in a way wall-clock milliseconds do not — the
+ * calibration is written in this file, rather than reaching for a native
+ * builtin, precisely so it pays the same instrumentation tax as the code it
+ * normalizes.
+ */
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+import { classifyPrompt } from "../src/prompt.mjs";
+
+const { claudeAdapter } = await import("agent-control-plane-core/claude");
+const { judgeSanitizeUserPrompt } =
+  await import("../claude-hooks/sanitize-user-prompt.mjs");
+
+const KB = 1024;
+const SMALL = 32 * KB;
+const LARGE = 256 * KB;
+const cp = (n) => String.fromCodePoint(n);
+const grow = (unit, n) => unit.repeat(Math.ceil(n / unit.length)).slice(0, n);
+
+/**
+ * Median of three timed runs after a warm-up call, in ms. Three is enough
+ * because the gates below are ratios with room to spare, and a wider sample
+ * would cost more wall clock than the regression it protects against.
+ */
+function measure(fn) {
+  fn();
+  const runs = [];
+  for (let i = 0; i < 3; i++) {
+    const started = performance.now();
+    fn();
+    runs.push(performance.now() - started);
+  }
+  return runs.sort((a, b) => a - b)[1];
+}
+
+// Prompt shapes with materially different cost profiles. The clean ones answer
+// from bulk regex passes; the rest each drive a different arm of the carve
+// analysis, which is per-code-point work no bulk pass can do. A homogeneous
+// "x".repeat(n) exercises only the first group, which is exactly how a
+// carve-path regression would slip through.
+const SHAPES = {
+  "ascii-prose": (n) =>
+    grow("The quick brown fox jumps over the lazy dog. ", n),
+  "cjk-prose": (n) => grow("速い茶色の狐が怠惰な犬を飛び越える。", n),
+  "emoji-prose": (n) => grow("🙂 ok 🚀 go 🎉 ", n),
+  "joiner-dense": (n) => grow("می" + cp(0x200c) + "خواهم ", n),
+  "vs-dense": (n) => grow("漢" + cp(0xe0100), n),
+  "payload-run": (n) => grow(cp(0x200b), n),
+  "payload-scattered": (n) => grow("a" + cp(0x00ad), n),
+  "emoji-zwj": (n) => grow("\u{1F3F3}️‍\u{1F308}", n),
+};
+
+// Shapes carrying no invisible code point at all — the overwhelming majority of
+// real pastes, and the ones the counters answer without the code-point array.
+const CLEAN = ["ascii-prose", "cjk-prose", "emoji-prose"];
+
+// Ceiling per shape at LARGE, in calibration units — roughly 2.5x what the shape
+// costs today, measured both standalone and under the parallel coverage run,
+// which is the headroom a shared runner needs while still catching the
+// order-of-magnitude regressions this file exists for. CLEAN_BUDGET is an order
+// tighter because a prompt with no invisible code point in it must never reach
+// the per-code-point analysis at all: past ten passes' worth of work, a clean
+// paste is being analyzed for something it does not contain.
+const CLEAN_BUDGET = 10;
+const BUDGET = {
+  "ascii-prose": CLEAN_BUDGET,
+  "cjk-prose": CLEAN_BUDGET,
+  "emoji-prose": CLEAN_BUDGET,
+  "joiner-dense": 180,
+  "vs-dense": 90,
+  "payload-run": 110,
+  "payload-scattered": 36,
+  "emoji-zwj": 80,
+};
+
+// LARGE is 8x SMALL, so linear scaling costs 8x. Anything past this is
+// super-linear in the prompt length — the shape of blow-up that turns a
+// tolerable paste into a hang — and it is measured on one machine in one
+// process, so it needs no headroom for machine speed, only for timer noise.
+const SCALING_LIMIT = 24;
+// Below this a SMALL measurement is timer noise, and its scaling ratio says
+// nothing. Shapes that cheap are pinned by their LARGE budget instead.
+const SCALABLE_FLOOR_MS = 2;
+
+const CALIBRATION_TEXT = SHAPES["ascii-prose"](LARGE);
+
+/** One pass over the prompt, a code point at a time — the unit every budget is
+ * quoted in. Deliberately trivial: it must not get faster or slower for any
+ * reason except the machine it runs on. */
+function calibrationPass(text) {
+  let seen = 0;
+  for (const ch of text) seen += ch.length;
+  return seen;
+}
+
+const calibrate = () => measure(() => calibrationPass(CALIBRATION_TEXT));
+
+/**
+ * `fn`'s cost in calibration units, calibrating on BOTH sides of the
+ * measurement and taking the larger unit. The test runner runs files in
+ * parallel, so the load on the machine drifts during a run; a single calibration
+ * taken up front can be read against a shape measured under quite different
+ * contention. Bracketing the measurement keeps the two comparable, and taking
+ * the larger unit resolves a drift in the direction that does not manufacture a
+ * failure.
+ */
+function unitsFor(fn) {
+  const before_ = calibrate();
+  const cost = measure(fn);
+  const unit = Math.max(before_, calibrate());
+  return { cost, unit, units: cost / unit };
+}
+
+/** @type {{unit: number, large: Record<string, number>, small: Record<string, number>, units: Record<string, number>}} */
+const timing = { unit: 0, large: {}, small: {}, units: {} };
+
+before(() => {
+  timing.unit = calibrate();
+  for (const [name, generate] of Object.entries(SHAPES)) {
+    const large = generate(LARGE);
+    const small = generate(SMALL);
+    const measured = unitsFor(() => classifyPrompt(large));
+    timing.large[name] = measured.cost;
+    timing.units[name] = measured.units;
+    timing.small[name] = measure(() => classifyPrompt(small));
+  }
+});
+
+describe("prompt-submit latency", () => {
+  it("the calibration is a measurement, not timer noise", () => {
+    // Every ratio below divides by this. A machine that materializes 256 KB in
+    // under a third of a millisecond is not one these gates can speak about, so
+    // say so loudly rather than passing on a division by noise.
+    assert.ok(
+      timing.unit > 0.3,
+      `calibration ran in ${timing.unit.toFixed(3)}ms — too fast to divide by`,
+    );
+  });
+
+  for (const name of Object.keys(SHAPES))
+    it(`${name}: a 256 KB prompt stays inside its budget`, () => {
+      assert.ok(
+        timing.units[name] <= BUDGET[name],
+        `${name} classified in ${timing.units[name].toFixed(1)} units (${timing.large[name].toFixed(1)}ms), budget ${BUDGET[name]}`,
+      );
+    });
+
+  for (const name of Object.keys(SHAPES))
+    it(`${name}: cost grows with prompt length, not faster`, (t) => {
+      if (timing.small[name] < SCALABLE_FLOOR_MS) {
+        t.skip(
+          `${timing.small[name].toFixed(2)}ms at 32 KB is below the ${SCALABLE_FLOOR_MS}ms noise floor`,
+        );
+        return;
+      }
+      const growth = timing.large[name] / timing.small[name];
+      assert.ok(
+        growth <= SCALING_LIMIT,
+        `${name} cost ${growth.toFixed(1)}x for 8x the prompt, limit ${SCALING_LIMIT}x`,
+      );
+    });
+
+  it("enough shapes clear the noise floor for the scaling gate to mean something", () => {
+    // Without this the scaling gate could silently degrade to zero shapes on a
+    // fast machine and still report green.
+    const scalable = Object.keys(SHAPES).filter(
+      (name) => timing.small[name] >= SCALABLE_FLOOR_MS,
+    );
+    assert.ok(
+      scalable.length >= 4,
+      `only ${scalable.length} shapes were timeable at 32 KB: ${scalable.join(", ")}`,
+    );
+  });
+
+  it("the shapes really do split into cheap and carve-path prompts", () => {
+    // A positive control on the budget table: if every shape were answered by
+    // the bulk regex passes, the carve-path budgets would be gating nothing and
+    // could be tightened to CLEAN_BUDGET. This fails when a shape stops driving
+    // the arm it was written for.
+    const cleanest = Math.max(...CLEAN.map((n) => timing.large[n]));
+    const carved = Object.keys(SHAPES).filter((n) => !CLEAN.includes(n));
+    for (const name of carved)
+      assert.ok(
+        timing.large[name] > cleanest,
+        `${name} (${timing.large[name].toFixed(1)}ms) no longer costs more than the cleanest prompt (${cleanest.toFixed(1)}ms) — it is not exercising the carve analysis`,
+      );
+  });
+
+  it("the hook entry carries the same budget as the classifier it wraps", () => {
+    // The gate the user actually waits on is the hook, not the library
+    // function. Judging adds only constant work, so a clean paste through
+    // judgeSanitizeUserPrompt must stay inside the same clean budget — this is
+    // what fails if the cost ever moves into the hook's own wrapper.
+    const prompt = SHAPES["ascii-prose"](LARGE);
+    const event = claudeAdapter.parse({
+      hook_event_name: "UserPromptSubmit",
+      prompt,
+    });
+    const { cost, units } = unitsFor(() => judgeSanitizeUserPrompt(event));
+    assert.ok(
+      units <= CLEAN_BUDGET,
+      `the hook judged a clean 256 KB prompt in ${units.toFixed(1)} units (${cost.toFixed(1)}ms), budget ${CLEAN_BUDGET}`,
+    );
+  });
+});

--- a/test/prompt-latency.test.mjs
+++ b/test/prompt-latency.test.mjs
@@ -118,10 +118,9 @@ const calibrate = () => measure(() => calibrationPass(CALIBRATION_TEXT));
  * failure.
  */
 function unitsFor(fn) {
-  const before_ = calibrate();
+  const opening = calibrate();
   const cost = measure(fn);
-  const unit = Math.max(before_, calibrate());
-  return { cost, unit, units: cost / unit };
+  return { cost, units: cost / Math.max(opening, calibrate()) };
 }
 
 /** @type {{unit: number, large: Record<string, number>, small: Record<string, number>, units: Record<string, number>}} */

--- a/test/prompt-latency.test.mjs
+++ b/test/prompt-latency.test.mjs
@@ -7,6 +7,12 @@
  * the correctness suites are indifferent to it, which is how a per-code-point
  * RegExp scan sat in the carve analysis charging ~250 ms per megabyte.
  *
+ * `stryker.conf.json` excludes this file from `tap.testFiles`: the mutation run
+ * instruments every source file and runs four workers at once, which blows the
+ * clean-prompt budget in Stryker's own dry run and aborts the whole gate — and a
+ * suite that re-times four seconds of prompts per mutant would cost more than
+ * every other suite combined while killing nothing a behavioural test does not.
+ *
  * Every budget is a RATIO against a calibration measured in this same process:
  * one code-point-by-code-point pass over a fixed 256 KB prompt, which is the
  * cheapest full read of a prompt anything here can do. Machine speed, CPU


### PR DESCRIPTION
## What & why

Make the carve analysis in `src/invisible.mjs` cheap enough that the prompt gate stops blocking submission on a large paste, and add latency gates so it cannot get expensive again unnoticed. An 8 MB ASCII paste went from 6229 ms to 81 ms through `classifyPrompt`; 1 MB from 602 ms to 11 ms.

`classifyPrompt` runs on every `UserPromptSubmit` and blocks the prompt, so its cost is dead wait. It called `analyzeCarve` twice — once through `countPayloadInvisible`, once through `payloadLongRunSample` → `payloadInvisibleView` — and each call made six full-length passes over the prompt, one of them three RegExp `.test` calls per code point. At 8 MB that split as: `cps.map(classify)` 922 ms, blank-filler budget 503 ms, `kind` map 268 ms, `markTagSequences` 217 ms, `Array.from` + tally 154 ms.

Claimed area: `src/invisible.mjs` carve analysis and the `classifyPrompt` latency path.

**No scan was bounded.** Every path still reads every code point. The short-circuits are necessary conditions checked in full — a whole-text scan for any invisible code point, a whole-text bulk regex for any long run — not caps, samples, or size-gated skips, so there is no input for which the gate now looks at less than it did.

Partitions: `src/invisible.mjs` + `test/invisible-fast-path.test.mjs` are the change and its equivalence proof (commit 1); `test/prompt-latency.test.mjs` is the regression gate (commit 2); the last commit stands that gate down under Stryker, where its ratios measure the instrumentation rather than the code.

## Review focus

Read `src/invisible.mjs:analyzeCarve` first — it is the security-relevant function, and the invariant the diff cannot show on one screen is that its `payloadInvis` feeds `SCATTERED_THRESHOLD` in `src/prompt.mjs:107`, so it must return a value **exactly** equal to the old one for every input, not approximately equal.

Three claims are worth checking against the code rather than the prose:

1. `classify` is now a `Map` lookup projected from `CF_CODEPOINTS` / `VS` / `BLANK_NON_CF` — the same three sets the `CHECKS` regexes are built from. The claim is that membership and a `u`-flag `.test` on a single-code-point class answer identically. `test/invisible-fast-path.test.mjs` checks that over every code point in U+0000..U+10FFFF.
2. `countPayloadInvisible` returns 0 without building the code-point array when `hasInvisibleCodePoint` is false. Sound because `payloadInvis` only ever increments at a position `classify` marked invisible.
3. `payloadLongRunSample` returns null when `LONG_RUN_RE` misses the raw text. Sound because the view is code-point-for-code-point with the text and only ever replaces an invisible with a space — it can shorten a run, never create one.

The part I am least sure of is `hasInvisibleCodePoint`&#39;s hand-rolled surrogate pairing (`src/invisible.mjs:525`). It is the one place that re-implements what the String iterator does; the property tests seed lone high and low surrogates and a split pair against it, but it is the line I would want a second pair of eyes on.

## How it was tested

- **Differential against the shipped implementation** (session evidence): the pre-change module vs. the new one over the 33-case `tests/golden-corpus.json`, 19 adversarial fixtures, and 4000 fast-check inputs — 24,312 assertions across `countPayloadInvisible`, `countEffectiveInvisible`, `payloadLongRunSample`, `payloadInvisibleView`, `stripInvisible`, `isIncidentalInvisible`, **0 mismatches**. Fixtures include joiner-dense Persian, emoji ZWJ with VS16, `🏳️‍🌈` repeats, lone high and low surrogates, a leading BOM (the surplus clamps and the count stays 1), a mostly-joiners prompt and a mostly-variation-selectors prompt.
- **Committed equivalence tests** — `node --test test/invisible-fast-path.test.mjs`, 114 pass. Each fast path is pinned against its pre-change definition expressed in exported API, with `payloadInvisibleView` (no short-circuit, walks the whole array) as the reference; a recorded table pins what each shape counted before; the classifier is checked exhaustively over the code-point space.
- **Non-vacuity of the equivalence tests**: breaking the joiner arm with `&amp;&amp; invisible.length &lt; 4` reds 3 cases, removing the arm reds 5. Also red for a `countPayloadInvisible` short-circuit capped at 100 chars (14), a long-run prefilter capped at 100 chars (8), a classifier that drops ZWNJ (4), a removed surplus clamp (6), skipped tag preservation (1), a loosened blank budget (2).
- **Latency gates** — `node --test test/prompt-latency.test.mjs`, 17 pass / 3 skipped below the noise floor, ~4 s. Against the pre-fix module 7 of the 8 budgets go red, the clean shapes by 3.5–7×. `payload-run` is the one shape that does not: that path did not get faster, and the gate does not claim otherwise. With `STRYKER_NAMESPACE` set, all 20 stand down with a reason in 0.2 s.
- `bash .github/scripts/run-mutation-dry-run.sh` locally: initial test run succeeded over the whole instrumented tree (39 files, 10,809 mutants). This is the check that was red on the previous head.
- `node scripts/coverage.mjs`: 3796 pass, 0 fail, 100% statement/branch/function/line on `src`. `pnpm lint` and `pnpm check` clean. `tests/golden.json` regenerates byte-identically, so the Python client&#39;s golden is unaffected.

Before / after, median of 3, node 22.22.2, `classifyPrompt` end to end:

| input | size | before | after |
| --- | --- | --- | --- |
| ASCII prose | 4 KB | 2.5 ms | 0.3 ms |
| ASCII prose | 1 MB | 602 ms | 11 ms |
| ASCII prose | 8 MB | 6229 ms | 81 ms |
| Persian prose, realistic ZWNJ density | 1 MB | 2360 ms | 1171 ms |
| joiner-dense, 50% ZWNJ | 1 MB | 2819 ms | 1317 ms |
| joiner-dense, 50% ZWNJ | 8 MB | 28136 ms | 13922 ms |
| variation-selector-dense | 1 MB | 1201 ms | 637 ms |
| variation-selector-dense | 8 MB | 11843 ms | 5868 ms |

## Decisions made

- **Fix `analyzeCarve` rather than add a payload-only counter.** A counter that computes just `payloadInvis` would leave `payloadLongRunSample` — the analysis&#39;s other caller, and ~2.9 s of the 8 MB cost — untouched, and would create a second implementation that has to stay exactly equal to the first forever.
- **Keep the code-point array on the carve path.** Eliminating it means rewriting ~10 neighbour predicates against a `Uint32Array` inside a security gate, for a further ~2× on adversarial input only. After this change the dominant term for a joiner-bearing prompt is `Intl.Segmenter` inside `carveStrip` (684 ms of the 1171 ms Persian case) — a different function on the strip path, worth its own change.
- **Latency budgets carry ~2.5× headroom.** They are sized for a loaded shared runner, so they catch order-of-magnitude regressions, not a 20% one. The carve-path budgets are forward guards; only the clean-prompt budget is a tight statement about the fix.
- **The latency suite stands itself down under Stryker instead of being excluded from `tap.testFiles`.** The exclusion route does not exist: the tap runner hands its patterns straight to `glob`, which has no negation, so a `!`-prefixed entry matches nothing and the suite runs anyway. The alternative — accepting the mutation run&#39;s instrumentation into the budgets — would mean sizing every budget for the slowest environment, which is how a latency gate stops catching anything.
- **One surviving mutant on `src/invisible.mjs:1188` is left alive.** `stripped === text ? 0 : …` mutated to always take the `else` arm computes the same number (two identical strings differ by zero code points), so it is equivalent by construction and no behavioural test can kill it. A `// Stryker disable next-line` would also suppress the `true`-arm mutant, which the suite does kill — silencing a real gate to tidy a report.

## Lessons Learned

- **What**: When writing a wall-clock performance gate, normalize against a calibration written **in the test file** (a plain JS pass over the same input), never against a native builtin like `Array.from`.
- **Where**: `CLAUDE.md` → Testing section.
- **Why**: Under `NODE_V8_COVERAGE` the instrumented JS under test slowed by ~3× while `Array.from` did not move at all, so a ratio calibrated on the builtin reported a 3× regression that did not exist — the gate passed standalone and failed the coverage run. A calibration that is itself instrumented JS held within ±15% across both environments.

- **What**: To keep a test file out of a Stryker run, have the file itself stand down on `process.env.STRYKER_NAMESPACE`; do not add a `!`-prefixed pattern to `tap.testFiles`.
- **Where**: `CLAUDE.md` → CI / GitHub Actions section.
- **Why**: `@stryker-mutator/tap-runner` passes `tap.testFiles` to `glob`, which has no negation support, so the `!` entry silently matches nothing and the file still runs — and if it fails, Stryker aborts every shard in the matrix from its dry run. `STRYKER_NAMESPACE` is set on every test process the tap runner spawns, in both the dry run and the mutant runs.