### PR TITLE
fix(claude-hooks): report empty hook stdin as its own error, not a failed scan

### DIFF
--- a/claude-hooks/lib/hook-io.mjs
+++ b/claude-hooks/lib/hook-io.mjs
@@ -387,12 +387,31 @@ export function lastStdinByteLength() {
 }
 
 /**
+ * A hook run that received no event at all: stdin closed with zero bytes. Its
+ * own type, not the `SyntaxError` an empty string gets from `JSON.parse`,
+ * because the two are different faults with different fixes — a malformed
+ * payload is a sender that sent something wrong, an empty one is a hook wired to
+ * a channel that sent nothing, and a caller that cannot tell them apart reports
+ * the wrong cause and offers remedies for content it never received.
+ */
+export class EmptyStdinError extends Error {
+  constructor() {
+    super("empty stdin: the hook received no payload");
+    this.name = "EmptyStdinError";
+  }
+}
+
+/**
  * @param {number} [maxBytes] cap before aborting (overridable for tests)
  * @returns {Promise<any>}
  */
 export async function readStdinJson(maxBytes = MAX_STDIN_BYTES) {
   const buf = await readAllBounded(process.stdin, maxBytes);
   lastStdinBytes = buf.length;
+  // Before the parse, so the empty case never reaches JSON.parse and never
+  // renders as malformed JSON. A non-empty payload — malformed or not — is
+  // untouched by this guard.
+  if (buf.length === 0) throw new EmptyStdinError();
   return JSON.parse(buf.toString());
 }
 

--- a/claude-hooks/lib/hook-io.mjs
+++ b/claude-hooks/lib/hook-io.mjs
@@ -408,9 +408,7 @@ export class EmptyStdinError extends Error {
 export async function readStdinJson(maxBytes = MAX_STDIN_BYTES) {
   const buf = await readAllBounded(process.stdin, maxBytes);
   lastStdinBytes = buf.length;
-  // Before the parse, so the empty case never reaches JSON.parse and never
-  // renders as malformed JSON. A non-empty payload — malformed or not — is
-  // untouched by this guard.
+  // Before the parse, so the empty case never renders as malformed JSON.
   if (buf.length === 0) throw new EmptyStdinError();
   return JSON.parse(buf.toString());
 }

--- a/claude-hooks/scan-loaded-instructions.mjs
+++ b/claude-hooks/scan-loaded-instructions.mjs
@@ -20,6 +20,7 @@
 import { readFileSync } from "node:fs";
 import {
   emitHookResponse,
+  EmptyStdinError,
   HookEvent,
   isMain,
   lazyImport,
@@ -82,6 +83,30 @@ function faultLine(ctx) {
   );
 }
 
+/**
+ * The parts for a run that received no event at all, or null when the fault is
+ * anything else. Zero bytes on stdin means no InstructionsLoaded payload was
+ * delivered, so no file was named and none went unscanned: the fault is in how
+ * the hook was INVOKED, not in a scan. Both postures render it the same way and
+ * neither arms the tool-call gate — that gate asks the user to clear something
+ * about this project's instruction files, and this fault says nothing about
+ * them, so arming it blocks the next tool call over a hook that was handed no
+ * event.
+ * @param {import("./lib/hook-fault.mjs").FaultContext} ctx
+ * @returns {import("./lib/hook-fault.mjs").FaultParts | null}
+ */
+function emptyPayloadParts(ctx) {
+  if (!(ctx.err instanceof EmptyStdinError)) return null;
+  return {
+    stderr:
+      `${HOOK_NAME} hook error: ${ctx.message}. No instruction file was named, so nothing ` +
+      "was scanned and nothing was left unguarded. Check how this hook is invoked: it reads " +
+      "its InstructionsLoaded event as JSON on stdin, and one wired to a channel that " +
+      "delivers nothing scans nothing for the whole session.\n",
+    exitCode: 1,
+  };
+}
+
 // This hook's entry in the one posture table (lib/hook-fault.mjs). Like
 // scan-invisible-chars it has no stdout verdict channel — InstructionsLoaded
 // cannot block, and its exit code is ignored — so both arms are stated
@@ -90,15 +115,17 @@ function faultLine(ctx) {
 registerFaultPolicy(HOOK_NAME, {
   event: HookEvent.INSTRUCTIONS_LOADED,
   guarded: "a loaded instruction file",
-  open: (ctx) => ({
-    stderr: `${faultLine(ctx)} Passing through unguarded; set AGENT_SANITIZER_FAIL_OPEN=0 to arm the tool-call gate instead.\n`,
-    exitCode: 1,
-  }),
-  closed: (ctx) => ({
-    stderr: `${faultLine(ctx)} Arming the tool-call gate (AGENT_SANITIZER_FAIL_OPEN=0).\n`,
-    exitCode: 1,
-    armAlert: true,
-  }),
+  open: (ctx) =>
+    emptyPayloadParts(ctx) ?? {
+      stderr: `${faultLine(ctx)} Passing through unguarded; set AGENT_SANITIZER_FAIL_OPEN=0 to arm the tool-call gate instead.\n`,
+      exitCode: 1,
+    },
+  closed: (ctx) =>
+    emptyPayloadParts(ctx) ?? {
+      stderr: `${faultLine(ctx)} Arming the tool-call gate (AGENT_SANITIZER_FAIL_OPEN=0).\n`,
+      exitCode: 1,
+      armAlert: true,
+    },
 });
 
 /**

--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=b54f1c548096f70259d3cba6883ac8e40f105848a7d15feff79a1a79f29b6515
-58767b5f6b6dec5a647456e1462c95f5b6ef9f5d2c12d12914db0a65829579d1  agent-sanitizer-hooks-darwin-arm64
-54002105f9759a48431e46b1173c429c688e2ed9d453109f30f22227d3952d6a  agent-sanitizer-hooks-darwin-x64
-b235621df3fdc0624622d64e4c0ac15d2f545bce1697afb8e4cc7c7ea58f8551  agent-sanitizer-hooks-linux-arm64
-9ad498f32196b22076369a33114f17a8ff0434a5b8551c663359affd0f16e838  agent-sanitizer-hooks-linux-x64
+# bundle=98375b5bab48547deb370b3ee93b28afd23ea2ae399fc23ebbd40aa3c8da8985
+d7587b001c9e7113d68f8e77cfa14a87a913445de5997f263488aa89ce26cdf8  agent-sanitizer-hooks-darwin-arm64
+3ef221a9ffe42116de90df7b8f4db0344b94cb80c85d7578a611bbe5c231ab1b  agent-sanitizer-hooks-darwin-x64
+386ceeca8a61b48e83f53ad6c62214dfa4b0009846b25c75f1366154be82be8e  agent-sanitizer-hooks-linux-arm64
+38afe6936c42bc88af63c68240c71550f4e2587dbf9c3bf5f8f55a09083b2edf  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -169,6 +169,7 @@ function lastStdinByteLength() {
 async function readStdinJson(maxBytes = MAX_STDIN_BYTES) {
   const buf = await readAllBounded(process.stdin, maxBytes);
   lastStdinBytes = buf.length;
+  if (buf.length === 0) throw new EmptyStdinError();
   return JSON.parse(buf.toString());
 }
 function registerLazyModules(modules) {
@@ -381,7 +382,7 @@ function writeFileNoFollow(path2, content3, mode = 384) {
     closeSync(fd);
   }
 }
-var defaultSharedState, shared, HookEvent, PermissionDecision, FAIL_OPEN_ENV, FAIL_CLOSED_VALUES, FAIL_CLOSED_SET, DISABLED_HOOKS_ENV, LONE_SURROGATE_RE, MAX_STDIN_BYTES, lastStdinBytes, lazyImportErrors, DEFAULT_MISSING_PACKAGE_REMEDY, UNTRUSTED_TEXT_CAP, HOOKGATE_MARKER_STEM;
+var defaultSharedState, shared, HookEvent, PermissionDecision, FAIL_OPEN_ENV, FAIL_CLOSED_VALUES, FAIL_CLOSED_SET, DISABLED_HOOKS_ENV, LONE_SURROGATE_RE, MAX_STDIN_BYTES, lastStdinBytes, EmptyStdinError, lazyImportErrors, DEFAULT_MISSING_PACKAGE_REMEDY, UNTRUSTED_TEXT_CAP, HOOKGATE_MARKER_STEM;
 var init_hook_io = __esm({
   "claude-hooks/lib/hook-io.mjs"() {
     "use strict";
@@ -413,6 +414,12 @@ var init_hook_io = __esm({
     LONE_SURROGATE_RE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
     MAX_STDIN_BYTES = 64 * 1024 * 1024;
     lastStdinBytes = null;
+    EmptyStdinError = class extends Error {
+      constructor() {
+        super("empty stdin: the hook received no payload");
+        this.name = "EmptyStdinError";
+      }
+    };
     lazyImportErrors = /* @__PURE__ */ new Map();
     DEFAULT_MISSING_PACKAGE_REMEDY = "reinstall the hook dependencies (pnpm install) and retry.";
     UNTRUSTED_TEXT_CAP = 500;
@@ -69009,6 +69016,14 @@ function readInstructions(filePath) {
 function faultLine2(ctx) {
   return `${HOOK_NAME5} hook error: ${ctx.message}. An instruction file Claude Code just loaded was NOT scanned for hidden Unicode, so any payload in it reaches the model unvetted.`;
 }
+function emptyPayloadParts(ctx) {
+  if (!(ctx.err instanceof EmptyStdinError)) return null;
+  return {
+    stderr: `${HOOK_NAME5} hook error: ${ctx.message}. No instruction file was named, so nothing was scanned and nothing was left unguarded. Check how this hook is invoked: it reads its InstructionsLoaded event as JSON on stdin, and one wired to a channel that delivers nothing scans nothing for the whole session.
+`,
+    exitCode: 1
+  };
+}
 function readLoadedFile(payload) {
   const { file_path: filePath, load_reason: loadReason } = (
     /** @type {Record<string, unknown>} */
@@ -69123,17 +69138,17 @@ var init_scan_loaded_instructions = __esm({
     registerFaultPolicy(HOOK_NAME5, {
       event: HookEvent.INSTRUCTIONS_LOADED,
       guarded: "a loaded instruction file",
-      open: (ctx) => ({
+      open: (ctx) => emptyPayloadParts(ctx) ?? {
         stderr: `${faultLine2(ctx)} Passing through unguarded; set AGENT_SANITIZER_FAIL_OPEN=0 to arm the tool-call gate instead.
 `,
         exitCode: 1
-      }),
-      closed: (ctx) => ({
+      },
+      closed: (ctx) => emptyPayloadParts(ctx) ?? {
         stderr: `${faultLine2(ctx)} Arming the tool-call gate (AGENT_SANITIZER_FAIL_OPEN=0).
 `,
         exitCode: 1,
         armAlert: true
-      })
+      }
     });
     if (isMain(import.meta.url)) {
       await cliMain4();

--- a/test/claude-hooks-exports.test.mjs
+++ b/test/claude-hooks-exports.test.mjs
@@ -223,6 +223,7 @@ const PUBLISHED_EXPORTS = {
   "lib/hook-io": [
     "DEFAULT_MISSING_PACKAGE_REMEDY",
     "DISABLED_HOOKS_ENV",
+    "EmptyStdinError",
     "FAIL_CLOSED_VALUES",
     "FAIL_OPEN_ENV",
     "HookEvent",

--- a/test/claude-hooks-loaded-instructions.test.mjs
+++ b/test/claude-hooks-loaded-instructions.test.mjs
@@ -296,21 +296,30 @@ describe("the alert accumulates rather than clobbering", () => {
 });
 
 describe("the hook CLI, driven end to end on a real event", () => {
-  /** Run the hook as Claude Code does: one JSON event on stdin. */
-  function fire(payload) {
+  /**
+   * Run the hook with `input` verbatim on stdin, so a test can drive the bytes
+   * a host actually delivers — including the ones no `JSON.stringify` can
+   * produce, like nothing at all.
+   */
+  function fireRaw(input, env = {}) {
     const result = spawnSync(
       process.execPath,
       [join(repoRoot, "claude-hooks", "scan-loaded-instructions.mjs")],
       {
-        input: JSON.stringify(payload),
+        input,
         encoding: "utf8",
-        env: { ...process.env, CLAUDE_PROJECT_DIR: projectDir },
+        env: { ...process.env, CLAUDE_PROJECT_DIR: projectDir, ...env },
       },
     );
     return {
       ...result,
       json: result.stdout ? JSON.parse(result.stdout) : null,
     };
+  }
+
+  /** Run the hook as Claude Code does: one JSON event on stdin. */
+  function fire(payload) {
+    return fireRaw(JSON.stringify(payload));
   }
 
   it("cleans the file and answers on both channels", () => {
@@ -402,6 +411,41 @@ describe("the hook CLI, driven end to end on a real event", () => {
     assert.match(stderr, /scan-loaded-instructions/u);
     assert.match(stderr, /file_path/u);
     assert.notEqual(status, 0);
+  });
+
+  // An empty stdin is a hook that was handed no event at all — a different
+  // fault from a file it could not scan, with a different fix. Reported as
+  // itself, or the operator is sent to the gate's remedies (a symlink on the
+  // path, a permission bit, `pnpm install`) for a file that was never read.
+  it("names an empty payload as its own fault, not an unscanned file", () => {
+    const { stderr, stdout, status } = fireRaw("");
+    assert.match(stderr, /scan-loaded-instructions hook error/u);
+    assert.match(stderr, /received no payload/u);
+    // The two claims that are false here: no file went unscanned, and nothing
+    // was malformed — `JSON.parse` never saw the empty buffer.
+    assert.doesNotMatch(stderr, /NOT scanned/u);
+    assert.doesNotMatch(stderr, /Unexpected end of JSON input/u);
+    assert.equal(stdout, "");
+    assert.notEqual(status, 0);
+  });
+
+  it("does not arm the tool-call gate on an empty payload, even fail-closed", () => {
+    const { stderr } = fireRaw("", { AGENT_SANITIZER_FAIL_OPEN: "0" });
+    assert.match(stderr, /received no payload/u);
+    assert.equal(existsSync(ALERT_FILE), false);
+  });
+
+  // The other half of that distinction, and what keeps the assertions above
+  // from passing vacuously: a non-empty payload that is malformed still reads
+  // as an unscanned file and still arms the gate under the strict posture.
+  it("still reports a non-empty malformed payload as an unscanned file", () => {
+    const { stderr, status } = fireRaw("{not json", {
+      AGENT_SANITIZER_FAIL_OPEN: "0",
+    });
+    assert.match(stderr, /NOT scanned/u);
+    assert.doesNotMatch(stderr, /received no payload/u);
+    assert.notEqual(status, 0);
+    assert.ok(existsSync(ALERT_FILE), "the PreToolUse gate was not armed");
   });
 });
 


### PR DESCRIPTION
Claimed area: `readStdinJson` in `claude-hooks/lib/hook-io.mjs`, and `scan-loaded-instructions`' fault posture.

## Summary

`readStdinJson` now throws an exported `EmptyStdinError` when stdin closes with zero bytes, and `scan-loaded-instructions` reports that fault as what it is instead of as a failed scan.

Before: the empty buffer went straight to `JSON.parse`, so `printf '' | node claude-hooks/scan-loaded-instructions.mjs` died with `SyntaxError: Unexpected end of JSON input`. `cliMain`'s catch turned that into the hook's generic report — "An instruction file Claude Code just loaded was NOT scanned for hidden Unicode" — and under `AGENT_SANITIZER_FAIL_OPEN=0` armed the tool-call gate, whose remedies (fix a symlink, make a file readable, run `pnpm install`) all act on a file that was never read. Every claim in that alert is false when no payload arrived, and a false alert on the gate is the alert fatigue the detection layers exist to avoid.

An empty payload and a malformed one are different faults with different fixes: a malformed payload is a sender that sent something wrong; an empty one is a hook wired to a channel that sends nothing.

## Changes

- `claude-hooks/lib/hook-io.mjs` — `EmptyStdinError` ("empty stdin: the hook received no payload"), thrown from `readStdinJson` before the parse.
- `claude-hooks/scan-loaded-instructions.mjs` — both posture arms route an `EmptyStdinError` through `emptyPayloadParts`, which names the real cause and arms nothing. The other arms are unchanged.
- `test/claude-hooks-exports.test.mjs` — `EmptyStdinError` added to the `lib/hook-io` published-export snapshot (the SSOT contract test for that surface).
- `plugin/dist/hooks/` — bundle and hook-binary digest manifest regenerated.

Observable change for consumers of `claude-hooks/lib/hook-io`: empty stdin throws `EmptyStdinError` rather than a `SyntaxError`, and the module publishes that class. The clearer message also reaches the other `readStdinJson` callers (`lib/control-plane.mjs`, `sanitize-user-prompt.mjs`, `plugin-hooks.mjs`); their postures are unchanged.

## Review focus

Read `claude-hooks/scan-loaded-instructions.mjs:86-131` first — the judgment is that an empty payload arms no alert in *either* posture, which is the one place this diff deliberately withholds enforcement a strict-posture operator might expect. It relies on an invariant the diff can't show on one screen: `hook-fault.mjs` is the only reader of `failOpenEnabled`, so the branch stays inside the posture table rather than short-circuiting `cliMain`'s catch. `hook-io.mjs`'s guard is a byte-length check; the rest is tests and regenerated artifacts.

## How it was tested

- `pnpm test` (full suite incl. the coverage ratchet), `pnpm lint`, `pnpm check`, `pnpm format:check` — all pass.
- Three cases added to the end-to-end CLI block in `test/claude-hooks-loaded-instructions.test.mjs`, driving the real hook as a subprocess (`fire` now delegates to a `fireRaw` that can send bytes no `JSON.stringify` produces): empty stdin names its own fault and asserts the two false claims are absent (`NOT scanned`, `Unexpected end of JSON input`); empty stdin arms no alert even under `AGENT_SANITIZER_FAIL_OPEN=0`; and `{not json` still reports as an unscanned file and still arms the gate under the strict posture.
- Non-vacuity: with both source files stashed, the first two cases go red and the third stays green.

## Decisions made

- **An empty payload arms the tool-call gate in neither posture.** Zero bytes means no `InstructionsLoaded` event was delivered, so nothing is known to be wrong with this project's instruction files. Under the alternative — arm it under `AGENT_SANITIZER_FAIL_OPEN=0`, as every other fault does — a strict-posture operator gets a blocking ask on the next tool call whose remedies name a file that was never read. The neighbouring case is untouched: a payload that arrives but carries no `file_path` is harness-contract drift, still faults through `readLoadedFile`, and still arms the gate.
- **`EmptyStdinError` is exported from `hook-io` rather than kept module-private.** Every hook reads stdin through that one function, and a caller that cannot type-test the condition ends up matching on message text.
