### PR TITLE
fix(enable-auto-update): report a refused registry write instead of crashing

### DIFF
--- a/plugin/scripts/enable-auto-update.mjs
+++ b/plugin/scripts/enable-auto-update.mjs
@@ -83,6 +83,27 @@ const rerunCommand = (disable) =>
   `node ${shellQuote(process.argv[1])}${disable ? " --disable" : ""}`;
 
 /**
+ * Removes the temp file this run staged, reporting whether it is gone.
+ *
+ * Unlinking needs write permission on the directory, which is exactly what a
+ * refused rename says we may not have — so a refusal here is reported in the
+ * message below rather than crashing over it with the trace this path exists to
+ * remove. Any other errno still propagates.
+ *
+ * @param {string} temp
+ */
+function removeStaged(temp) {
+  try {
+    rmSync(temp, { force: true });
+    return true;
+  } catch (error) {
+    const code = /** @type {NodeJS.ErrnoException} */ (error).code;
+    if (!REFUSED.has(code ?? "")) throw error;
+    return false;
+  }
+}
+
+/**
  * Replaces the registry, staged through a sibling temp file so an interrupted
  * write cannot leave the file Claude Code reads truncated.
  *
@@ -95,16 +116,17 @@ const rerunCommand = (disable) =>
  */
 function replaceRegistry(path, contents, disable) {
   const temp = `${path}.agent-sanitizer.tmp`;
+  let staged = false;
   try {
     writeFileSync(temp, contents, "utf-8");
+    staged = true;
     renameSync(temp, path);
   } catch (error) {
     const code = /** @type {NodeJS.ErrnoException} */ (error).code;
     if (!REFUSED.has(code ?? "")) throw error;
-    // A refused create leaves nothing behind, which `force` passes over; a
-    // refused rename leaves a temp file in a directory the write just proved
-    // writable, so this cannot be the thing that throws over the message below.
-    rmSync(temp, { force: true });
+    // Only a temp file this run wrote is ours to remove; one an interrupted
+    // earlier run left behind belongs to no one we can speak for.
+    const litter = staged && !removeStaged(temp) ? temp : null;
     fail(
       `cannot write ${path} (${code}) — the OS refused it. Claude Code's Bash ` +
         `sandbox confines writes to the workspace, so no session that runs ` +
@@ -114,7 +136,11 @@ function replaceRegistry(path, contents, disable) {
         `Or toggle it without a terminal: /plugin -> Marketplaces -> ` +
         `${MARKETPLACE} -> Enable auto-update.\n` +
         `If the terminal refuses it too, the file's owner or permissions need ` +
-        `fixing.`,
+        `fixing.` +
+        (litter
+          ? `\nThe staged copy at ${litter} could not be cleaned up either; ` +
+            `delete it once the permissions are fixed.`
+          : ""),
     );
   }
 }

--- a/plugin/scripts/enable-auto-update.mjs
+++ b/plugin/scripts/enable-auto-update.mjs
@@ -16,7 +16,7 @@
  * it does not recognize. A Claude Code release that moves or restructures the
  * file makes this exit non-zero with what it found — never silently no-op.
  */
-import { readFileSync, renameSync, writeFileSync } from "node:fs";
+import { readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -57,6 +57,42 @@ export function knownMarketplacesPath(env = process.env) {
 function fail(message) {
   process.stderr.write(`agent-sanitizer: ${message}\n`);
   process.exit(1);
+}
+
+/** Errno codes that mean the OS refused the write, not that the write is wrong. */
+const REFUSED = new Set(["EPERM", "EACCES", "EROFS"]);
+
+/**
+ * Replaces the registry, staged through a sibling temp file so an interrupted
+ * write cannot leave the file Claude Code reads truncated.
+ *
+ * A refused write is a state the user can act on, so it exits with the two
+ * routes that do work instead of a stack trace; every other errno propagates.
+ *
+ * @param {string} path
+ * @param {string} contents
+ */
+function replaceRegistry(path, contents) {
+  const temp = `${path}.agent-sanitizer.tmp`;
+  try {
+    writeFileSync(temp, contents, "utf-8");
+    renameSync(temp, path);
+  } catch (error) {
+    const code = /** @type {NodeJS.ErrnoException} */ (error).code;
+    if (!REFUSED.has(code ?? "")) throw error;
+    // A refused create leaves nothing behind, which `force` passes over; a
+    // refused rename leaves a temp file in a directory the write just proved
+    // writable, so this cannot be the thing that throws over the message below.
+    rmSync(temp, { force: true });
+    fail(
+      `cannot write ${path} (${code}) — the OS refused it. Claude Code's Bash ` +
+        `sandbox confines writes to the workspace, so a sandboxed session ` +
+        `cannot reach the plugin cache at all: run this from a terminal ` +
+        `outside Claude Code. If it is refused there too, the file's owner or ` +
+        `permissions need fixing. Either way the toggle is reachable from ` +
+        `/plugin -> Marketplaces -> ${MARKETPLACE} -> Enable auto-update.`,
+    );
+  }
 }
 
 /**
@@ -115,11 +151,8 @@ export function main(argv = process.argv.slice(2), env = process.env) {
     ...config,
     [MARKETPLACE]: { ...entry, autoUpdate: desired },
   };
-  // Same 2-space encoding Claude Code writes, staged through a sibling temp file
-  // so an interrupted write cannot leave the registry truncated.
-  const temp = `${path}.agent-sanitizer.tmp`;
-  writeFileSync(temp, JSON.stringify(updated, null, 2), "utf-8");
-  renameSync(temp, path);
+  // Same 2-space encoding Claude Code writes.
+  replaceRegistry(path, JSON.stringify(updated, null, 2));
 
   process.stdout.write(
     desired

--- a/plugin/scripts/enable-auto-update.mjs
+++ b/plugin/scripts/enable-auto-update.mjs
@@ -63,6 +63,26 @@ function fail(message) {
 const REFUSED = new Set(["EPERM", "EACCES", "EROFS"]);
 
 /**
+ * Wraps `word` so a POSIX shell sees it as one literal argument. Marketplace
+ * installs sit under a versioned directory below the user's home, so the path
+ * this quotes routinely contains a space and sometimes a quote.
+ *
+ * @param {string} word
+ */
+const shellQuote = (word) => `'${word.replaceAll("'", `'\\''`)}'`;
+
+/**
+ * The command line that reruns this invocation, for a human to paste into a
+ * terminal. The refusal below is the one failure the agent running the skill
+ * cannot act on itself — the sandbox denies it whatever it tries — so the
+ * message has to hand the work back ready to run, not describe it.
+ *
+ * @param {boolean} disable
+ */
+const rerunCommand = (disable) =>
+  `node ${shellQuote(process.argv[1])}${disable ? " --disable" : ""}`;
+
+/**
  * Replaces the registry, staged through a sibling temp file so an interrupted
  * write cannot leave the file Claude Code reads truncated.
  *
@@ -71,8 +91,9 @@ const REFUSED = new Set(["EPERM", "EACCES", "EROFS"]);
  *
  * @param {string} path
  * @param {string} contents
+ * @param {boolean} disable  which invocation to hand back for a rerun
  */
-function replaceRegistry(path, contents) {
+function replaceRegistry(path, contents, disable) {
   const temp = `${path}.agent-sanitizer.tmp`;
   try {
     writeFileSync(temp, contents, "utf-8");
@@ -86,11 +107,14 @@ function replaceRegistry(path, contents) {
     rmSync(temp, { force: true });
     fail(
       `cannot write ${path} (${code}) — the OS refused it. Claude Code's Bash ` +
-        `sandbox confines writes to the workspace, so a sandboxed session ` +
-        `cannot reach the plugin cache at all: run this from a terminal ` +
-        `outside Claude Code. If it is refused there too, the file's owner or ` +
-        `permissions need fixing. Either way the toggle is reachable from ` +
-        `/plugin -> Marketplaces -> ${MARKETPLACE} -> Enable auto-update.`,
+        `sandbox confines writes to the workspace, so no session that runs ` +
+        `under it can reach the plugin cache; rerunning here cannot succeed.\n` +
+        `Run this yourself, in a terminal outside Claude Code:\n` +
+        `  ${rerunCommand(disable)}\n` +
+        `Or toggle it without a terminal: /plugin -> Marketplaces -> ` +
+        `${MARKETPLACE} -> Enable auto-update.\n` +
+        `If the terminal refuses it too, the file's owner or permissions need ` +
+        `fixing.`,
     );
   }
 }
@@ -152,7 +176,7 @@ export function main(argv = process.argv.slice(2), env = process.env) {
     [MARKETPLACE]: { ...entry, autoUpdate: desired },
   };
   // Same 2-space encoding Claude Code writes.
-  replaceRegistry(path, JSON.stringify(updated, null, 2));
+  replaceRegistry(path, JSON.stringify(updated, null, 2), disable);
 
   process.stdout.write(
     desired

--- a/plugin/skills/enable-auto-update/SKILL.md
+++ b/plugin/skills/enable-auto-update/SKILL.md
@@ -33,10 +33,12 @@ The script refuses rather than guessing, and each refusal has one fix:
   first, then re-run this skill.
 - **`cannot write … the OS refused it`** — most often Claude Code's Bash
   sandbox, which confines writes to the workspace: the script cannot reach the
-  plugin cache from a sandboxed session, however it is invoked. Tell the
-  user to run the command in a terminal outside Claude Code, or to use `/plugin`
-  → **Marketplaces** → `agent-sanitizer` → **Enable auto-update**. Do not retry
-  the script or edit the registry by hand.
+  plugin cache from a sandboxed session, however it is invoked — this is the one
+  refusal you cannot clear yourself. Show the user the `node '…'` command line
+  the error prints, verbatim, for them to paste into a terminal outside Claude
+  Code, and offer `/plugin` → **Marketplaces** → `agent-sanitizer` → **Enable
+  auto-update** as the no-terminal route. Do not retry the script, re-run it with
+  different permissions, or edit the registry by hand.
 - **Unrecognized entry shape** — a Claude Code release changed the registry
   format. Do not edit the file by hand: send the user to `/plugin` →
   **Marketplaces** → `agent-sanitizer` → **Enable auto-update**, and report that

--- a/plugin/skills/enable-auto-update/SKILL.md
+++ b/plugin/skills/enable-auto-update/SKILL.md
@@ -31,6 +31,12 @@ The script refuses rather than guessing, and each refusal has one fix:
   added, or was added under a different Claude Code config directory. Tell the
   user to run `/plugin marketplace add AlexanderMattTurner/agent-sanitizer`
   first, then re-run this skill.
+- **`cannot write … the OS refused it`** — most often Claude Code's Bash
+  sandbox, which confines writes to the workspace: the script cannot reach the
+  plugin cache from a sandboxed session, however it is invoked. Tell the
+  user to run the command in a terminal outside Claude Code, or to use `/plugin`
+  → **Marketplaces** → `agent-sanitizer` → **Enable auto-update**. Do not retry
+  the script or edit the registry by hand.
 - **Unrecognized entry shape** — a Claude Code release changed the registry
   format. Do not edit the file by hand: send the user to `/plugin` →
   **Marketplaces** → `agent-sanitizer` → **Enable auto-update**, and report that

--- a/plugin/test/enable-auto-update.test.mjs
+++ b/plugin/test/enable-auto-update.test.mjs
@@ -179,6 +179,32 @@ test(
   },
 );
 
+test(
+  "a refused cleanup is reported, not thrown over the message",
+  // Staging exists because a run can be interrupted, so a leftover temp file is
+  // a state the next run meets. Rewriting that file needs no directory
+  // permission, so the write succeeds and the RENAME is what gets refused —
+  // then the unlink is refused too, on the same missing directory permission.
+  { skip: process.getuid?.() === 0 && "root writes through mode bits" },
+  () => {
+    const { dir, path } = registry(ENTRY);
+    const temp = `${path}.agent-sanitizer.tmp`;
+    writeFileSync(temp, "{half-written", "utf-8");
+    chmodSync(dir, 0o555);
+    try {
+      const { stderr } = runExpectingFailure(dir);
+      assert.match(stderr, /cannot write .* \(EACCES\)/);
+      assert.doesNotMatch(stderr, /\n\s+at /);
+      assert.ok(
+        stderr.includes(`The staged copy at ${temp} could not be cleaned up`),
+        `leftover temp file not reported in:\n${stderr}`,
+      );
+    } finally {
+      chmodSync(dir, 0o755);
+    }
+  },
+);
+
 for (const args of [[], ["--disable"]])
   test(
     `a refused ${args.join(" ") || "enable"} hands back a runnable command line`,

--- a/plugin/test/enable-auto-update.test.mjs
+++ b/plugin/test/enable-auto-update.test.mjs
@@ -7,6 +7,7 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import {
+  chmodSync,
   copyFileSync,
   existsSync,
   mkdtempSync,
@@ -150,6 +151,33 @@ test("a non-boolean autoUpdate refuses instead of overwriting it", () => {
   assert.match(stderr, /not a boolean/);
   assert.equal(readFileSync(path, "utf-8"), before);
 });
+
+test(
+  "a write the OS refuses names the routes that do work, not a stack trace",
+  // Claude Code's Bash sandbox denies writes under the plugin cache, which is
+  // how this arrives in the wild; a read-only directory is the portable stand-in.
+  { skip: process.getuid?.() === 0 && "root writes through mode bits" },
+  () => {
+    const { dir, path } = registry(ENTRY);
+    const before = readFileSync(path, "utf-8");
+    chmodSync(dir, 0o555);
+    try {
+      const { status, stderr } = runExpectingFailure(dir);
+      assert.equal(status, 1);
+      assert.match(
+        stderr,
+        /cannot write .*known_marketplaces\.json \(EACCES\)/,
+      );
+      assert.match(stderr, /\/plugin -> Marketplaces/);
+      // An uncaught errno exits 1 too — the absence of a trace is the fix.
+      assert.doesNotMatch(stderr, /\n\s+at /);
+      assert.equal(readFileSync(path, "utf-8"), before);
+      assert.equal(existsSync(`${path}.agent-sanitizer.tmp`), false);
+    } finally {
+      chmodSync(dir, 0o755);
+    }
+  },
+);
 
 test("a corrupt registry propagates rather than being rewritten over", () => {
   const dir = mkdtempSync(join(tmpdir(), "agent-sanitizer-corrupt-"));

--- a/plugin/test/enable-auto-update.test.mjs
+++ b/plugin/test/enable-auto-update.test.mjs
@@ -63,9 +63,9 @@ function run(dir, args = [], script = SCRIPT) {
   return result;
 }
 
-function runExpectingFailure(dir, args = []) {
+function runExpectingFailure(dir, args = [], script = SCRIPT) {
   try {
-    run(dir, args);
+    run(dir, args, script);
   } catch (error) {
     return error;
   }
@@ -178,6 +178,32 @@ test(
     }
   },
 );
+
+for (const args of [[], ["--disable"]])
+  test(
+    `a refused ${args.join(" ") || "enable"} hands back a runnable command line`,
+    // The agent running the skill cannot get past this refusal by any route the
+    // sandbox allows, so the message's job is to be pasteable by the human.
+    { skip: process.getuid?.() === 0 && "root writes through mode bits" },
+    () => {
+      // An install path with a space in it is ordinary on macOS and Windows; an
+      // unquoted command line there pastes as two arguments and fails.
+      const scriptDir = mkdtempSync(join(tmpdir(), "agent sanitizer path-"));
+      const copied = join(scriptDir, "enable-auto-update.mjs");
+      copyFileSync(SCRIPT, copied);
+      // Each direction has to already be the opposite, or the script exits 0
+      // before it ever reaches a write.
+      const { dir } = registry({ ...ENTRY, autoUpdate: args.length > 0 });
+      chmodSync(dir, 0o555);
+      try {
+        const { stderr } = runExpectingFailure(dir, args, copied);
+        const line = `\n  node '${copied}'${args.map((a) => ` ${a}`).join("")}\n`;
+        assert.ok(stderr.includes(line), `no rerun line in:\n${stderr}`);
+      } finally {
+        chmodSync(dir, 0o755);
+      }
+    },
+  );
 
 test("a corrupt registry propagates rather than being rewritten over", () => {
   const dir = mkdtempSync(join(tmpdir(), "agent-sanitizer-corrupt-"));


### PR DESCRIPTION
Claimed area: the write path in `plugin/scripts/enable-auto-update.mjs` and its skill doc.

## Summary

Turn a refused registry write into the script's normal refusal — a message naming a pasteable command and the `/plugin` route — instead of an unhandled errno.

`/agent-sanitizer:enable-auto-update` currently dies like this:

```
Error: EPERM: operation not permitted, open '/Users/…/.claude/plugins/known_marketplaces.json.agent-sanitizer.tmp'
    at writeFileSync (node:fs:2437:20)
    at main (…/enable-auto-update.mjs:121:3)
```

The script already refuses cleanly for every registry state it anticipated (no registry, unregistered marketplace, unknown entry shape, non-boolean flag), but the write itself was unguarded — and that is the failure users actually hit, because Claude Code's Bash sandbox confines writes to the workspace and so cannot reach the plugin cache. It is also the one refusal the agent running the skill cannot clear on its own: no retry, no re-invocation, no alternate invocation gets past it. So the message hands the work back ready to run — the shell-quoted `node '…'` command line for a human to paste into a terminal outside Claude Code, plus `/plugin` → Marketplaces → agent-sanitizer → Enable auto-update as the no-terminal route.

`EPERM`/`EACCES`/`EROFS` on the write, the rename, or the temp-file cleanup take that path. Every other errno still propagates.

## Changes

- `plugin/scripts/enable-auto-update.mjs`: `replaceRegistry()` holds the temp-write + rename and maps the three refusal codes onto the existing `fail()` form. `removeStaged()` reports whether the staged temp file could be unlinked rather than crashing when it could not — the cleanup runs in exactly the situation that can refuse it. A temp file this run did not write is left alone. `shellQuote()`/`rerunCommand()` build the pasteable line; marketplace install paths carry a version segment and often a space.
- `plugin/test/enable-auto-update.test.mjs`: four cases behind a `0555` registry directory — the message and no stack trace; a refused cleanup reported rather than thrown; the rerun line quoted correctly for both `enable` and `--disable` from a script path containing a space. Skipped under uid 0, which writes through mode bits.
- `plugin/skills/enable-auto-update/SKILL.md`: the refusal bullet tells the agent to surface the printed command verbatim and not to retry.

## Review focus

`replaceRegistry()` + `removeStaged()` in `plugin/scripts/enable-auto-update.mjs`. The non-obvious part: rewriting an existing temp file needs no permission on the *directory*, so a stale temp left by an interrupted run makes `writeFileSync` succeed and `renameSync` fail — and then the `rmSync` fails on the same missing directory permission. That is why cleanup is refusal-tolerant rather than merely guarded on "did we stage it". Check that only the three codes are absorbed, in both functions.

## How it was tested

- `node --test plugin/test/enable-auto-update.test.mjs` as an unprivileged user: 19 pass, 0 skipped. As root the four permission cases skip (root writes through mode bits), 15 pass.
- Non-vacuity: each new case run against the code without the corresponding fix. Without the write guard, the two rerun-line cases and the no-stack-trace case fail on the raw `at writeFileSync` trace; with only a `staged` guard added, the cleanup case still fails on `EACCES … at rmSync`.
- Also exercised by hand: sticky `1777` directory with a foreign-owned registry (rename refused, `EPERM`, staged copy removed cleanly).
- `pnpm lint`, `pnpm check` pass.

## Decisions made

- **The message names the sandbox as the likely cause**, hedged with "if the terminal refuses it too, the file's owner or permissions need fixing" — a bare "permission denied" is accurate and useless, but the hedge keeps a plain ownership problem from being misdiagnosed.
- **A refused cleanup is reported, not silently swallowed**: the error names the staged copy it could not remove so the user can delete it alongside the permission fix.
- **No fallback write path.** A retry or an alternate location would make the failure rarer without making the toggle take effect; the registry only counts where Claude Code reads it.