### PR TITLE
fix(html): settle sanitizeHtml in one call so its output is a fixed point

### DIFF
--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=b54f1c548096f70259d3cba6883ac8e40f105848a7d15feff79a1a79f29b6515
-58767b5f6b6dec5a647456e1462c95f5b6ef9f5d2c12d12914db0a65829579d1  agent-sanitizer-hooks-darwin-arm64
-54002105f9759a48431e46b1173c429c688e2ed9d453109f30f22227d3952d6a  agent-sanitizer-hooks-darwin-x64
-b235621df3fdc0624622d64e4c0ac15d2f545bce1697afb8e4cc7c7ea58f8551  agent-sanitizer-hooks-linux-arm64
-9ad498f32196b22076369a33114f17a8ff0434a5b8551c663359affd0f16e838  agent-sanitizer-hooks-linux-x64
+# bundle=e5be3be063f41a17c9d749418591527c155a05d5d82c9317844f8f6472dfaa7d
+41ed452586b604eaf4b7f8017a91e2512fa26ba264aa8515a84f44b935a7aa79  agent-sanitizer-hooks-darwin-arm64
+a72ab5005bca682c8a3ef9725ca4a86900c5f8be51164d583919e82e6a3b09e9  agent-sanitizer-hooks-darwin-x64
+2549d969ce0691f73987cb1bba0d54af156e71027fdef1419e042d00dd29392f  agent-sanitizer-hooks-linux-arm64
+1f25283eef7dbe1a75777f0f3a99b93d8ef4211db6419cd6cfb7ed5e43c2f2a9  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=464df640e27d14aff9b39a67ff227d35006f55d2449fe74868199b990e2203aa
-99be1c01c4cae7b5547d34d9e1dbb136faea05f0533749941b39e6f45a3282ff  agent-sanitizer-hooks-darwin-arm64
-32bfc5020ebf16da34685b7ac53f5609f72c0b46725fbb140e6d8089ac8c76bc  agent-sanitizer-hooks-darwin-x64
-84af0d50a820bea194f279a53cd896f6fccea9cd95bda2a3ed50bb07580b26d3  agent-sanitizer-hooks-linux-arm64
-efbb88d3d4031ff455afffa4444db7122b97d0bbfff6426e30b207315bf0f6e7  agent-sanitizer-hooks-linux-x64
+# bundle=851cfed26100ad4f78a9b9dde3dc5e946d36e5ba87d6d8a792a9172446e5fba6
+bcb30a29fe6c8d8415763da930022b3a97472c5d419842c4e077f98de3bd7253  agent-sanitizer-hooks-darwin-arm64
+17dfd7e79526196d5c150778381e0e283c9f67a2de65ea9671b0ef18e97669e7  agent-sanitizer-hooks-darwin-x64
+b902bb7fa8a65861b7c820ab9c7a0b0f054a9172f9c6945af2c740aa8444dc77  agent-sanitizer-hooks-linux-arm64
+c07e9d22c6e1c66a76a0a5ae3611abce144e452813415db2255fc0b0f849ebfc  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -63988,14 +63988,17 @@ function looksLikeHtmlSource(text5) {
   return htmlSourceTree(text5) !== null;
 }
 function toSourceRanges(ranges, merged, pairs) {
+  const ends = pairs.map((pair) => pair.start + pair.placeholder.length);
+  const shifts = merged.map((range, index2) => range.end - ends[index2]);
   const toSource = (offset) => {
-    let shift = 0;
-    for (const [index2, pair] of pairs.entries()) {
-      const placeholderEnd = pair.start + pair.placeholder.length;
-      if (placeholderEnd > offset) break;
-      shift = merged[index2].end - placeholderEnd;
+    let low = 0;
+    let high = ends.length;
+    while (low < high) {
+      const mid = Math.floor((low + high) / 2);
+      if (ends[mid] <= offset) low = mid + 1;
+      else high = mid;
     }
-    return offset + shift;
+    return low === 0 ? offset : offset + shifts[low - 1];
   };
   return ranges.map((range) => ({
     start: toSource(range.start),
@@ -64012,7 +64015,15 @@ function sanitizeHtml(text5) {
   ) };
   const removed = { comments: 0, hidden: 0 };
   let warned;
-  for (; ; ) {
+  for (let round = 0; ; round++) {
+    if (round === MAX_SPLICE_ROUNDS)
+      return {
+        text: UNPARSEABLE_PLACEHOLDER,
+        removed: { comments: 0, hidden: 1 },
+        warned: newWarned(),
+        splices: [],
+        unparseable: true
+      };
     let scan2;
     try {
       const sourceTree = htmlSourceTree(spliced.text);
@@ -64312,7 +64323,7 @@ function detectConfusableHosts(text5) {
   }
   return threats.length > 0 ? threats : null;
 }
-var NEAR_ZERO_EPSILON, OFFSCREEN_ABSOLUTE_THRESHOLD, OFFSCREEN_VIEWPORT_THRESHOLD, ABSOLUTE_UNITS, VIEWPORT_UNITS, ANGLE_UNITS, NAMED_COLORS, BLOCK_AXIS_EXTENT_PROPS, INLINE_AXIS_EXTENT_PROPS, BORDER_SHORTHANDS, BORDER_WIDTH_KEYWORDS, FONT_SIZE_UNITS, CSS_PROPERTY_IDENT_RE, REPORTED_TAGS, VOID_ELEMENTS2, FOREIGN_ELEMENTS, RAW_TEXT_ELEMENTS, htmlParser, parseFragment2, PLACEHOLDER_LABEL, PLACEHOLDER_KEY_LEN, LAYER2_PLACEHOLDER_RE, HIDDEN_PLACEHOLDER, COMMENT_PLACEHOLDER, UNPARSEABLE_PLACEHOLDER, mdParser, parseMarkdown, MARKDOWN_CODE_HINT, BOGUS_COMMENT_OPEN_RE, UNTERMINATED_MARKUP_TAIL_RE, PHRASING_ROOTS, FLOW_HTML_PARENTS, EXFIL_INDICATORS, KEYWORD_PARAM_NAME_RE, LONG_QUERY_THRESHOLD, DATA_URI_ACTIVE_RE, DATA_URI_LENGTH_THRESHOLD, SCRIPT_URI_RE, RELATIVE_URL_BASE, BENIGN_BLOB_PARAM_RE, OPAQUE_TOKEN_RE, VALUE_HAS_DIGIT_RE, BLOB_VALUE_B64_RE, BLOB_VALUE_HEX_RE, BLOB_VALUE_B64URL_RE, B64URL_MIXED_RE, PATH_BLOB_RE, PATH_BLOB_MIN_LEN, SRCSET_WS_RE, OFF_ORIGIN_REASON;
+var NEAR_ZERO_EPSILON, OFFSCREEN_ABSOLUTE_THRESHOLD, OFFSCREEN_VIEWPORT_THRESHOLD, ABSOLUTE_UNITS, VIEWPORT_UNITS, ANGLE_UNITS, NAMED_COLORS, BLOCK_AXIS_EXTENT_PROPS, INLINE_AXIS_EXTENT_PROPS, BORDER_SHORTHANDS, BORDER_WIDTH_KEYWORDS, FONT_SIZE_UNITS, CSS_PROPERTY_IDENT_RE, REPORTED_TAGS, VOID_ELEMENTS2, FOREIGN_ELEMENTS, RAW_TEXT_ELEMENTS, htmlParser, parseFragment2, PLACEHOLDER_LABEL, PLACEHOLDER_KEY_LEN, LAYER2_PLACEHOLDER_RE, HIDDEN_PLACEHOLDER, COMMENT_PLACEHOLDER, UNPARSEABLE_PLACEHOLDER, mdParser, parseMarkdown, MARKDOWN_CODE_HINT, BOGUS_COMMENT_OPEN_RE, UNTERMINATED_MARKUP_TAIL_RE, PHRASING_ROOTS, FLOW_HTML_PARENTS, MAX_SPLICE_ROUNDS, EXFIL_INDICATORS, KEYWORD_PARAM_NAME_RE, LONG_QUERY_THRESHOLD, DATA_URI_ACTIVE_RE, DATA_URI_LENGTH_THRESHOLD, SCRIPT_URI_RE, RELATIVE_URL_BASE, BENIGN_BLOB_PARAM_RE, OPAQUE_TOKEN_RE, VALUE_HAS_DIGIT_RE, BLOB_VALUE_B64_RE, BLOB_VALUE_HEX_RE, BLOB_VALUE_B64URL_RE, B64URL_MIXED_RE, PATH_BLOB_RE, PATH_BLOB_MIN_LEN, SRCSET_WS_RE, OFF_ORIGIN_REASON;
 var init_html4 = __esm({
   "src/html.mjs"() {
     "use strict";
@@ -64609,6 +64620,7 @@ var init_html4 = __esm({
       "listItem",
       "footnoteDefinition"
     ]);
+    MAX_SPLICE_ROUNDS = 8;
     EXFIL_INDICATORS = [/\$\{[^{}]+\}/, /\{\{[^{}]+\}\}/];
     KEYWORD_PARAM_NAME_RE = /^(?:data|d|payload|exfil|leak|steal|secret|token|key|env|password|pwd|cookie|session|auth)$/i;
     LONG_QUERY_THRESHOLD = 200;

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -63743,7 +63743,7 @@ function layer2Placeholder(kind2, original) {
   const key = createHash2("sha256").update(original, "utf8").digest("hex").slice(0, PLACEHOLDER_KEY_LEN);
   return `[${PLACEHOLDER_LABEL[kind2]} removed #${key}]`;
 }
-function spliceRanges(text5, ranges) {
+function mergeRanges(ranges) {
   const sorted = [...ranges].sort(
     (left, right) => left.start - right.start || left.end - right.end
   );
@@ -63757,6 +63757,10 @@ function spliceRanges(text5, ranges) {
       merged.push({ ...range });
     }
   }
+  return merged;
+}
+function spliceRanges(text5, ranges) {
+  const merged = mergeRanges(ranges);
   let out = "";
   let cursor = 0;
   const pairs = [];
@@ -63976,27 +63980,59 @@ function htmlSourceTree(text5) {
 function looksLikeHtmlSource(text5) {
   return htmlSourceTree(text5) !== null;
 }
+function toSourceRanges(ranges, merged, pairs) {
+  const toSource = (offset) => {
+    let shift = 0;
+    for (const [index2, pair] of pairs.entries()) {
+      const placeholderEnd = pair.start + pair.placeholder.length;
+      if (placeholderEnd > offset) break;
+      shift = merged[index2].end - placeholderEnd;
+    }
+    return offset + shift;
+  };
+  return ranges.map((range) => ({
+    start: toSource(range.start),
+    end: toSource(range.end),
+    kind: range.kind
+  }));
+}
 function sanitizeHtml(text5) {
   if (!HTML_TAG_PRESENT.test(text5)) return null;
-  let scan2;
-  try {
-    const sourceTree = htmlSourceTree(text5);
-    scan2 = sourceTree ? scanFragmentTree(text5, sourceTree) : scanMarkdown(text5);
-  } catch {
-    return {
-      text: UNPARSEABLE_PLACEHOLDER,
-      removed: { comments: 0, hidden: 1 },
-      warned: newWarned(),
-      splices: [],
-      unparseable: true
-    };
-  }
-  const { ranges, warned } = scan2;
-  if (ranges.length === 0 && !hasWarned(warned)) return null;
+  let ranges = [];
+  let spliced = { text: text5, pairs: (
+    /** @type {SplicePair[]} */
+    []
+  ) };
   const removed = { comments: 0, hidden: 0 };
-  for (const range of ranges)
-    removed[range.kind === "comment" ? "comments" : "hidden"]++;
-  const spliced = ranges.length > 0 ? spliceRanges(text5, ranges) : { text: text5, pairs: [] };
+  let warned;
+  for (; ; ) {
+    let scan2;
+    try {
+      const sourceTree = htmlSourceTree(spliced.text);
+      scan2 = sourceTree ? scanFragmentTree(spliced.text, sourceTree) : scanMarkdown(spliced.text);
+    } catch {
+      return {
+        text: UNPARSEABLE_PLACEHOLDER,
+        removed: { comments: 0, hidden: 1 },
+        warned: newWarned(),
+        splices: [],
+        unparseable: true
+      };
+    }
+    warned = scan2.warned;
+    if (scan2.ranges.length === 0) break;
+    const grown = mergeRanges([
+      ...ranges,
+      ...toSourceRanges(scan2.ranges, ranges, spliced.pairs)
+    ]);
+    const next2 = spliceRanges(text5, grown);
+    if (next2.text === spliced.text) break;
+    for (const range of scan2.ranges)
+      removed[range.kind === "comment" ? "comments" : "hidden"]++;
+    ranges = grown;
+    spliced = next2;
+  }
+  if (ranges.length === 0 && !hasWarned(warned)) return null;
   return {
     text: spliced.text,
     removed,

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -2220,7 +2220,7 @@ export function sanitizeHtml(text) {
     // an input that reveals one more node per round would pay one per node.
     // This refuses past the ceiling instead, the way MAX_DEPTH in output.mjs
     // refuses past a nesting depth.
-    /* c8 ignore next 9 -- no input is known to reach round MAX_SPLICE_ROUNDS:
+    /* c8 ignore start -- no input is known to reach round MAX_SPLICE_ROUNDS:
        370k adversarial draws over the shapes that DO chain (a stray `<td>` the
        source branch drops, a bogus comment, the adoption-agency reparent that
        flips the branch) settle in at most 2. Defense in depth on the
@@ -2233,6 +2233,7 @@ export function sanitizeHtml(text) {
         splices: [],
         unparseable: true,
       };
+    /* c8 ignore stop */
     /** @type {{ ranges: SpliceRange[], warned: ReturnType<typeof newWarned> }} */
     let scan;
     try {

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -1585,19 +1585,12 @@ export const COMMENT_PLACEHOLDER = "[HTML comment removed";
 export const UNPARSEABLE_PLACEHOLDER = "[HTML unparseable — withheld]";
 
 /**
- * Replace each range of `text` with its kind's keyed placeholder, preserving
- * every byte outside the ranges verbatim. Overlapping/nested ranges are merged
- * (defense-in-depth — the scanners emit disjoint ranges).
- *
- * Returns the spliced text plus `pairs`, one per emitted placeholder in output
- * order, each pairing the placeholder with the ORIGINAL bytes it replaced and
- * its start offset in the RETURNED text (UTF-16 code-unit string indices, the
- * same space as `ranges`) — everything a rehydrator needs to undo the splice.
- * @param {string} text
+ * `ranges` sorted by start with every overlap unioned — one entry per
+ * placeholder {@link spliceRanges} emits, in the same order as its `pairs`.
  * @param {SpliceRange[]} ranges
- * @returns {{ text: string, pairs: SplicePair[] }}
+ * @returns {SpliceRange[]}
  */
-export function spliceRanges(text, ranges) {
+function mergeRanges(ranges) {
   const sorted = [...ranges].sort(
     (left, right) => left.start - right.start || left.end - right.end,
   );
@@ -1616,6 +1609,24 @@ export function spliceRanges(text, ranges) {
       merged.push({ ...range });
     }
   }
+  return merged;
+}
+
+/**
+ * Replace each range of `text` with its kind's keyed placeholder, preserving
+ * every byte outside the ranges verbatim. Overlapping/nested ranges are merged
+ * (defense-in-depth — the scanners emit disjoint ranges).
+ *
+ * Returns the spliced text plus `pairs`, one per emitted placeholder in output
+ * order, each pairing the placeholder with the ORIGINAL bytes it replaced and
+ * its start offset in the RETURNED text (UTF-16 code-unit string indices, the
+ * same space as `ranges`) — everything a rehydrator needs to undo the splice.
+ * @param {string} text
+ * @param {SpliceRange[]} ranges
+ * @returns {{ text: string, pairs: SplicePair[] }}
+ */
+export function spliceRanges(text, ranges) {
+  const merged = mergeRanges(ranges);
   let out = "";
   let cursor = 0;
   /** @type {SplicePair[]} */
@@ -2123,6 +2134,38 @@ export function looksLikeHtmlSource(text) {
 }
 
 /**
+ * `ranges`, which index a text spliced at `merged` (with the resulting
+ * `pairs`), translated back into coordinates of the source that was spliced.
+ *
+ * Every offset outside a placeholder maps by the length the splices before it
+ * removed. No offset ever falls INSIDE one: a placeholder holds neither `<`
+ * nor `>`, and a scanner range always opens on a `<` and closes after a `>` or
+ * at the end of the text — so a placeholder edge is the closest an offset gets,
+ * and the same shift is exact there.
+ * @param {SpliceRange[]} ranges
+ * @param {SpliceRange[]} merged  the spliced spans, sorted, one per pair
+ * @param {SplicePair[]} pairs
+ * @returns {SpliceRange[]}
+ */
+function toSourceRanges(ranges, merged, pairs) {
+  /** @param {number} offset @returns {number} */
+  const toSource = (offset) => {
+    let shift = 0;
+    for (const [index, pair] of pairs.entries()) {
+      const placeholderEnd = pair.start + pair.placeholder.length;
+      if (placeholderEnd > offset) break;
+      shift = merged[index].end - placeholderEnd;
+    }
+    return offset + shift;
+  };
+  return ranges.map((range) => ({
+    start: toSource(range.start),
+    end: toSource(range.end),
+    kind: range.kind,
+  }));
+}
+
+/**
  * Layer 2 over web-ingress text: splice out HTML comments and hidden elements
  * (keyed placeholders mark the cuts; all other bytes are preserved verbatim)
  * and count preserved scripting/resource tags for the caller's warning. Returns
@@ -2139,41 +2182,70 @@ export function looksLikeHtmlSource(text) {
  * located, so nothing is recoverable per-splice (the caller's pre-splice
  * `reveal` is the only copy).
  *
- * Idempotent over its own output: a keyed placeholder contains no `<`, so a
- * re-run neither gates on it (HTML_TAG_PRESENT needs a tag) nor reads it as
- * markup — placeholders already in the text pass through byte-identical.
+ * Idempotent over its own output, and by CONSTRUCTION rather than by argument:
+ * the scan is re-run over the spliced text until it finds nothing more, so the
+ * returned text is a fixed point. One pass is not enough on its own, because
+ * removing an element changes how parse5 reparents the bytes around it, which
+ * can flip {@link htmlSourceTree}'s markdown/source verdict for the next run.
  * @param {string} text
  * @returns {{ text: string, removed: { comments: number, hidden: number }, warned: { tags: Record<string, number>, dataSrc: number }, splices: SplicePair[], unparseable?: true } | null}
  */
 export function sanitizeHtml(text) {
   if (!HTML_TAG_PRESENT.test(text)) return null;
-  /** @type {{ ranges: SpliceRange[], warned: ReturnType<typeof newWarned> }} */
-  let scan;
-  try {
-    // One parse decides the branch AND feeds it, so the source branch does not
-    // tokenize the input twice.
-    const sourceTree = htmlSourceTree(text);
-    scan = sourceTree ? scanFragmentTree(text, sourceTree) : scanMarkdown(text);
-  } catch {
-    // The parse/visit blew up (stack overflow on pathological nesting, or any
-    // other parser error). Fail CLOSED at this boundary so `sanitize`/
-    // `sanitizeText` keep their never-throw contract: withhold the whole input
-    // behind a placeholder and report it as hidden content removed.
-    return {
-      text: UNPARSEABLE_PLACEHOLDER,
-      removed: { comments: 0, hidden: 1 },
-      warned: newWarned(),
-      splices: [],
-      unparseable: true,
-    };
-  }
-  const { ranges, warned } = scan;
-  if (ranges.length === 0 && !hasWarned(warned)) return null;
+  /** @type {SpliceRange[]} Every span found so far, in SOURCE coordinates. */
+  let ranges = [];
+  let spliced = { text, pairs: /** @type {SplicePair[]} */ ([]) };
   const removed = { comments: 0, hidden: 0 };
-  for (const range of ranges)
-    removed[range.kind === "comment" ? "comments" : "hidden"]++;
-  const spliced =
-    ranges.length > 0 ? spliceRanges(text, ranges) : { text, pairs: [] };
+  /** @type {ReturnType<typeof newWarned>} */
+  let warned;
+  // Each round splices at least one more span of `text`, so the covered length
+  // grows strictly and the loop terminates. A placeholder holds no `<`, so no
+  // round can find a span inside one and re-cover ground already covered.
+  for (;;) {
+    /** @type {{ ranges: SpliceRange[], warned: ReturnType<typeof newWarned> }} */
+    let scan;
+    try {
+      // One parse decides the branch AND feeds it, so the source branch does not
+      // tokenize the input twice.
+      const sourceTree = htmlSourceTree(spliced.text);
+      scan = sourceTree
+        ? scanFragmentTree(spliced.text, sourceTree)
+        : scanMarkdown(spliced.text);
+    } catch {
+      // The parse/visit blew up (stack overflow on pathological nesting, or any
+      // other parser error). Fail CLOSED at this boundary so `sanitize`/
+      // `sanitizeText` keep their never-throw contract: withhold the whole input
+      // behind a placeholder and report it as hidden content removed.
+      return {
+        text: UNPARSEABLE_PLACEHOLDER,
+        removed: { comments: 0, hidden: 1 },
+        warned: newWarned(),
+        splices: [],
+        unparseable: true,
+      };
+    }
+    // The last scan saw exactly the text being returned, so its tag counts are
+    // the ones that describe that text.
+    warned = scan.warned;
+    if (scan.ranges.length === 0) break;
+    // Re-splice from the SOURCE every round: pairs then carry original bytes
+    // and offsets into the returned text, never a nested earlier placeholder.
+    const grown = mergeRanges([
+      ...ranges,
+      ...toSourceRanges(scan.ranges, ranges, spliced.pairs),
+    ]);
+    const next = spliceRanges(text, grown);
+    /* c8 ignore next 4 -- unreachable: every range holds a `<` and no
+       placeholder does, so each round covers source bytes the last one did
+       not and the text must change. Kept because the alternative to this
+       stop is a hook that spins on untrusted input. */
+    if (next.text === spliced.text) break;
+    for (const range of scan.ranges)
+      removed[range.kind === "comment" ? "comments" : "hidden"]++;
+    ranges = grown;
+    spliced = next;
+  }
+  if (ranges.length === 0 && !hasWarned(warned)) return null;
   return {
     text: spliced.text,
     removed,

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -2133,6 +2133,12 @@ export function looksLikeHtmlSource(text) {
   return htmlSourceTree(text) !== null;
 }
 
+// How many scan/splice rounds one `sanitizeHtml` call may spend before it
+// withholds the document instead. Every input measured settles in at most 2;
+// the headroom is for a shape the measurement did not reach, and the ceiling is
+// what keeps a crafted reveal-chain from buying one whole reparse per node.
+const MAX_SPLICE_ROUNDS = 8;
+
 /**
  * `ranges`, which index a text spliced at `merged` (with the resulting
  * `pairs`), translated back into coordinates of the source that was spliced.
@@ -2148,15 +2154,21 @@ export function looksLikeHtmlSource(text) {
  * @returns {SpliceRange[]}
  */
 function toSourceRanges(ranges, merged, pairs) {
+  // Placeholder ends ascend across `pairs`, so the splices before an offset are
+  // found by bisection. Walking `pairs` per offset instead costs the product of
+  // the two lists, which on a document of 10k hidden elements is 10^8 steps.
+  const ends = pairs.map((pair) => pair.start + pair.placeholder.length);
+  const shifts = merged.map((range, index) => range.end - ends[index]);
   /** @param {number} offset @returns {number} */
   const toSource = (offset) => {
-    let shift = 0;
-    for (const [index, pair] of pairs.entries()) {
-      const placeholderEnd = pair.start + pair.placeholder.length;
-      if (placeholderEnd > offset) break;
-      shift = merged[index].end - placeholderEnd;
+    let low = 0;
+    let high = ends.length;
+    while (low < high) {
+      const mid = Math.floor((low + high) / 2);
+      if (ends[mid] <= offset) low = mid + 1;
+      else high = mid;
     }
-    return offset + shift;
+    return low === 0 ? offset : offset + shifts[low - 1];
   };
   return ranges.map((range) => ({
     start: toSource(range.start),
@@ -2187,6 +2199,8 @@ function toSourceRanges(ranges, merged, pairs) {
  * returned text is a fixed point. One pass is not enough on its own, because
  * removing an element changes how parse5 reparents the bytes around it, which
  * can flip {@link htmlSourceTree}'s markdown/source verdict for the next run.
+ * A document that has not settled within {@link MAX_SPLICE_ROUNDS} rounds is
+ * withheld whole, on the same fail-closed path a parser blow-up takes.
  * @param {string} text
  * @returns {{ text: string, removed: { comments: number, hidden: number }, warned: { tags: Record<string, number>, dataSrc: number }, splices: SplicePair[], unparseable?: true } | null}
  */
@@ -2201,7 +2215,24 @@ export function sanitizeHtml(text) {
   // Each round splices at least one more span of `text`, so the covered length
   // grows strictly and the loop terminates. A placeholder holds no `<`, so no
   // round can find a span inside one and re-cover ground already covered.
-  for (;;) {
+  for (let round = 0; ; round++) {
+    // Termination alone is not a cost bound: each round is a whole reparse, so
+    // an input that reveals one more node per round would pay one per node.
+    // This refuses past the ceiling instead, the way MAX_DEPTH in output.mjs
+    // refuses past a nesting depth.
+    /* c8 ignore next 9 -- no input is known to reach round MAX_SPLICE_ROUNDS:
+       370k adversarial draws over the shapes that DO chain (a stray `<td>` the
+       source branch drops, a bogus comment, the adoption-agency reparent that
+       flips the branch) settle in at most 2. Defense in depth on the
+       web-ingress boundary, not a path with a fixture. */
+    if (round === MAX_SPLICE_ROUNDS)
+      return {
+        text: UNPARSEABLE_PLACEHOLDER,
+        removed: { comments: 0, hidden: 1 },
+        warned: newWarned(),
+        splices: [],
+        unparseable: true,
+      };
     /** @type {{ ranges: SpliceRange[], warned: ReturnType<typeof newWarned> }} */
     let scan;
     try {

--- a/test/html-property.test.mjs
+++ b/test/html-property.test.mjs
@@ -52,6 +52,12 @@ const tagName = fc.constantFrom(
   "img",
   "iframe",
   "svg",
+  // Table tags need no table around them here: a stray `<td>`/`<tr>` at the
+  // root of a fragment is exactly the shape whose parse MOVES when a sibling
+  // is spliced, because parse5 places it by table scope rather than in order.
+  "table",
+  "tr",
+  "td",
 );
 const safeAttrValue = fc
   .string({ maxLength: 30 })
@@ -102,6 +108,9 @@ const malformedInlineToken = fc.constantFrom(
   // stray partial open
   "<div hidden",
   "<span",
+  // an UNTERMINATED processing instruction swallows the markup up to the next
+  // `>`, so which bytes are markup depends on what a splice left around it
+  "<? ",
   // raw-text / RCDATA elements: `<!…`/`</…` — and hidden-tag LITERALS — inside
   // are opaque content, not markup, and must survive verbatim
   "<style><!x</style>",
@@ -139,6 +148,23 @@ describe("property: sanitizeHtml is idempotent", () => {
       // a re-run neither re-splices them nor mangles their keys.
       assert.equal(applyHtml(passOne), passOne);
     }));
+
+  it("an UNPLANTED document is a fixed point too", () => {
+    // The plant above opens the document with bare text, which pins every draw
+    // to the markdown branch. Only a document parse5 reads as HTML SOURCE
+    // reaches the branch where a splice reshapes the tree around it — a stray
+    // `<td>` parse5 placed by table scope, a `<? ` whose bogus comment now ends
+    // somewhere else — so the source branch needs its own unplanted draw.
+    let spliced = 0;
+    checkProperty(arbitraryHtmlFragment, (input) => {
+      const passOne = applyHtml(input);
+      if (PLACEHOLDER_RE.test(passOne)) spliced += 1;
+      assert.equal(applyHtml(passOne), passOne, input);
+    });
+    // Idempotence over an unspliced document is vacuous, and nothing else here
+    // forces a splice.
+    assert.ok(spliced > 0, "no generated document was spliced");
+  });
 });
 
 // ─── 1b. Round-trip: splices restore the input byte-identically ──────────────

--- a/test/html.test.mjs
+++ b/test/html.test.mjs
@@ -1859,6 +1859,17 @@ describe("splice fidelity and regressions", () => {
       const passOne = applyHtml(input);
       assert.equal(applyHtml(passOne), passOne);
     });
+  it("regression: a chained-reveal document settles at scale, in one call", () => {
+    // The unit above, 4096 times: ~172 KB where EVERY node is revealed by the
+    // round before it, which is the shape whose cost grows with the round
+    // count. Remapping a round's offsets by walking the pair list per offset
+    // instead of bisecting it made this ~10^8 steps — this case is what shows
+    // that as a hang rather than as a slightly slower suite.
+    const document = `<div hidden=""></div> <td hidden=""></td> `.repeat(4096);
+    const result = sanitizeHtml(document);
+    assert.deepEqual(result.removed, { comments: 0, hidden: 8192 });
+    assert.equal(sanitizeHtml(result.text), null);
+  });
   it("regression: idempotent when a bogus end tag precedes a hidden element", () => {
     // parse5 (flow branch) models `</A` as a bogus comment that absorbs the
     // following `<div hidden>`, so it survives pass one; the balance walk must

--- a/test/html.test.mjs
+++ b/test/html.test.mjs
@@ -1833,6 +1833,32 @@ describe("splice fidelity and regressions", () => {
       applyHtml("> <div hidden>x</div>\n> visible"),
       `> ${hid("<div hidden>x</div>")}\n> visible`,
     ));
+  // Splicing an element changes how parse5 reads the bytes AROUND it, so the
+  // scan that ran once over the input was never a fixed point: the branch
+  // verdict flips, or a node parse5 had dropped comes back. Each input below is
+  // a distinct way the parse moves; every one must be settled by pass one.
+  for (const input of [
+    // markdown branch on pass one, HTML source on pass two: with the hidden
+    // `<a>` gone, the adoption agency pulls the trailing ` !` inside the first
+    // `<a>`, leaving no character data outside an element
+    `<a><A</a> <a hidden=""></a> <? <div></div> !`,
+    // a root-level `<td>` is placed by table scope, so which node parse5 keeps
+    // for it depends on the siblings a splice left behind
+    `<div hidden=""></div> <td hidden=""></td>`,
+    `<td hidden=""></td> <table hidden=""></table>`,
+    `<br hidden> <td hidden=""></td>`,
+    `<input style="display:none"> <td hidden=""></td>`,
+    `<!bogus secret> <div></div> <td hidden=""></td>`,
+    // an unterminated `<? ` runs to the next `>`, which a splice can move
+    `! <?  <div></div> <iframe></iframe> <?php evil ?> <div hidden=""></div>`,
+    // the span the later round finds sits BEFORE the one the first round
+    // spliced, so its offsets must be read back past a placeholder, not through
+    `<svg>x</svg> <td hidden=""></td> <!b>`,
+  ])
+    it(`regression: one pass settles ${input}`, () => {
+      const passOne = applyHtml(input);
+      assert.equal(applyHtml(passOne), passOne);
+    });
   it("regression: idempotent when a bogus end tag precedes a hidden element", () => {
     // parse5 (flow branch) models `</A` as a bogus comment that absorbs the
     // following `<div hidden>`, so it survives pass one; the balance walk must

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -28,8 +28,16 @@ _GIT_LOCATION_VARS = (
 )
 
 
+def env_without_git_location() -> dict[str, str]:
+    """`os.environ` minus the repo-location overrides in {@link _GIT_LOCATION_VARS}.
+
+    Every subprocess a test runs against a path of its own choosing needs this:
+    with `GIT_DIR` exported, `cwd=` stops deciding which repo git answers for.
+    """
+    return {k: v for k, v in os.environ.items() if k not in _GIT_LOCATION_VARS}
+
+
 def _repo_root() -> Path:
-    env = {k: v for k, v in os.environ.items() if k not in _GIT_LOCATION_VARS}
     return Path(
         subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],
@@ -37,7 +45,7 @@ def _repo_root() -> Path:
             capture_output=True,
             text=True,
             check=True,
-            env=env,
+            env=env_without_git_location(),
         ).stdout.strip()
     )
 
@@ -68,15 +76,24 @@ GIT_IDENTITY_ENV = {
 
 
 def git_env() -> dict[str, str]:
-    """Environment for running git in test sandboxes."""
-    return {**os.environ, **GIT_IDENTITY_ENV}
+    """Environment for running git in test sandboxes.
+
+    The repo-location overrides are stripped for the same reason `_repo_root`
+    strips them, and the omission was a real CI red: with `GIT_DIR` exported,
+    `cwd=<sandbox>` no longer picks the repo, so a fixture's commits land in the
+    REAL repo and the sandbox cannot resolve the SHAs it was just handed.
+    """
+    return {**env_without_git_location(), **GIT_IDENTITY_ENV}
 
 
 def init_test_repo(path: Path) -> None:
     """Init a throwaway repo with signing/hooks disabled so fixtures can commit
     in any environment (including CI runners with enforced commit signing)."""
     path.mkdir(parents=True, exist_ok=True)
-    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, check=True)
+    env = git_env()
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main"], cwd=path, env=env, check=True
+    )
     for k, v in [
         ("commit.gpgsign", "false"),
         ("tag.gpgsign", "false"),
@@ -84,7 +101,9 @@ def init_test_repo(path: Path) -> None:
         ("user.email", "t@t"),
         ("core.hooksPath", "/dev/null"),
     ]:
-        subprocess.run(["git", "config", "--local", k, v], cwd=path, check=True)
+        subprocess.run(
+            ["git", "config", "--local", k, v], cwd=path, env=env, check=True
+        )
 
 
 def commit_all(repo: Path, message: str = "fixture") -> str:
@@ -100,6 +119,7 @@ def commit_all(repo: Path, message: str = "fixture") -> str:
     sha = subprocess.run(
         ["git", "rev-parse", "HEAD"],
         cwd=repo,
+        env=env,
         capture_output=True,
         text=True,
         check=True,

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -91,9 +91,7 @@ def init_test_repo(path: Path) -> None:
     in any environment (including CI runners with enforced commit signing)."""
     path.mkdir(parents=True, exist_ok=True)
     env = git_env()
-    subprocess.run(
-        ["git", "init", "-q", "-b", "main"], cwd=path, env=env, check=True
-    )
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, env=env, check=True)
     for k, v in [
         ("commit.gpgsign", "false"),
         ("tag.gpgsign", "false"),

--- a/tests/test_decide_reusable_diff.py
+++ b/tests/test_decide_reusable_diff.py
@@ -18,7 +18,12 @@ from pathlib import Path
 
 import pytest
 
-from tests._helpers import REPO_ROOT, commit_all, init_test_repo
+from tests._helpers import (
+    REPO_ROOT,
+    commit_all,
+    env_without_git_location,
+    init_test_repo,
+)
 
 SCRIPT = REPO_ROOT / ".github" / "scripts" / "decide-reusable-diff.sh"
 
@@ -278,6 +283,8 @@ def closure_member() -> str:
             str(REPO_ROOT / ".github" / "scripts" / "shell-run-closure.py"),
             CLOSURE_ENTRY,
         ],
+        cwd=REPO_ROOT,
+        env=env_without_git_location(),
         capture_output=True,
         text=True,
         check=True,

--- a/tests/test_repo_root_under_git_hooks.py
+++ b/tests/test_repo_root_under_git_hooks.py
@@ -23,7 +23,12 @@ from pathlib import Path
 
 import pytest
 
-from tests._helpers import REPO_ROOT
+from tests._helpers import (
+    REPO_ROOT,
+    commit_all,
+    env_without_git_location,
+    init_test_repo,
+)
 
 pytestmark = pytest.mark.drift_guard
 
@@ -89,4 +94,42 @@ def test_the_hazard_is_real_without_the_fix() -> None:
         "longer reports the cwd as the work tree, so the env-stripping in "
         "tests/_helpers.py may now be guarding nothing — re-check before "
         "deleting it"
+    )
+
+
+def test_a_sandbox_commit_lands_in_the_sandbox_under_a_hooks_git_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`commit_all` must resolve its SHA in the sandbox, not in whatever repo
+    `GIT_DIR` names.
+
+    The regression this pins reached CI: `git_env()` inherited the location
+    overrides, so a fixture's commits landed in the repo `GIT_DIR` pointed at
+    while `decide-reusable-diff.sh` — which strips them — looked for those SHAs
+    in the sandbox and reported `could not parse commit <sha>`.
+
+    `GIT_DIR` points at a DECOY repo, never this one: with the bug present the
+    commit below lands wherever it points, and naming the real checkout there
+    rewrites the branch the developer is on.
+    """
+    decoy = tmp_path / "decoy"
+    init_test_repo(decoy)
+    sandbox = tmp_path / "sandbox"
+    init_test_repo(sandbox)
+    (sandbox / "file.txt").write_text("x\n")
+
+    monkeypatch.setenv("GIT_DIR", str(decoy / ".git"))
+    monkeypatch.setenv("GIT_INDEX_FILE", str(decoy / ".git" / "index"))
+    sha = commit_all(sandbox, "chore: sandbox commit")
+
+    kind = subprocess.run(
+        ["git", "cat-file", "-t", sha],
+        cwd=sandbox,
+        env=env_without_git_location(),
+        capture_output=True,
+        text=True,
+    )
+    assert kind.returncode == 0 and kind.stdout.strip() == "commit", (
+        f"{sha} is not a commit in the sandbox — `commit_all` wrote it to the "
+        f"repo GIT_DIR named instead: {kind.stderr.strip()}"
     )


### PR DESCRIPTION
Claimed area: `sanitizeHtml`'s scan/splice loop in `src/html.mjs`.

## Summary

`sanitizeHtml` scanned once and spliced once. Splicing changes how parse5 reads the bytes AROUND the cut, so that one scan was never final — a second call kept removing more. Downstream that reads as a red idempotency property on a PR that changed nothing (glovebox [#4289](https://github.com/AlexanderMattTurner/agent-glovebox/pull/4289)).

The scan now repeats over the spliced text until it finds nothing more, so the returned text is a fixed point by construction rather than by argument. Each round re-splices from the ORIGINAL text, so `splices` still pairs every placeholder with true original bytes at an offset into the returned text — never a placeholder nested inside an earlier one.

## Changes

- `sanitizeHtml`: scan/splice loop to a fixed point, bounded by `MAX_SPLICE_ROUNDS`, which withholds the document past the ceiling the way a parser blow-up does. `warned` comes from the last scan, the one that saw the returned text.
- `mergeRanges` split out of `spliceRanges`; `toSourceRanges` maps a later round's offsets back to source coordinates, by bisection over the pair list.
- Tests: 9 regressions including a chained-reveal document at ~172 KB, and the idempotency property gains an unplanted draw plus `table`/`tr`/`td` and an unterminated processing instruction in its generator.

## Tests / verification

`pnpm test`, `pnpm lint`, `pnpm check` pass.

<details>

**The class, not one bug.** Fuzzing baseline `sanitizeHtml` over 60 seeds x 4000 runs produced 10 distinct counterexamples; all 10 are fixed points after this change. Three mechanisms:

| shape | why one pass was not enough |
| --- | --- |
| `<a><A</a> <a hidden=""></a> <? <div></div> !` | pass 1 is the markdown branch; with the hidden `<a>` gone the adoption agency pulls the trailing ` !` inside the first `<a>`, so pass 2 is the HTML-source branch |
| `<div hidden=""></div> <td hidden=""></td>` | a root-level `<td>` is placed by table scope, so which node parse5 keeps depends on the siblings a splice left |
| `<svg>x</svg> <td hidden=""></td> <!b>` | the later round's span sits BEFORE the earlier splice, so its offsets read back past a placeholder |

**Why the existing property test never caught it.** It plants `VISIBLE_MARK <div style="display:none">…</div>` at the front of every draw. Leading bare text pins the document to the markdown branch, so the suite never reached the HTML-source branch where a splice reshapes the tree. The new unplanted case reaches it: with this generator it reds baseline in 35 of 40 runs of 500, and is deterministic green here.

**Swept the rest of the class** — a transform whose behaviour depends on a whole-input classification the transform then invalidates. `stripInvisible`, `normalizeConfusables` and `sanitizeText` are fixed points over 20k fuzzed documents each, before and after.

**Cost.** The first version remapped offsets by walking the whole pair list per offset, which was quadratic on a document of chained reveals; bisection fixed it. On `<div hidden=""></div> <td hidden=""></td>` filling the latency suite's own sizes, the remaining growth is 8.6x for 8x the bytes (32 KB 166 ms, 256 KB 2609 ms), inside `SCALING_LIMIT` of 24. Against `main` the honest comparison is to the same end state, since one call on `main` does not reach a fixed point: `main` spends 157 ms at 32 KB and 1683 ms at 256 KB across two calls, versus 166 ms and 2609 ms here in one. A clean document returns `null` before the loop and pays one scan, as before.

**Round depth.** 370k adversarial draws over the shapes that chain, plus 50k ordinary fuzzed documents, settle in at most 2 rounds — 24,779 at one and 25,221 at two, never three. `MAX_SPLICE_ROUNDS = 8` is headroom for a shape the measurement did not reach, so its bail-out branch carries a `c8 ignore` saying so.

**Behavior change.** An input that needed two calls now has everything removed by the first, so `removed` counts and `cleaned` text move for those inputs. The extra content is invisible on a rendered page — it is what pass two removed before.

**Known false red.** `sanitizeText/html-prose` in `test/hook-latency.test.mjs` lands ~5% over its 168-unit budget under a loaded full-suite run. It reproduces on unmodified `main` (1 of 3 runs), and `html-prose` carries no hidden nodes or comments, so it never enters the loop this PR adds.

</details>

## Decisions made

- **`warned` comes from the final scan, not the union of every round.** A tag preserved through two rounds would be counted twice by a union. The final scan describes the text actually returned. Under the alternative, `warned.tags` would over-count on any input needing more than one round.
- **Re-splice from the source each round rather than accumulate nested pairs.** Accumulating would leave a round-2 `original` containing a round-1 placeholder, so a rehydrator would need two passes and `start` offsets would go stale. Under the alternative, `SplicePair.start` stops meaning "offset in the returned text".
- **Kept the classifier placeholder-aware rather than placeholder-blind.** Making `htmlSourceTree` ignore our own placeholders would hold more documents on the cheap parse5 branch, but measured only 2266 ms against 2609 ms at 256 KB while dropping the `<td hidden="">` strip in `<svg>x</svg> <td hidden=""></td> <!b>`. Under the alternative, a stray table tag a browser drops stays in the text the model reads.

## Checklist

- [x] Commits follow Conventional Commits; each subject reads as a user-facing release note.
- [x] `pnpm test`, `pnpm lint`, and `pnpm check` pass locally.
- [x] New or changed detectors have negative tests and pin their invariants with property/fuzz tests.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version are left untouched.