### PR TITLE
refactor(plugin): extract the shared SessionStart provisioning scaffolding

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -216,6 +216,7 @@ scripts/provision-redactor.sh  SessionStart provisioning of the Python redactor
 scripts/provision-hook-binary.sh  SessionStart provisioning of the compiled hook binary
 scripts/build-plugin.mjs     builds dist/ from claude-hooks/ against this repo's src/
 scripts/build-hook-binaries.mjs  compiles the bundle into the per-platform release binaries
+scripts/lib/provision-common.sh  the scaffolding both SessionStart provisioners share
 scripts/lib/hook-timing.sh   shell port of the hook timer, for the SessionStart scripts
 scripts/lib/node-resolve.sh  the node search, for hosts whose PATH never saw a shell rc
 scripts/lib/node-floor.sh    the node version floor (generated from engines.node — do not edit)

--- a/plugin/scripts/lib/hook-timing.sh
+++ b/plugin/scripts/lib/hook-timing.sh
@@ -1,11 +1,12 @@
 # shellcheck shell=bash
-# The shell port of claude-hooks/lib/hook-timing.mjs, for the two SessionStart
-# entry points that never reach node: scripts/safe-launch.sh (whose preflight —
-# a PATH probe and the redactor-daemon resolution — runs before the hook it
-# launches can time anything) and
-# scripts/provision-redactor.sh (which is a python install, not a node process).
+# The shell port of claude-hooks/lib/hook-timing.mjs, for the entry points that
+# never reach node: scripts/safe-launch.sh (whose preflight — a PATH probe and
+# the redactor-daemon resolution — runs before the hook it launches can time
+# anything), and the two SessionStart provisioners, which are a python install
+# and a download rather than node processes and reach this through
+# lib/provision-common.sh.
 #
-# Sourced by both, so the shell answer is written once rather than twice; that
+# Sourced, so the shell answer is written once rather than three times; that
 # node module is still the SSOT for the thresholds and the prose, and
 # test/hook-timing-shell-parity.test.mjs runs both implementations over the same
 # inputs and asserts byte-identical output, so a reworded notice or a moved

--- a/plugin/scripts/lib/provision-common.sh
+++ b/plugin/scripts/lib/provision-common.sh
@@ -1,0 +1,62 @@
+# shellcheck shell=bash
+# `source=` paths below are relative to this file, not to shellcheck's cwd.
+# shellcheck source-path=SCRIPTDIR
+# The shared scaffolding of the SessionStart provisioners (provision-redactor.sh
+# and provision-hook-binary.sh). Both resolve the same plugin root, both must
+# report their wall-clock against the provisioning budget rather than the
+# per-hook one, and both owe the operator a loud line when the artifact they
+# just installed is not actually runnable — three answers that are the same for
+# reasons that have nothing to do with what either one installs.
+#
+# A caller resolves its own directory (it cannot source a file whose path it has
+# not resolved yet) and sources this; everything after that line is shared.
+
+# The plugin root, for the caller — the one variable this file publishes rather
+# than keeps to itself, hence the disable.
+# shellcheck disable=SC2034
+plugin_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+_provision_lib_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+_provision_step=""
+_provision_started_ms=""
+
+# Start measuring a one-time provisioning step named $1.
+#
+# A provisioning step blocks session start under the same 1800s harness timeout
+# as every hook, and nothing downstream can attribute that wait to it: the hooks
+# it provisions FOR deliberately exclude one-time provisioning from their own
+# budgets.
+provision_begin() {
+  _provision_step="${1:?provision_begin needs a step name}"
+  _provision_started_ms=""
+  if [[ ! -r "$_provision_lib_dir/hook-timing.sh" ]]; then
+    # Degraded, not fatal: an install missing the timer can still provision.
+    echo "agent-sanitizer: $_provision_lib_dir/hook-timing.sh is missing — provisioning timing disabled (reinstall the plugin)" >&2
+    return 0
+  fi
+  # shellcheck source=hook-timing.sh
+  . "$_provision_lib_dir/hook-timing.sh"
+  _provision_started_ms="$(hook_timing_now_ms)"
+}
+
+# Report the elapsed time of the step `provision_begin` named, appending $1 as
+# step-specific advice. Silent when it was fast, and silent when the timer was
+# unavailable — so a caller can arm this from an EXIT trap unconditionally,
+# which is the only placement that also covers its failure arms.
+provision_report_elapsed() {
+  [[ -n "$_provision_started_ms" ]] || return 0
+  report_slow_provision "$_provision_step" "$_provision_started_ms" "${1:-}"
+}
+
+# Refuse to claim success unless $1 is executable, saying $2 if it is not.
+#
+# The post-condition, not the exit status of whatever wrote it: an install whose
+# every command returned 0 and left nothing runnable is exactly the failure a
+# provisioner must not report as done, because the launcher then finds no
+# artifact and the operator has been told there is one.
+provision_require_executable() {
+  local path="${1:?provision_require_executable needs a path}"
+  [[ -x "$path" ]] && return 0
+  echo "${2:?provision_require_executable needs a message}" >&2
+  exit 1
+}

--- a/plugin/scripts/lib/provision-common.sh
+++ b/plugin/scripts/lib/provision-common.sh
@@ -11,12 +11,13 @@
 # A caller resolves its own directory (it cannot source a file whose path it has
 # not resolved yet) and sources this; everything after that line is shared.
 
+_provision_lib_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
 # The plugin root, for the caller — the one variable this file publishes rather
 # than keeps to itself, hence the disable.
 # shellcheck disable=SC2034
-plugin_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+plugin_root="$(cd -- "$_provision_lib_dir/../.." && pwd)"
 
-_provision_lib_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 _provision_step=""
 _provision_started_ms=""
 
@@ -48,7 +49,8 @@ provision_report_elapsed() {
   report_slow_provision "$_provision_step" "$_provision_started_ms" "${1:-}"
 }
 
-# Refuse to claim success unless $1 is executable, saying $2 if it is not.
+# Return when $1 is executable; otherwise say $2 and exit 1, aborting the
+# caller. Never call it as `$(…)` — the exit would die with the subshell.
 #
 # The post-condition, not the exit status of whatever wrote it: an install whose
 # every command returned 0 and left nothing runnable is exactly the failure a

--- a/plugin/scripts/provision-hook-binary.sh
+++ b/plugin/scripts/provision-hook-binary.sh
@@ -27,7 +27,12 @@ esac
 
 data_dir="${1:?usage: provision-hook-binary.sh <plugin-data-dir>}"
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-plugin_root="$(cd -- "$script_dir/.." && pwd)"
+if [[ ! -r "$script_dir/lib/provision-common.sh" ]]; then
+  echo "agent-sanitizer: $script_dir/lib/provision-common.sh is missing — the hook binary will not be provisioned (reinstall the plugin)" >&2
+  exit 1
+fi
+# shellcheck source=lib/provision-common.sh
+. "$script_dir/lib/provision-common.sh"
 
 # Only the platforms the release carries binaries for (the case arms mirror
 # PLATFORMS in build-hook-binaries.mjs; provision-hook-binary.test.mjs drives
@@ -50,22 +55,12 @@ installed_stamp="$dest_dir/.manifest-installed"
 reject_stamp="$dest_dir/.download-rejected"
 download=""
 
-# A ~100 MB download can dominate session start, and it blocks under the same
-# 1800s harness timeout as every hook — so it reports itself against the
-# provisioning budget, not the per-hook one (see lib/hook-timing.sh), with
-# download advice rather than the default's installer advice.
-provision_started_ms=0
-if [[ -r "$script_dir/lib/hook-timing.sh" ]]; then
-  # shellcheck source=lib/hook-timing.sh
-  . "$script_dir/lib/hook-timing.sh"
-  provision_started_ms="$(hook_timing_now_ms)"
-else
-  echo "agent-sanitizer: $script_dir/lib/hook-timing.sh is missing — provisioning timing disabled (reinstall the plugin)" >&2
-  report_slow_provision() { :; }
-fi
-# $download is empty until mktemp names one, so this removes a partial transfer
-# and never another process's file.
-trap 'rm -f -- "${download:-}"; report_slow_provision "hook binary download" "$provision_started_ms" "The binary is ~100 MB, so this mostly measures the connection to github.com"' EXIT
+# Download advice rather than the shared default's installer advice: telling a
+# user mid-download that uv would help is advice about the wrong step.
+# $download is empty until mktemp names one, so the cleanup removes a partial
+# transfer and never another process's file.
+provision_begin "hook binary download"
+trap 'rm -f -- "${download:-}"; provision_report_elapsed "The binary is ~100 MB, so this mostly measures the connection to github.com"' EXIT
 
 if [[ ! -f "$manifest" ]]; then
   echo "agent-sanitizer: $manifest is missing — the hook binary cannot be verified, so it will not be provisioned (reinstall the plugin)" >&2
@@ -241,10 +236,6 @@ mv -f -- "$download" "$binary" || install_failed "mv"
 download=""
 cp -- "$manifest" "$installed_stamp" || install_failed "recording the install stamp"
 rm -f -- "$reject_stamp" || install_failed "clearing the reject stamp"
-# The success line is gated on the POST-CONDITION, not on the commands above
-# exiting 0 — this is what may not lie to the operator about a dead install.
-if [[ ! -x "$binary" ]]; then
-  echo "agent-sanitizer: install finished but $binary is not an executable file — $consequence" >&2
-  exit 1
-fi
+provision_require_executable "$binary" \
+  "agent-sanitizer: install finished but $binary is not an executable file — $consequence"
 echo "agent-sanitizer: hook binary provisioned into $binary — hooks now run with no node dependency" >&2

--- a/plugin/scripts/provision-redactor.sh
+++ b/plugin/scripts/provision-redactor.sh
@@ -71,7 +71,7 @@ else
 fi
 
 provision_require_executable "$venv/bin/agent-secret-redactor-daemon" \
-  "agent-sanitizer: install finished but $venv/bin/agent-secret-redactor-daemon is missing"
+  "agent-sanitizer: install finished but $venv/bin/agent-secret-redactor-daemon is not an executable file"
 cp -- "$req" "$stamp"
 cp -- "$wheel" "$wheel_stamp"
 echo "agent-sanitizer: secret-redaction engine provisioned into $venv" >&2

--- a/plugin/scripts/provision-redactor.sh
+++ b/plugin/scripts/provision-redactor.sh
@@ -18,24 +18,18 @@ fi
 
 data_dir="${1:?usage: provision-redactor.sh <plugin-data-dir>}"
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-plugin_root="$(cd -- "$script_dir/.." && pwd)"
-
-# This install blocks session start with a 1800s harness timeout above it, and
-# nothing downstream can attribute the wait to it: the hooks it provisions FOR
-# deliberately exclude one-time provisioning from their own budgets, so a
-# pathological install was, until now, wall-clock nobody reported. Budgeted as
-# provisioning, not as a hook — see lib/hook-timing.sh for why that is a
-# different threshold and a different message. The trap covers every exit,
-# including the idempotent early return (which is fast, so it prints nothing)
-# and the failure arms.
-if [[ -r "$script_dir/lib/hook-timing.sh" ]]; then
-  # shellcheck source=lib/hook-timing.sh
-  . "$script_dir/lib/hook-timing.sh"
-  provision_started_ms="$(hook_timing_now_ms)"
-  trap 'report_slow_provision "secret-redaction engine install" "$provision_started_ms"' EXIT
-else
-  echo "agent-sanitizer: $script_dir/lib/hook-timing.sh is missing — provisioning timing disabled (reinstall the plugin)" >&2
+if [[ ! -r "$script_dir/lib/provision-common.sh" ]]; then
+  echo "agent-sanitizer: $script_dir/lib/provision-common.sh is missing — the secret-redaction engine (Layer 4) cannot be provisioned (reinstall the plugin)" >&2
+  exit 1
 fi
+# shellcheck source=lib/provision-common.sh
+. "$script_dir/lib/provision-common.sh"
+
+# The trap covers every exit, including the idempotent early return (which is
+# fast, so it prints nothing) and the failure arms.
+provision_begin "secret-redaction engine install"
+trap provision_report_elapsed EXIT
+
 req="$plugin_root/requirements.txt"
 # The engine itself ships as a wheel beside the zipapp rather than being resolved
 # from PyPI: the venv and the committed daemon.pyz are then the SAME build, so
@@ -76,10 +70,8 @@ else
   exit 1
 fi
 
-[[ -x "$venv/bin/agent-secret-redactor-daemon" ]] || {
-  echo "agent-sanitizer: install finished but $venv/bin/agent-secret-redactor-daemon is missing" >&2
-  exit 1
-}
+provision_require_executable "$venv/bin/agent-secret-redactor-daemon" \
+  "agent-sanitizer: install finished but $venv/bin/agent-secret-redactor-daemon is missing"
 cp -- "$req" "$stamp"
 cp -- "$wheel" "$wheel_stamp"
 echo "agent-sanitizer: secret-redaction engine provisioned into $venv" >&2

--- a/plugin/test/plugin-bundle.test.mjs
+++ b/plugin/test/plugin-bundle.test.mjs
@@ -1857,6 +1857,57 @@ test("provision fails loud when no Python toolchain exists", (t) => {
   assert.match(res.stderr, /UNREDACTED/);
 });
 
+test("an install that produces no daemon fails loud, not silently", (t) => {
+  const plugin = stagePlugin(t);
+  const bin = stubBin(t, ["python3", "uv", "pip"]);
+  // A toolchain whose every command exits 0 while producing nothing: the state
+  // an exit-status check reports as a successful install, leaving the launcher
+  // to find no daemon after the operator was told there is one.
+  writeFileSync(join(bin, "uv"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+  const res = spawnSync(
+    "bash",
+    [
+      join(plugin, "scripts", "provision-redactor.sh"),
+      join(scratch(t), "data"),
+    ],
+    {
+      encoding: "utf8",
+      env: { PATH: bin, AGENT_SANITIZER_SECRETS_ENABLED: "1" },
+    },
+  );
+  assert.equal(res.status, 1);
+  assert.match(
+    res.stderr,
+    /install finished but .*agent-secret-redactor-daemon is missing/,
+  );
+  assert.equal(res.stderr.includes("provisioned into"), false, res.stderr);
+});
+
+test("a missing shared provisioning lib refuses to provision", (t) => {
+  const plugin = stagePlugin(t);
+  rmSync(join(plugin, "scripts", "lib", "provision-common.sh"));
+  const res = spawnSync(
+    "bash",
+    [
+      join(plugin, "scripts", "provision-redactor.sh"),
+      join(scratch(t), "data"),
+    ],
+    {
+      encoding: "utf8",
+      env: {
+        PATH: stubBin(t, ["python3", "uv", "pip"]),
+        AGENT_SANITIZER_SECRETS_ENABLED: "1",
+      },
+    },
+  );
+  assert.equal(res.status, 1);
+  assert.match(res.stderr, /provision-common\.sh is missing/);
+  // It aborts AT the missing source rather than running on undefined
+  // scaffolding: the toolchain check further down never gets to speak, and an
+  // unset `plugin_root` would have looked for the lock file at `/`.
+  assert.equal(res.stderr.includes("python3 not found"), false, res.stderr);
+});
+
 test("provision is a silent no-op without the secret opt-in", (t) => {
   const plugin = stagePlugin(t);
   const res = spawnSync(

--- a/plugin/test/plugin-bundle.test.mjs
+++ b/plugin/test/plugin-bundle.test.mjs
@@ -1878,7 +1878,7 @@ test("an install that produces no daemon fails loud, not silently", (t) => {
   assert.equal(res.status, 1);
   assert.match(
     res.stderr,
-    /install finished but .*agent-secret-redactor-daemon is missing/,
+    /install finished but .*agent-secret-redactor-daemon is not an executable file/,
   );
   assert.equal(res.stderr.includes("provisioned into"), false, res.stderr);
 });
@@ -1902,9 +1902,10 @@ test("a missing shared provisioning lib refuses to provision", (t) => {
   );
   assert.equal(res.status, 1);
   assert.match(res.stderr, /provision-common\.sh is missing/);
-  // It aborts AT the missing source rather than running on undefined
-  // scaffolding: the toolchain check further down never gets to speak, and an
-  // unset `plugin_root` would have looked for the lock file at `/`.
+  // It aborts AT the missing source, naming the file: the toolchain check
+  // further down never gets to speak, and `set -u` on the first unset variable
+  // the lib was to define would abort with `plugin_root: unbound variable`,
+  // which names nothing an operator can act on.
   assert.equal(res.stderr.includes("python3 not found"), false, res.stderr);
 });
 
@@ -1976,6 +1977,39 @@ test("a healthy launcher run says nothing about timing", (t) => {
   // Non-vacuity for the two cases above: with the real threshold in force the
   // same run is silent, so they are observing the report and not just any
   // stderr the launcher happens to produce.
+  assert.equal(res.stderr.includes("PERFORMANCE"), false, res.stderr);
+});
+
+test("a missing timing lib degrades to untimed provisioning, not to failure", (t) => {
+  const plugin = stagePlugin(t);
+  rmSync(join(plugin, "scripts", "lib", "hook-timing.sh"));
+  const data = join(scratch(t), "data");
+  const venvBin = join(data, "venv", "bin");
+  mkdirSync(venvBin, { recursive: true });
+  writeFileSync(join(venvBin, "agent-secret-redactor-daemon"), "#!/bin/sh\n", {
+    mode: 0o755,
+  });
+  stampProvisionInputs(plugin, data);
+  const res = spawnSync(
+    "bash",
+    [join(plugin, "scripts", "provision-redactor.sh"), data],
+    {
+      encoding: "utf8",
+      env: {
+        PATH: stubBin(t, ["python3", "uv", "pip"]),
+        AGENT_SANITIZER_SECRETS_ENABLED: "1",
+        ...REPORT_EVERY_RUN,
+      },
+    },
+  );
+  // An install that can still provision must still provision: under
+  // `set -euo pipefail` a non-zero from the timing arm would turn a missing
+  // stopwatch into an aborted Layer 4.
+  assert.equal(res.status, 0, res.stderr);
+  assert.match(res.stderr, /hook-timing\.sh is missing/);
+  assert.match(res.stderr, /timing disabled/);
+  // Nothing pretends to have measured: the thresholds are 0 here, so a live
+  // timer would report on this very run.
   assert.equal(res.stderr.includes("PERFORMANCE"), false, res.stderr);
 });
 

--- a/plugin/test/provision-hook-binary.test.mjs
+++ b/plugin/test/provision-hook-binary.test.mjs
@@ -324,6 +324,52 @@ test("a missing manifest refuses to provision", (t) => {
   assert.ok(!existsSync(curlLog));
 });
 
+test("a slow download reports against the one-time setup budget", (t) => {
+  const staged = stageProvisionable(t);
+  const { path } = provisionPath(t, staged.fixture);
+  // Threshold 0 rather than a real overrun: what is under test is that this
+  // script measures and reports at all, and with the advice that fits a
+  // download — the shared default names an installer, which is advice about
+  // the wrong step here.
+  const res = provision(staged, path, {
+    _AGENT_SANITIZER_SLOW_PROVISION_MS: "0",
+  });
+  assert.equal(res.status, 0, res.stderr);
+  assert.match(
+    res.stderr,
+    /PERFORMANCE: one-time setup \(hook binary download\)/,
+  );
+  assert.match(res.stderr, /~100 MB/);
+  // The install budget, not the per-call one: a ~100 MB transfer charged to a
+  // 1s hook budget would report on every cold session and name the wrong cost.
+  assert.equal(res.stderr.includes("hook took"), false, res.stderr);
+});
+
+test("a fast download says nothing about timing", (t) => {
+  const staged = stageProvisionable(t);
+  const { path } = provisionPath(t, staged.fixture);
+  const res = provision(staged, path);
+  // Non-vacuity for the case above: with the real threshold in force the same
+  // run is silent, so it observes the report and not just any stderr.
+  assert.equal(res.status, 0, res.stderr);
+  assert.equal(res.stderr.includes("PERFORMANCE"), false, res.stderr);
+});
+
+test("a missing shared provisioning lib refuses to provision", (t) => {
+  const staged = stageProvisionable(t);
+  rmSync(join(staged.plugin, "scripts", "lib", "provision-common.sh"));
+  const { path, curlLog } = provisionPath(t, staged.fixture);
+  const res = provision(staged, path);
+  // A truncated install must not run on whatever the shell makes of the
+  // missing definitions: unset `plugin_root` would resolve the manifest to
+  // `/dist/hooks/...` and the reader below would answer for a file nobody
+  // shipped.
+  assert.equal(res.status, 1);
+  assert.match(res.stderr, /provision-common\.sh is missing/);
+  assert.match(res.stderr, /reinstall the plugin/);
+  assert.ok(!existsSync(curlLog));
+});
+
 // What `uname -s`/`-m` report on each platform the release carries a binary
 // for. A platform the script's `case` cannot name is a platform whose users
 // silently keep the node dependency the binary exists to remove, so every key

--- a/plugin/test/provision-hook-binary.test.mjs
+++ b/plugin/test/provision-hook-binary.test.mjs
@@ -360,14 +360,50 @@ test("a missing shared provisioning lib refuses to provision", (t) => {
   rmSync(join(staged.plugin, "scripts", "lib", "provision-common.sh"));
   const { path, curlLog } = provisionPath(t, staged.fixture);
   const res = provision(staged, path);
-  // A truncated install must not run on whatever the shell makes of the
-  // missing definitions: unset `plugin_root` would resolve the manifest to
-  // `/dist/hooks/...` and the reader below would answer for a file nobody
-  // shipped.
+  // It aborts AT the missing source, naming the file: under `set -u` the first
+  // thing the lib was to define aborts with `provision_begin: command not
+  // found`, which names nothing an operator can act on, and nothing is
+  // downloaded on the way there.
   assert.equal(res.status, 1);
   assert.match(res.stderr, /provision-common\.sh is missing/);
   assert.match(res.stderr, /reinstall the plugin/);
   assert.ok(!existsSync(curlLog));
+});
+
+test("a missing timing lib degrades to an untimed download, not to failure", (t) => {
+  const staged = stageProvisionable(t);
+  rmSync(join(staged.plugin, "scripts", "lib", "hook-timing.sh"));
+  const { path } = provisionPath(t, staged.fixture);
+  const res = provision(staged, path, {
+    _AGENT_SANITIZER_SLOW_PROVISION_MS: "0",
+  });
+  // A host that can still download must still download: under
+  // `set -euo pipefail` a non-zero from the timing arm would turn a missing
+  // stopwatch into a host left on the node path the binary exists to replace.
+  assert.equal(res.status, 0, res.stderr);
+  assert.match(res.stderr, /hook-timing\.sh is missing/);
+  assert.match(res.stderr, /hook binary provisioned/);
+  // Nothing pretends to have measured: the threshold is 0 here, so a live
+  // timer would report on this very run.
+  assert.equal(res.stderr.includes("PERFORMANCE"), false, res.stderr);
+});
+
+test("a binary that lands un-executable is not reported as provisioned", (t) => {
+  const staged = stageProvisionable(t);
+  // chmod is the only thing that makes the download executable, so a no-op one
+  // reproduces an install whose every command exits 0 while leaving nothing
+  // runnable — the state the stamps written just above the check would
+  // otherwise record as "provisioned from this manifest".
+  const { path } = provisionPath(t, staged.fixture);
+  writeFileSync(join(path, "chmod"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+  const res = provision(staged, path);
+  assert.equal(res.status, 1);
+  assert.match(res.stderr, /install finished but .* is not an executable file/);
+  assert.equal(
+    res.stderr.includes("hook binary provisioned"),
+    false,
+    res.stderr,
+  );
 });
 
 // What `uname -s`/`-m` report on each platform the release carries a binary


### PR DESCRIPTION
## Summary

Move the scaffolding both SessionStart provisioners duplicate — the plugin-root walk, the source-or-warn dance around the shell timer, and the post-condition check that keeps a dead install from reporting success — into `plugin/scripts/lib/provision-common.sh`, and cover the arms that extraction made shared. This is the deferred item from #304, which added the second provisioner and noted the extraction belonged in its own diff.

The duplication had already drifted: the two timing blocks carried different comments and different fallbacks for a missing `hook-timing.sh` (`provision-redactor.sh` armed no trap at all, `provision-hook-binary.sh` stubbed `report_slow_provision`).

**Review focus:** `plugin/scripts/lib/provision-common.sh` first. Two invariants span files and can't be seen on one screen:

1. `provision_begin`'s missing-timer arm must `return 0`. Both callers run under `set -euo pipefail` and invoke it as a plain command, so a non-zero there turns a missing stopwatch into an aborted Layer 4 (and a host left on the node path the hook binary exists to replace). That is what lets both callers drop their `if [[ -r hook-timing.sh ]]` branch, and it now has a test on each side.
2. `provision_report_elapsed` passes `"${1:-}"` through `report_slow_provision`'s `$3` into `slow_provision_notice`'s `$4`, whose `${4:-Installing uv makes it faster}` treats an empty string as unset — so the redactor keeps the default installer advice while the download keeps its own (`plugin/test/provision-hook-binary.test.mjs` asserts the `~100 MB` text, not just that something was reported).

The part I'm least sure of is the `# shellcheck disable=SC2034` on `plugin_root`: it is the one variable this file publishes to its caller rather than keeping private, and shellcheck can't see the caller. The alternative was a `provision_plugin_root()` the caller assigns from, which trades the directive for a line at each call site.

## Changes

- **New** `plugin/scripts/lib/provision-common.sh`: `plugin_root`, `provision_begin <step>` / `provision_report_elapsed [advice]`, `provision_require_executable <path> <message>`. The step name and start time stay module-private; the caller arms the report from its trap without naming them.
- `provision-redactor.sh` and `provision-hook-binary.sh` keep only the bootstrap line that resolves their own directory — a script cannot source a file whose path it has not resolved yet — plus their own EXIT trap, since the hook-binary one must also `rm -f` a partial download.
- A missing `provision-common.sh` is a loud refusal in both scripts (exit 1, naming the file and the consequence) rather than the `set -u` abort on the first thing the lib was to define, which names nothing an operator can act on.
- The redactor's post-condition message said "is missing" while the shared check tests `-x` — a daemon installed mode 644 would send the operator hunting for a file that is right there. It now matches the hook-binary wording, "is not an executable file".
- `plugin/scripts/lib/hook-timing.sh`'s header named the two scripts that used to source it directly; the provisioners now reach it through `provision-common.sh`.
- `plugin/README.md` Contents block lists the new lib.

## Tests / verification

- `node --test plugin/test/plugin-bundle.test.mjs plugin/test/provision-hook-binary.test.mjs test/hook-timing-shell-parity.test.mjs` — 226 pass. New cases, per provisioner: a missing shared lib refuses to provision; a missing `hook-timing.sh` degrades to untimed provisioning rather than failing; a slow download reports `PERFORMANCE: one-time setup (hook binary download)` with the `~100 MB` advice (fast one silent); an install whose every command exits 0 while leaving nothing runnable fails loud — driven on the redactor with a no-op `uv`, and on the hook binary with a no-op `chmod`, which is the riskier arm because the install stamps are written before the check.
- Non-vacuity, run explicitly rather than argued: inverting the missing-lib guard to `if false` turns both refusal tests red; changing `provision_begin`'s degraded arm to `return 1` turns both degradation tests red; deleting the `provision_require_executable` call turns the no-daemon test red. The fast-download and fast-provisioning tests are the negative controls for the two timing tests.
- `node --test test/guard-pairs.test.mjs .github/scripts/script-reachability.test.mjs` (13) and `uv run --frozen pytest tests/test_python_floor.py tests/test_safe_launch.py` (142) pass.
- `shellcheck -x -P ".claude/hooks:.github/scripts"` clean on all five plugin shell files; `pnpm lint`, `pnpm check` and `pnpm format` clean.

## Decisions made

- **Timing state is module-private, not published.** `provision_begin` stores the step name and start time in `_provision_*` and `provision_report_elapsed` binds them, instead of the caller writing `report_slow_provision "$provision_step" "$provision_started_ms"` in its own trap. The caller no longer has to know the variable names, and shellcheck sees them used within the file. The alternative — publishing both — needs two more `SC2034` disables and re-exposes the missing-timer branch each caller had to handle.
- **The traps stay caller-owned.** `provision-hook-binary.sh`'s must also remove a partial download, and the step-specific advice string reads best at the call site; a shared trap-arming helper would have to take a cleanup callback to cover one caller.
- **Each caller keeps its own missing-lib message.** The consequence differs (Layer 4 unprovisioned vs. the binary not provisioned) and it is the one thing that cannot be shared, since it must be said before the shared file loads.
