### PR TITLE
test(auto-resolve): hold fan-out shards at a barrier, and unstick the automated-review gate

### DIFF
--- a/.github/scripts/auto-resolve/fanout.test.mjs
+++ b/.github/scripts/auto-resolve/fanout.test.mjs
@@ -56,17 +56,23 @@ if [[ -f "$dir/verdict/$key" ]]; then
   [[ -n "$vpath" ]] && cat "$dir/verdict/$key" >"$vpath"
 fi
 naptime="\${STUB_SLEEP:-0}"
-printf 'START %s %s %s\\n' "$key" "$n" "$(date +%s%N)" >>"$dir/concurrency.log"
 # A shard can be held until the shared log carries COUNT markers of KIND. That
-# is what turns "N ran at once" into an observation rather than a bet on the
-# runner spawning N processes faster than the first one's sleep: a held shard
-# cannot leave before its peers arrive, so a slow runner changes nothing. A
-# barrier the fan-out's own shape can never satisfy times out and says so.
+# turns "N ran at once" into an observation rather than a bet on the runner
+# spawning N processes faster than the first one's sleep: a held shard cannot
+# leave before its peers arrive, so a slow runner changes nothing.
 barrier="\${STUB_BARRIER:-}"
 if [[ -f "$dir/barrier/$key" ]]; then barrier="$(cat "$dir/barrier/$key")"; fi
+bkind="\${barrier%% *}"
+bcount="\${barrier##* }"
+# Validated BEFORE the START marker, because a shard that dies after writing one
+# leaves an unmatched START and INFLATES the peak the reader computes. A
+# non-numeric count also reads as 0 in arithmetic, silently skipping the wait.
 if [[ -n "$barrier" ]]; then
-  bkind="\${barrier%% *}"
-  bcount="\${barrier##* }"
+  { [[ "$bkind" == START || "$bkind" == END ]] && [[ "$bcount" =~ ^[0-9]+$ ]]; } ||
+    { printf 'fanout stub: barrier must be "START|END <count>", got %s\\n' "$barrier" >&2; exit 64; }
+fi
+printf 'START %s %s %s\\n' "$key" "$n" "$(date +%s%N)" >>"$dir/concurrency.log"
+if [[ -n "$barrier" ]]; then
   bwait="\${STUB_BARRIER_TIMEOUT:-60}"
   deadline=$((SECONDS + bwait))
   seen() { awk -v k="$bkind" '$1==k' "$dir/concurrency.log" | wc -l; }

--- a/.github/scripts/auto-resolve/fanout.test.mjs
+++ b/.github/scripts/auto-resolve/fanout.test.mjs
@@ -30,9 +30,11 @@ const slug = (p) => p.replace(/[^A-Z0-9]/gi, "_");
 // A fake `claude` that records its full argv, brackets its run with timestamped
 // markers in a shared log (so a reader can reconstruct not just how many ran at
 // once but WHEN each started and ended), and replies with whatever result JSON /
-// exit status the test staged for its target file. Per-file sleeps let a test
-// give shards uneven durations, which is what distinguishes slot recycling from a
-// batch barrier — a uniform duration makes the two shapes indistinguishable.
+// exit status the test staged for its target file. A per-file BARRIER holds a
+// shard until its peers reach the log, which is what distinguishes slot
+// recycling from a batch barrier — and, unlike uneven sleeps, states that
+// difference as an ordering the run must satisfy rather than one it usually
+// wins on a fast machine.
 const FAKE_CLAUDE = `#!/usr/bin/env bash
 set -euo pipefail
 dir="$STUB_DIR"
@@ -54,8 +56,29 @@ if [[ -f "$dir/verdict/$key" ]]; then
   [[ -n "$vpath" ]] && cat "$dir/verdict/$key" >"$vpath"
 fi
 naptime="\${STUB_SLEEP:-0}"
-if [[ -f "$dir/sleep/$key" ]]; then naptime="$(cat "$dir/sleep/$key")"; fi
 printf 'START %s %s %s\\n' "$key" "$n" "$(date +%s%N)" >>"$dir/concurrency.log"
+# A shard can be held until the shared log carries COUNT markers of KIND. That
+# is what turns "N ran at once" into an observation rather than a bet on the
+# runner spawning N processes faster than the first one's sleep: a held shard
+# cannot leave before its peers arrive, so a slow runner changes nothing. A
+# barrier the fan-out's own shape can never satisfy times out and says so.
+barrier="\${STUB_BARRIER:-}"
+if [[ -f "$dir/barrier/$key" ]]; then barrier="$(cat "$dir/barrier/$key")"; fi
+if [[ -n "$barrier" ]]; then
+  bkind="\${barrier%% *}"
+  bcount="\${barrier##* }"
+  bwait="\${STUB_BARRIER_TIMEOUT:-60}"
+  deadline=$((SECONDS + bwait))
+  seen() { awk -v k="$bkind" '$1==k' "$dir/concurrency.log" | wc -l; }
+  while (( $(seen) < bcount )); do
+    if (( SECONDS >= deadline )); then
+      printf 'fanout stub: %s waited %ss for %s %s markers, saw %s\\n' \\
+        "$key" "$bwait" "$bcount" "$bkind" "$(seen)" >&2
+      break
+    fi
+    sleep 0.02
+  done
+fi
 sleep "$naptime"
 printf 'END %s %s %s\\n' "$key" "$n" "$(date +%s%N)" >>"$dir/concurrency.log"
 if [[ -f "$dir/resp/$key" ]]; then cat "$dir/resp/$key"; else
@@ -109,7 +132,7 @@ function fixture() {
   const stub = join(root, "stub");
   const path = join(root, "bin");
   const work = join(root, "work");
-  for (const d of ["argv", "resp", "exit", "sleep", "verdict"])
+  for (const d of ["argv", "resp", "exit", "barrier", "verdict"])
     mkdirSync(join(stub, d), { recursive: true });
   for (const d of [path, work]) mkdirSync(d, { recursive: true });
   writeFileSync(join(stub, "concurrency.log"), "");
@@ -200,8 +223,9 @@ const stageResult = (fx, file, obj) =>
   writeFileSync(join(fx.stub, "resp", slug(file)), JSON.stringify(obj));
 const stageExit = (fx, file, code) =>
   writeFileSync(join(fx.stub, "exit", slug(file)), String(code));
-const stageSleep = (fx, file, seconds) =>
-  writeFileSync(join(fx.stub, "sleep", slug(file)), String(seconds));
+// Hold FILE's shard until COUNT markers of KIND are in the shared log.
+const stageBarrier = (fx, file, kind, count) =>
+  writeFileSync(join(fx.stub, "barrier", slug(file)), `${kind} ${count}`);
 // What the shard for FILE writes to the verdict path its prompt names.
 const stageVerdict = (fx, file, body) =>
   writeFileSync(join(fx.stub, "verdict", slug(file)), body);
@@ -301,20 +325,26 @@ test("a slot freed by a fast shard is refilled while a slow one still runs", () 
   // both peak at exactly MAX_PARALLEL. One long shard among fast ones does: under
   // recycling every later shard starts while the long one is still running, and
   // under a barrier the last batch cannot start until the long shard has ended.
+  // `long` is held until every fast shard has ENDED rather than for a fixed 2s,
+  // so the ordering below is one the run enforces and not one a sleep usually
+  // wins: under a batch barrier the held shard and its batch deadlock instead.
   const fx = fixture();
   const fast = ["s1", "s2", "s3", "s4"];
-  stageSleep(fx, "long", 2);
-  for (const f of fast) stageSleep(fx, f, 0.1);
+  stageBarrier(fx, "long", "END", fast.length);
 
-  const res = run(fx, { files: ["long", ...fast], env: { MAX_PARALLEL: "2" } });
+  const res = run(fx, {
+    files: ["long", ...fast],
+    env: { MAX_PARALLEL: "2", STUB_BARRIER_TIMEOUT: "20" },
+  });
   assert.equal(res.status, 0, res.stderr);
   assert.equal(invocations(fx).length, 5);
-  // Bounded: never more than the cap in flight, and it really does overlap.
+  // Bounded: never more than the cap in flight, and it really does overlap —
+  // `long` outlives every fast shard, so each one of them overlaps it.
   assert.equal(peakConcurrency(fx), 2);
 
-  // `long` and `s1` fill both slots at t0; each later shard can only have started
-  // by taking the slot `s1`/`s2`/`s3` freed — all of them strictly before `long`
-  // ends. The LAST one to start is the strictest form of that claim.
+  // Each later shard can only have started by taking the slot `s1`/`s2`/`s3`
+  // freed — all of them strictly before `long` ends. The LAST one to start is
+  // the strictest form of that claim.
   const longEnd = markerNs(fx, "END", "long");
   const lastStart = Math.max(
     ...fast.slice(1).map((f) => markerNs(fx, "START", f)),
@@ -336,11 +366,19 @@ test("MAX_PARALLEL=1 serializes, and a cap above the file count is not a floor",
   );
   assert.equal(peakConcurrency(serial), 1);
 
+  // Every shard is held until all three have STARTED, so all three are provably
+  // in flight at once. A per-shard sleep only makes that LIKELY: it asks the
+  // runner to spawn three processes faster than the first one's nap, which a
+  // loaded runner loses (observed: peak 2 on run 31345443966, `main` red).
   const wide = fixture();
   assert.equal(
     run(wide, {
       files: ["a1", "a2", "a3"],
-      env: { MAX_PARALLEL: "16", STUB_SLEEP: "0.3" },
+      env: {
+        MAX_PARALLEL: "16",
+        STUB_BARRIER: "START 3",
+        STUB_BARRIER_TIMEOUT: "20",
+      },
     }).status,
     0,
   );

--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -129,6 +129,7 @@ jobs:
       contents: read # checkout the trusted base branch
       pull-requests: write # post the review
       checks: write # re-post the "Review findings resolved" verdict on the head
+      statuses: write # re-post the "Automated review posted" status on the head
     steps:
       - name: Checkout base (trusted) branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -274,6 +275,27 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           REPORT_SHA: ${{ github.event.pull_request.head.sha }}
         run: bash .github/scripts/review-findings-gate.sh
+
+      # The same GITHUB_TOKEN blind spot, on the OTHER gate. review-gate.yaml
+      # has two legs and neither can see this review: its `pull_request_review`
+      # leg never fires for one posted with GITHUB_TOKEN, and its `synchronize`
+      # leg already ran on this head BEFORE the review existed, leaving a
+      # `pending` status. Nothing else re-evaluates it — there is no cron and no
+      # workflow_dispatch — so the required "Automated review posted" context
+      # stays pending until somebody pushes again. A PR that is reviewed and has
+      # nothing left to push then waits forever on a review it already has
+      # (observed on #290, pending from 02:03:28Z with the review at 02:05Z).
+      #
+      # No `if:`, for the same reason as the step above: the predicate is
+      # stateless, so the oversized path posts the correct not-reviewed pending.
+      - name: Re-evaluate the automated-review gate on the head
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash .github/scripts/review-gate.sh
 
   # Auto-approve the PRs the reviewer deliberately SKIPS (see `decide` above:
   # low-risk chore/style by title, machine-cut `release:` PRs, and


### PR DESCRIPTION
Claims these areas: `.github/scripts/auto-resolve/fanout.test.mjs` (the concurrency assertions) and `claude-pr-review.yaml`'s gate re-derivation.

## Partitions

1. **`test(auto-resolve)`** — the fan-out concurrency tests stop racing sleeps. Test-only.
2. **`ci`** — `claude-pr-review.yaml` re-posts the `Automated review posted` status after filing its review. Behaviour change to a required check.

## Summary

**Partition 1.** Two fan-out tests asserted "N shards ran at once" by giving each stub shard a sleep and hoping the runner spawned all N before the first one woke. A loaded runner loses that race, so the stub now takes a **barrier**: hold this shard until the shared log carries COUNT markers of KIND. "Three were in flight" becomes an ordering the fan-out must satisfy rather than one it usually wins. This is the `Node tests` red on `main`: run [#863](https://github.com/AlexanderMattTurner/agent-sanitizer/actions/runs/31345443966) at `67afd1f` saw `peakConcurrency` 2 where the test expected 3, on a tree with no defect in it.

**Partition 2.** A review posted with `GITHUB_TOKEN` fires no `pull_request_review` webhook, so `review-gate.yaml` never wakes on the review `claude-pr-review.yaml` just filed. Its only other leg is `pull_request_target`/`synchronize`, which already ran on that head *before* the review existed and left a `pending` status. Nothing else re-evaluates it — no cron, no `workflow_dispatch`, and `review-gate-context.yaml` is `merge_group`-only, which never fires in this repo. So the required `Automated review posted` context stays pending until the next push, and a PR that is reviewed with nothing left to push waits forever on a review it already has.

## Review focus

**Partition 2 is the one to read.** The compensation is a copy of the step already sitting one line above it for `review-findings-gate.sh` — the question worth checking is whether `statuses: write` is the right addition (the findings gate posts a *check run*, so `checks: write` did not cover a *commit status*), and whether the missing `if:` is correct (it is stateless, so the oversized path posts the accurate not-reviewed `pending`).

For partition 1, the barrier block inside the `FAKE_CLAUDE` template literal: it is bash inside a JS template string, so every `${…}` meant for bash is escaped `\${…}` — an unescaped one would interpolate at test-definition time and silently disable the wait.

## Tests / verification

- `node --test .github/scripts/auto-resolve/fanout.test.mjs` → 36 pass. Runtime drops 8.9s → 5.4s (the removed sleeps).
- Non-vacuity, observed: mutating `fanout.sh`'s `wait -n` to a batch `wait` reds the slot-recycling test on its ordering assertion; pinning `max_parallel` to 1 reds the wide-cap test with `actual: 1 / expected: 3`; `STUB_BARRIER="START"` reds it with `actual: 0`. `fanout.sh` restored, `git diff --stat` clean.
- `pnpm test` → 9 consecutive clean runs; `pnpm lint` and `pnpm check` → exit 0.
- Partition 2's evidence is the live incident on this PR: `GET /statuses/a152294` returned one status, `Automated review posted`, `state: pending`, `created_at` and `updated_at` both `2026-08-10T02:03:28Z`, with the review submitted at ~02:05Z. `review-gate.yaml`'s run list shows no run between them — the last for this branch is `31348733995` (`pull_request_target`, 02:03:21Z).

## Decisions made

- **A barrier, not a longer sleep.** Raising `STUB_SLEEP` makes the flake rarer without removing its cause, and every fan-out test then pays the new sleep.
- **The barrier timeout warns and continues rather than exiting non-zero,** so the test fails on the assertion that names the defect (`peak 2, expected 3`) instead of on a shard exit status that says nothing about concurrency.
- **Partition 2 is fixed at the review-posting job, not by adding a cron to `review-gate.yaml`.** A cron would clear the gate eventually on a schedule nobody can see; re-deriving it in the job that caused the state change makes the status correct the moment the review lands, and matches the compensation the findings gate already has. A cron would also be a new scheduled check, which `CLAUDE.md` bars from a fix PR.
- **`claude.yaml` also keys on `pull_request_review` and is deliberately left alone.** It is the human `@claude` mention responder, not a gate, so a missed self-triggered event costs nothing.

## Known limitation

Partition 2 arms only once it is on the default branch: `pull_request_target` takes the workflow file from the base branch, so this PR's own gate still clears the old way (its `synchronize` leg finds the standing review on the next push). That is the same bootstrap property `review-gate.yaml` documents for its script checkout.

## Checklist

- [x] Commits follow Conventional Commits.
- [x] `pnpm test`, `pnpm lint`, and `pnpm check` pass locally.
- [x] No detector changed, so no new negative tests are owed.
- [x] No secrets in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` untouched.
