### PR TITLE
fix(invisible): scan hidden runs without the regexp stack limit

### DIFF
--- a/claude-hooks/lib/authored-content.mjs
+++ b/claude-hooks/lib/authored-content.mjs
@@ -53,10 +53,35 @@ import { lazyImport } from "./hook-io.mjs";
 const { stripAnsiFully } = /** @type {typeof import("agent-sanitizer")} */ (
   await lazyImport("agent-sanitizer")
 );
-const { STRIP, LONG_RUN_RE, SCATTERED_THRESHOLD, stripInvisible } =
+const { STRIP, LONG_RUN_THRESHOLD, SCATTERED_THRESHOLD, stripInvisible } =
   /** @type {typeof import("agent-sanitizer/invisible")} */ (
     await lazyImport("agent-sanitizer/invisible")
   );
+
+/**
+ * "A run of {@link LONG_RUN_THRESHOLD} or more invisibles", bounded per match.
+ *
+ * Built from the engine's own class and threshold rather than imported as a
+ * ready-made pattern or scan function, because the bundle resolves
+ * `agent-sanitizer` to the PINNED published engine, which trails this repo:
+ * anything this hook imports has to exist in that pin, or the import binds
+ * undefined and the hook fails closed on every payload. STRIP and
+ * LONG_RUN_THRESHOLD are the primitives that define a long run, so deriving the
+ * pattern here keeps the answer identical to the engine's across pins, with no
+ * version-specific scan API to adopt when the pin moves.
+ *
+ * The upper bound is what makes it safe on a large payload: V8 pushes one
+ * backtrack entry per iteration of a quantifier onto a stack capped at 64 MB,
+ * so an UNBOUNDED run pattern throws `RangeError: Maximum call stack size
+ * exceeded` once a single run passes ~8.4 M code points — an 8 MB paste of
+ * zero-widths into a Write body is exactly that. A bound of 2^20 iterations
+ * sits ~8x under the ceiling, and a longer run still answers yes: any run of at
+ * least the threshold contains a prefix this matches.
+ */
+const LONG_RUN_CHUNK_RE = new RegExp(
+  `(?:${STRIP.source}){${LONG_RUN_THRESHOLD},${1 << 20}}`,
+  "gu",
+);
 
 // Content fields the model authors, per tool. Paths and confusables are the
 // confusable layer's domain; here we target the free-text fields that carry
@@ -140,8 +165,8 @@ export function authoredScopeDecision(tool) {
 // user→model surfaces share one definition of "stego payload".
 /** @param {string} text */
 function isPayloadCapable(text) {
-  LONG_RUN_RE.lastIndex = 0;
-  if (LONG_RUN_RE.test(text)) return true;
+  LONG_RUN_CHUNK_RE.lastIndex = 0;
+  if (LONG_RUN_CHUNK_RE.test(text)) return true;
   return (text.match(STRIP)?.length ?? 0) >= SCATTERED_THRESHOLD;
 }
 

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -67539,8 +67539,8 @@ function authoredScopeDecision(tool) {
   return { kind: "undeclared" };
 }
 function isPayloadCapable(text5) {
-  LONG_RUN_RE2.lastIndex = 0;
-  if (LONG_RUN_RE2.test(text5)) return true;
+  LONG_RUN_CHUNK_RE.lastIndex = 0;
+  if (LONG_RUN_CHUNK_RE.test(text5)) return true;
   return (text5.match(STRIP2)?.length ?? 0) >= SCATTERED_THRESHOLD2;
 }
 function sanitizeField(value) {
@@ -67598,15 +67598,19 @@ function sanitizeAuthoredContent(tool, toolInput) {
   if (changed.length === 0) return null;
   return { updatedInput, changed };
 }
-var stripAnsiFully2, STRIP2, LONG_RUN_RE2, SCATTERED_THRESHOLD2, stripInvisible2, AUTHORED_FIELDS, EXEMPT_TOOLS, EXEMPT_TOOL_PATTERNS;
+var stripAnsiFully2, STRIP2, LONG_RUN_THRESHOLD2, SCATTERED_THRESHOLD2, stripInvisible2, LONG_RUN_CHUNK_RE, AUTHORED_FIELDS, EXEMPT_TOOLS, EXEMPT_TOOL_PATTERNS;
 var init_authored_content = __esm({
   async "claude-hooks/lib/authored-content.mjs"() {
     "use strict";
     init_hook_io();
     ({ stripAnsiFully: stripAnsiFully2 } = /** @type {typeof import("agent-sanitizer")} */
     await lazyImport("agent-sanitizer"));
-    ({ STRIP: STRIP2, LONG_RUN_RE: LONG_RUN_RE2, SCATTERED_THRESHOLD: SCATTERED_THRESHOLD2, stripInvisible: stripInvisible2 } = /** @type {typeof import("agent-sanitizer/invisible")} */
+    ({ STRIP: STRIP2, LONG_RUN_THRESHOLD: LONG_RUN_THRESHOLD2, SCATTERED_THRESHOLD: SCATTERED_THRESHOLD2, stripInvisible: stripInvisible2 } = /** @type {typeof import("agent-sanitizer/invisible")} */
     await lazyImport("agent-sanitizer/invisible"));
+    LONG_RUN_CHUNK_RE = new RegExp(
+      `(?:${STRIP2.source}){${LONG_RUN_THRESHOLD2},${1 << 20}}`,
+      "gu"
+    );
     AUTHORED_FIELDS = Object.freeze(
       Object.assign(/* @__PURE__ */ Object.create(null), {
         Write: ["content"],
@@ -70053,8 +70057,8 @@ __export(scan_invisible_chars_exports, {
   ALERT_FILE: () => ALERT_FILE,
   CLAUDE_CONTEXT_SUBDIRS: () => CLAUDE_CONTEXT_SUBDIRS,
   CLAUDE_INSTRUCTION_GLOBS: () => CLAUDE_INSTRUCTION_GLOBS,
-  LONG_RUN_RE: () => LONG_RUN_RE3,
-  LONG_RUN_THRESHOLD: () => LONG_RUN_THRESHOLD2,
+  LONG_RUN_RE: () => LONG_RUN_RE2,
+  LONG_RUN_THRESHOLD: () => LONG_RUN_THRESHOLD3,
   TOTAL_INVISIBLE_THRESHOLD: () => TOTAL_INVISIBLE_THRESHOLD,
   cliMain: () => cliMain3,
   decodeRun: () => decodeRun2,
@@ -70088,8 +70092,8 @@ async function ensureSanitizerLoaded() {
     reloaded
   );
   ({
-    LONG_RUN_RE: LONG_RUN_RE3,
-    LONG_RUN_THRESHOLD: LONG_RUN_THRESHOLD2,
+    LONG_RUN_RE: LONG_RUN_RE2,
+    LONG_RUN_THRESHOLD: LONG_RUN_THRESHOLD3,
     SCATTERED_THRESHOLD: TOTAL_INVISIBLE_THRESHOLD
   } = bound.invisible);
   ({ decodeRun: instrDecodeRun, scanText: scanText2, cleanFile: cleanFile2 } = bound.instructions);
@@ -70279,7 +70283,7 @@ All ${cleaned} file(s) cleaned on disk automatically. NOTE: these files load as 
   process.stderr.write(report + "\n");
   return [report];
 }
-var LONG_RUN_RE3, LONG_RUN_THRESHOLD2, TOTAL_INVISIBLE_THRESHOLD, instrDecodeRun, scanText2, cleanFile2, HOOK_NAME4;
+var LONG_RUN_RE2, LONG_RUN_THRESHOLD3, TOTAL_INVISIBLE_THRESHOLD, instrDecodeRun, scanText2, cleanFile2, HOOK_NAME4;
 var init_scan_invisible_chars = __esm({
   async "claude-hooks/scan-invisible-chars.mjs"() {
     "use strict";
@@ -70290,8 +70294,8 @@ var init_scan_invisible_chars = __esm({
     init_hook_timing();
     init_claude_context();
     ({
-      LONG_RUN_RE: LONG_RUN_RE3,
-      LONG_RUN_THRESHOLD: LONG_RUN_THRESHOLD2,
+      LONG_RUN_RE: LONG_RUN_RE2,
+      LONG_RUN_THRESHOLD: LONG_RUN_THRESHOLD3,
       SCATTERED_THRESHOLD: TOTAL_INVISIBLE_THRESHOLD
     } = /** @type {typeof import("agent-sanitizer/invisible")} */
     await lazyImport("agent-sanitizer/invisible"));

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -46,6 +46,8 @@ export {
   LONG_RUN_RE,
   LONG_RUN_THRESHOLD,
   SCATTERED_THRESHOLD,
+  findLongRuns,
+  hasLongRun,
 } from "./invisible.mjs";
 
 // Layer 2/3 cheap pre-gates. Re-exported from the dependency-free `./gates.mjs`

--- a/src/instructions.mjs
+++ b/src/instructions.mjs
@@ -35,7 +35,7 @@ import {
 import { randomBytes } from "node:crypto";
 import { join, relative, resolve, isAbsolute, dirname, sep } from "node:path";
 import {
-  LONG_RUN_RE,
+  findLongRuns,
   SCATTERED_THRESHOLD,
   countPayloadInvisible,
   stripInvisible,
@@ -202,23 +202,24 @@ export function decodeRun(run) {
  */
 export function scanText(content) {
   const findings = [];
-  LONG_RUN_RE.lastIndex = 0;
-  let match;
   let runChars = 0;
-  // The line number is carried forward across matches. Deriving it per match
-  // from the start of the file — `content.slice(0, match.index).split("\n")` —
-  // copies the whole prefix and materializes every line before the match, so a
-  // file carrying many runs pays that once per run: quadratic in the file
-  // length, on the SessionStart path the user waits for. `exec` yields matches
-  // in increasing index order, so this scan only ever moves forward.
+  // The line number is carried forward across runs. Deriving it per run from
+  // the start of the file — `content.slice(0, run.index).split("\n")` — copies
+  // the whole prefix and materializes every line before the run, so a file
+  // carrying many runs pays that once per run: quadratic in the file length, on
+  // the SessionStart path the user waits for. Runs arrive in increasing index
+  // order, so this scan only ever moves forward.
   let line = 1;
   let counted = 0;
-  while ((match = LONG_RUN_RE.exec(content)) !== null) {
-    for (; counted < match.index; counted++)
+  for (const run of findLongRuns(content)) {
+    for (; counted < run.index; counted++)
       if (content.charCodeAt(counted) === NEWLINE) line++;
-    const charCount = [...match[0]].length;
-    runChars += charCount;
-    findings.push({ line, charCount, ...decodeRun(match[0]) });
+    runChars += run.charCount;
+    findings.push({
+      line,
+      charCount: run.charCount,
+      ...decodeRun(run.text),
+    });
   }
 
   // Threshold-evasion: scattered invisible chars not in a long run can still be

--- a/src/invisible.mjs
+++ b/src/invisible.mjs
@@ -157,10 +157,92 @@ export const LONG_RUN_THRESHOLD = 10;
  * payload-capable even without a long run (threshold-evasion catch). */
 export const SCATTERED_THRESHOLD = 30;
 
+/**
+ * The long-run pattern, declaratively: {@link LONG_RUN_THRESHOLD} or more
+ * consecutive {@link STRIP} code points.
+ *
+ * Scan a document with {@link findLongRuns}, not with this: `exec`/`test`
+ * throw `RangeError: Maximum call stack size exceeded` once a run passes
+ * ~8.4 M code points, because V8 pushes one backtrack entry per iteration of
+ * an unbounded quantifier onto a stack capped at 64 MB. This stays public as
+ * the pattern itself, and as the independent oracle the scan is differenced
+ * against (test/invisible-fast-path.test.mjs).
+ */
 export const LONG_RUN_RE = new RegExp(
   `(?:${STRIP.source}){${LONG_RUN_THRESHOLD},}`,
   REGEX_FLAGS,
 );
+
+// Iterations per `exec` below, which is what bounds the backtrack stack each
+// one needs: a match can push at most this many entries, ~8x under the ceiling
+// an unbounded quantifier walks into on an 8 MB payload. Runs longer than this
+// are stitched from consecutive matches, so the bound costs an extra `exec`
+// per megabyte of PAYLOAD and nothing at all on ordinary text.
+const RUN_CHUNK = 1 << 20;
+
+const LONG_RUN_CHUNK_RE = new RegExp(
+  `(?:${STRIP.source}){${LONG_RUN_THRESHOLD},${RUN_CHUNK}}`,
+  REGEX_FLAGS,
+);
+
+// The same class, sticky and from one repetition, to carry a run past the chunk
+// bound: anchored at the end of the previous match, it either extends the run
+// or fails immediately.
+const RUN_TAIL_RE = new RegExp(`(?:${STRIP.source}){1,${RUN_CHUNK}}`, "yu");
+
+/**
+ * Every maximal run of at least {@link LONG_RUN_THRESHOLD} consecutive
+ * payload-capable invisible code points in `text`, in order: `index` is the
+ * run's UTF-16 offset, `text` its verbatim slice, `charCount` its length in
+ * code points.
+ *
+ * What {@link LONG_RUN_RE} means, in the form every scanner in this package
+ * uses — because that regex cannot answer for a large document, and an 8 MB
+ * paste of zero-widths (the exact payload the scan exists to catch) is what
+ * took out the SessionStart scanner, the prompt gate and the tool-output tier
+ * alike. Bounding the quantifier bounds the backtrack stack per `exec`; a run
+ * that hits the bound is continued by {@link RUN_TAIL_RE} until it ends, so the
+ * runs reported are maximal at any length.
+ * @param {string} text
+ * @returns {Generator<{ index: number, text: string, charCount: number }>}
+ */
+export function* findLongRuns(text) {
+  // Both regexes are module-level and carry `lastIndex`, and a generator can be
+  // suspended anywhere — including inside another scan of another text. Every
+  // exec below therefore sets its own start position first, so no scan can
+  // inherit a position from one it interleaved with.
+  let pos = 0;
+  for (;;) {
+    LONG_RUN_CHUNK_RE.lastIndex = pos;
+    const match = LONG_RUN_CHUNK_RE.exec(text);
+    if (match === null) return;
+    let end = LONG_RUN_CHUNK_RE.lastIndex;
+    // A run shorter than the bound fails this on the first try, for the cost of
+    // one anchored no-match.
+    for (;;) {
+      RUN_TAIL_RE.lastIndex = end;
+      if (RUN_TAIL_RE.exec(text) === null) break;
+      end = RUN_TAIL_RE.lastIndex;
+    }
+    const run = text.slice(match.index, end);
+    yield { index: match.index, text: run, charCount: codePointLength(run) };
+    pos = end;
+  }
+}
+
+/**
+ * True when `text` carries at least one {@link findLongRuns} run.
+ *
+ * The bounded pattern answers this on its own: a run long enough to be reported
+ * is long enough to match, whether or not the match reaches the run's end — so
+ * the yes/no costs one anchored scan and never measures the run.
+ * @param {string} text
+ * @returns {boolean}
+ */
+export function hasLongRun(text) {
+  LONG_RUN_CHUNK_RE.lastIndex = 0;
+  return LONG_RUN_CHUNK_RE.test(text);
+}
 
 /**
  * The agent-facing "Stripped: …" note for a Layer-1 strip: the removed category
@@ -1150,12 +1232,10 @@ export function payloadLongRunSample(text) {
   // The view is code-point-for-code-point with `text` and only ever REPLACES an
   // invisible with a space, so a run in the view is a run in `text`: no long run
   // in the raw text means none in the view. This hides no payload — the bulk
-  // regex reads the whole text, and a run it finds still goes through the full
+  // scan reads the whole text, and a run it finds still goes through the full
   // carve analysis below to decide what of it is really payload.
-  LONG_RUN_RE.lastIndex = 0;
-  if (!LONG_RUN_RE.test(text)) return null;
-  LONG_RUN_RE.lastIndex = 0;
-  return payloadInvisibleView(text).match(LONG_RUN_RE)?.[0] ?? null;
+  if (!hasLongRun(text)) return null;
+  return findLongRuns(payloadInvisibleView(text)).next().value?.text ?? null;
 }
 
 /**

--- a/test/hook-engine-pin.test.mjs
+++ b/test/hook-engine-pin.test.mjs
@@ -160,8 +160,11 @@ describe("the hook layer against the pinned engine", () => {
       (target) => target.alias?.[ENGINE] === PIN,
     );
     assert.equal(aliased.length, 1);
+    // Compared as a tail, not against `repoRoot`: Stryker runs this from a
+    // sandbox copy, where the target's absolute entry is under the sandbox
+    // while `git rev-parse` still answers with the real checkout.
     assert.ok(
-      aliased[0].entry.startsWith(join(repoRoot, "claude-hooks")),
+      aliased[0].entry.endsWith(join("claude-hooks", "plugin-hooks.mjs")),
       `the aliased bundle entry moved to ${aliased[0].entry}`,
     );
   });

--- a/test/hook-engine-pin.test.mjs
+++ b/test/hook-engine-pin.test.mjs
@@ -1,0 +1,189 @@
+/**
+ * Every engine name the hook layer binds must exist in the PINNED engine.
+ *
+ * The plugin bundle resolves the hooks' `agent-sanitizer` specifiers to the
+ * `sanitizer-engine` npm alias — a published release that trails this repo — so
+ * a hook may only use API the pin already ships. Reaching for an export added
+ * on main binds `undefined` at load, and the hook then fails CLOSED on every
+ * payload it was supposed to sanitize. Nothing in the source says which names
+ * are safe, and the symptom (a hook that refuses everything) does not name the
+ * missing export, so this resolves the question mechanically: destructure sites
+ * are read off acorn's AST, and each name is looked up in the pinned engine's
+ * real module namespace.
+ *
+ * A red here is not a reason to widen the pin's imports — it says either the
+ * hook must derive the value from primitives the pin already exports, or the
+ * `sanitizer-engine` pin in package.json has to move to a release carrying it.
+ */
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import assert from "node:assert/strict";
+import { describe, it, before } from "node:test";
+
+import { parse } from "acorn";
+
+import { BUNDLE_TARGETS } from "../scripts/lib/bundle-esbuild.mjs";
+
+const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+  encoding: "utf8",
+}).trim();
+
+/** The engine specifier prefix the bundle aliases, and what it aliases to. */
+const ENGINE = "agent-sanitizer";
+const PIN = "sanitizer-engine";
+
+/** Hook-layer sources: what the plugin bundle is built from. */
+const hookSources = () =>
+  // Both pathspecs: git's `**/` requires an intermediate directory, so the
+  // recursive form alone silently skips the hook entry points at the root.
+  execFileSync(
+    "git",
+    ["ls-files", "claude-hooks/*.mjs", "claude-hooks/**/*.mjs"],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+    },
+  )
+    .split("\n")
+    .filter((path) => path && !path.endsWith(".test.mjs"));
+
+/** Every node in the tree, so a binding nested in a function is seen too. */
+function* nodes(node) {
+  if (node === null || typeof node !== "object") return;
+  if (Array.isArray(node)) {
+    for (const item of node) yield* nodes(item);
+    return;
+  }
+  if (typeof node.type !== "string") return;
+  yield node;
+  for (const value of Object.values(node)) yield* nodes(value);
+}
+
+/** The engine specifier a `lazyImport("…")` / `import("…")` call names, if any. */
+function engineSpecifier(node) {
+  if (node.type === "ImportExpression") return engineLiteral(node.source);
+  if (
+    node.type !== "CallExpression" ||
+    node.callee.type !== "Identifier" ||
+    node.callee.name !== "lazyImport"
+  )
+    return null;
+  return engineLiteral(node.arguments[0]);
+}
+
+/** The engine specifier `arg` is, as a string literal, or null. */
+function engineLiteral(arg) {
+  if (arg?.type !== "Literal" || typeof arg.value !== "string") return null;
+  return arg.value === ENGINE || arg.value.startsWith(`${ENGINE}/`)
+    ? arg.value
+    : null;
+}
+
+/**
+ * Every `{ A, B: local } = <engine load>` and `import { A } from "<engine>"` in
+ * the hook layer, as {file, specifier, name} rows.
+ *
+ * Deliberately only these two forms: they are how the layer actually binds
+ * engine API, and a namespace threaded through a variable and read by member
+ * access later cannot be resolved without type inference — a guess there would
+ * report names the engine never had to export.
+ */
+function engineBindings(file, source) {
+  const rows = [];
+  for (const node of nodes(
+    parse(source, {
+      ecmaVersion: "latest",
+      sourceType: "module",
+    }),
+  )) {
+    if (
+      node.type === "ImportDeclaration" &&
+      (node.source.value === ENGINE ||
+        String(node.source.value).startsWith(`${ENGINE}/`))
+    )
+      for (const spec of node.specifiers)
+        if (spec.type === "ImportSpecifier")
+          rows.push({
+            file,
+            specifier: node.source.value,
+            name: spec.imported.name,
+          });
+    if (node.type !== "VariableDeclarator" || node.id.type !== "ObjectPattern")
+      continue;
+    const specifier = [...nodes(node.init)]
+      .map(engineSpecifier)
+      .find((found) => found !== null);
+    if (!specifier) continue;
+    for (const property of node.id.properties)
+      if (property.type === "Property" && property.key.type === "Identifier")
+        rows.push({ file, specifier, name: property.key.name });
+  }
+  return rows;
+}
+
+/** @type {Array<{file: string, specifier: string, name: string}>} */
+let bindings = [];
+/** @type {Map<string, object>} */
+const namespaces = new Map();
+
+before(async () => {
+  bindings = hookSources().flatMap((file) =>
+    engineBindings(file, readFileSync(join(repoRoot, file), "utf8")),
+  );
+  for (const { specifier } of bindings)
+    if (!namespaces.has(specifier))
+      namespaces.set(specifier, await import(specifier.replace(ENGINE, PIN)));
+});
+
+describe("the hook layer against the pinned engine", () => {
+  it("binds only names the pin exports", () => {
+    const version = JSON.parse(
+      readFileSync(join(repoRoot, "package.json"), "utf8"),
+    ).devDependencies[PIN];
+    const missing = bindings.filter(
+      ({ specifier, name }) => !(name in namespaces.get(specifier)),
+    );
+    assert.deepEqual(
+      missing,
+      [],
+      `these hook bindings do not exist in the pinned engine (${version}) — ` +
+        "derive them from primitives the pin exports, or move the pin",
+    );
+  });
+
+  // `claude-hooks/` is scanned because that is where the aliased bundle's entry
+  // lives. Were a second target to adopt the alias — or this one to move — the
+  // scan above would keep passing while checking the wrong tree.
+  it("scans the tree the pin's alias actually applies to", () => {
+    const aliased = BUNDLE_TARGETS.filter(
+      (target) => target.alias?.[ENGINE] === PIN,
+    );
+    assert.equal(aliased.length, 1);
+    assert.ok(
+      aliased[0].entry.startsWith(join(repoRoot, "claude-hooks")),
+      `the aliased bundle entry moved to ${aliased[0].entry}`,
+    );
+  });
+
+  // The scan is a source read, so it keeps passing if the pattern it looks for
+  // is refactored away: pin the sites it must still find.
+  it("reads the sites it exists to check", () => {
+    const seen = new Set(
+      bindings.map(
+        ({ file, specifier, name }) => `${file} ${specifier} ${name}`,
+      ),
+    );
+    for (const site of [
+      "claude-hooks/lib/authored-content.mjs agent-sanitizer/invisible STRIP",
+      "claude-hooks/lib/authored-content.mjs agent-sanitizer/invisible LONG_RUN_THRESHOLD",
+      "claude-hooks/lib/authored-content.mjs agent-sanitizer stripAnsiFully",
+      "claude-hooks/scan-invisible-chars.mjs agent-sanitizer/instructions scanText",
+    ])
+      assert.ok(seen.has(site), `the AST scan no longer finds: ${site}`);
+    assert.ok(
+      new Set(bindings.map((row) => row.file)).size >= 3,
+      `only ${new Set(bindings.map((row) => row.file)).size} hook files bind engine API`,
+    );
+  });
+});

--- a/test/hook-latency.test.mjs
+++ b/test/hook-latency.test.mjs
@@ -78,6 +78,29 @@ async function measure(fn) {
   return best;
 }
 
+/** A timed block has to last at least this long to be a measurement rather than
+ * timer noise. */
+const MIN_BLOCK_MS = 5;
+
+/**
+ * The per-call cost of `fn`, timed over as many calls as it takes to be a
+ * measurement.
+ *
+ * One 32 KB pass costs a fraction of a millisecond on a fast machine, and that
+ * is the number the scaling gate divides by. Timing a batch and dividing keeps
+ * the small end meaningful at any machine speed, so the gate covers every case
+ * instead of losing the cheap ones to the timer's resolution.
+ */
+async function measurePerCall(fn) {
+  const single = await measure(fn);
+  const repeats = Math.ceil(MIN_BLOCK_MS / Math.max(single, Number.EPSILON));
+  if (repeats <= 1) return single;
+  const block = await measure(async () => {
+    for (let i = 0; i < repeats; i++) await fn();
+  });
+  return block / repeats;
+}
+
 // Text shapes with materially different cost profiles. The clean ones answer
 // from bulk regex passes; the rest each drive a different arm of the carve
 // analysis or the HTML layer, which is per-code-point (or per-node) work no bulk
@@ -186,9 +209,6 @@ const ENTRIES = {
 // paste into a hang — and it is measured on one machine in one process, so it
 // needs no headroom for machine speed, only for timer noise.
 const SCALING_LIMIT = 24;
-// Below this a SMALL measurement is timer noise, and its scaling ratio says
-// nothing. Cases that cheap are pinned by their LARGE budget instead.
-const SCALABLE_FLOOR_MS = 2;
 
 /**
  * The one path whose cost is known to grow faster than its input, pinned where
@@ -325,7 +345,7 @@ before(async () => {
     const measured = await unitsFor(() => run(large, shape));
     timing.large[name] = measured.cost;
     timing.units[name] = measured.units;
-    timing.small[name] = await measure(() => run(small, shape));
+    timing.small[name] = await measurePerCall(() => run(small, shape));
   }
   for (const [entry, { run }] of Object.entries(ENTRIES))
     // Not "html-prose", so `sanitizeText` takes the Layer-1 path the majority of
@@ -393,37 +413,13 @@ describe("hook-path latency", () => {
     });
 
   for (const { name } of CASES)
-    timed(`${name}: cost grows with input length, not faster`, (t) => {
-      if (timing.small[name] < SCALABLE_FLOOR_MS) {
-        t.skip(
-          `${timing.small[name].toFixed(2)}ms at 32 KB is below the ${SCALABLE_FLOOR_MS}ms noise floor`,
-        );
-        return;
-      }
+    timed(`${name}: cost grows with input length, not faster`, () => {
       const growth = timing.large[name] / timing.small[name];
       assert.ok(
         growth <= SCALING_LIMIT,
         `${name} cost ${growth.toFixed(1)}x for 8x the input, limit ${SCALING_LIMIT}x`,
       );
     });
-
-  timed(
-    "enough cases clear the noise floor for the scaling gate to mean something",
-    () => {
-      // Without this the scaling gate could silently degrade to zero cases on a
-      // fast machine and still report green — and pooling the count across
-      // entries would hide one entry losing all of its coverage.
-      for (const entry of Object.keys(ENTRIES)) {
-        const scalable = CASES.filter(
-          (c) => c.entry === entry && timing.small[c.name] >= SCALABLE_FLOOR_MS,
-        );
-        assert.ok(
-          scalable.length >= 4,
-          `only ${scalable.length} ${entry} cases were timeable at 32 KB: ${scalable.map((c) => c.name).join(", ")}`,
-        );
-      }
-    },
-  );
 
   for (const entry of Object.keys(ENTRIES))
     timed(`${entry}: the shapes really do split into cheap and heavy`, () => {

--- a/test/invisible-fast-path.test.mjs
+++ b/test/invisible-fast-path.test.mjs
@@ -48,8 +48,9 @@ const STRIP_ONE = new RegExp(STRIP.source, "u");
 const referencePayload = (text) =>
   [...payloadInvisibleView(text)].filter((ch) => STRIP_ONE.test(ch)).length;
 
-/** The runs the pattern itself matches — what findLongRuns must reproduce
- * without the regex engine (see its header for why it cannot use one). */
+/** The runs the pattern itself matches — what findLongRuns must reproduce with
+ * a bounded quantifier (see its header for why the unbounded pattern cannot
+ * scan a large document). */
 const referenceRuns = (text) =>
   [...text.matchAll(new RegExp(LONG_RUN_RE.source, "gu"))].map((match) => ({
     index: match.index,

--- a/test/invisible-fast-path.test.mjs
+++ b/test/invisible-fast-path.test.mjs
@@ -7,6 +7,8 @@
  * slow definition it replaced, expressed in exported API:
  *
  *   countPayloadInvisible(t)   == payload code points in payloadInvisibleView(t)
+ *   findLongRuns(t)            == t.matchAll(LONG_RUN_RE)
+ *   hasLongRun(t)              == LONG_RUN_RE.test(t)
  *   payloadLongRunSample(t)    == payloadInvisibleView(t).match(LONG_RUN_RE)
  *   countEffectiveInvisible(t) == payload + max(0, cpLen(t) - cpLen(strip(t)) - payload)
  *
@@ -25,6 +27,8 @@ import {
   VS,
   countEffectiveInvisible,
   countPayloadInvisible,
+  findLongRuns,
+  hasLongRun,
   payloadInvisibleView,
   payloadLongRunSample,
   stripInvisible,
@@ -43,6 +47,15 @@ const STRIP_ONE = new RegExp(STRIP.source, "u");
 /** The slow-path payload count: what the carve analysis left unmasked. */
 const referencePayload = (text) =>
   [...payloadInvisibleView(text)].filter((ch) => STRIP_ONE.test(ch)).length;
+
+/** The runs the pattern itself matches — what findLongRuns must reproduce
+ * without the regex engine (see its header for why it cannot use one). */
+const referenceRuns = (text) =>
+  [...text.matchAll(new RegExp(LONG_RUN_RE.source, "gu"))].map((match) => ({
+    index: match.index,
+    text: match[0],
+    charCount: [...match[0]].length,
+  }));
 
 /** The pre-short-circuit definitions of the two derived entry points. */
 const referenceLongRun = (text) =>
@@ -153,6 +166,10 @@ describe("counting fast paths agree exactly with the carve analysis", () => {
   for (const [name, text] of Object.entries(SHAPES)) {
     it(`${name}: countPayloadInvisible`, () =>
       assert.equal(countPayloadInvisible(text), referencePayload(text)));
+    it(`${name}: findLongRuns`, () =>
+      assert.deepEqual([...findLongRuns(text)], referenceRuns(text)));
+    it(`${name}: hasLongRun`, () =>
+      assert.equal(hasLongRun(text), referenceRuns(text).length > 0));
     it(`${name}: payloadLongRunSample`, () =>
       assert.equal(payloadLongRunSample(text), referenceLongRun(text)));
     it(`${name}: countEffectiveInvisible`, () =>
@@ -211,6 +228,31 @@ describe("property: no input separates a fast path from the analysis", () => {
     )
     .map((chars) => chars.join(""));
 
+  // Single-character draws practically never land ten invisibles in a row, so
+  // the long-run properties draw CHUNKS straddling the threshold instead:
+  // adjacent chunks merge into one run, and a visible draw between them cuts it.
+  const arbRunText = fc
+    .array(
+      fc.oneof(
+        { weight: 3, arbitrary: fc.constantFrom(...NOTABLE) },
+        {
+          weight: 2,
+          arbitrary: fc
+            .tuple(
+              fc.constantFrom(...NOTABLE.filter((ch) => STRIP_ONE.test(ch))),
+              fc.integer({ min: 4, max: 14 }),
+            )
+            .map(([ch, n]) => ch.repeat(n)),
+        },
+      ),
+      { maxLength: 12 },
+    )
+    .map((parts) => parts.join(""));
+  const arbAnyText = fc.oneof(
+    { weight: 1, arbitrary: arbText },
+    { weight: 3, arbitrary: arbRunText },
+  );
+
   it("countPayloadInvisible", () =>
     fc.assert(
       fc.property(arbText, (text) =>
@@ -219,9 +261,25 @@ describe("property: no input separates a fast path from the analysis", () => {
       { numRuns: 2000 },
     ));
 
+  it("findLongRuns", () => {
+    // Counted, not assumed: a draw distribution that never produced a run of
+    // ten would make every assertion below `[] === []`.
+    let withRun = 0;
+    fc.assert(
+      fc.property(arbAnyText, (text) => {
+        const runs = referenceRuns(text);
+        if (runs.length > 0) withRun++;
+        assert.deepEqual([...findLongRuns(text)], runs);
+        assert.equal(hasLongRun(text), runs.length > 0);
+      }),
+      { numRuns: 2000 },
+    );
+    assert.ok(withRun > 0, "no draw carried a long run");
+  });
+
   it("payloadLongRunSample", () =>
     fc.assert(
-      fc.property(arbText, (text) =>
+      fc.property(arbAnyText, (text) =>
         assert.equal(payloadLongRunSample(text), referenceLongRun(text)),
       ),
       { numRuns: 2000 },

--- a/test/invisible.test.mjs
+++ b/test/invisible.test.mjs
@@ -23,6 +23,8 @@ import {
   LONG_RUN_RE,
   LONG_RUN_THRESHOLD,
   SCATTERED_THRESHOLD,
+  findLongRuns,
+  hasLongRun,
   CONSECUTIVE_JOINER_CAP,
   CONSECUTIVE_SELECTOR_CAP,
   TOTAL_PRESERVED_JOINER_BUDGET,
@@ -647,6 +649,80 @@ describe("LONG_RUN_RE", () => {
     assert.equal(
       LONG_RUN_RE.test(cp(0x200b).repeat(LONG_RUN_THRESHOLD - 1)),
       false,
+    );
+  });
+});
+
+// ─── findLongRuns / hasLongRun ───────────────────────────────────────────────
+// The scan every consumer of "long run" uses. Its equivalence to the pattern is
+// differenced over a corpus and 2000 draws in invisible-fast-path.test.mjs;
+// these pin the edges by hand — the threshold, the UTF-16-vs-code-point units,
+// and the stitching of one match to the next.
+
+describe("findLongRuns", () => {
+  const ZWSP = cp(0x200b);
+  const TAG_A = cp(0xe0041); // astral: two UTF-16 units per code point
+
+  it("yields a run of exactly the threshold, with its offset and length", () =>
+    assert.deepEqual(
+      [...findLongRuns(`ab${ZWSP.repeat(10)}cd`)],
+      [{ index: 2, text: ZWSP.repeat(10), charCount: 10 }],
+    ));
+
+  it("yields nothing for a run one short of the threshold", () =>
+    assert.deepEqual([...findLongRuns(`ab${ZWSP.repeat(9)}cd`)], []));
+
+  it("counts an astral run in code points, and indexes it in UTF-16 units", () =>
+    assert.deepEqual(
+      [...findLongRuns(`ab${TAG_A.repeat(10)}`)],
+      [{ index: 2, text: TAG_A.repeat(10), charCount: 10 }],
+    ));
+
+  it("does not fuse two runs split by a visible character", () =>
+    assert.deepEqual(
+      [...findLongRuns(`${ZWSP.repeat(10)}x${ZWSP.repeat(12)}`)].map((run) => [
+        run.index,
+        run.charCount,
+      ]),
+      [
+        [0, 10],
+        [11, 12],
+      ],
+    ));
+
+  it("closes a run that reaches the end of the text", () =>
+    assert.deepEqual(
+      [...findLongRuns(ZWSP.repeat(11))],
+      [{ index: 0, text: ZWSP.repeat(11), charCount: 11 }],
+    ));
+
+  it("mixes categories inside one run", () => {
+    const mixed = ZWSP.repeat(5) + cp(0xfe00).repeat(3) + cp(0x2800).repeat(2);
+    assert.deepEqual(
+      [...findLongRuns(mixed)],
+      [{ index: 0, text: mixed, charCount: 10 }],
+    );
+  });
+
+  it("hasLongRun answers the same question", () => {
+    assert.equal(hasLongRun(`a${ZWSP.repeat(10)}b`), true);
+    assert.equal(hasLongRun(`a${ZWSP.repeat(9)}b`), false);
+    assert.equal(hasLongRun(""), false);
+  });
+
+  it("two scans interleave without stealing each other's position", () => {
+    const first = findLongRuns(`${ZWSP.repeat(10)}x${ZWSP.repeat(11)}`);
+    const second = findLongRuns(`y${ZWSP.repeat(12)}`);
+    const opening = first.next().value;
+    const other = second.next().value;
+    const resumed = first.next().value;
+    assert.deepEqual(
+      [opening, other, resumed].map((run) => [run.index, run.charCount]),
+      [
+        [0, 10],
+        [1, 12],
+        [11, 11],
+      ],
     );
   });
 });

--- a/test/long-run-scan-limit.test.mjs
+++ b/test/long-run-scan-limit.test.mjs
@@ -1,0 +1,93 @@
+/**
+ * The blocking entry points survive a payload longer than a regex can match.
+ *
+ * V8 pushes one backtrack entry per iteration of an unbounded quantifier onto a
+ * regexp stack capped at 64 MB, so `LONG_RUN_RE.exec` throws `RangeError:
+ * Maximum call stack size exceeded` once a single run passes ~8.4 M code
+ * points. Every consumer of "long run" scanned with that regex, so an 8 MB
+ * paste of zero-widths — the exact payload the scan exists to catch — took out
+ * the SessionStart scanner (scanText), the prompt gate (classifyPrompt) and the
+ * tool-output pipeline (sanitizeText) alike: the layer failed by throwing
+ * rather than by reporting.
+ *
+ * The fixture has to be that big to reach the bound, so this suite costs ~20
+ * seconds and ~16 MB of fixture. It lives in its own file for that reason, and
+ * stands down under Stryker, where the tap runner would re-run it once per
+ * mutant that touches these modules — for a verdict the differential suites
+ * already reach on inputs a thousand times smaller.
+ */
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  LONG_RUN_RE,
+  findLongRuns,
+  hasLongRun,
+  payloadLongRunSample,
+} from "../src/invisible.mjs";
+import { scanText } from "../src/instructions.mjs";
+import { classifyPrompt } from "../src/prompt.mjs";
+import { sanitizeText } from "../src/output.mjs";
+
+const MUTATION_RUN = process.env.STRYKER_NAMESPACE
+  ? "an 8 MB fixture re-run per mutant costs hours; the differential suites cover these paths"
+  : null;
+
+const ZWSP = "​";
+const RUN_LENGTH = 8 * 1024 * 1024;
+/** Built in `before` so a stood-down run allocates nothing. */
+let RUN = "";
+
+before(() => {
+  if (!MUTATION_RUN) RUN = ZWSP.repeat(RUN_LENGTH);
+});
+
+/** An `it` that stands down under Stryker (see the header). */
+const huge = (name, fn) =>
+  it(name, async (t) => {
+    if (MUTATION_RUN) {
+      t.skip(MUTATION_RUN);
+      return;
+    }
+    await fn(t);
+  });
+
+describe("a run past the regexp engine's limit", () => {
+  // The pin on RUN_LENGTH: below the bound this whole suite would pass on the
+  // unbounded regex it exists to retire. A V8 that lifts the bound turns this
+  // red, which is the signal to re-measure it — not to shrink the fixture.
+  huge("is a run LONG_RUN_RE itself cannot match", () => {
+    LONG_RUN_RE.lastIndex = 0;
+    assert.throws(() => LONG_RUN_RE.exec(RUN), RangeError);
+  });
+
+  huge("findLongRuns reports it as one run", () =>
+    assert.deepEqual(
+      [...findLongRuns(RUN)].map((run) => [run.index, run.charCount]),
+      [[0, RUN_LENGTH]],
+    ),
+  );
+
+  huge("hasLongRun sees it", () => assert.equal(hasLongRun(RUN), true));
+
+  huge("payloadLongRunSample returns the whole run", () =>
+    assert.equal(payloadLongRunSample(RUN)?.length, RUN_LENGTH),
+  );
+
+  huge("scanText reports one finding on it", () => {
+    const findings = scanText(RUN);
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].charCount, RUN_LENGTH);
+    assert.equal(findings[0].method, "zero-width binary encoding");
+  });
+
+  huge("classifyPrompt blocks it", () =>
+    assert.equal(classifyPrompt(RUN).action, "block"),
+  );
+
+  huge("sanitizeText strips it", async () => {
+    const { cleaned, found } = await sanitizeText(RUN);
+    assert.equal(cleaned, "");
+    assert.deepEqual(found, ["cf-format"]);
+  });
+});

--- a/test/long-run-scan-limit.test.mjs
+++ b/test/long-run-scan-limit.test.mjs
@@ -33,8 +33,12 @@ const MUTATION_RUN = process.env.STRYKER_NAMESPACE
   ? "an 8 MB fixture re-run per mutant costs hours; the differential suites cover these paths"
   : null;
 
-const ZWSP = "​";
-const RUN_LENGTH = 8 * 1024 * 1024;
+const ZWSP = "\u200B";
+// Deliberately NOT a multiple of the scan's chunk bound: an aligned length
+// lands every stitched match exactly on the end of the run, so a final tail
+// shorter than the bound — what RUN_TAIL_RE's lower bound is for — would never
+// be exercised by anything (the property draws top out at 14 code points).
+const RUN_LENGTH = 8 * 1024 * 1024 + 7;
 /** Built in `before` so a stood-down run allocates nothing. */
 let RUN = "";
 

--- a/test/long-run-scan-limit.test.mjs
+++ b/test/long-run-scan-limit.test.mjs
@@ -28,6 +28,7 @@ import {
 import { scanText } from "../src/instructions.mjs";
 import { classifyPrompt } from "../src/prompt.mjs";
 import { sanitizeText } from "../src/output.mjs";
+import { sanitizeAuthoredContent } from "../claude-hooks/lib/authored-content.mjs";
 
 const MUTATION_RUN = process.env.STRYKER_NAMESPACE
   ? "an 8 MB fixture re-run per mutant costs hours; the differential suites cover these paths"
@@ -88,6 +89,18 @@ describe("a run past the regexp engine's limit", () => {
   huge("classifyPrompt blocks it", () =>
     assert.equal(classifyPrompt(RUN).action, "block"),
   );
+
+  // The hook layer reaches this through the PINNED engine, which has no bounded
+  // scan to import — its own bound is derived from the engine's STRIP class and
+  // threshold, so this holds at any pin.
+  huge("the authored-content hook strips it from a Write body", () => {
+    const result = sanitizeAuthoredContent("Write", {
+      file_path: "/tmp/x.md",
+      content: RUN,
+    });
+    assert.equal(result?.updatedInput.content, "");
+    assert.deepEqual(result?.changed, ["content (invisible characters)"]);
+  });
 
   huge("sanitizeText strips it", async () => {
     const { cleaned, found } = await sanitizeText(RUN);


### PR DESCRIPTION
Claims: `src/invisible.mjs` long-run scanning, `src/instructions.mjs` `scanText`, `claude-hooks/lib/authored-content.mjs`. Fixes the crash #293 files under &#34;Pre-existing crash, untouched&#34;.

## Summary

Makes the hidden-run scan answer on a payload longer than a regex can match. `scanText` (SessionStart), `classifyPrompt` (UserPromptSubmit) and `sanitizeText` (tool output) all threw `RangeError: Maximum call stack size exceeded` on an 8 MB run of zero-widths — the layer failing by throwing rather than by reporting the payload it exists to catch.

The throw was `LONG_RUN_RE.exec`. V8 pushes one backtrack entry per iteration of an unbounded quantifier onto a regexp stack capped at 64 MB, so `(?:…){10,}` dies once a single match passes ~8.4 M code points; bisected here, the longest run it matches is **8 388 574** code points and 8 388 575 throws. `+` and a bare character class hit the same wall — it is the match length, not the pattern&#39;s shape.

`findLongRuns` is that scan with the quantifier **bounded** — `{10,1048576}` per `exec`, ~8x under the ceiling — and a run that reaches the bound continued by a sticky `{1,1048576}` until it ends. Reported runs are still maximal at any length; only the stack a single `exec` needs is bounded. On the 8 MiB fixture `scanText` now reports one finding of 8 388 615 chars, `classifyPrompt` returns `block`, `sanitizeText` returns `cleaned === &#34;&#34;`.

**The plugin&#39;s authored-content hook is fixed too, without waiting for a release.** `claude-hooks/lib/authored-content.mjs` scanned with the same unbounded `LONG_RUN_RE`, so an 8 MB paste into a `Write`/`Edit` body threw into that hook&#39;s fail-open warning. It cannot import `hasLongRun`: the plugin bundle resolves `agent-sanitizer` to the **pinned** published engine (2.20.0), and a hook binding a name the pin lacks binds `undefined` and fails **closed** on every payload. So the hook derives its own bounded pattern from `STRIP` and `LONG_RUN_THRESHOLD` — the primitives that define a long run, present in every engine version. The answer is identical to the engine&#39;s, it is safe at any pin, and there is nothing to adopt when the pin moves.

## Review focus

Read **`src/invisible.mjs:196-224`** (`findLongRuns`) first — the stitching loop is where a wrong answer would live and it spans two module-level regexes. Two invariants it rests on:

- **Maximality.** `LONG_RUN_CHUNK_RE` finds the run&#39;s start and takes up to `RUN_CHUNK` code points; `RUN_TAIL_RE` is sticky at the previous match&#39;s end, so a run longer than the bound is one yielded record, not several. Both have a positive minimum, so `pos` always advances — no empty match, no spin.
- **Reentrancy.** Both regexes carry `lastIndex` and a generator can suspend anywhere, including inside another scan. Every `exec` sets its own start position immediately before running, so an interleaved scan cannot inherit a position. `test/invisible.test.mjs`&#39;s &#34;two scans interleave&#34; case pins this.

The line I am least sure of is `hasLongRun` (`src/invisible.mjs:236`): it answers from the **bounded** pattern, so it is only right because a run long enough to report is long enough to match — the match need not reach the run&#39;s end. It is differenced against `LONG_RUN_RE.test` over the whole fast-path corpus and 2000 draws. The hook&#39;s copy of that reasoning is the same argument on the pinned engine&#39;s class.

### Why not a hand-rolled scan

The first version walked UTF-16 units in JS with a per-code-point lookup. It is correct, and it is much slower exactly where the scan does no work today — under c8 a JS loop in `src/` is instrumented while a native regex is not:

| cell | before | JS scan | bounded regex |
|---|---:|---:|---:|
| scanText/ascii-prose | 2.0 units | 6.9 | 2.0 |
| scanText/cjk-prose | 3.6 | 8.9 | 3.3 |
| classifyPrompt/cjk-prose | 6.4 | 14.3 | 5.8 |
| sanitizeText/payload-scattered | 1.6 | 8.2 | 1.4 |

`CHEAP_BUDGET` in `test/hook-latency.test.mjs` is 10 units, so the JS scan reds that gate outright. The bounded regex is at parity on every cell: clean text pays one native scan as before, and the extra `exec` costs one per megabyte of payload.

## Changes

- **`src/invisible.mjs`** — `findLongRuns` (generator over `{ index, text, charCount }`) and `hasLongRun`, both exported; `payloadLongRunSample` reads them. `LONG_RUN_RE` is byte-identical and still exported, now documented as the pattern and the test oracle, with the reason not to scan a document with it.
- **`src/instructions.mjs`** — `scanText` iterates `findLongRuns`; `charCount` comes off the run instead of `[...match[0]].length`.
- **`src/index.mjs`** — re-exports the two.
- **`claude-hooks/lib/authored-content.mjs`** — `isPayloadCapable` tests a bounded pattern built from the pinned engine&#39;s `STRIP` and `LONG_RUN_THRESHOLD` instead of its unbounded `LONG_RUN_RE`. `plugin/dist` rebuilt.
- **`test/hook-engine-pin.test.mjs`** (new) — the drift guard: every engine name the hook layer destructures, read off acorn&#39;s AST, looked up in the **pinned** engine&#39;s real module namespace.
- **`test/long-run-scan-limit.test.mjs`** (new) — the regression: all three entry points plus the authored-content hook on a fixture of `8 MiB + 7` code points.
- **`test/invisible.test.mjs`** — edges by hand: the threshold, an astral run (UTF-16 index vs code-point count), two runs split by a visible char, a run ending at EOF, mixed categories in one run, interleaved generators.
- **`test/invisible-fast-path.test.mjs`** — `findLongRuns`/`hasLongRun` differenced against `text.matchAll(LONG_RUN_RE)` over the existing 27-shape corpus and 2000 property draws.
- **`test/hook-latency.test.mjs`** — the 32 KB (small-end) timing is taken over a block of repeats and divided (`measurePerCall`) instead of from one call, so the scaling gate keeps its coverage on a fast runner. The 2 ms `SCALABLE_FLOOR_MS` skip and the meta-guard that policed it are gone with it.

## Tests / verification

- **Differential** — `node --test test/invisible-fast-path.test.mjs`: every corpus shape and 2000 draws assert `[...findLongRuns(t)]` deep-equals the regex&#39;s own `matchAll` (index, text, code-point count) and `hasLongRun(t) === LONG_RUN_RE.test(t)`.
- **Non-vacuity, property draws** — the first differential run went **red** on `no draw carried a long run`: the existing single-character arbitrary practically never lands ten invisibles in a row, so the long-run properties (`payloadLongRunSample`&#39;s included) had been asserting `null === null`. The draws now include invisible chunks of 4–14 that merge and split around the threshold, and a counter fails the test if no draw carries a run.
- **Non-vacuity, the stitching loop** — the fixture is `8 MiB + 7` rather than a multiple of `RUN_CHUNK`, so a final tail shorter than the bound is exercised. Narrowing `RUN_TAIL_RE` to a fixed `{RUN_CHUNK}` reds 3 cases (`findLongRuns`, `payloadLongRunSample`, `scanText`); at an aligned length that mutation passes the whole suite.
- **Non-vacuity, the latency scaling gate** — CI went red on `only 1 scanText cases were timeable at 32 KB`. On a fast runner a single 32 KB pass costs a fraction of a millisecond, i.e. under the timer&#39;s resolution, so 5 of 6 `scanText` shapes were skipped rather than gated. Timing a block and dividing fixes the measurement itself: the suite now runs **0 skipped** (was 17), and the previously-dropped cheap cases come in at growth ratios 7.5–8.3 for 8x the input — near-linear, against a limit of 24.
- **Both new guards were watched to fail.** Restoring the hook&#39;s quantifier to `{10,}` reds the new `Write`-body case with `RangeError`; adding `hasLongRun` to the hook&#39;s destructure reds the drift guard, naming `hasLongRun` and the pin (2.20.0). The drift guard also pins the four sites its AST scan must still find, so a refactor cannot make it pass on an empty read.
- **The regression pins its own fixture size** — `LONG_RUN_RE.exec(RUN)` is asserted to throw `RangeError`. Below the ceiling the whole suite would pass on the unbounded regex it exists to retire.
- **Gate** — `node scripts/coverage.mjs` green (`src/` at 100%); `npx tsc --noEmit`, `npx tsc -p tsconfig.hooks.json --noEmit`, `npx eslint .`, `npx prettier --check .` clean; `node plugin/scripts/build-plugin.mjs` regenerates to no diff.

## Known, not fixed

**The SessionStart instruction scan still runs the pinned engine&#39;s `scanText` inside the plugin.** That path is the engine&#39;s own, not the hook&#39;s, so an 8 MB instruction file still throws there until the `sanitizer-engine` pin moves to a release carrying this fix. Nothing in the hook layer can substitute for it, and the drift guard is what makes the pin bump a one-line change rather than a hunt.

**8 MB is still slow, and this PR does not claim otherwise.** The fixture takes ~17 s across the entry points, ~0.1 s of it in the scan. That cost is #293&#39;s subject, not this one&#39;s.

## Decisions made

- **`LONG_RUN_RE` stays exported rather than being deleted as vestigial.** It is the published pattern, `claude-hooks/scan-invisible-chars.mjs` duck-types the loaded engine on it, and it is the independent oracle the new scan is differenced against — deleting it would leave the scan checked only against itself. Its header now states what it must not be used for. Under the alternative it goes and the differential loses its reference.
- **The hook derives its bound from primitives rather than staging an adoption of `hasLongRun`.** A staged switch would leave a second copy live until someone remembered to delete it on the next pin bump — the churn CLAUDE.md warns about. Deriving from `STRIP` + `LONG_RUN_THRESHOLD` is version-independent by construction, so there is no follow-up. Under the alternative the hook waits for the release and carries an interim path with a removal TODO.
- **The drift guard reads destructures and static imports only**, not namespaces threaded through a variable and read by member access later — resolving those needs type inference, and a guess there would report names the engine never had to export. Precision over recall, per the code-style rule; the one such site (`scan-invisible-chars`&#39;s cold-start rebind) re-binds by destructuring, which is read.
- **The regression suite stands down under Stryker**, following `test/hook-latency.test.mjs`&#39;s precedent: the tap runner would re-run a 17 s, 16 MB file once per mutant touching these modules, for a verdict the differential suites reach on inputs a thousand times smaller. It runs in full under `node --test` and under coverage.
- **The chunk bound is 1 Mi iterations.** Large enough that no realistic document pays a second `exec` (a 256 KB all-payload paste is one match), small enough to sit ~8x under the measured ceiling. A smaller bound runs the stitching loop more often on payloads; a larger one shrinks the margin for nothing.
- **The fast-runner latency red was fixed by amplifying the measurement, not by lowering the floor or re-running.** A wider floor or a retry only makes the skip rarer, leaving the gate silently vacuous on the fastest machines. Timing a block of repeats makes the small-end number a measurement at any machine speed, which is what let the floor, the skip and its meta-guard all be deleted rather than tuned. Under the alternative the floor is re-tuned per runner class and the cheap cases stay ungated.

## Interaction with #293

Both touch `src/invisible.mjs`, and #293 is already `dirty` against `main`. This change is confined to the long-run scan and its two call sites, so whichever lands second resolves a small conflict in one region — `LONG_RUN_RE`&#39;s neighbourhood and `payloadLongRunSample`&#39;s two lines.