### PR TITLE
Stage regenerated files so a generated-file conflict can auto-resolve

### DIFF
--- a/.claude/hooks/worktree-teardown-check.test.mjs
+++ b/.claude/hooks/worktree-teardown-check.test.mjs
@@ -19,6 +19,7 @@ import {
   judgeTeardown,
   linkedWorktrees,
 } from "./worktree-teardown-check.mjs";
+import { cleanGitEnv } from "../../test/helpers/git-env.mjs";
 
 /** Payload shape Claude Code hands a PreToolUse hook. */
 const bash = (command) => ({ tool_name: "Bash", tool_input: { command } });
@@ -201,16 +202,12 @@ describe("judgeTeardown", () => {
 describe("against a real repository", () => {
   it("sees work that git diff does not: staged changes in a live worktree", () => {
     const root = mkdtempSync(join(tmpdir(), "worktree-teardown-"));
-    // Git's own environment must not leak in from whatever invoked this suite.
-    // Under the pre-commit hook `GIT_INDEX_FILE` names the OUTER repo's
-    // temporary index, so `git worktree add` in this throwaway repo dies with
-    // `.git/index: index file open failed: Not a directory` — green standalone,
-    // red from a hook, which is where it actually has to run.
-    const cleanEnv = Object.fromEntries(
-      Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_")),
-    );
+    // cleanGitEnv: under the pre-commit hook `GIT_INDEX_FILE` names the OUTER
+    // repo's temporary index, so `git worktree add` in this throwaway repo
+    // dies with `.git/index: index file open failed: Not a directory` — green
+    // standalone, red from a hook, which is where it actually has to run.
     const git = (args, cwd) =>
-      execFileSync("git", args, { cwd, encoding: "utf8", env: cleanEnv });
+      execFileSync("git", args, { cwd, encoding: "utf8", env: cleanGitEnv });
     try {
       git(["init", "-q", "-b", "main", "."], root);
       git(["config", "user.email", "t@example.invalid"], root);

--- a/.github/scripts/auto-resolve/bundle.sh
+++ b/.github/scripts/auto-resolve/bundle.sh
@@ -122,14 +122,28 @@ if [[ ${#staged_list[@]} -gt 0 ]]; then
 fi
 
 # Deferred regeneration: generator-owned outputs whose sources were among the
-# LLM-resolved conflicts. With the sources now staged clean, the regen pre-pass
-# resolves them deterministically (regenerate + stage). Only reachable when the
-# repo has a resolve-generated script (else DEFERRED_REGEN is always empty).
+# LLM-resolved conflicts. With the sources now staged clean, the regen pass
+# re-derives them and stages the result. Only reachable when the repo has a
+# resolve-generated script (else DEFERRED_REGEN is always empty).
 read -ra deferred_list <<<"${DEFERRED_REGEN:-}"
 if [[ ${#deferred_list[@]} -gt 0 ]] && has_resolve_generated; then
+  regen_rc=0
   # shellcheck disable=SC2119  # no flags: this is the plain regenerate-everything run
-  # echo-fallback-ok: regeneration is best-effort by design; the unmerged check below is the real gate
-  run_resolve_generated || echo "resolve-generated errored — the unmerged check below decides."
+  run_resolve_generated || regen_rc=$?
+  # Staging is what turns a regeneration into a RESOLUTION: generator output
+  # written to the working tree leaves the path UNMERGED in the index, so the
+  # check below rejects every unstaged deferred path. Gated on a clean run —
+  # resolve-generated stops at its first failing rule, and a later rule's output
+  # still holds git's "ours" side, never a generator's answer.
+  if [[ "$regen_rc" -eq 0 ]]; then
+    for f in "${deferred_list[@]}"; do
+      [[ -e "$f" ]] || continue
+      git add -- "$f"
+    done
+  else
+    # echo-fallback-ok: diagnostic only; the unmerged check below fails the run
+    echo "resolve-generated exited ${regen_rc} — deferred paths left unstaged."
+  fi
   still_unmerged=()
   for f in "${deferred_list[@]}"; do
     [[ -n "$(git ls-files -u -- "$f")" ]] && still_unmerged+=("$f")

--- a/.github/scripts/auto-resolve/bundle.sh
+++ b/.github/scripts/auto-resolve/bundle.sh
@@ -127,6 +127,21 @@ fi
 # resolve-generated script (else DEFERRED_REGEN is always empty).
 read -ra deferred_list <<<"${DEFERRED_REGEN:-}"
 if [[ ${#deferred_list[@]} -gt 0 ]] && has_resolve_generated; then
+  # Snapshot every deferred path BEFORE the generator runs, so "did the
+  # generator answer for this path?" is observable afterwards. A generator-owned
+  # conflict can be MARKER-FREE — binary, or modify/delete — and prepare.sh
+  # routes on ownership before either classification, so git leaves its
+  # surviving side verbatim in the working tree. Staging on existence alone
+  # would commit that stale side as if it were generated output, and the marker
+  # scan below cannot see a file that never had markers.
+  declare -A regen_before=()
+  for f in "${deferred_list[@]}"; do
+    if [[ -e "$f" || -L "$f" ]]; then
+      regen_before["$f"]="$(git hash-object -- "$f")"
+    else
+      regen_before["$f"]=absent
+    fi
+  done
   regen_rc=0
   # shellcheck disable=SC2119  # no flags: this is the plain regenerate-everything run
   run_resolve_generated || regen_rc=$?
@@ -137,7 +152,18 @@ if [[ ${#deferred_list[@]} -gt 0 ]] && has_resolve_generated; then
   # still holds git's "ours" side, never a generator's answer.
   if [[ "$regen_rc" -eq 0 ]]; then
     for f in "${deferred_list[@]}"; do
-      [[ -e "$f" ]] || continue
+      if [[ ! -e "$f" && ! -L "$f" ]]; then
+        # Gone after a clean run, having been there before it: the resolved
+        # sources no longer produce this artifact, so the DELETION is the
+        # generated answer and staging it resolves the path. A path absent on
+        # both sides of the run got no answer at all — leave it unmerged.
+        [[ "${regen_before["$f"]}" == absent ]] && continue
+        git add -A -- "$f"
+        continue
+      fi
+      # Byte-identical to what the merge left behind is not evidence of a
+      # rewrite; leave it unmerged so the refusal below names it.
+      [[ "$(git hash-object -- "$f")" == "${regen_before["$f"]}" ]] && continue
       git add -- "$f"
     done
   else

--- a/.github/scripts/auto-resolve/bundle.test.mjs
+++ b/.github/scripts/auto-resolve/bundle.test.mjs
@@ -242,21 +242,48 @@ test("a deferred generated file is regenerated from the resolved source and STAG
   assert.notEqual(git(work, "show", "HEAD:gen.txt"), "feature side\n");
 });
 
-test("a deferred generated file that the generator never rewrites still fails loud", () => {
-  // The generator DELETES gen.txt instead of regenerating it, so bundle.sh's
-  // `[[ -e "$f" ]]` skips staging it and it stays unmerged — the failure this
-  // refusal exists to produce.
+test("a generator that DELETES a deferred file stages the deletion, which is its answer", () => {
+  // The resolved sources no longer produce gen.txt. Requiring the path to still
+  // exist would leave its unmerged stages in place and reject a resolution the
+  // generator did make.
   const { work } = midMergeGenerated({
     generatorBody: 'import { rmSync } from "node:fs";\nrmSync("gen.txt");\n',
   });
   writeFileSync(join(work, "a.md"), "resolved\n");
-  const { error, merging, bundle, ghCalls } = runBundle(work, "a.md", {
+  const { error, merging, bundle } = runBundle(work, "a.md", {
+    DEFERRED_REGEN: "gen.txt",
+  });
+  assert.equal(error, null);
+  assert.equal(merging, false);
+  assert.ok(existsSync(bundle));
+  assert.equal(
+    git(work, "ls-tree", "--name-only", "HEAD", "gen.txt").trim(),
+    "",
+    "gen.txt survived a commit that was supposed to record its deletion",
+  );
+});
+
+test("a generator that exits 0 without rewriting a deferred file fails loud, before the marker scan", () => {
+  // The blind spot this guards: a generator-owned conflict can be MARKER-FREE
+  // (binary, modify/delete), so the marker scan cannot tell git's surviving
+  // side from generated output. Staging on existence alone would bundle the
+  // stale side. Evidence of a rewrite is the content changing, and the refusal
+  // has to come from the unmerged check — reaching the marker scan at all means
+  // the stale side was already staged.
+  const { work } = midMergeGenerated({ generatorBody: "process.exit(0);\n" });
+  writeFileSync(join(work, "a.md"), "resolved\n");
+  const { error, merging, bundle, ghCalls, stdout } = runBundle(work, "a.md", {
     DEFERRED_REGEN: "gen.txt",
   });
   assert.notEqual(error, null);
   assert.equal(merging, false); // merge aborted
   assert.ok(!existsSync(bundle));
   assert.match(ghCalls.join("\n"), /could not be regenerated/);
+  assert.doesNotMatch(
+    stdout,
+    /Conflict markers still present/,
+    "the run reached the marker scan, so the unrewritten path had been staged",
+  );
 });
 
 test("a FAILING generator leaves the deferred path unstaged rather than committing git's 'ours'", () => {

--- a/.github/scripts/auto-resolve/bundle.test.mjs
+++ b/.github/scripts/auto-resolve/bundle.test.mjs
@@ -243,8 +243,9 @@ test("a deferred generated file is regenerated from the resolved source and STAG
 });
 
 test("a deferred generated file that the generator never rewrites still fails loud", () => {
-  // The generator writes a DIFFERENT path, so gen.txt keeps git's "ours" bytes
-  // and stays unmerged — the failure this refusal exists to produce.
+  // The generator DELETES gen.txt instead of regenerating it, so bundle.sh's
+  // `[[ -e "$f" ]]` skips staging it and it stays unmerged — the failure this
+  // refusal exists to produce.
   const { work } = midMergeGenerated({
     generatorBody: 'import { rmSync } from "node:fs";\nrmSync("gen.txt");\n',
   });

--- a/.github/scripts/auto-resolve/bundle.test.mjs
+++ b/.github/scripts/auto-resolve/bundle.test.mjs
@@ -3,10 +3,19 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { writeFileSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
-import { midMerge, midMergeModifyDelete, runBundle } from "./fixtures.mjs";
+import {
+  midMerge,
+  midMergeModifyDelete,
+  midMergeGenerated,
+  runBundle,
+} from "./fixtures.mjs";
+import { cleanGitEnv } from "../../../test/helpers/git-env.mjs";
 
 const git = (cwd, ...args) =>
-  execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
+  execFileSync("git", ["-C", cwd, ...args], {
+    encoding: "utf8",
+    env: cleanGitEnv,
+  });
 
 test("bundle commits the merge and emits a bundle when the resolution stays in the conflicted set", () => {
   const { work } = midMerge();
@@ -18,6 +27,7 @@ test("bundle commits the merge and emits a bundle when the resolution stays in t
   // The bundle carries the merge commit under the handoff ref, and nothing else.
   const listed = execFileSync("git", ["bundle", "list-heads", bundle], {
     encoding: "utf8",
+    env: cleanGitEnv,
   });
   assert.match(listed, /refs\/auto-resolve\/result/);
   assert.equal(listed.trim().split("\n").length, 1);
@@ -206,4 +216,57 @@ test("the self-review is skipped, and the merge still bundled, when it is turned
   });
   assert.equal(error, null);
   assert.ok(existsSync(bundle));
+});
+
+// ─── Deferred regeneration (DEFERRED_REGEN). A generator-owned file whose
+// SOURCE also conflicted is regenerated here, after the LLM resolves that
+// source. Regenerating alone is not a resolution: generator output written to
+// the working tree leaves the path unmerged in the index, so bundle.sh must
+// stage it. ──────────────────────────────────────────────────────────────────
+
+test("a deferred generated file is regenerated from the resolved source and STAGED, so the merge bundles", () => {
+  const { work } = midMergeGenerated();
+  writeFileSync(join(work, "a.md"), "resolved: feature + main\n");
+  const { error, merging, bundle } = runBundle(work, "a.md", {
+    DEFERRED_REGEN: "gen.txt",
+  });
+  assert.equal(error, null);
+  assert.equal(merging, false);
+  assert.ok(existsSync(bundle));
+  // The committed bytes are the GENERATOR's answer for the resolved source —
+  // not git's "ours" side, which staging blindly would have preserved.
+  assert.equal(
+    git(work, "show", "HEAD:gen.txt"),
+    "generated from: resolved: feature + main\n",
+  );
+  assert.notEqual(git(work, "show", "HEAD:gen.txt"), "feature side\n");
+});
+
+test("a deferred generated file that the generator never rewrites still fails loud", () => {
+  // The generator writes a DIFFERENT path, so gen.txt keeps git's "ours" bytes
+  // and stays unmerged — the failure this refusal exists to produce.
+  const { work } = midMergeGenerated({
+    generatorBody: 'import { rmSync } from "node:fs";\nrmSync("gen.txt");\n',
+  });
+  writeFileSync(join(work, "a.md"), "resolved\n");
+  const { error, merging, bundle, ghCalls } = runBundle(work, "a.md", {
+    DEFERRED_REGEN: "gen.txt",
+  });
+  assert.notEqual(error, null);
+  assert.equal(merging, false); // merge aborted
+  assert.ok(!existsSync(bundle));
+  assert.match(ghCalls.join("\n"), /could not be regenerated/);
+});
+
+test("a FAILING generator leaves the deferred path unstaged rather than committing git's 'ours'", () => {
+  const { work } = midMergeGenerated({
+    generatorBody: "process.exit(3);\n",
+  });
+  writeFileSync(join(work, "a.md"), "resolved\n");
+  const { error, bundle, ghCalls } = runBundle(work, "a.md", {
+    DEFERRED_REGEN: "gen.txt",
+  });
+  assert.notEqual(error, null);
+  assert.ok(!existsSync(bundle));
+  assert.match(ghCalls.join("\n"), /could not be regenerated/);
 });

--- a/.github/scripts/auto-resolve/fanout.test.mjs
+++ b/.github/scripts/auto-resolve/fanout.test.mjs
@@ -19,6 +19,7 @@ import {
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { cleanGitEnv } from "../../../test/helpers/git-env.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SCRIPT = join(HERE, "fanout.sh");
@@ -160,8 +161,8 @@ function run(fx, { files, create = files, env = {} } = {}) {
     encoding: "utf8",
     cwd: fx.work,
     env: {
-      ...process.env,
-      PATH: `${fx.path}:${process.env.PATH}`,
+      ...cleanGitEnv,
+      PATH: `${fx.path}:${cleanGitEnv.PATH}`,
       STUB_DIR: fx.stub,
       CONFLICT_LIST: files.join(" "),
       PR_NUMBER: "41",
@@ -247,7 +248,7 @@ function gate(fx, executionFile) {
   const res = spawnSync("bash", [GATE], {
     encoding: "utf8",
     env: {
-      ...process.env,
+      ...cleanGitEnv,
       EXECUTION_FILE: executionFile,
       GITHUB_OUTPUT: out,
       CONTEXT: "Claude conflict resolution",
@@ -914,7 +915,10 @@ test("the actor gate admits a write-access human and the relay bot", () => {
 // falsifiable to carry.
 function midMergeWork(fx, f, { bulkPrCommits = 0 } = {}) {
   const g = (...a) =>
-    execFileSync("git", ["-C", fx.work, ...a], { encoding: "utf8" });
+    execFileSync("git", ["-C", fx.work, ...a], {
+      encoding: "utf8",
+      env: cleanGitEnv,
+    });
   g("init", "-q", "-b", "main");
   g("config", "user.email", "t@t");
   g("config", "user.name", "t");

--- a/.github/scripts/auto-resolve/fixtures.mjs
+++ b/.github/scripts/auto-resolve/fixtures.mjs
@@ -164,7 +164,7 @@ function runBundle(work, conflictList, env = {}) {
   chmodSync(ghPath, 0o755);
   const bundleDir = join(root, "bundle-out");
   let error = null;
-  let stdout = "";
+  let stdout;
   try {
     stdout = execFileSync("bash", [SCRIPT], {
       cwd: work,

--- a/.github/scripts/auto-resolve/fixtures.mjs
+++ b/.github/scripts/auto-resolve/fixtures.mjs
@@ -189,6 +189,9 @@ function runBundle(work, conflictList, env = {}) {
     });
   } catch (err) {
     error = err;
+    // A failing run is exactly when a test needs to know HOW FAR bundle.sh got,
+    // and execFileSync throws its output away unless it is read off the error.
+    stdout = err.stdout ?? "";
   }
   let merging = true;
   try {

--- a/.github/scripts/auto-resolve/fixtures.mjs
+++ b/.github/scripts/auto-resolve/fixtures.mjs
@@ -12,18 +12,26 @@ import {
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { cleanGitEnv } from "../../../test/helpers/git-env.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SCRIPT = join(HERE, "bundle.sh");
 const scratch = () => mkdtempSync(join(tmpdir(), "auto-resolve-bundle-"));
 const git = (cwd, ...args) =>
-  execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
+  execFileSync("git", ["-C", cwd, ...args], {
+    encoding: "utf8",
+    env: cleanGitEnv,
+  });
 
 // A work clone mid-merge: `main` and `feature` both edit a.md, and b.md exists
 // cleanly on both. Merging main into feature conflicts on a.md only. Both
 // branches are pushed, so the merge's two parents are reachable from origin —
 // which is what the land step requires.
-function midMerge({ bContent = "b base\n", extraConflict = null } = {}) {
+function midMerge({
+  bContent = "b base\n",
+  extraConflict = null,
+  seed = null,
+} = {}) {
   const root = scratch();
   const origin = join(root, "origin.git");
   const work = join(root, "work");
@@ -34,6 +42,9 @@ function midMerge({ bContent = "b base\n", extraConflict = null } = {}) {
   git(work, "config", "commit.gpgsign", "false");
   writeFileSync(join(work, "a.md"), "base\n");
   writeFileSync(join(work, "b.md"), bContent);
+  // Files both branches share unchanged (a repo's committed tooling), so they
+  // are present mid-merge without being part of the conflict.
+  if (seed) seed(work);
   if (extraConflict) {
     mkdirSync(dirname(join(work, extraConflict)), { recursive: true });
     writeFileSync(join(work, extraConflict), "base\n");
@@ -97,6 +108,42 @@ function midMergeModifyDelete() {
   return { work, origin, root };
 }
 
+// A mid-merge tree that also declares regen rules: `gen.txt` is generator-owned
+// and conflicts alongside its source `a.md`, which is exactly the case
+// prepare.sh defers to bundle.sh's post-LLM regeneration. The generator is
+// committed (bundle.sh refuses untracked files) and derives its output from the
+// resolved source, so a test can tell a real regeneration from git's "ours".
+//
+// `generatorBody` is the committed generator's script body; the default writes
+// gen.txt from a.md. Pass a failing body to exercise the refusal path.
+function midMergeGenerated({ generatorBody = null } = {}) {
+  const body =
+    generatorBody ??
+    `import { readFileSync, writeFileSync } from "node:fs";
+writeFileSync("gen.txt", "generated from: " + readFileSync("a.md", "utf8"));
+`;
+  return midMerge({
+    extraConflict: "gen.txt",
+    seed: (w) => {
+      mkdirSync(join(w, ".github", "scripts"), { recursive: true });
+      mkdirSync(join(w, "config"), { recursive: true });
+      writeFileSync(
+        join(w, ".github", "scripts", "resolve-generated.mjs"),
+        readFileSync(join(HERE, "..", "resolve-generated.mjs"), "utf8"),
+      );
+      writeFileSync(
+        join(w, "config", "auto-resolve-regen-rules.json"),
+        JSON.stringify({
+          rules: [
+            { generator: "gen.mjs", sources: ["a.md"], owns: ["gen.txt"] },
+          ],
+        }),
+      );
+      writeFileSync(join(w, "gen.mjs"), body);
+    },
+  });
+}
+
 // Runs bundle.sh in `work` with a fake `gh` on PATH that records every
 // invocation, so a test can assert on the comment(s)/labels it posts. The
 // self-review is left unconfigured (no OAuth token in the environment), so
@@ -123,7 +170,7 @@ function runBundle(work, conflictList, env = {}) {
       cwd: work,
       encoding: "utf8",
       env: {
-        ...process.env,
+        ...cleanGitEnv,
         HEAD_REF: "feature",
         BASE_REF: "main",
         PR: "1",
@@ -137,7 +184,7 @@ function runBundle(work, conflictList, env = {}) {
         CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_5: "",
         CLAUDE_CODE_OAUTH_TOKEN_FALLBACK_6: "",
         ...env,
-        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        PATH: `${binDir}:${cleanGitEnv.PATH ?? ""}`,
       },
     });
   } catch (err) {
@@ -160,4 +207,4 @@ function runBundle(work, conflictList, env = {}) {
   };
 }
 
-export { midMerge, midMergeModifyDelete, runBundle };
+export { midMerge, midMergeModifyDelete, midMergeGenerated, runBundle };

--- a/.github/scripts/auto-resolve/land.test.mjs
+++ b/.github/scripts/auto-resolve/land.test.mjs
@@ -12,11 +12,15 @@ import {
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { midMerge, runBundle } from "./fixtures.mjs";
+import { cleanGitEnv } from "../../../test/helpers/git-env.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SCRIPT = join(HERE, "land.sh");
 const git = (cwd, ...args) =>
-  execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
+  execFileSync("git", ["-C", cwd, ...args], {
+    encoding: "utf8",
+    env: cleanGitEnv,
+  });
 
 // Produces a real bundle the way the resolve job does, then hands back a FRESH
 // clone standing in for the land job's own checkout — which shares no state
@@ -90,7 +94,7 @@ function runLand(landDir, bundleDir, env = {}) {
       cwd: landDir,
       encoding: "utf8",
       env: {
-        ...process.env,
+        ...cleanGitEnv,
         HEAD_REF: "feature",
         BASE_REF: "main",
         PR: "1",
@@ -99,7 +103,7 @@ function runLand(landDir, bundleDir, env = {}) {
         BUNDLE_DIR: bundleDir,
         RUNNER_TEMP: runnerTemp,
         ...env,
-        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        PATH: `${binDir}:${cleanGitEnv.PATH ?? ""}`,
       },
     });
   } catch (err) {

--- a/.github/scripts/auto-resolve/mark-attempt.test.mjs
+++ b/.github/scripts/auto-resolve/mark-attempt.test.mjs
@@ -9,11 +9,15 @@ import { mkdtempSync, writeFileSync, readFileSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { cleanGitEnv } from "../../../test/helpers/git-env.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SCRIPT = join(HERE, "mark-attempt.sh");
 const git = (cwd, ...args) =>
-  execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
+  execFileSync("git", ["-C", cwd, ...args], {
+    encoding: "utf8",
+    env: cleanGitEnv,
+  });
 
 // A one-commit repo plus a recording `gh`; returns the run result, the recorded
 // gh argv lines, and the SHA the script should have marked.
@@ -41,8 +45,8 @@ function runMark({ ghExit = 0 } = {}) {
     cwd: work,
     encoding: "utf8",
     env: {
-      ...process.env,
-      PATH: `${root}:${process.env.PATH ?? ""}`,
+      ...cleanGitEnv,
+      PATH: `${root}:${cleanGitEnv.PATH ?? ""}`,
       REPO: "owner/repo",
       GH_TOKEN: "x",
       // One attempt, no backoff: the gh-down case would otherwise sit through the

--- a/.github/scripts/auto-resolve/prepare.sh
+++ b/.github/scripts/auto-resolve/prepare.sh
@@ -135,35 +135,13 @@ if git merge --no-edit "origin/${BASE_REF}"; then
   exit 0
 fi
 
-# Optional deterministic pre-pass: when the repo declares regen rules, re-derive
-# its generated files from the merged sources. This writes the working tree only
-# — nothing is staged here, because mid-merge the sources may still carry
-# conflict markers, so any output built now is provisional. The classification
-# below routes every generator-owned conflict to BUNDLE, which regenerates from
-# the RESOLVED sources and stages that. Skipped entirely (and the whole
-# generated-file classification collapses to empty) when the repo declares none.
-if has_resolve_generated; then
-  # shellcheck disable=SC2119  # no flags: this is the plain regenerate-everything run
-  # echo-fallback-ok: regeneration is best-effort by design; the bundle step's unmerged check is the real gate
-  run_resolve_generated || echo "resolve-generated made no change (or errored) — continuing."
-else
-  echo "no $RESOLVE_GENERATED_CONFIG — skipping the deterministic generated-file pre-pass."
-fi
-
+# Generator-owned conflicts are never regenerated HERE: whatever this pre-pass
+# could write mid-merge is provisional (sources may still carry markers) and
+# gets staged nowhere, so it changes no unmerged path's stage and BUNDLE
+# regenerates from scratch anyway once the LLM resolves the sources. Classifying
+# owned conflicts below is the only thing this step needs `has_resolve_generated`
+# for.
 mapfile -t conflicts < <(git diff --name-only --diff-filter=U)
-declare -A unmerged=()
-for f in "${conflicts[@]}"; do unmerged["$f"]=1; done
-
-# A resolve-generated pre-pass may also rewrite UNOWNED splice outputs in the
-# working tree. Those bytes are not part of the deterministic resolution —
-# restore them to the merged index state so the bundle step's out-of-set guard sees
-# only the LLM's edits. (A worktree diff lists unmerged paths too; those are the
-# conflicts themselves, not regen noise.) A no-op with no resolve-generated
-# script, since then git diff --name-only lists only the conflicts.
-while IFS= read -r f; do
-  [[ -z "$f" || -n "${unmerged["$f"]:-}" ]] && continue
-  git checkout -- "$f"
-done < <(git diff --name-only)
 
 if [[ ${#conflicts[@]} -eq 0 ]]; then
   echo "All conflicts resolved deterministically — committing without Claude."

--- a/.github/scripts/auto-resolve/prepare.sh
+++ b/.github/scripts/auto-resolve/prepare.sh
@@ -135,11 +135,13 @@ if git merge --no-edit "origin/${BASE_REF}"; then
   exit 0
 fi
 
-# Optional deterministic pre-pass: when the repo defines a `resolve-generated`
-# script, regenerate + stage conflicted fully-generated files so Claude only ever
-# sees genuine source conflicts. Non-fatal on its own; skipped entirely (and the
-# whole generated-file classification collapses to empty) when the repo has no
-# such script.
+# Optional deterministic pre-pass: when the repo declares regen rules, re-derive
+# its generated files from the merged sources. This writes the working tree only
+# — nothing is staged here, because mid-merge the sources may still carry
+# conflict markers, so any output built now is provisional. The classification
+# below routes every generator-owned conflict to BUNDLE, which regenerates from
+# the RESOLVED sources and stages that. Skipped entirely (and the whole
+# generated-file classification collapses to empty) when the repo declares none.
 if has_resolve_generated; then
   # shellcheck disable=SC2119  # no flags: this is the plain regenerate-everything run
   # echo-fallback-ok: regeneration is best-effort by design; the bundle step's unmerged check is the real gate
@@ -208,9 +210,9 @@ is_owned() {
   return 1
 }
 
-# Partition. An owned conflict means its source ALSO conflicted (the pre-pass
-# already resolved the clean-source ones) — the bundle step regenerates it after the
-# LLM resolves the source. A `-merge`-attributed or binary conflict has no
+# Partition. An owned conflict is never handed to the LLM — the bundle step
+# regenerates it from the sources once the LLM has resolved those. A
+# `-merge`-attributed or binary conflict has no
 # markers to resolve and no generator to rerun: only a human (relocking,
 # re-exporting the asset) can produce the right content.
 #

--- a/.github/scripts/auto-resolve/prepare.test.mjs
+++ b/.github/scripts/auto-resolve/prepare.test.mjs
@@ -11,13 +11,17 @@ import {
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { cleanGitEnv } from "../../../test/helpers/git-env.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SCRIPT = join(HERE, "prepare.sh");
 const scratch = () => mkdtempSync(join(tmpdir(), "auto-resolve-"));
 
 const git = (cwd, ...args) =>
-  execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
+  execFileSync("git", ["-C", cwd, ...args], {
+    encoding: "utf8",
+    env: cleanGitEnv,
+  });
 
 // Build an origin repo whose `main` and `feature` branches both edit `file`, so
 // merging main into feature conflicts on exactly that path. Returns a `work`
@@ -166,12 +170,12 @@ function runPrepare(work, extraEnv = {}, { mergiraf = "cannot-solve" } = {}) {
       cwd: work,
       encoding: "utf8",
       env: {
-        ...process.env,
+        ...cleanGitEnv,
         BASE_REF: "main",
         HEAD_REF: "feature",
         GITHUB_TOKEN: "x",
         GITHUB_OUTPUT: outFile,
-        PATH: `${ghBin}:${process.env.PATH ?? ""}`,
+        PATH: `${ghBin}:${cleanGitEnv.PATH ?? ""}`,
         ...extraEnv,
       },
     });

--- a/.github/scripts/auto-resolve/release-attempt.test.mjs
+++ b/.github/scripts/auto-resolve/release-attempt.test.mjs
@@ -11,11 +11,15 @@ import { mkdtempSync, writeFileSync, readFileSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { cleanGitEnv } from "../../../test/helpers/git-env.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SCRIPT = join(HERE, "release-attempt.sh");
 const git = (cwd, ...args) =>
-  execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
+  execFileSync("git", ["-C", cwd, ...args], {
+    encoding: "utf8",
+    env: cleanGitEnv,
+  });
 
 // A one-commit repo plus a recording `gh`. HEAD_SHA is deliberately NOT the
 // worktree's HEAD in the default case: the fast-forward no-op leaves HEAD on the
@@ -44,8 +48,8 @@ function runRelease({ ghExit = 0, headSha = "deadbeef" } = {}) {
     cwd: work,
     encoding: "utf8",
     env: {
-      ...process.env,
-      PATH: `${root}:${process.env.PATH ?? ""}`,
+      ...cleanGitEnv,
+      PATH: `${root}:${cleanGitEnv.PATH ?? ""}`,
       REPO: "owner/repo",
       GH_TOKEN: "x",
       HEAD_SHA: headSha,
@@ -84,7 +88,7 @@ test("it refuses to guess the SHA when prepare reported none", () => {
   const res = spawnSync("bash", [SCRIPT], {
     cwd: root,
     encoding: "utf8",
-    env: { ...process.env, REPO: "owner/repo", GH_TOKEN: "x" },
+    env: { ...cleanGitEnv, REPO: "owner/repo", GH_TOKEN: "x" },
   });
   assert.notEqual(res.status, 0);
   assert.match(res.stderr, /HEAD_SHA/);

--- a/.github/scripts/auto-resolve/self-review.test.mjs
+++ b/.github/scripts/auto-resolve/self-review.test.mjs
@@ -13,13 +13,17 @@ import {
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { cleanGitEnv } from "../../../test/helpers/git-env.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SCRIPT = join(HERE, "self-review.sh");
 const scratch = () => mkdtempSync(join(tmpdir(), "self-review-"));
 
 const git = (cwd, ...args) =>
-  execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
+  execFileSync("git", ["-C", cwd, ...args], {
+    encoding: "utf8",
+    env: cleanGitEnv,
+  });
 
 const CLEAN_REVIEW =
   "No suspicious merge-resolution deltas: every hand-authored change traces to a parent's intent.\n";
@@ -223,7 +227,7 @@ function runSelfReview({
       cwd: work,
       encoding: "utf8",
       env: {
-        ...process.env,
+        ...cleanGitEnv,
         ...ladder,
         BASE_WORKTREE: base,
         SELF_REVIEW_DIR: reviewDir,
@@ -234,7 +238,7 @@ function runSelfReview({
         CLAUDE_STUB_WORK: work,
         CLAUDE_STUB_CLEAN: CLEAN_REVIEW,
         CLAUDE_STUB_FLAGGED: FLAGGED_REVIEW,
-        PATH: `${bin}:${process.env.PATH ?? ""}`,
+        PATH: `${bin}:${cleanGitEnv.PATH ?? ""}`,
         ...env,
       },
     });

--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -59,118 +59,6 @@ else
   echo "pre-push: install uv (https://docs.astral.sh/uv/) or 'pip install pre-commit'; CI still enforces the suite." >&2
 fi
 
-# Hooks that only READ the tree, so running them concurrently is safe. The rest
-# — trailing-whitespace, end-of-file-fixer, mixed-line-ending, shfmt -w,
-# ruff-check --fix, ruff-format — REWRITE the files they check, and two of those
-# rewriting one file at the same time loses one of the two fixes, so they run
-# serially first (their output is also what the read-only hooks then see, the
-# same order a single `pre-commit run` gives).
-#
-# The list is an allowlist for a reason: a hook added to
-# .pre-commit-config.yaml and not named here runs in the serial pass, which is
-# slower and always correct. Only membership here asserts "safe to parallelise".
-readonly_hooks=(
-  check-added-large-files
-  check-case-conflict
-  check-executables-have-shebangs
-  check-hook-stdin-guarded
-  check-hook-timeouts
-  check-json
-  check-merge-conflict
-  check-proto-pollution
-  check-shebang-scripts-are-executable
-  check-symlinks
-  check-test-repo-root
-  check-tier1
-  check-tier2
-  check-extras
-  check-yaml
-  dot-directory-test-suites
-  lint-skills
-  shellcheck
-  validate-config
-  zizmor
-)
-
-# Run the pushed-range pre-commit suite, serial fixers first and the read-only
-# hooks fanned out. Returns pre-commit's own exit status, so the caller's
-# exit-code-3 (provisioning failure) branch keeps working.
-#
-# The fan-out is gated on a CLEAN working tree, and that gate is the whole
-# safety argument. pre-commit stashes unstaged changes for the duration of a
-# run and restores them after, so concurrent invocations stash and restore over
-# each other: measured, that reports "files were modified by this hook" against
-# an untouched tree and fails suites that pass in isolation. With no unstaged
-# changes there is nothing to stash, and the read-only hooks below touch
-# nothing else. A dirty tree falls back to one serial run — slower, and the
-# behaviour this hook has always had.
-precommit_range() {
-  local from="$1" to="$2" rc=0 out hook parallel=() config_ids
-  # `git diff` with no arguments is exactly pre-commit's stash condition:
-  # tracked changes present in the working tree but not the index.
-  if ! git diff --quiet; then
-    out=$("${precommit_cmd[@]}" run --from-ref "$from" --to-ref "$to" \
-      --show-diff-on-failure </dev/null 2>&1) || rc=$?
-    printf '%s\n' "$out"
-    return "$rc"
-  fi
-  config_ids=$(sed -n 's/^[[:space:]]*-\{0,1\}[[:space:]]*id:[[:space:]]*\([^[:space:]]*\).*/\1/p' \
-    "$git_root/.pre-commit-config.yaml")
-  # Intersect with what the config actually declares: a stale entry above would
-  # otherwise make `pre-commit run <id>` die on an unknown hook. Anything this
-  # misses simply stays out of `parallel`, and so is never added to SKIP —
-  # a missed id runs serially rather than not running at all.
-  for hook in "${readonly_hooks[@]}"; do
-    grep -qxF "$hook" <<<"$config_ids" && parallel+=("$hook")
-  done
-
-  local skip=""
-  [[ ${#parallel[@]} -gt 0 ]] && skip=$(
-    IFS=,
-    echo "${parallel[*]}"
-  )
-  out=$(SKIP="$skip" "${precommit_cmd[@]}" run --from-ref "$from" --to-ref "$to" \
-    --show-diff-on-failure </dev/null 2>&1) || rc=$?
-  printf '%s\n' "$out"
-  [[ "$rc" -eq 0 ]] || return "$rc"
-  [[ ${#parallel[@]} -eq 0 ]] && return 0
-
-  local tmp runner jobs
-  tmp=$(mktemp -d)
-  runner="$tmp/run-hook"
-  # The single quotes are deliberate: everything but the %q substitutions is the
-  # CHILD's source text, and expanding it here would bake this shell's values in.
-  # shellcheck disable=SC2016
-  {
-    echo '#!/bin/bash'
-    echo 'rc=0'
-    printf 'out=$(%s run "$1" --from-ref %q --to-ref %q --show-diff-on-failure </dev/null 2>&1) || rc=$?\n' \
-      "$(printf '%q ' "${precommit_cmd[@]}")" "$from" "$to"
-    printf 'printf "%%s\\n" "$out" >%q/"$1".log\n' "$tmp"
-    printf 'echo "$rc" >%q/"$1".rc\n' "$tmp"
-  } >"$runner"
-  chmod +x "$runner"
-  jobs=$(getconf _NPROCESSORS_ONLN 2>/dev/null) || jobs=4
-  printf '%s\n' "${parallel[@]}" | xargs -P "$jobs" -n1 "$runner"
-
-  # Report every failure, not just the first: the hooks ran concurrently, so
-  # stopping at one would hide results already computed.
-  for hook in "${parallel[@]}"; do
-    local hook_rc
-    hook_rc=$(<"$tmp/$hook.rc")
-    [[ "$hook_rc" -eq 0 ]] && continue
-    cat "$tmp/$hook.log"
-    # A real lint failure (1) outranks a provisioning failure (3). The caller
-    # degrades to a loud SKIP on 3, so letting 3 win would turn a hook that
-    # genuinely failed into "network blocked, never mind" and let the push
-    # through.
-    [[ "$rc" -eq 1 ]] && continue
-    rc="$hook_rc"
-  done
-  rm -rf "$tmp"
-  return "$rc"
-}
-
 # origin's default branch — the base the new-branch fallback diffs against.
 # "origin/main" is a documented, widely-correct default for the (rare) case
 # origin/HEAD isn't set locally; a wrong guess here only widens the diffed
@@ -274,7 +162,9 @@ while read -r -u 3 _local_ref local_sha remote_ref remote_sha; do
   # signatures instead would be self-defeating, since --show-diff-on-failure can
   # print a diff of THIS file containing those very strings.
   precommit_rc=0
-  precommit_range "$from_ref" "$local_sha" || precommit_rc=$?
+  precommit_out=$("${precommit_cmd[@]}" run --from-ref "$from_ref" --to-ref "$local_sha" --show-diff-on-failure </dev/null 2>&1) ||
+    precommit_rc=$?
+  printf '%s\n' "$precommit_out"
   if [[ "$precommit_rc" -eq 3 ]]; then
     echo "pre-push: pre-commit could not PROVISION a hook environment (network/egress blocked, not a lint failure) — SKIPPING the pushed-range run. CI still enforces the full suite on the PR." >&2
     continue

--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -59,6 +59,118 @@ else
   echo "pre-push: install uv (https://docs.astral.sh/uv/) or 'pip install pre-commit'; CI still enforces the suite." >&2
 fi
 
+# Hooks that only READ the tree, so running them concurrently is safe. The rest
+# — trailing-whitespace, end-of-file-fixer, mixed-line-ending, shfmt -w,
+# ruff-check --fix, ruff-format — REWRITE the files they check, and two of those
+# rewriting one file at the same time loses one of the two fixes, so they run
+# serially first (their output is also what the read-only hooks then see, the
+# same order a single `pre-commit run` gives).
+#
+# The list is an allowlist for a reason: a hook added to
+# .pre-commit-config.yaml and not named here runs in the serial pass, which is
+# slower and always correct. Only membership here asserts "safe to parallelise".
+readonly_hooks=(
+  check-added-large-files
+  check-case-conflict
+  check-executables-have-shebangs
+  check-hook-stdin-guarded
+  check-hook-timeouts
+  check-json
+  check-merge-conflict
+  check-proto-pollution
+  check-shebang-scripts-are-executable
+  check-symlinks
+  check-test-repo-root
+  check-tier1
+  check-tier2
+  check-extras
+  check-yaml
+  dot-directory-test-suites
+  lint-skills
+  shellcheck
+  validate-config
+  zizmor
+)
+
+# Run the pushed-range pre-commit suite, serial fixers first and the read-only
+# hooks fanned out. Returns pre-commit's own exit status, so the caller's
+# exit-code-3 (provisioning failure) branch keeps working.
+#
+# The fan-out is gated on a CLEAN working tree, and that gate is the whole
+# safety argument. pre-commit stashes unstaged changes for the duration of a
+# run and restores them after, so concurrent invocations stash and restore over
+# each other: measured, that reports "files were modified by this hook" against
+# an untouched tree and fails suites that pass in isolation. With no unstaged
+# changes there is nothing to stash, and the read-only hooks below touch
+# nothing else. A dirty tree falls back to one serial run — slower, and the
+# behaviour this hook has always had.
+precommit_range() {
+  local from="$1" to="$2" rc=0 out hook parallel=() config_ids
+  # `git diff` with no arguments is exactly pre-commit's stash condition:
+  # tracked changes present in the working tree but not the index.
+  if ! git diff --quiet; then
+    out=$("${precommit_cmd[@]}" run --from-ref "$from" --to-ref "$to" \
+      --show-diff-on-failure </dev/null 2>&1) || rc=$?
+    printf '%s\n' "$out"
+    return "$rc"
+  fi
+  config_ids=$(sed -n 's/^[[:space:]]*-\{0,1\}[[:space:]]*id:[[:space:]]*\([^[:space:]]*\).*/\1/p' \
+    "$git_root/.pre-commit-config.yaml")
+  # Intersect with what the config actually declares: a stale entry above would
+  # otherwise make `pre-commit run <id>` die on an unknown hook. Anything this
+  # misses simply stays out of `parallel`, and so is never added to SKIP —
+  # a missed id runs serially rather than not running at all.
+  for hook in "${readonly_hooks[@]}"; do
+    grep -qxF "$hook" <<<"$config_ids" && parallel+=("$hook")
+  done
+
+  local skip=""
+  [[ ${#parallel[@]} -gt 0 ]] && skip=$(
+    IFS=,
+    echo "${parallel[*]}"
+  )
+  out=$(SKIP="$skip" "${precommit_cmd[@]}" run --from-ref "$from" --to-ref "$to" \
+    --show-diff-on-failure </dev/null 2>&1) || rc=$?
+  printf '%s\n' "$out"
+  [[ "$rc" -eq 0 ]] || return "$rc"
+  [[ ${#parallel[@]} -eq 0 ]] && return 0
+
+  local tmp runner jobs
+  tmp=$(mktemp -d)
+  runner="$tmp/run-hook"
+  # The single quotes are deliberate: everything but the %q substitutions is the
+  # CHILD's source text, and expanding it here would bake this shell's values in.
+  # shellcheck disable=SC2016
+  {
+    echo '#!/bin/bash'
+    echo 'rc=0'
+    printf 'out=$(%s run "$1" --from-ref %q --to-ref %q --show-diff-on-failure </dev/null 2>&1) || rc=$?\n' \
+      "$(printf '%q ' "${precommit_cmd[@]}")" "$from" "$to"
+    printf 'printf "%%s\\n" "$out" >%q/"$1".log\n' "$tmp"
+    printf 'echo "$rc" >%q/"$1".rc\n' "$tmp"
+  } >"$runner"
+  chmod +x "$runner"
+  jobs=$(getconf _NPROCESSORS_ONLN 2>/dev/null) || jobs=4
+  printf '%s\n' "${parallel[@]}" | xargs -P "$jobs" -n1 "$runner"
+
+  # Report every failure, not just the first: the hooks ran concurrently, so
+  # stopping at one would hide results already computed.
+  for hook in "${parallel[@]}"; do
+    local hook_rc
+    hook_rc=$(<"$tmp/$hook.rc")
+    [[ "$hook_rc" -eq 0 ]] && continue
+    cat "$tmp/$hook.log"
+    # A real lint failure (1) outranks a provisioning failure (3). The caller
+    # degrades to a loud SKIP on 3, so letting 3 win would turn a hook that
+    # genuinely failed into "network blocked, never mind" and let the push
+    # through.
+    [[ "$rc" -eq 1 ]] && continue
+    rc="$hook_rc"
+  done
+  rm -rf "$tmp"
+  return "$rc"
+}
+
 # origin's default branch — the base the new-branch fallback diffs against.
 # "origin/main" is a documented, widely-correct default for the (rare) case
 # origin/HEAD isn't set locally; a wrong guess here only widens the diffed
@@ -162,9 +274,7 @@ while read -r -u 3 _local_ref local_sha remote_ref remote_sha; do
   # signatures instead would be self-defeating, since --show-diff-on-failure can
   # print a diff of THIS file containing those very strings.
   precommit_rc=0
-  precommit_out=$("${precommit_cmd[@]}" run --from-ref "$from_ref" --to-ref "$local_sha" --show-diff-on-failure </dev/null 2>&1) ||
-    precommit_rc=$?
-  printf '%s\n' "$precommit_out"
+  precommit_range "$from_ref" "$local_sha" || precommit_rc=$?
   if [[ "$precommit_rc" -eq 3 ]]; then
     echo "pre-push: pre-commit could not PROVISION a hook environment (network/egress blocked, not a lint failure) — SKIPPING the pushed-range run. CI still enforces the full suite on the PR." >&2
     continue

--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -105,26 +105,36 @@ while read -r -u 3 _local_ref local_sha remote_ref remote_sha; do
   # Deliberately BEFORE the pre-commit tool gate below, so it still runs on a
   # machine that has no pre-commit. `git push --no-verify` remains the override.
   #
-  # It asks about FEATURE branches, so it is not asked of a push aimed at the
-  # default branch itself. There "introduces nothing new" is never a stale local
-  # ref: a genuine no-op never reaches a hook (git answers "Everything
-  # up-to-date" first), so the only push it can describe is a deliberate
-  # rollback — including the one that restores a default branch someone
-  # clobbered, which is exactly when a refusal citing merged pull requests is
-  # both wrong and hardest to argue with.
+  # A ref pushed at $default_branch itself only reaches "ahead == 0" via a
+  # non-fast-forward (force) push — an ordinary push that adds nothing is
+  # rejected by git before this hook runs at all. That force can be a
+  # deliberate ROLLBACK (restoring a clobbered default branch) as easily as an
+  # accidental stale-ref push, and this hook cannot tell those apart — so it
+  # still refuses, the same as any other ref, but with wording that does not
+  # call a legitimate rollback a stale branch: the "restart from the default"
+  # advice is nonsense against the default branch's own ref, and `--no-verify`
+  # is the one mechanism that stays correct either way.
   if [[ "$remote_ref" == "$default_remote_ref" ]]; then
-    : # a push to the default branch itself; the rule does not apply
-  elif ! git rev-parse --verify --quiet "${default_branch}^{commit}" >/dev/null; then
-    echo "pre-push: ${default_branch} is not present locally — SKIPPING the merged-history check. Run 'git fetch origin' to enable it." >&2
+    default_ref_message=true
   else
+    default_ref_message=false
+  fi
+  if git rev-parse --verify --quiet "${default_branch}^{commit}" >/dev/null; then
     ahead=$(git rev-list --count "${default_branch}..${local_sha}")
     if [[ "$ahead" -eq 0 ]]; then
-      echo "pre-push: refusing to push ${remote_ref} — every commit in it is already contained in ${default_branch}, so this push introduces nothing." >&2
-      echo "pre-push: this is what a stale local ref looks like after its pull request merged. Restart the branch from the current default and put the follow-up work there:" >&2
-      echo "pre-push:   git fetch origin && git checkout -B \"\${branch}\" ${default_branch}" >&2
-      echo "pre-push: if the branch really does carry unmerged commits, fetch first — the local view of ${default_branch} may be behind. Override with 'git push --no-verify'." >&2
+      if [[ "$default_ref_message" == "true" ]]; then
+        echo "pre-push: refusing to force-push ${remote_ref} — it adds no commit beyond ${default_branch}." >&2
+        echo "pre-push: if this restores a default branch that was force-pushed to a bad state, that is a deliberate rollback, not a stale ref — override with 'git push --no-verify'." >&2
+      else
+        echo "pre-push: refusing to push ${remote_ref} — every commit in it is already contained in ${default_branch}, so this push introduces nothing." >&2
+        echo "pre-push: this is what a stale local ref looks like after its pull request merged. Restart the branch from the current default and put the follow-up work there:" >&2
+        echo "pre-push:   git fetch origin && git checkout -B \"\${branch}\" ${default_branch}" >&2
+        echo "pre-push: if the branch really does carry unmerged commits, fetch first — the local view of ${default_branch} may be behind. Override with 'git push --no-verify'." >&2
+      fi
       exit 1
     fi
+  else
+    echo "pre-push: ${default_branch} is not present locally — SKIPPING the merged-history check. Run 'git fetch origin' to enable it." >&2
   fi
 
   # No pre-commit anywhere: already announced above, so skip quietly here.

--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -66,6 +66,10 @@ fi
 # missing/wrong default branch is caught downstream when the range itself
 # fails to resolve. echo-fallback-ok: degraded default, not masked failure.
 default_branch=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || echo origin/main)
+# The same branch as a REMOTE ref, to recognise a push aimed at the default
+# branch itself. `default_branch` is "<remote>/<branch>"; only the remote name
+# is stripped, so a default branch containing a slash survives intact.
+default_remote_ref="refs/heads/${default_branch#*/}"
 
 # git feeds one line per ref being pushed: <local ref> <local sha> <remote ref>
 # <remote sha>. Check each pushed range. A remote sha of all zeros is a new
@@ -100,7 +104,19 @@ while read -r -u 3 _local_ref local_sha remote_ref remote_sha; do
   # carrying one new commit passes and there is no false positive to tune.
   # Deliberately BEFORE the pre-commit tool gate below, so it still runs on a
   # machine that has no pre-commit. `git push --no-verify` remains the override.
-  if git rev-parse --verify --quiet "${default_branch}^{commit}" >/dev/null; then
+  #
+  # It asks about FEATURE branches, so it is not asked of a push aimed at the
+  # default branch itself. There "introduces nothing new" is never a stale local
+  # ref: a genuine no-op never reaches a hook (git answers "Everything
+  # up-to-date" first), so the only push it can describe is a deliberate
+  # rollback — including the one that restores a default branch someone
+  # clobbered, which is exactly when a refusal citing merged pull requests is
+  # both wrong and hardest to argue with.
+  if [[ "$remote_ref" == "$default_remote_ref" ]]; then
+    : # a push to the default branch itself; the rule does not apply
+  elif ! git rev-parse --verify --quiet "${default_branch}^{commit}" >/dev/null; then
+    echo "pre-push: ${default_branch} is not present locally — SKIPPING the merged-history check. Run 'git fetch origin' to enable it." >&2
+  else
     ahead=$(git rev-list --count "${default_branch}..${local_sha}")
     if [[ "$ahead" -eq 0 ]]; then
       echo "pre-push: refusing to push ${remote_ref} — every commit in it is already contained in ${default_branch}, so this push introduces nothing." >&2
@@ -109,8 +125,6 @@ while read -r -u 3 _local_ref local_sha remote_ref remote_sha; do
       echo "pre-push: if the branch really does carry unmerged commits, fetch first — the local view of ${default_branch} may be behind. Override with 'git push --no-verify'." >&2
       exit 1
     fi
-  else
-    echo "pre-push: ${default_branch} is not present locally — SKIPPING the merged-history check. Run 'git fetch origin' to enable it." >&2
   fi
 
   # No pre-commit anywhere: already announced above, so skip quietly here.

--- a/.hooks/pre-push.test.mjs
+++ b/.hooks/pre-push.test.mjs
@@ -20,6 +20,7 @@ import { join } from "node:path";
 import { after, before, describe, it } from "node:test";
 
 import { repoRoot } from "../test/helpers/repo-root.mjs";
+import { cleanGitEnv } from "../test/helpers/git-env.mjs";
 
 const HOOK = join(repoRoot, ".hooks", "pre-push");
 const ZERO = "0".repeat(40);
@@ -28,15 +29,8 @@ let scratch;
 let origin;
 let clone;
 
-// Git's own environment must not leak in from whatever invoked this suite:
-// under the pre-commit hook `GIT_INDEX_FILE` names the OUTER repo's temporary
-// index, and every git call in this throwaway repo would use it.
-const cleanEnv = Object.fromEntries(
-  Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_")),
-);
-
 const git = (args, cwd) =>
-  execFileSync("git", args, { cwd, encoding: "utf8", env: cleanEnv }).trim();
+  execFileSync("git", args, { cwd, encoding: "utf8", env: cleanGitEnv }).trim();
 
 /**
  * Run the hook against `clone` with one ref line on stdin.
@@ -114,6 +108,31 @@ describe("pre-push merged-history guard", () => {
     );
     assert.equal(status, 0);
     assert.doesNotMatch(stderr, /already contained/);
+  });
+
+  it("allows a ROLLBACK of the default branch, which introduces nothing new", () => {
+    // Restoring a clobbered default branch pushes an ANCESTOR of origin/main,
+    // so `rev-list --count origin/main..<sha>` is 0 — indistinguishable from a
+    // stale feature branch by that count alone, and refused before the
+    // exemption. The remote sha is non-zero: this ref already exists.
+    git(["checkout", "-q", "-B", "ahead", "origin/main"], clone);
+    writeFileSync(join(clone, "later.txt"), "later\n");
+    git(["add", "-A"], clone);
+    git(["commit", "-qm", "feat: later work"], clone);
+    const rollbackTo = git(["rev-parse", "origin/main"], clone);
+    const current = headOf("HEAD");
+    const { status, stderr } = runHook(
+      `refs/heads/ahead ${rollbackTo} refs/heads/main ${current}`,
+    );
+    assert.equal(status, 0, `expected the rollback to pass, stderr: ${stderr}`);
+    assert.doesNotMatch(stderr, /already contained/);
+    // Non-vacuity: the SAME sha aimed at a feature branch is still refused, so
+    // the pass above comes from the ref being the default branch and nothing else.
+    const feature = runHook(
+      `refs/heads/ahead ${rollbackTo} refs/heads/other ${current}`,
+    );
+    assert.equal(feature.status, 1);
+    assert.match(feature.stderr, /every commit in it is already contained/);
   });
 
   it("skips a branch deletion", () => {

--- a/.hooks/pre-push.test.mjs
+++ b/.hooks/pre-push.test.mjs
@@ -14,14 +14,7 @@
  */
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import {
-  chmodSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, before, describe, it } from "node:test";
@@ -58,51 +51,6 @@ function runHook(refLine) {
 }
 
 const headOf = (ref) => git(["rev-parse", ref], clone);
-
-/**
- * Run the hook with a recording `pre-commit` stub first on PATH.
- *
- * `failing` names a hook id the stub should fail, so a test can prove one
- * concurrent hook's failure still aborts the push. Every invocation appends its
- * `SKIP` value and its argv to a log, which is what the fan-out assertions read.
- */
-function runHookWithStub(
-  refLine,
-  { failing = null, unprovisioned = null } = {},
-) {
-  const binDir = join(scratch, "stubbin");
-  const log = join(scratch, "precommit-calls");
-  mkdirSync(binDir, { recursive: true });
-  writeFileSync(log, "");
-  const stub = join(binDir, "pre-commit");
-  writeFileSync(
-    stub,
-    `#!/usr/bin/env bash\nprintf 'SKIP=%s ARGV=%s\\n' "\${SKIP:-}" "$*" >>${JSON.stringify(log)}\n` +
-      (failing
-        ? `[[ "\${2:-}" == ${JSON.stringify(failing)} ]] && { echo "stub: ${failing} failed"; exit 1; }\n`
-        : "") +
-      (unprovisioned
-        ? `[[ "\${2:-}" == ${JSON.stringify(unprovisioned)} ]] && exit 3\n`
-        : "") +
-      "exit 0\n",
-  );
-  chmodSync(stub, 0o755);
-  const result = spawnSync("bash", [HOOK], {
-    cwd: clone,
-    input: `${refLine}\n`,
-    encoding: "utf8",
-    env: {
-      PATH: `${binDir}:/usr/bin:/bin`,
-      HOME: join(scratch, "home"),
-    },
-  });
-  return {
-    status: result.status,
-    stdout: result.stdout,
-    stderr: result.stderr,
-    calls: readFileSync(log, "utf8").split("\n").filter(Boolean),
-  };
-}
 
 before(() => {
   scratch = mkdtempSync(join(tmpdir(), "pre-push-guard-"));
@@ -218,108 +166,6 @@ describe("pre-push merged-history guard", () => {
     } finally {
       git(["fetch", "-q", "origin"], clone);
       git(["remote", "set-head", "origin", "-a"], clone);
-    }
-  });
-});
-
-/**
- * The pushed-range lint is the expensive half of this hook, and the hooks that
- * only READ the tree are fanned out concurrently to pay for it. What that
- * partition must never do is drop a hook: every id the serial pass is told to
- * SKIP has to reappear as its own invocation, or a check silently stops running
- * on push while still reading as "pre-commit ran".
- */
-describe("pre-push pushed-range fan-out", () => {
-  let sha;
-
-  before(() => {
-    // The hook reads the real config to intersect its allowlist against the
-    // hooks that actually exist, so the throwaway clone needs one.
-    writeFileSync(
-      join(clone, ".pre-commit-config.yaml"),
-      [
-        "repos:",
-        "  - repo: local",
-        "    hooks:",
-        "      - id: trailing-whitespace",
-        "      - id: check-yaml",
-        "      - id: check-tier1",
-        "      - id: retired-hook-not-in-config",
-        "",
-      ].join("\n"),
-    );
-    git(["checkout", "-q", "-B", "fanout", "origin/main"], clone);
-    git(["add", "-A"], clone);
-    git(["commit", "-qm", "chore: seed a pre-commit config"], clone);
-    sha = headOf("HEAD");
-  });
-
-  const refLine = () => `refs/heads/fanout ${sha} refs/heads/fanout ${ZERO}`;
-
-  it("skips the read-only hooks serially and runs each of them on its own", () => {
-    const { status, calls } = runHookWithStub(refLine());
-    assert.equal(status, 0);
-
-    const serial = calls.filter((c) => /ARGV=run --from-ref/.test(c));
-    assert.equal(serial.length, 1, `expected one serial pass, got: ${calls}`);
-    const skipped = /SKIP=(\S*) /.exec(serial[0])[1].split(",").filter(Boolean);
-    // The mutating hook must NOT be skipped — it is why the serial pass exists.
-    assert.ok(!skipped.includes("trailing-whitespace"));
-    assert.deepEqual(skipped.slice().sort(), ["check-tier1", "check-yaml"]);
-
-    // Every skipped hook comes back as its own run. Deriving the expectation
-    // from `skipped` is what makes this a partition check rather than a list
-    // of names that can drift away from the hook's allowlist.
-    for (const hook of skipped) {
-      assert.equal(
-        calls.filter((c) => c.includes(`ARGV=run ${hook} --from-ref`)).length,
-        1,
-        `${hook} was skipped in the serial pass and never run on its own`,
-      );
-    }
-  });
-
-  it("does not invoke a hook the config no longer declares", () => {
-    // A stale allowlist entry would otherwise reach `pre-commit run <unknown>`,
-    // which dies and blocks every push.
-    const { calls } = runHookWithStub(refLine());
-    assert.ok(!calls.join("\n").includes("retired-hook-not-in-config"));
-  });
-
-  it("fails the push when one concurrently-run hook fails", () => {
-    const { status, stdout } = runHookWithStub(refLine(), {
-      failing: "check-tier1",
-    });
-    assert.equal(status, 1, "a failing read-only hook must abort the push");
-    assert.match(stdout, /stub: check-tier1 failed/);
-  });
-
-  it("lets a real failure outrank another hook's provisioning skip", () => {
-    // Exit 3 is "could not install a hook environment", which the caller
-    // degrades to a loud skip. If it won over a hook that genuinely failed, a
-    // sandbox that cannot reach an index would wave every lint error through.
-    const { status, stderr } = runHookWithStub(refLine(), {
-      failing: "check-tier1",
-      // check-yaml, not some hook absent from the fixture config: an id the
-      // config never declares is never run, and the case would prove nothing.
-      unprovisioned: "check-yaml",
-    });
-    assert.equal(status, 1, "a lint failure was masked by a provisioning skip");
-    assert.doesNotMatch(stderr, /could not PROVISION/);
-  });
-
-  it("falls back to ONE serial run when the working tree is dirty", () => {
-    // Concurrent pre-commit processes stash and restore unstaged changes over
-    // each other, which corrupts the tree mid-run. Nothing to stash is what
-    // makes the fan-out safe, so a dirty tree must not take it.
-    writeFileSync(join(clone, "seed.txt"), "dirtied, unstaged\n");
-    try {
-      const { status, calls } = runHookWithStub(refLine());
-      assert.equal(status, 0);
-      assert.equal(calls.length, 1, `expected one run, got: ${calls}`);
-      assert.match(calls[0], /^SKIP= ARGV=run --from-ref/);
-    } finally {
-      git(["checkout", "--", "seed.txt"], clone);
     }
   });
 });

--- a/.hooks/pre-push.test.mjs
+++ b/.hooks/pre-push.test.mjs
@@ -14,7 +14,14 @@
  */
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, before, describe, it } from "node:test";
@@ -51,6 +58,51 @@ function runHook(refLine) {
 }
 
 const headOf = (ref) => git(["rev-parse", ref], clone);
+
+/**
+ * Run the hook with a recording `pre-commit` stub first on PATH.
+ *
+ * `failing` names a hook id the stub should fail, so a test can prove one
+ * concurrent hook's failure still aborts the push. Every invocation appends its
+ * `SKIP` value and its argv to a log, which is what the fan-out assertions read.
+ */
+function runHookWithStub(
+  refLine,
+  { failing = null, unprovisioned = null } = {},
+) {
+  const binDir = join(scratch, "stubbin");
+  const log = join(scratch, "precommit-calls");
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(log, "");
+  const stub = join(binDir, "pre-commit");
+  writeFileSync(
+    stub,
+    `#!/usr/bin/env bash\nprintf 'SKIP=%s ARGV=%s\\n' "\${SKIP:-}" "$*" >>${JSON.stringify(log)}\n` +
+      (failing
+        ? `[[ "\${2:-}" == ${JSON.stringify(failing)} ]] && { echo "stub: ${failing} failed"; exit 1; }\n`
+        : "") +
+      (unprovisioned
+        ? `[[ "\${2:-}" == ${JSON.stringify(unprovisioned)} ]] && exit 3\n`
+        : "") +
+      "exit 0\n",
+  );
+  chmodSync(stub, 0o755);
+  const result = spawnSync("bash", [HOOK], {
+    cwd: clone,
+    input: `${refLine}\n`,
+    encoding: "utf8",
+    env: {
+      PATH: `${binDir}:/usr/bin:/bin`,
+      HOME: join(scratch, "home"),
+    },
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    calls: readFileSync(log, "utf8").split("\n").filter(Boolean),
+  };
+}
 
 before(() => {
   scratch = mkdtempSync(join(tmpdir(), "pre-push-guard-"));
@@ -166,6 +218,108 @@ describe("pre-push merged-history guard", () => {
     } finally {
       git(["fetch", "-q", "origin"], clone);
       git(["remote", "set-head", "origin", "-a"], clone);
+    }
+  });
+});
+
+/**
+ * The pushed-range lint is the expensive half of this hook, and the hooks that
+ * only READ the tree are fanned out concurrently to pay for it. What that
+ * partition must never do is drop a hook: every id the serial pass is told to
+ * SKIP has to reappear as its own invocation, or a check silently stops running
+ * on push while still reading as "pre-commit ran".
+ */
+describe("pre-push pushed-range fan-out", () => {
+  let sha;
+
+  before(() => {
+    // The hook reads the real config to intersect its allowlist against the
+    // hooks that actually exist, so the throwaway clone needs one.
+    writeFileSync(
+      join(clone, ".pre-commit-config.yaml"),
+      [
+        "repos:",
+        "  - repo: local",
+        "    hooks:",
+        "      - id: trailing-whitespace",
+        "      - id: check-yaml",
+        "      - id: check-tier1",
+        "      - id: retired-hook-not-in-config",
+        "",
+      ].join("\n"),
+    );
+    git(["checkout", "-q", "-B", "fanout", "origin/main"], clone);
+    git(["add", "-A"], clone);
+    git(["commit", "-qm", "chore: seed a pre-commit config"], clone);
+    sha = headOf("HEAD");
+  });
+
+  const refLine = () => `refs/heads/fanout ${sha} refs/heads/fanout ${ZERO}`;
+
+  it("skips the read-only hooks serially and runs each of them on its own", () => {
+    const { status, calls } = runHookWithStub(refLine());
+    assert.equal(status, 0);
+
+    const serial = calls.filter((c) => /ARGV=run --from-ref/.test(c));
+    assert.equal(serial.length, 1, `expected one serial pass, got: ${calls}`);
+    const skipped = /SKIP=(\S*) /.exec(serial[0])[1].split(",").filter(Boolean);
+    // The mutating hook must NOT be skipped — it is why the serial pass exists.
+    assert.ok(!skipped.includes("trailing-whitespace"));
+    assert.deepEqual(skipped.slice().sort(), ["check-tier1", "check-yaml"]);
+
+    // Every skipped hook comes back as its own run. Deriving the expectation
+    // from `skipped` is what makes this a partition check rather than a list
+    // of names that can drift away from the hook's allowlist.
+    for (const hook of skipped) {
+      assert.equal(
+        calls.filter((c) => c.includes(`ARGV=run ${hook} --from-ref`)).length,
+        1,
+        `${hook} was skipped in the serial pass and never run on its own`,
+      );
+    }
+  });
+
+  it("does not invoke a hook the config no longer declares", () => {
+    // A stale allowlist entry would otherwise reach `pre-commit run <unknown>`,
+    // which dies and blocks every push.
+    const { calls } = runHookWithStub(refLine());
+    assert.ok(!calls.join("\n").includes("retired-hook-not-in-config"));
+  });
+
+  it("fails the push when one concurrently-run hook fails", () => {
+    const { status, stdout } = runHookWithStub(refLine(), {
+      failing: "check-tier1",
+    });
+    assert.equal(status, 1, "a failing read-only hook must abort the push");
+    assert.match(stdout, /stub: check-tier1 failed/);
+  });
+
+  it("lets a real failure outrank another hook's provisioning skip", () => {
+    // Exit 3 is "could not install a hook environment", which the caller
+    // degrades to a loud skip. If it won over a hook that genuinely failed, a
+    // sandbox that cannot reach an index would wave every lint error through.
+    const { status, stderr } = runHookWithStub(refLine(), {
+      failing: "check-tier1",
+      // check-yaml, not some hook absent from the fixture config: an id the
+      // config never declares is never run, and the case would prove nothing.
+      unprovisioned: "check-yaml",
+    });
+    assert.equal(status, 1, "a lint failure was masked by a provisioning skip");
+    assert.doesNotMatch(stderr, /could not PROVISION/);
+  });
+
+  it("falls back to ONE serial run when the working tree is dirty", () => {
+    // Concurrent pre-commit processes stash and restore unstaged changes over
+    // each other, which corrupts the tree mid-run. Nothing to stash is what
+    // makes the fan-out safe, so a dirty tree must not take it.
+    writeFileSync(join(clone, "seed.txt"), "dirtied, unstaged\n");
+    try {
+      const { status, calls } = runHookWithStub(refLine());
+      assert.equal(status, 0);
+      assert.equal(calls.length, 1, `expected one run, got: ${calls}`);
+      assert.match(calls[0], /^SKIP= ARGV=run --from-ref/);
+    } finally {
+      git(["checkout", "--", "seed.txt"], clone);
     }
   });
 });

--- a/.hooks/pre-push.test.mjs
+++ b/.hooks/pre-push.test.mjs
@@ -110,11 +110,12 @@ describe("pre-push merged-history guard", () => {
     assert.doesNotMatch(stderr, /already contained/);
   });
 
-  it("allows a ROLLBACK of the default branch, which introduces nothing new", () => {
-    // Restoring a clobbered default branch pushes an ANCESTOR of origin/main,
-    // so `rev-list --count origin/main..<sha>` is 0 — indistinguishable from a
-    // stale feature branch by that count alone, and refused before the
-    // exemption. The remote sha is non-zero: this ref already exists.
+  it("still refuses a force-push to the default branch that adds nothing, with rollback-aware wording", () => {
+    // A ref pushed AT origin/main only reaches "ahead == 0" via a force push —
+    // an ordinary push adding nothing is rejected by git before the hook runs.
+    // The hook cannot tell a deliberate rollback from an accidental stale
+    // force-push, so it still refuses; only the message changes, so the
+    // rollback case doesn't get told to "restart the branch" against itself.
     git(["checkout", "-q", "-B", "ahead", "origin/main"], clone);
     writeFileSync(join(clone, "later.txt"), "later\n");
     git(["add", "-A"], clone);
@@ -124,15 +125,20 @@ describe("pre-push merged-history guard", () => {
     const { status, stderr } = runHook(
       `refs/heads/ahead ${rollbackTo} refs/heads/main ${current}`,
     );
-    assert.equal(status, 0, `expected the rollback to pass, stderr: ${stderr}`);
+    assert.equal(status, 1, `expected the refusal, stderr: ${stderr}`);
     assert.doesNotMatch(stderr, /already contained/);
-    // Non-vacuity: the SAME sha aimed at a feature branch is still refused, so
-    // the pass above comes from the ref being the default branch and nothing else.
+    assert.doesNotMatch(stderr, /restart the branch/i);
+    assert.match(stderr, /deliberate rollback/);
+    assert.match(stderr, /--no-verify/);
+    // Non-vacuity: the SAME sha aimed at a feature branch gets the ordinary
+    // feature-branch wording instead, so the message above is keyed on the
+    // ref being the default branch and nothing else.
     const feature = runHook(
       `refs/heads/ahead ${rollbackTo} refs/heads/other ${current}`,
     );
     assert.equal(feature.status, 1);
     assert.match(feature.stderr, /every commit in it is already contained/);
+    assert.doesNotMatch(feature.stderr, /deliberate rollback/);
   });
 
   it("skips a branch deletion", () => {

--- a/test/helpers/git-env.mjs
+++ b/test/helpers/git-env.mjs
@@ -1,0 +1,20 @@
+/**
+ * A `process.env` with git's own variables removed, for any test that builds a
+ * throwaway repository and drives it with `git`.
+ *
+ * `GIT_DIR`, `GIT_INDEX_FILE` and `GIT_WORK_TREE` OVERRIDE `git -C <dir>` and
+ * `{ cwd }` — they name the repository directly, so a child git inherits the
+ * caller's repository no matter which directory it is pointed at. Two callers
+ * set them: git itself, for every hook it runs (a suite driven by `pre-commit`
+ * inherits the outer repo's temporary index), and anyone reproducing a hook
+ * environment by hand. Either way a fixture's `git commit`, `git branch -M
+ * main` and `git push origin main` land in the REAL repository and, with a real
+ * `origin`, on the real remote.
+ *
+ * Filtering the whole `GIT_*` prefix rather than the three names above keeps
+ * `GIT_OBJECT_DIRECTORY`, `GIT_COMMON_DIR`, `GIT_NAMESPACE` and any future
+ * sibling out too; a fixture repo needs none of them.
+ */
+export const cleanGitEnv = Object.fromEntries(
+  Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_")),
+);


### PR DESCRIPTION
Claims: `.github/scripts/auto-resolve/` (bundle + prepare), `.hooks/pre-push`, and the `GIT_*` isolation of every test fixture.

## Summary

PR #311 conflicted on generated files even though this repo has an auto-resolve pipeline for exactly that case, and the auto-resolve run failed. Root cause: `bundle.sh` **regenerated** the deferred generator-owned files but never **staged** them. Generator output written to the working tree leaves the path `UNMERGED` in the index, so the very next check rejected every deferred path and the run aborted — the generated-file path had never worked.

Proven empirically in a scratch repo, not by reading.

## Changes

- **`bundle.sh` — stage the regeneration.** The deferred paths are staged after a clean `resolve-generated` run. Staging is gated on the run exiting 0: `resolve-generated` stops at its first failing rule, and a later rule's output would still hold git's "ours" side.
- **`bundle.sh` — require evidence of a rewrite before staging.** A generator-owned conflict can be marker-free (binary, or modify/delete): `prepare.sh` routes on ownership *before* either classification, so git leaves its surviving side verbatim and the marker scan cannot see it. Each deferred path's content is now hashed before the generator runs, and only a path whose content actually changed is staged.
- **`bundle.sh` — a generator-driven deletion is a resolution.** Present before a clean run and absent after means the resolved sources no longer produce that artifact; the deletion is staged. Absent on both sides still fails loud.
- **`prepare.sh` — delete the dead regen pre-pass.** Whatever it wrote mid-merge was provisional (the sources could still carry markers) and was staged nowhere, so it changed no unmerged path's stage, and `bundle.sh` regenerates from scratch afterwards regardless. A comment claiming the pre-pass was the real gate is corrected.
- **`.hooks/pre-push` — keep the merged-history guard on the default branch.** A ref pushed at the default branch reaching "ahead == 0" is a force-push, which can be a deliberate rollback or an accidental stale ref; the hook cannot tell them apart, so it still refuses. Only the wording changes, so a legitimate rollback isn't told to "restart the branch" against itself. `--no-verify` stays the override.
- **`test/helpers/git-env.mjs` — new shared `cleanGitEnv`.** `GIT_DIR` / `GIT_INDEX_FILE` / `GIT_WORK_TREE` override both `git -C <dir>` and a child's `cwd`, and git exports them into every hook it runs. A fixture that inherits them writes to the *outer* repository. Applied across all 10 suites that build throwaway repos.

## Tests

- 3 new `bundle.test.mjs` cases: staged regeneration (asserts the committed bytes are the generator's answer, not git's "ours"), a generator-driven deletion staging as a deletion, and a generator that exits 0 without rewriting failing loud *before* the marker scan.
- 1 new `pre-push.test.mjs` case for the default-branch wording, with a non-vacuity control that the same SHA aimed at a feature ref gets the ordinary wording.
- Every new test verified non-vacuous against the unfixed code.
- `bundle.test.mjs` 19/19, auto-resolve suite 131/131, `pre-push.test.mjs` 6/6.
- The suites were verified immune to `GIT_*`: identical results with and without `GIT_DIR` set, and the real repo untouched afterwards.

## Decisions made

- **A generator whose output is byte-identical to git's surviving side now fails the run rather than being staged.** There is no clock-free way to tell "the generator produced exactly this" from "the generator never touched it", and this direction hands off to a human instead of bundling possibly-stale content. The alternative — staging on existence alone — is what the P1 review comment flagged.
- **Parallelising the pre-push pre-commit run was built, measured, and reverted** (`1c362f4`, reverted by `861265d`). pre-commit's own overhead is 0.4s, so the ~16s is real hook work and parallelism was the only lever. Two findings killed it: concurrent `pre-commit run` processes stash and restore unstaged changes over each other (measured: bogus "files were modified by this hook" against an untouched tree, plus a suite failing that passes 12/12 in isolation), and even gated on a clean tree the fan-out came in at 15.4s against a ~16s serial baseline — the tail is a single hook, `check-symlinks` at 5.7s standalone and 9.2s under contention. The commit and its revert are both kept so the measurement isn't lost. The real target is that one hook, not the scheduling.

## Lessons Learned

- **What:** Don't parallelise `pre-commit` by running one process per hook id. **Where:** any template `.hooks/pre-push` that runs `pre-commit run --from-ref/--to-ref`. **Why:** pre-commit stashes unstaged tracked changes for the duration of a run and restores them after, so concurrent invocations restore over each other and corrupt the working tree mid-run — it surfaces as "files were modified by this hook" against a tree nothing touched, and as unrelated suites failing. A clean-tree gate makes it safe but not faster; measure the per-hook tail before reaching for scheduling.
- **What:** Ship a `cleanGitEnv` helper and use it in every test that builds a throwaway git repo. **Where:** `test/helpers/git-env.mjs` in the template. **Why:** `GIT_DIR`/`GIT_INDEX_FILE`/`GIT_WORK_TREE` override `git -C` and a child process's `cwd`, and git exports them to every hook it runs. A fixture that inherits them silently operates on the real repository and its remote — this cost a clobbered `main` in the session that produced this PR.
