### PR TITLE
ci: re-derive both review gates wherever review state changes, and reconcile on a cron

### DIFF
--- a/.github/scripts/approve-if-reviewer-hold-clear.sh
+++ b/.github/scripts/approve-if-reviewer-hold-clear.sh
@@ -207,20 +207,44 @@ dismiss_stale_hold() {
 # it refuses any approval of a PR the token's own actor authored. Stand down
 # LOUDLY on both, naming the remedy. Any OTHER failure is real and exits
 # non-zero.
+# Every write below is a REVIEW made with GITHUB_TOKEN, and GitHub emits no
+# pull_request_review event for one — so both review-keyed gates would keep a
+# verdict that predates it: pending after an approve, or GREEN after a dismissal
+# that left nothing standing. The second is fail-open on a required merge gate,
+# so the re-derivation lives here beside the writes, covering the push-time
+# resolver and the periodic sweep alike instead of being re-implemented per
+# caller (the same reason the verdict itself lives in this one script).
+#
+# Safe for every PR this script ACTS on, and it acts on no others: it reaches a
+# write only when the reviewer's latest review is a live hold or comment, so the
+# deliberately-skipped class — never reviewed, its gate cleared by hand — is
+# never reached and never overwritten.
+rederive_review_gates() {
+  local head_sha
+  head_sha="$(gh api "repos/${GH_REPO}/pulls/${PR}" --jq '.head.sha')"
+  # Both run in report mode, so each posts its verdict and exits 0 whatever that
+  # verdict is: a red finding here must not fail the sweep of the other PRs.
+  REPORT_SHA="$head_sha" bash "$SCRIPT_DIR/review-findings-gate.sh"
+  HEAD_SHA="$head_sha" bash "$SCRIPT_DIR/review-gate.sh"
+}
+
 approve_err=""
 if ! approve_err="$(gh pr review "$PR" --repo "$GH_REPO" --approve --body \
   "Automated approval: ${cleared_by}, so this satisfies the review-required ruleset. Re-request review if a human should take a closer look." 2>&1)"; then
   if [[ "$approve_err" == *"not permitted to approve pull requests"* ]]; then
     echo "hold is clear, but this token cannot approve: GitHub blocks approvals from GitHub Actions." >&2
     dismiss_stale_hold "${cleared_by}, so this hold no longer reflects the pull request's state." || exit 1
+    rederive_review_gates
     exit 0
   fi
   if [[ "$approve_err" == *"Can not approve your own pull request"* ]]; then
     echo "hold is clear, but this token's actor authored PR #${PR}, and GitHub refuses a self-approval." >&2
     dismiss_stale_hold "${cleared_by}, so this hold no longer reflects the pull request's state." || exit 1
+    rederive_review_gates
     exit 0
   fi
   echo "failed to post the clearing approval: ${approve_err}" >&2
   exit 1
 fi
 echo "${cleared_by} and reviewer was holding (${latest_state}); approved to satisfy the review gate" >&2
+rederive_review_gates

--- a/.github/scripts/approve-if-reviewer-hold-clear.sh
+++ b/.github/scripts/approve-if-reviewer-hold-clear.sh
@@ -222,10 +222,18 @@ dismiss_stale_hold() {
 rederive_review_gates() {
   local head_sha
   head_sha="$(gh api "repos/${GH_REPO}/pulls/${PR}" --jq '.head.sha')"
-  # Both run in report mode, so each posts its verdict and exits 0 whatever that
-  # verdict is: a red finding here must not fail the sweep of the other PRs.
-  REPORT_SHA="$head_sha" bash "$SCRIPT_DIR/review-findings-gate.sh"
-  HEAD_SHA="$head_sha" bash "$SCRIPT_DIR/review-gate.sh"
+  # Independent predicates, so neither is allowed to abort the other: under
+  # `set -e` a sequenced pair would let the FIRST one's 403 or API fault leave
+  # the second unre-derived, and the fail-open gate is the one that must not be
+  # skipped. It therefore runs first AND each reports on its own, with the worst
+  # status returned so a real fault still reaches the caller loudly.
+  #
+  # Both run in report mode, so a red VERDICT is not a failure here — only an
+  # inability to post one is.
+  local rc=0
+  HEAD_SHA="$head_sha" bash "$SCRIPT_DIR/review-gate.sh" || rc=$?
+  REPORT_SHA="$head_sha" bash "$SCRIPT_DIR/review-findings-gate.sh" || rc=$?
+  return "$rc"
 }
 
 approve_err=""

--- a/.github/scripts/reconcile-review-gate.sh
+++ b/.github/scripts/reconcile-review-gate.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Re-derive the `Automated review posted` status on the head of EVERY open PR.
+#
+# The gate is a pure function of review state, but review-gate.yaml only
+# recomputes it on `pull_request_review` and on a push. Neither fires when this
+# repo's own automation changes that state: a review posted or dismissed with
+# GITHUB_TOKEN emits no `pull_request_review` event (GitHub's recursion guard),
+# and nothing pushes afterwards. The status then keeps whatever it last
+# computed, and it is wrong in BOTH directions:
+#
+#   * stale pending — a review landed after the last push, so a reviewed PR
+#     waits forever on a review it already has (observed on #290);
+#   * stale success — the only standing review was dismissed (which is the
+#     ROUTINE outcome of the hold sweeper, because GitHub refuses approvals from
+#     an Actions token), leaving a required merge gate green with nothing
+#     reviewing the PR. That direction is fail-OPEN, so it is the reason this
+#     reconciler runs unconditionally rather than only on PRs it touched.
+#
+# Every mutation site also re-derives the gate inline, so this is the safety
+# net, not the mechanism: it bounds how long any stale verdict can survive to
+# one sweep interval, including one left by a site added later that forgets.
+# It writes nothing but that status, and the verdict itself stays in
+# review-gate.sh so the sweep and the per-event paths cannot drift.
+#
+# Env: GH_TOKEN, GH_REPO (owner/name); RUN_URL optional (passed through).
+set -euo pipefail
+
+: "${GH_REPO:?GH_REPO required}"
+: "${GH_TOKEN:?GH_TOKEN required}"
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# EVERY open PR, drafts and bot-authored included — deliberately wider than
+# sweep-reviewer-holds.sh's human/non-draft filter. The skipped class is
+# bot-authored, and it is the class most likely to be stranded: it gets its
+# approval on `opened` and then never pushes again.
+readonly PR_LIMIT=200
+prs_json="$(gh pr list --repo "$GH_REPO" --state open --limit "$PR_LIMIT" \
+  --json number,headRefOid)"
+if [[ "$(jq 'length' <<<"$prs_json")" -ge "$PR_LIMIT" ]]; then
+  echo "::warning::reconcile-review-gate: open-PR page hit the ${PR_LIMIT} cap; PRs beyond it keep whatever status they last computed. Raise PR_LIMIT or paginate." >&2
+fi
+
+rows="$(jq -r '.[] | "\(.number) \(.headRefOid)"' <<<"$prs_json")" || {
+  echo "::error::reconcile-review-gate: jq failed to read the open-PR list" >&2
+  exit 1
+}
+entries=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && entries+=("$line")
+done <<<"$rows"
+
+status=0
+for entry in "${entries[@]}"; do
+  pr="${entry%% *}"
+  head_sha="${entry##* }"
+  echo "::group::PR #${pr}"
+  # One PR failing must not abort the rest, but a real API/token fault still has
+  # to surface, so record it and exit non-zero at the end.
+  if ! PR="$pr" HEAD_SHA="$head_sha" bash "$here/review-gate.sh"; then
+    echo "reconcile-review-gate: PR #${pr} could not be evaluated" >&2
+    status=1
+  fi
+  echo "::endgroup::"
+done
+
+exit "$status"

--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -339,6 +339,7 @@ jobs:
       contents: read # sparse-checkout the trusted approval script
       pull-requests: write # submit an approving review
       checks: write # clear the review-findings gate for the skipped class
+      statuses: write # re-post the "Automated review posted" status on the head
     steps:
       - name: Checkout base (trusted) approval script
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -347,7 +348,9 @@ jobs:
           # decide/review jobs: the script is trusted repo content, no PR code runs.
           ref: ${{ github.event.pull_request.base.ref }}
           persist-credentials: false
-          sparse-checkout: .github/scripts/auto-approve-skipped-pr.sh
+          sparse-checkout: |
+            .github/scripts/auto-approve-skipped-pr.sh
+            .github/scripts/review-gate.sh
           sparse-checkout-cone-mode: false
       - name: Approve so a review-required ruleset doesn't strand a skipped PR
         if: >-
@@ -393,3 +396,23 @@ jobs:
             -f "conclusion=success" \
             -f "output[title]=green: review deliberately skipped" \
             -f "output[summary]=This PR is in the class the reviewer skips (bot-authored, or a chore/style/release title), so no automated review was run and there are no findings to resolve. Add the needs-auto-review label to force a full review." >/dev/null
+
+      # The approval above is a REVIEW posted with GITHUB_TOKEN, so it fires no
+      # pull_request_review event, and review-gate.yaml's other leg already ran
+      # on this head — on `opened`, before the approval existed. Without this the
+      # whole skipped class sits on a pending required status until someone
+      # pushes, and that class (bot PRs, chore/style/release titles) is the one
+      # least likely to ever push again.
+      #
+      # `always()` for the same reason as the step above: the predicate is
+      # stateless, so a failed approve posts the honest `pending` rather than a
+      # green nothing earned, and the job still goes red on the approve itself.
+      - name: Re-evaluate the automated-review gate on the head
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash .github/scripts/review-gate.sh

--- a/.github/workflows/claude-review-thread-resolve.yaml
+++ b/.github/workflows/claude-review-thread-resolve.yaml
@@ -57,6 +57,7 @@ jobs:
       contents: read # checkout the trusted base branch
       pull-requests: write # resolve threads and post the audit replies
       checks: write # re-post the "Review findings resolved" verdict on the head
+      statuses: write # re-derive the "Automated review posted" status on the head
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_REPO: ${{ github.repository }}
@@ -183,3 +184,17 @@ jobs:
         env:
           REPORT_SHA: ${{ github.event.pull_request.head.sha }}
         run: bash .github/scripts/review-findings-gate.sh
+
+      # The approve/dismiss above is a REVIEW written with GITHUB_TOKEN, so it
+      # fires no pull_request_review event, and review-gate.yaml's push leg ran
+      # on this head before it. Without this the other required gate keeps a
+      # verdict that predates the review this job just filed — pending when it
+      # approved, or green when it dismissed the only standing review, which is
+      # the fail-open direction.
+      #
+      # No `if:`, for the same reason as the step above: stateless and idempotent.
+      - name: Re-derive the automated-review gate after resolving
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash .github/scripts/review-gate.sh

--- a/.github/workflows/claude-reviewer-hold-clear.yaml
+++ b/.github/workflows/claude-reviewer-hold-clear.yaml
@@ -25,11 +25,12 @@ name: Claude reviewer-hold sweeper
 # SECURITY — schedule + workflow_dispatch run from the DEFAULT branch (trusted repo
 # content) with the base repo's GITHUB_TOKEN; the job checks out ONLY the trusted
 # approval scripts and executes no PR code — it reads thread/review state via the
-# API and can only post an approval or a commit status. Least privilege:
-# contents:read (checkout the scripts) + pull-requests:write (post the approval) +
-# statuses:write (post the gate verdict), nothing else, so even an unexpected PR
-# can only be approved or have its gate status corrected, never pushed to, merged,
-# or otherwise reached.
+# API and can only post an approval, a commit status or a check run. Least
+# privilege: contents:read (checkout the scripts) + pull-requests:write (post the
+# approval) + statuses:write (the `Automated review posted` verdict) +
+# checks:write (the `Review findings resolved` verdict), nothing else, so even an
+# unexpected PR can only be approved or have its gate verdicts corrected, never
+# pushed to, merged, or otherwise reached.
 
 on:
   schedule:
@@ -47,7 +48,8 @@ jobs:
     permissions:
       contents: read # sparse-checkout the trusted approval scripts
       pull-requests: write # submit the approving review
-      statuses: write # re-derive the "Automated review posted" gate; no other scope
+      statuses: write # re-derive the "Automated review posted" gate
+      checks: write # re-post the "Review findings resolved" check run; no other scope
     env:
       # The sweep's own PR listing runs on the Actions token.
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-reviewer-hold-clear.yaml
+++ b/.github/workflows/claude-reviewer-hold-clear.yaml
@@ -12,12 +12,24 @@ name: Claude reviewer-hold sweeper
 # The approve itself is state-based and idempotent (approve-if-reviewer-hold-
 # clear.sh reads current thread + review state), so a sweep never double-approves.
 #
+# The same cron carries a SECOND reconciler, for the same reason in a different
+# shape: the `Automated review posted` status is a pure function of review state
+# that only recomputes on `pull_request_review` or a push, and this repo's own
+# automation changes that state with GITHUB_TOKEN, which fires neither.
+# reconcile-review-gate.sh re-derives it for every open PR, bounding a stale
+# verdict — pending on a reviewed PR, or green on one whose only review was
+# dismissed — to one sweep interval. Both duties are the same job because both
+# are state-based reconcilers over the open-PR list, and a second scheduled
+# workflow would pay a whole run to do one API read.
+#
 # SECURITY — schedule + workflow_dispatch run from the DEFAULT branch (trusted repo
 # content) with the base repo's GITHUB_TOKEN; the job checks out ONLY the trusted
 # approval scripts and executes no PR code — it reads thread/review state via the
-# API and can only post an approval. Least privilege: contents:read (checkout the
-# scripts) + pull-requests:write (post the approval), nothing else, so even an
-# unexpected PR can only be approved, never pushed to, merged, or otherwise reached.
+# API and can only post an approval or a commit status. Least privilege:
+# contents:read (checkout the scripts) + pull-requests:write (post the approval) +
+# statuses:write (post the gate verdict), nothing else, so even an unexpected PR
+# can only be approved or have its gate status corrected, never pushed to, merged,
+# or otherwise reached.
 
 on:
   schedule:
@@ -34,7 +46,8 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read # sparse-checkout the trusted approval scripts
-      pull-requests: write # submit the approving review; no other scope
+      pull-requests: write # submit the approving review
+      statuses: write # re-derive the "Automated review posted" gate; no other scope
     env:
       # The sweep's own PR listing runs on the Actions token.
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -54,3 +67,12 @@ jobs:
           sparse-checkout-cone-mode: false
       - name: Sweep open PRs and clear any cleared reviewer hold
         run: bash .github/scripts/sweep-reviewer-holds.sh
+
+      # `always()`: the two reconcilers are independent, and a hold the sweep
+      # could not clear is no reason to leave every open PR's gate status stale.
+      - name: Reconcile the automated-review gate across open PRs
+        if: always()
+        env:
+          # GH_TOKEN and GH_REPO come from the job env above.
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash .github/scripts/reconcile-review-gate.sh

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -42,6 +42,9 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
+  # review-gate-exempt: this is the @claude mention responder, not a merge gate.
+  # It posts no required status or check run, so a review of its own that fires
+  # no webhook costs a missed reply, never a stale verdict on a PR's merge.
   pull_request_review:
     types: [submitted]
   issues:

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     ]
   },
   "devDependencies": {
-    "sanitizer-engine": "npm:agent-sanitizer@2.20.0",
     "@commitlint/cli": "^21.0.1",
     "@commitlint/config-conventional": "^21.0.1",
     "@eslint/js": "10.0.1",
@@ -77,8 +76,10 @@
     "globals": "17.6.0",
     "lint-staged": "^17.0.5",
     "prettier": "^3.0.0",
+    "sanitizer-engine": "npm:agent-sanitizer@2.20.0",
     "typescript": "6.0.3",
-    "typescript-eslint": "8.61.0"
+    "typescript-eslint": "8.61.0",
+    "yaml": "^2.9.0"
   },
   "license": "Apache-2.0",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       typescript-eslint:
         specifier: 8.61.0
         version: 8.61.0(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
 
 packages:
 

--- a/test/review-gate-compensation.test.mjs
+++ b/test/review-gate-compensation.test.mjs
@@ -1,0 +1,240 @@
+/**
+ * A gate whose verdict is a pure function of PR review state can only be as
+ * fresh as the last thing that recomputed it, and in this repo the events that
+ * would recompute it do not fire.
+ *
+ * `review-gate.yaml` and `review-findings-gate.yaml` both key on
+ * `pull_request_review`. GitHub does not emit that event for a review posted,
+ * dismissed or edited with GITHUB_TOKEN — the recursion guard — so every review
+ * this repo's own automation files is invisible to them. Their other leg is a
+ * push, which has already happened by the time the review lands. The verdict
+ * then survives as whatever it last computed, wrong in both directions: pending
+ * on a PR that has been reviewed (observed on #290, and auto-merge waits on it
+ * forever), or green on one whose only review was dismissed, which is fail-open
+ * on a required merge gate.
+ *
+ * So the invariant, checked here: EVERY job that mutates review state also
+ * re-derives EVERY review-keyed gate, in the same job. Both sides are derived
+ * from the tree rather than listed — a new gate on that trigger, or a new job
+ * that posts a review, is caught the day it is written rather than the day a PR
+ * hangs. `reconcile-review-gate.sh`'s cron bounds the damage to one sweep
+ * interval; this bounds it to zero for anything a reviewer can see in a diff.
+ *
+ * An exemption is a `# review-gate-exempt: <reason>` marker in the exempt
+ * workflow's own file, so the excuse travels with the thing it excuses and
+ * deleting the workflow deletes the excuse.
+ *
+ * LIMIT, stated rather than implied: the call graph is TEXTUAL, so a script that
+ * still names a gate reads as re-deriving it even if the call is now dead code.
+ * What this catches is the realistic regression — a new review-writing job, or a
+ * reverted block — and all three of those red it. What it cannot catch is a
+ * live-but-unreachable call, which is a job for review and for lint.
+ */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { parse } from "yaml";
+
+const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+  encoding: "utf8",
+}).trim();
+
+const tracked = (glob) =>
+  execFileSync("git", ["ls-files", "--", glob], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  })
+    .split("\n")
+    .filter(Boolean);
+
+const read = (relative) => readFileSync(join(repoRoot, relative), "utf8");
+
+const workflowPaths = [
+  ...tracked(".github/workflows/*.yaml"),
+  ...tracked(".github/workflows/*.yml"),
+];
+const scriptPaths = tracked(".github/scripts/*.sh");
+
+/**
+ * Two shapes, one marker. Bare — `# review-gate-exempt: <reason>` — on a
+ * workflow that keys on `pull_request_review` but is no gate. Qualified —
+ * `# review-gate-exempt(<context>): <reason>` — on a workflow whose jobs change
+ * review state and deliberately do NOT re-derive that one gate.
+ */
+const EXEMPT_MARKER = /#\s*review-gate-exempt:\s*(?<reason>\S.*)/;
+const SCOPED_EXEMPT =
+  /#\s*review-gate-exempt\((?<context>[^)]+)\):\s*(?<reason>\S.*)/g;
+
+const scopedExemptions = (source) =>
+  new Set([...source.matchAll(SCOPED_EXEMPT)].map((m) => m.groups.context));
+
+/** Every `run:` body in a workflow, keyed by the job that owns it. */
+function jobsWithRunBodies(source) {
+  const doc = parse(source);
+  return Object.entries(doc?.jobs ?? {}).map(([id, job]) => ({
+    id,
+    runs: (job?.steps ?? [])
+      .map((step) => step?.run)
+      .filter((run) => typeof run === "string"),
+  }));
+}
+
+/**
+ * The scripts a shell command invokes, as repo-relative `.github/scripts` paths.
+ * Matched on the FULL path, never the bare basename: `reconcile-review-gate.sh`
+ * ends with `review-gate.sh`, so a basename test reports a job as running a gate
+ * it never runs — the guard would then pass by mis-reading its own evidence.
+ */
+const scriptsIn = (command) =>
+  scriptPaths.filter((path) => command.includes(path));
+
+/** How one script names another, on a boundary so a suffix cannot collide. */
+const invocationOf = (path) =>
+  new RegExp(`(?:^|[\\s"'/])${path.slice(".github/scripts/".length)}\\b`, "m");
+
+/**
+ * A script MUTATES review state when it CREATES or DISMISSES a review — the two
+ * acts that move the gates' predicates. Matched on the write verb, so the reads
+ * every gate script performs against the same `/reviews` endpoint do not count
+ * themselves in, and an edit of a review's BODY does not either (it changes no
+ * predicate). Derived from what the scripts call, so a writer added later joins
+ * this set without anyone remembering to list it.
+ */
+const MUTATES_REVIEW =
+  /gh pr review|(?:-X|--method) POST[^\n]*\/reviews\b|(?:-X|--method) PUT[^\n]*\/dismissals\b/;
+
+/**
+ * Which scripts each script can reach, as a call graph over `.github/scripts`.
+ * BOTH questions this file asks are reachability questions — "does this job end
+ * up writing a review?" and "does it end up re-deriving the gate?" — and the
+ * hops are real: the cron job runs `sweep-reviewer-holds.sh`, which delegates to
+ * `approve-if-reviewer-hold-clear.sh`, which is where both the write and the
+ * re-derivation live. A depth-1 answer to either one is wrong.
+ */
+const callGraph = new Map(
+  scriptPaths.map((path) => [
+    path,
+    scriptPaths.filter(
+      (other) => other !== path && invocationOf(other).test(read(path)),
+    ),
+  ]),
+);
+
+const reachableFrom = (roots) => {
+  const seen = new Set(roots);
+  const stack = [...roots];
+  while (stack.length > 0)
+    for (const next of callGraph.get(stack.pop()) ?? []) {
+      if (seen.has(next)) continue;
+      seen.add(next);
+      stack.push(next);
+    }
+  return seen;
+};
+
+const writesReviewDirectly = new Set(
+  scriptPaths.filter((path) => MUTATES_REVIEW.test(read(path))),
+);
+
+const reviewMutatingScripts = scriptPaths.filter((path) =>
+  [...reachableFrom([path])].some((reached) =>
+    writesReviewDirectly.has(reached),
+  ),
+);
+
+/**
+ * A workflow is a review-keyed GATE when it triggers on `pull_request_review`
+ * and is not exempt. Two things can then re-derive its verdict, and a job needs
+ * EITHER: run the gate's own script, or write the gate's context directly — the
+ * skipped class does the latter on purpose, because the gate's real predicate
+ * says red for a PR nothing reviewed and the skip decision is what licenses it.
+ * The context string is read out of the script that owns it rather than restated
+ * here, so a rename moves both sides at once.
+ */
+const CONTEXT_CONSTANT = /^(?:CHECK_NAME|GATE_CONTEXT)="(?<context>[^"]+)"/m;
+
+const reviewKeyedGates = workflowPaths.flatMap((path) => {
+  const source = read(path);
+  const doc = parse(source);
+  if (!("pull_request_review" in (doc?.on ?? {}))) return [];
+  if (EXEMPT_MARKER.test(source)) return [];
+  const scripts = [
+    ...new Set(
+      jobsWithRunBodies(source).flatMap((job) => job.runs.flatMap(scriptsIn)),
+    ),
+  ];
+  const contexts = scripts
+    .map((script) => CONTEXT_CONSTANT.exec(read(script))?.groups.context)
+    .filter(Boolean);
+  return [{ path, scripts, contexts }];
+});
+
+describe("review-keyed gates are re-derived wherever review state changes", () => {
+  // Non-vacuity: the whole file passes trivially if either side comes up empty,
+  // which is exactly what a refactor that renames a trigger or a script would do.
+  it("finds both a gate and a review-mutating script to check", () => {
+    assert.ok(
+      reviewKeyedGates.length > 0,
+      "no workflow triggers on pull_request_review — the derivation is broken, not the repo",
+    );
+    assert.ok(
+      reviewMutatingScripts.length > 0,
+      "no .github/scripts file posts or dismisses a review — the derivation is broken",
+    );
+    for (const gate of reviewKeyedGates)
+      assert.ok(
+        gate.contexts.length > 0,
+        `${gate.path} keys on pull_request_review but no script it runs declares a CHECK_NAME/GATE_CONTEXT, so no job can be shown to compensate for it`,
+      );
+  });
+
+  it("every job that mutates review state re-derives every gate", () => {
+    const gaps = [];
+    for (const path of workflowPaths) {
+      const source = read(path);
+      const exempt = scopedExemptions(source);
+      for (const job of jobsWithRunBodies(source)) {
+        const body = job.runs.join("\n");
+        const ran = job.runs.flatMap(scriptsIn);
+        if (!ran.some((script) => reviewMutatingScripts.includes(script)))
+          continue;
+        for (const gate of reviewKeyedGates) {
+          if (gate.contexts.some((context) => exempt.has(context))) continue;
+          // Re-derivation is transitive too: a step that runs the reconciler
+          // runs the gate script, one call deeper.
+          const reached = reachableFrom(ran);
+          const rederived =
+            gate.scripts.some((script) => reached.has(script)) ||
+            gate.contexts.some((context) => body.includes(context));
+          if (!rederived)
+            gaps.push(
+              `${path}:${job.id} changes review state but re-derives neither ${gate.scripts.join("/")} nor its context ${JSON.stringify(gate.contexts)}`,
+            );
+        }
+      }
+    }
+    assert.deepEqual(
+      gaps,
+      [],
+      "a review posted with GITHUB_TOKEN fires no pull_request_review event, so each of these leaves a required gate holding a stale verdict",
+    );
+  });
+
+  it("every exemption states a reason", () => {
+    for (const path of workflowPaths) {
+      const source = read(path);
+      const match = EXEMPT_MARKER.exec(source);
+      if (!match) continue;
+      assert.ok(
+        "pull_request_review" in (parse(source)?.on ?? {}),
+        `${path} is marked review-gate-exempt but does not key on pull_request_review — delete the stale marker`,
+      );
+      assert.ok(
+        match.groups.reason.trim().length > 10,
+        `${path}'s review-gate-exempt marker needs a reason, not a token`,
+      );
+    }
+  });
+});

--- a/test/review-gate-compensation.test.mjs
+++ b/test/review-gate-compensation.test.mjs
@@ -198,7 +198,13 @@ describe("review-keyed gates are re-derived wherever review state changes", () =
       for (const job of jobsWithRunBodies(source)) {
         const body = job.runs.join("\n");
         const ran = job.runs.flatMap(scriptsIn);
-        if (!ran.some((script) => reviewMutatingScripts.includes(script)))
+        // A step can write a review INLINE — this tree already posts a check run
+        // that way — and such a job reaches no script at all, so testing only
+        // `ran` would let the very regression this file promises to catch pass.
+        if (
+          !MUTATES_REVIEW.test(body) &&
+          !ran.some((script) => reviewMutatingScripts.includes(script))
+        )
           continue;
         for (const gate of reviewKeyedGates) {
           if (gate.contexts.some((context) => exempt.has(context))) continue;


### PR DESCRIPTION
Claims this area: the `pull_request_review`-keyed gates and every job that writes a review. Follows [#290](https://github.com/AlexanderMattTurner/agent-sanitizer/pull/290), which fixed one site of this class.

## Summary

A required gate whose verdict is a pure function of PR review state is refreshed only by `pull_request_review` — an event GitHub never emits for a review this repo's own automation writes with `GITHUB_TOKEN`. The verdict then survives as whatever it last computed, and it is wrong in **both** directions:

- **stale pending** strands a reviewed PR with auto-merge armed — the observed case;
- **stale success** is worse. The hold sweeper's *routine* outcome is a dismissal, because GitHub refuses approvals from an Actions token, so the only standing review can vanish while the required gate stays green.

Three writers reach review state and none re-derived both gates: `post-pr-review.sh` (fixed in #290), `auto-approve-skipped-pr.sh`, and `approve-if-reviewer-hold-clear.sh`. Each now re-derives at its own site, three layers deep so a site added later still cannot strand a PR: inline at every write, a cron reconciler over every open PR, and a test that fails the PR which introduces an uncompensated writer.

## Review focus

**`approve-if-reviewer-hold-clear.sh`.** It is the fail-open site, and the argument that the new call is safe is the one to check: it reaches a write only when the reviewer's latest review is a live hold or comment, so the deliberately-skipped class — never reviewed, its gate cleared by hand — is never reached and never overwritten. If that reading is wrong, this posts red over a deliberate green.

Second: the asymmetry in `reconcile-review-gate.sh`. It is blanket for `Automated review posted` and deliberately does **not** touch the findings gate, because the status' predicate ("an undismissed review exists") is satisfied by the skipped class's auto-approval while the findings gate's is not.

## How it was tested

- `node --test test/review-gate-compensation.test.mjs` → 3 pass; with `test/guard-pairs.test.mjs` → 13 pass.
- Non-vacuity, observed, each mutation reverted after: dropping the review job's re-derivation step → 1 gap; reverting the approval script's block → 1 gap; removing `claude.yaml`'s exemption → 2 gaps; an inline `gh pr review --approve` in a job that re-derives nothing → 2 gaps, both named. Each returns to green on revert.
- `bash -n` on both changed shell scripts; `eslint` and `prettier --check` clean; pre-commit (shellcheck, shfmt, zizmor) passed on each commit.

## Decisions made

- **The guard parses YAML with the `yaml` package rather than matching workflow text.** `.claude/rules/code-style.md` requires a parser when the input has a grammar; a dev dependency is not weighed.
- **The findings gate is re-derived at the write sites, not on the cron.** A blanket sweep would post red over the skipped class's deliberate green. The write sites are never reached for a PR the reviewer never reviewed, so they are the safe place.
- **The reconciler rides the existing twice-hourly sweep** instead of a new scheduled workflow, which would pay a whole run to do one API read.
- **`claude.yaml` is exempt by marker.** It keys on `pull_request_review` but is the `@claude` mention responder, not a gate — a missed self-triggered event costs a reply, never a verdict.

## What review caught

Three findings, all correct, all fixed in `17bc41d`:

- **Blocking.** The sweep job had `statuses: write` but not `checks: write`, and its `permissions:` block is explicit, so every unlisted scope is `none`. It is the *only* caller of `rederive_review_gates()`, so 100% of that function's runs would have 403'd on the check-run POST — and `set -e` would then abort before `review-gate.sh`, leaving `Automated review posted` green with nothing standing. The fix inverted into the exact fail-open direction it exists to close.
- The two gates are independent predicates and were sequenced under `set -e`, so the first one's fault made the *fail-open* one unreachable. It now runs first, each reports on its own, and the worst status is returned.
- The guard tested only scripts for review writes, never a job's own `run:` body, so an inline `gh pr review --approve` reached zero gates and passed.

This also corrects a claim an earlier version of this description made: `approve-if-reviewer-hold-clear.sh` has exactly **one** caller (`sweep-reviewer-holds.sh:50`), not two. The push-time resolver runs `resolve-addressed-threads.sh` and is covered by its own two workflow steps, not by the script edit.

## Known limitation

The call graph is textual, so a script that still names a gate reads as re-deriving it even if the call became dead code. That is stated in the test header. It catches the realistic regression — a new review-writing job, or a reverted block — and not a live-but-unreachable call.
