### PR TITLE
ci: fetch the PR diff through the API so escape sequences cannot block review

### DIFF
--- a/.github/scripts/prepare-pr-review-input.sh
+++ b/.github/scripts/prepare-pr-review-input.sh
@@ -2,8 +2,8 @@
 # Fetch the untrusted PR diff + metadata and run them through the
 # agent-sanitizer (sanitize-pr-input.mjs) BEFORE the review agent sees
 # them. The agent reads only the sanitized files this writes — never the raw
-# `gh pr diff` — so an injection payload hidden in the diff (zero-width control
-# text, ANSI escapes, exfil beacons) cannot reach the agent intact.
+# diff — so an injection payload hidden in it (zero-width control text, ANSI
+# escapes, exfil beacons) cannot reach the agent intact.
 #
 # Oversized-diff guard: the base-only checkout means diff.txt is the ONLY source
 # of the PR's changes — the agent cannot reconstruct them from the trusted base

--- a/.github/scripts/prepare-pr-review-input.sh
+++ b/.github/scripts/prepare-pr-review-input.sh
@@ -44,10 +44,17 @@ emit_output() {
 # diff.txt ever reaches the reviewer.
 raw_diff="$(mktemp)"
 trap 'rm -f "$raw_diff"' EXIT
+# The diff media type via `gh api`, not `gh pr diff`: that command refuses to
+# emit a diff holding terminal escape sequences unless --allow-escape-sequences
+# is passed, so it fails closed on exactly the payloads this pipeline exists to
+# sanitize — and that flag is absent from older gh builds. The API response
+# carries no such guard, and only the sanitizer below ever reads these bytes.
+#
 # retry_stdout via a command substitution: a transient blip re-fetches the whole
 # diff and only the succeeding attempt's bytes land in raw_diff. A plain `retry
 # … >"$raw_diff"` would leak a failing attempt's error body into the file.
-raw_diff_content="$(retry_stdout gh pr diff "$PR")"
+raw_diff_content="$(retry_stdout gh api "repos/{owner}/{repo}/pulls/${PR}" \
+  -H "Accept: application/vnd.github.v3.diff")"
 printf '%s\n' "$raw_diff_content" >"$raw_diff"
 
 diff_lines="$(wc -l <"$raw_diff" | tr -d '[:space:]')"

--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -9,9 +9,9 @@ name: Claude PR review
 #   trusted context (with secrets), so to stay safe this job:
 #     1. checks out the BASE branch, never the untrusted PR head — no
 #        fork-authored code is ever checked out or executed here;
-#     2. reads the PR's changes only as DATA via `gh pr diff` (a unified diff
-#        fetched from the API), and the prompt treats that diff as untrusted
-#        input, never as instructions;
+#     2. reads the PR's changes only as DATA (a unified diff fetched from the
+#        API), and the prompt treats that diff as untrusted input, never as
+#        instructions;
 #     3. holds least privilege — contents:read + pull-requests:write only, so
 #        even a successful prompt injection can post a PR comment but cannot
 #        push code, merge, or reach any other scope.
@@ -171,8 +171,8 @@ jobs:
       - name: Fetch and sanitize the untrusted PR input
         # Runs the diff + metadata through the agent-sanitizer BEFORE Claude
         # sees them, writing sanitized files under runner.temp. Claude reads only
-        # those files (below), never the raw `gh pr diff` — so an injection hidden
-        # in the diff (invisible control text, ANSI escapes, exfil beacons) is
+        # those files (below), never the raw diff — so an injection hidden
+        # in it (invisible control text, ANSI escapes, exfil beacons) is
         # neutralized before it can reach the agent. Also gates the review by
         # size: a diff over MAX_DIFF_LINES sets oversized=true and the Opus read
         # is skipped (the notice step below asks for a human review instead).


### PR DESCRIPTION
## Summary

`gh pr diff` refuses to emit a diff containing terminal escape sequences unless `--allow-escape-sequences` is passed. `prepare-pr-review-input.sh` therefore fails **closed** on exactly the payload class the reviewer's sanitizer pipeline exists to inspect — the job dies before `sanitize-pr-input.mjs` ever runs, so the PR gets no automated review at all.

Observed on #320, which carries a raw ESC byte in its diff (`test/claude-hooks-authored-scope.test.mjs:35`, pre-existing, pulled into a hunk as context):

```
the diff contains terminal escape sequences; pass --allow-escape-sequences to output it anyway
ci-retry: 'gh pr diff 320' failed (attempt 1/5); retrying in 2s
...
ci-retry: 'gh pr diff 320' still failing after 5 attempts — giving up
##[error]Process completed with exit code 1.
```

Two things make this worse than a one-off. The refusal is permanent but the retry wrapper makes it *read* like a transient network blip, so all five attempts are spent on it. And the failure is self-perpetuating from the affected PR's side: you cannot delete a raw byte from a file without that byte appearing in the diff as a deletion, so neither keeping nor removing the offending line clears it.

## Changes

- `.github/scripts/prepare-pr-review-input.sh` fetches the diff with `gh api "repos/{owner}/{repo}/pulls/${PR}" -H "Accept: application/vnd.github.v3.diff"` instead of `gh pr diff "$PR"`.

Chosen over `gh pr diff --allow-escape-sequences`: that flag works on the hosted runner (its own error message names it) but is absent from older gh builds a self-hosted runner may carry, so it swaps one version-dependent failure for another. The API response carries no terminal guard on any version.

Passing raw escape bytes through is safe here precisely because this script's whole job is to run them through `sanitize-pr-input.mjs` before the reviewer reads them. The bytes land in a `mktemp` file outside `PR_INPUT_DIR`, which is the only directory the review step grants the agent — that boundary is unchanged. `gh`'s guard protects a terminal, and there is never a terminal in this path.

## Tests / verification

- `bash -n .github/scripts/prepare-pr-review-input.sh` — clean. `script-reachability.test.mjs` passes (pre-commit guard-pair).
- **This PR is its own end-to-end test.** It is reviewed by `main`'s *current* script — the one still calling `gh pr diff` — which succeeds because this diff holds no ESC byte. A green `Claude PR review` here confirms the change is correctly scoped and not self-blocking. Gated before commit: `git diff origin/main...HEAD | grep -c $'\x1b'` → `0`.
- The fix's real proof lands after merge: #320's `Claude PR review` job re-checks out `base.ref`, picks up this script, and should go green on a diff that currently kills it.

Deliberately carries **only** the script. #320 also touches `test/claude-hooks-authored-scope.test.mjs` to spell its `ESC` constant as `""` (which that line's own comment already claims it is); bringing that here would put a raw ESC deletion in *this* diff and reproduce the deadlock in a new PR. Three other test files still hold literal ESC bytes — this script fix is the systemic answer, so sweeping them would move the landmine rather than remove it.

## Lessons Learned

- **What**: Fetch the PR diff with `gh api "repos/{owner}/{repo}/pulls/$PR" -H "Accept: application/vnd.github.v3.diff"` instead of `gh pr diff "$PR"`.
- **Where**: `.github/scripts/prepare-pr-review-input.sh` (consumed by `claude-pr-review.yaml` and `claude-review-thread-resolve.yaml`).
- **Why**: `gh pr diff`'s escape-sequence refusal makes the automated reviewer fail closed on exactly the payloads it exists to inspect. Any downstream repo whose diff touches a generated bundle, a CLI-output snapshot, or an ANSI test fixture silently gets no review, and the retry wrapper disguises the permanent refusal as a transient blip. The API media type has no terminal guard on any gh version.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8V3DMSvfeWjiRuDng2eDp)_