### PR TITLE
fix(ci): fetch the PR diff with curl, not gh api, to clear the escape-sequence guard

### DIFF
--- a/.github/scripts/prepare-pr-review-input.sh
+++ b/.github/scripts/prepare-pr-review-input.sh
@@ -12,8 +12,9 @@
 # MAX_DIFF_LINES lines this skips the review, emitting oversized=true so the
 # caller posts a "please review manually" notice instead of spending the read.
 #
-# Requires: gh authenticated (GH_TOKEN/GH_REPO), node + `pnpm install` done
-# (agent-sanitizer on the module path). Emits to GITHUB_OUTPUT:
+# Requires: GH_TOKEN/GH_REPO (the diff fetch calls the API directly with these;
+# `gh pr view` below still expects them as gh's own auth env vars), node +
+# `pnpm install` done (agent-sanitizer on the module path). Emits to GITHUB_OUTPUT:
 #   oversized=true|false       — whether the review was skipped for size
 #   diff_lines=<n>             — the diff's line count (only when oversized)
 # Writes into $PR_INPUT_DIR (only when NOT oversized):
@@ -28,6 +29,8 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib-ci-retry.sh"
 
 : "${PR:?PR number required}"
 : "${PR_INPUT_DIR:?PR_INPUT_DIR required}"
+: "${GH_TOKEN:?GH_TOKEN required}"
+: "${GH_REPO:?GH_REPO required}"
 
 MAX_DIFF_LINES="${MAX_DIFF_LINES:-20000}"
 
@@ -44,17 +47,23 @@ emit_output() {
 # diff.txt ever reaches the reviewer.
 raw_diff="$(mktemp)"
 trap 'rm -f "$raw_diff"' EXIT
-# The diff media type via `gh api`, not `gh pr diff`: that command refuses to
-# emit a diff holding terminal escape sequences unless --allow-escape-sequences
-# is passed, so it fails closed on exactly the payloads this pipeline exists to
-# sanitize — and that flag is absent from older gh builds. The API response
-# carries no such guard, and only the sanitizer below ever reads these bytes.
+# curl for the diff media type, not `gh api`/`gh pr diff`: gh's own
+# client-side safety guard (pkg/iostreams content sanitization) refuses to
+# print ANY response holding a raw terminal escape sequence unless
+# --allow-escape-sequences is passed, and that guard fires identically whether
+# the request is made through `gh pr diff` or `gh api` — it is not a `pr diff`
+# quirk, so switching gh subcommands cannot clear it. curl has no such guard,
+# and only the sanitizer below ever reads these bytes.
 #
 # retry_stdout via a command substitution: a transient blip re-fetches the whole
 # diff and only the succeeding attempt's bytes land in raw_diff. A plain `retry
 # … >"$raw_diff"` would leak a failing attempt's error body into the file.
-raw_diff_content="$(retry_stdout gh api "repos/{owner}/{repo}/pulls/${PR}" \
-  -H "Accept: application/vnd.github.v3.diff")"
+api_url="${GITHUB_API_URL:-https://api.github.com}"
+raw_diff_content="$(retry_stdout curl -fsS \
+  -H "Authorization: Bearer ${GH_TOKEN}" \
+  -H "Accept: application/vnd.github.v3.diff" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "${api_url}/repos/${GH_REPO}/pulls/${PR}")"
 printf '%s\n' "$raw_diff_content" >"$raw_diff"
 
 diff_lines="$(wc -l <"$raw_diff" | tr -d '[:space:]')"


### PR DESCRIPTION
## Summary

PR #321 tried to fix `Claude PR review`/`Review findings resolved` staying red on any PR whose diff contains a raw terminal escape sequence, by switching `.github/scripts/prepare-pr-review-input.sh` from `gh pr diff` to `gh api ... -H "Accept: application/vnd.github.v3.diff"`. That switch didn't actually fix anything: `gh`'s escape-sequence refusal (`pkg/iostreams` content sanitization) is not specific to `gh pr diff` — it fires identically for `gh api` (`pkg/cmd/api/api.go` wraps the same `iostreams.ErrEscapeSequence`/`--allow-escape-sequences` guard). #320 reproduced the exact same failure after #321 merged, just with the error now coming from `gh api` instead of `gh pr diff`:

```
the response contains terminal escape sequences; pass --allow-escape-sequences to output it anyway
ci-retry: 'gh api repos/{owner}/{repo}/pulls/320 -H Accept: application/vnd.github.v3.diff' still failing after 5 attempts — giving up
```

This PR fetches the diff with `curl` instead of any `gh` subcommand. `curl` has no client-side content-sanitization layer, so it fetches the diff media type unconditionally; the sanitizer downstream is the only thing that ever reads or filters these bytes, exactly as the surrounding comments already describe.

## Changes

- `.github/scripts/prepare-pr-review-input.sh`: replace the `gh api` diff fetch with a direct `curl` call against `${GITHUB_API_URL:-https://api.github.com}/repos/${GH_REPO}/pulls/${PR}` (same media type, same retry wrapper), matching the existing `curl`-against-the-API pattern already used elsewhere in this repo (`report-job-result.sh`, `check-token-scope.sh`). Added explicit `GH_TOKEN`/`GH_REPO` requiredness guards since they're now read directly rather than only via `gh`'s own env-var convention.

## Tests / verification

- `bash -n` and `shellcheck` clean.
- Local end-to-end repro: served a mock diff response containing a raw ESC byte (`\x1b[m`) from a throwaway HTTP server, pointed the script at it via `GITHUB_API_URL`, and confirmed the fetch succeeds where `gh api`/`gh pr diff` refuse — the script writes a sanitized `diff.txt` with the ANSI escape stripped and correctly flagged in `sanitizer-report.txt`.
- Confirmed via `curl` against the same local server that the raw ESC byte passes through untouched (`od -c` shows `033` intact) — there is no equivalent of `gh`'s guard to trip.
- The guarded test pair for `.github/scripts/` (`script-reachability.test.mjs`) and the authored-scope partition tests pass.
- This PR's own diff carries no raw escape bytes (`git diff origin/main...HEAD | grep -c $'\x1b'` → `0`), so it is reviewable by `main`'s current script without hitting the bug it fixes.

## Checklist

- [x] Commits follow Conventional Commits; subject reads as a user-facing release note.
- [x] `bash -n`/`shellcheck` pass locally (full `pnpm test` not re-run for this single-file CI script change; the guarded reachability/partition tests were run directly).
- [x] N/A — this is a CI script fix, not a detector change.
- [x] No real secrets/tokens in the diff, tests, or description (the mock server used a `dummy-token` placeholder).
- [x] `CHANGELOG.md` and `package.json` version untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8V3DMSvfeWjiRuDng2eDp)_