### PR TITLE
test(secrets): pin that the allowlist disable reaches the filters that actually run

### DIFF
--- a/tests/secrets/test_secrets_engine.py
+++ b/tests/secrets/test_secrets_engine.py
@@ -432,6 +432,37 @@ def test_allowlist_filter_is_disabled_inside_configure_plugins():
         )
 
 
+def test_allowlist_filter_is_absent_from_the_filters_that_actually_run():
+    """The sibling above pins the SETTINGS dict; this pins what actually runs.
+
+    ``Settings.disable_filters`` only pops from a dict, while the filters
+    ``scan_line`` applies come from ``get_filters`` — an ``lru_cache`` OVER that
+    dict. The disable therefore only bites because ``transient_settings`` calls
+    ``cache_bust()`` on entry (``settings.py``), clearing ``get_filters`` so the
+    first rebuild after the pop reflects the pruned dict. That is an upstream
+    internal, not a documented contract: a detect-secrets that stopped busting
+    would leave settings looking correct while the stale, permissive filter list
+    kept running — silently reopening the self-allowlisting hole — and every
+    other test in this block would still pass.
+    """
+    from detect_secrets.core.scan import scan_line
+    from detect_secrets.settings import get_filters
+
+    allowlist = "detect_secrets.filters.allowlist.is_line_allowlisted"
+    # Non-vacuity: the filter really is live outside the block, so its absence
+    # inside is caused by `configure_plugins` and not by it never being there.
+    assert allowlist in [f.path for f in get_filters()]
+
+    with E.configure_plugins():
+        assert allowlist not in [f.path for f in get_filters()]
+        # And it stays gone across a real scan, which re-clears the cache itself.
+        list(scan_line(f'aws_key = "{AWS_KEY}"'))
+        assert allowlist not in [f.path for f in get_filters()]
+
+    # Restored on exit: the disable is scoped to the block, not process-global.
+    assert allowlist in [f.path for f in get_filters()]
+
+
 @pytest.mark.parametrize(
     "comment",
     ["  # pragma: allowlist secret", "  // pragma: allowlist secret"],


### PR DESCRIPTION
Claimed area: the allowlist-pragma test block in `tests/secrets/test_secrets_engine.py` (added by #312). No overlap with #311 or #305.

## Summary

Assert over the filter list that **actually runs**, not just the settings dict.

#312's fix calls `get_settings().disable_filters("…allowlist.is_line_allowlisted")` in
`configure_plugins()`. `Settings.disable_filters` is a `dict.pop`, but the filters
`scan_line` applies come from `get_filters` — an `lru_cache` *over* that dict. The pop only
bites because `transient_settings` calls `cache_bust()` on entry, clearing `get_filters` so
the first rebuild reflects the pruned dict. That is an upstream implementation detail, not
a documented contract: a detect-secrets bump that stopped busting would leave settings
looking correct while the stale, permissive filter list kept running — silently reopening
the self-allowlisting hole — with every existing test in that block still green.

## Changes

- `tests/secrets/test_secrets_engine.py`: new
  `test_allowlist_filter_is_absent_from_the_filters_that_actually_run`, asserting over
  `get_filters()` that the allowlist filter is live outside the block, absent inside it,
  still absent after a real `scan_line` call, and restored on exit.

Tests only; no production code changes.

## Tests / verification

- `uv run pytest tests/secrets/` → 1793 passed, 5 skipped. `ruff check` and
  `ruff format --check` clean.
- **Non-vacuity, verified red.** With the `disable_filters` call removed from
  `configure_plugins()`, the new test fails alongside the four
  `test_allowlist_pragma_does_not_suppress_redaction` cases and
  `test_allowlist_filter_is_disabled_inside_configure_plugins` (6 failed, 2 passed);
  restoring the call turns all 8 green. `engine.py` was restored byte-for-byte after.
- The assertions outside the block are load-bearing for non-vacuity: the filter is asserted
  **present** there, so its absence inside is caused by `configure_plugins()` rather than by
  it never having been registered.

## Decisions made

**Pinned the upstream behaviour instead of adding a defensive `get_filters.cache_clear()`
to `engine.py`.** I first assumed the disable was safe because `scan_line` clears
`get_filters` on every call, and wrote the test around that — it failed, because the cache
is already correct on block entry (`transient_settings` → `cache_bust()` clears it before
the pop). So the merged fix needs no extra call; what it lacked was a guard on the upstream
behaviour it silently depends on. Under the alternative, `engine.py` would carry a redundant
line and still have no guard against the change that actually matters.

The critique sub-agent loop was skipped: the diff is one test function.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzxvHZQhx9X7vSXX3gC7gX)_