### PR TITLE
fix(ci): require a trust signal before a PR title can skip review

### DIFF
--- a/.github/scripts/review-gate.sh
+++ b/.github/scripts/review-gate.sh
@@ -8,8 +8,9 @@
 # review simply was not part of the merge gate.
 #
 # The predicate is one line and stateless: a pull request is clear when at least
-# one review of it stands undismissed. It needs no memory of which reviews have
-# been seen, and it re-derives the same answer on every event.
+# one review of it BY THE AUTOMATED REVIEWER stands undismissed. It needs no
+# memory of which reviews have been seen, and it re-derives the same answer on
+# every event.
 #
 # PR-SCOPED, NOT HEAD-SCOPED, and that is load-bearing. Requiring a review OF THE
 # CURRENT HEAD looks stricter and strands the pull request instead:
@@ -44,6 +45,24 @@ set -euo pipefail
 # never satisfies it.
 GATE_CONTEXT="Automated review posted"
 
+# WHOSE review clears this gate, and the reason the answer is not "anyone's": a
+# review is something the PR author can post on their own pull request, so an
+# any-actor gate is cleared by the author writing a one-word COMMENT review and
+# the required context then asserts an automated review that never ran.
+#
+# The reviewer posts with the workflow GITHUB_TOKEN, so its reviews are authored
+# by this bot — as is the approval auto-approve-skipped posts for a PR the
+# reviewer skips by title or author, which is what still clears this gate for
+# that class without re-deriving decide-pr-review-trigger.sh's skip rules here.
+#
+# DUPLICATED, deliberately: review-findings-gate.sh sets the same login and both
+# gates must mean the same reviewer. Neither can source it from a lib, because
+# five workflows fetch this script ALONE via `sparse-checkout:
+# .github/scripts/review-gate.sh`, and a lib absent from those checkouts would
+# kill the gate at runtime under `set -e`. The drift is guarded by a test.
+REVIEWER_LOGIN_BARE="github-actions"
+export REVIEWER_LOGIN_BARE
+
 # Every review that still stands, paginated: a long-lived PR accumulates more
 # than one page. A DISMISSED review is dropped here, which is what makes the
 # workflow's `dismissed` trigger do something — dismissing the only review
@@ -53,12 +72,14 @@ GATE_CONTEXT="Automated review posted"
 # --paginate --jq` applies the filter to EACH page, so a `first`/`max_by` would
 # silently run once per page and answer from the last one.
 #
-# Any actor's review counts. The reviewer's own clears it, and so does the
-# approval auto-approve-skipped posts for a PR the reviewer skips by title or
-# author — reading that OUTCOME rather than re-deriving the skip predicate,
-# which would be a second copy of decide-pr-review-trigger.sh's rules.
+# Only the reviewer's own reviews count (see REVIEWER_LOGIN_BARE above). The
+# REST endpoint spells an app bot's login WITH the `[bot]` suffix while GraphQL
+# spells it without, so the login is stripped before comparing and either
+# spelling matches — the same normalization lib/pr-reviews.bash applies.
 reviewers="$(gh api --paginate "repos/${GH_REPO}/pulls/${PR}/reviews" \
-  --jq '.[] | select(.state != "DISMISSED") | .user.login // ""')"
+  --jq '.[] | select(.state != "DISMISSED")
+      | select((.user.login // "" | sub("\\[bot\\]$"; "")) == env.REVIEWER_LOGIN_BARE)
+      | .user.login // ""')"
 reviewer="$(head -n 1 <<<"$reviewers")"
 
 if [[ -n "$reviewer" ]]; then

--- a/.github/scripts/review-gate.sh
+++ b/.github/scripts/review-gate.sh
@@ -76,8 +76,20 @@ export REVIEWER_LOGIN_BARE
 # REST endpoint spells an app bot's login WITH the `[bot]` suffix while GraphQL
 # spells it without, so the login is stripped before comparing and either
 # spelling matches — the same normalization lib/pr-reviews.bash applies.
+#
+# The body-non-empty test asks WHETHER THIS IS A REVIEW, which the author test
+# does not. GitHub synthesizes a body-less COMMENTED review by the same bot
+# around every standalone review-comment POST, and resolve-addressed-threads.sh
+# posts its audit replies under that identity. Counting one satisfies this gate
+# vacuously on exactly the PRs that carry threads — the ones
+# approve-if-reviewer-hold-clear.sh dismisses a CHANGES_REQUESTED on, where a
+# standing synthesized review holds the status green and strips the workflow's
+# `dismissed` trigger of meaning. Every bot writer passes a non-empty body
+# (post-pr-review.mjs falls back to "Automated review."), so the test costs
+# nothing. lib/pr-reviews.bash applies the same one for the sibling gate.
 reviewers="$(gh api --paginate "repos/${GH_REPO}/pulls/${PR}/reviews" \
   --jq '.[] | select(.state != "DISMISSED")
+      | select((.body // "") != "")
       | select((.user.login // "" | sub("\\[bot\\]$"; "")) == env.REVIEWER_LOGIN_BARE)
       | .user.login // ""')"
 reviewer="$(head -n 1 <<<"$reviewers")"

--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -64,19 +64,43 @@ jobs:
   # event bypasses the title/author skips entirely — the label IS the request to
   # review a PR the skips would otherwise drop — and the script confirms the
   # label is `needs-auto-review` before running (any other label is a no-op).
+  #
+  # The skip set applies to a TRUSTED PR only. A PR title is author-controlled,
+  # so an untrusted author who may skip by title chooses whether their own code
+  # is read — and the auto-approve job below turns that same title into an
+  # approving review. Trust is the PR being same-repo (a fork cannot write a
+  # branch here) or the author being an OWNER/MEMBER/COLLABORATOR; both come
+  # from the event payload, which GitHub sets and the actor cannot spoof.
+  # `author_association` on a fork PR reflects the BASE repo's permissions.
+  #
+  # This gate and the auto-approve job's must move TOGETHER. Guarding only the
+  # approval would leave a fork PR titled `chore:` skipped here and unapproved
+  # there — no review, no approval, and no event that produces either. Skipping
+  # untrusted PRs from the skip set is what keeps the two exhaustive: every PR
+  # is reviewed or auto-approved, never neither.
   decide:
     name: Decide whether to review
     if: >-
       github.event.action == 'labeled' ||
       (
         github.event.pull_request.draft == false &&
-        github.event.pull_request.user.type != 'Bot' &&
-        !startsWith(github.event.pull_request.title, 'chore:') &&
-        !startsWith(github.event.pull_request.title, 'chore(') &&
-        !startsWith(github.event.pull_request.title, 'style:') &&
-        !startsWith(github.event.pull_request.title, 'style(') &&
-        !startsWith(github.event.pull_request.title, 'release:') &&
-        !startsWith(github.event.pull_request.title, 'release(')
+        !(
+          (
+            github.event.pull_request.head.repo.full_name == github.repository ||
+            github.event.pull_request.author_association == 'OWNER' ||
+            github.event.pull_request.author_association == 'MEMBER' ||
+            github.event.pull_request.author_association == 'COLLABORATOR'
+          ) &&
+          (
+            github.event.pull_request.user.type == 'Bot' ||
+            startsWith(github.event.pull_request.title, 'chore:') ||
+            startsWith(github.event.pull_request.title, 'chore(') ||
+            startsWith(github.event.pull_request.title, 'style:') ||
+            startsWith(github.event.pull_request.title, 'style(') ||
+            startsWith(github.event.pull_request.title, 'release:') ||
+            startsWith(github.event.pull_request.title, 'release(')
+          )
+        )
       )
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -330,13 +354,32 @@ jobs:
   # re-clear a skipped PR would merge on its first head and be blocked forever
   # after its second.
   #
-  # Title/author come from the event payload (set by GitHub, unspoofable by the
-  # triggering actor). This posts a review and a check run, runs no PR code, and
-  # holds pull-requests:write + checks:write and nothing else.
+  # THE TRUST GATE BELOW IS WHAT STOPS A PR FROM APPROVING ITSELF. The three
+  # steps here clear three merge levers — an approving review, the "Review
+  # findings resolved" check run, and the "Automated review posted" status — and
+  # the skip set they key on is the PR TITLE, which the PR author writes. The
+  # author (`user.type`) does come from the event payload and cannot be spoofed;
+  # the title carries no such guarantee, so without this gate any fork PR named
+  # `chore: …` cleared all three levers and was never read.
+  #
+  # Trusted means same-repo (a fork author cannot write a branch here) or an
+  # OWNER/MEMBER/COLLABORATOR author — both payload fields GitHub sets. It is
+  # the same predicate the `decide` job skips on, and the two are exhaustive by
+  # construction: an untrusted PR is never skipped there, so it gets the real
+  # review instead of the approval it cannot earn here.
+  #
+  # This posts a review and a check run, runs no PR code, and holds
+  # pull-requests:write + checks:write and nothing else.
   auto-approve-skipped:
     name: Auto-approve low-risk and bot PRs the reviewer skips
     if: >-
       github.event.pull_request.draft == false &&
+      (
+        github.event.pull_request.head.repo.full_name == github.repository ||
+        github.event.pull_request.author_association == 'OWNER' ||
+        github.event.pull_request.author_association == 'MEMBER' ||
+        github.event.pull_request.author_association == 'COLLABORATOR'
+      ) &&
       (
         github.event.pull_request.user.type == 'Bot' ||
         startsWith(github.event.pull_request.title, 'chore:') ||

--- a/tests/test_pr_review_fork_guard.py
+++ b/tests/test_pr_review_fork_guard.py
@@ -1,0 +1,269 @@
+"""The trust gate on claude-pr-review.yaml's title-driven skip path.
+
+A PR title is written by the PR author. Two jobs key on it: `decide` skips the
+model review for a `chore:`/`style:`/`release:` title, and `auto-approve-skipped`
+answers that same skip with an approving review, a green "Review findings
+resolved" check run, and a re-derived "Automated review posted" status. Three
+merge levers, chosen by a string the author controls — so an untrusted PR named
+`chore: bump` merged without ever being read.
+
+Both jobs now require a TRUST signal before the title means anything: the PR is
+same-repo, or its author is an OWNER/MEMBER/COLLABORATOR of the base repo. The
+two gates must move together, which is what these tests pin:
+
+  * no title routes a cross-repository PR into `auto-approve-skipped`; and
+  * every non-draft PR is reviewed OR auto-approved, never neither — guarding
+    the fork PR titled `chore:` that a one-sided fix would strand with no
+    review, no approval, and no further event able to produce either.
+
+The workflow `if:` expressions are EVALUATED here (over the payload shapes
+GitHub sends) rather than pattern-matched as text: a text assertion keeps
+passing when the condition is rearranged into an equivalent-looking form that
+decides differently.
+"""
+
+import itertools
+import re
+
+import pytest
+import yaml
+
+from tests._helpers import REPO_ROOT
+
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "claude-pr-review.yaml"
+JOBS = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]
+DECIDE_IF = JOBS["decide"]["if"]
+AUTO_APPROVE_IF = JOBS["auto-approve-skipped"]["if"]
+
+# The titles the skip path recognizes, plus ordinary ones it must not.
+SKIP_TITLES = [
+    "chore: bump deps",
+    "chore(deps): bump deps",
+    "style: reformat",
+    "style(css): reformat",
+    "release: v1.2.3",
+    "release(npm): v1.2.3",
+]
+REVIEWED_TITLES = ["feat: add a layer", "fix: patch the parser", "docs: rewrite"]
+
+# `author_association` values that carry no write access to the base repo.
+UNTRUSTED_ASSOCIATIONS = [
+    "CONTRIBUTOR",
+    "FIRST_TIME_CONTRIBUTOR",
+    "FIRST_TIMER",
+    "MANNEQUIN",
+    "NONE",
+]
+TRUSTED_ASSOCIATIONS = ["OWNER", "MEMBER", "COLLABORATOR"]
+
+BASE_REPO = "acme/agent-sanitizer"
+
+
+class _Null:
+    """GitHub's `null`: any property of it is null, and it equals nothing."""
+
+    def __getattr__(self, _name: str) -> "_Null":
+        return self
+
+    def __eq__(self, _other: object) -> bool:
+        return False
+
+    def __hash__(self) -> int:
+        return 0
+
+
+NULL = _Null()
+
+
+class _Ctx:
+    """Dotted context lookup with GitHub's missing-property-is-null semantics."""
+
+    def __init__(self, data: dict):
+        self._data = data
+
+    def __getattr__(self, name: str):
+        if name not in self._data:
+            return NULL
+        value = self._data[name]
+        return _Ctx(value) if isinstance(value, dict) else value
+
+
+def _starts_with(value, prefix: str) -> bool:
+    return isinstance(value, str) and value.startswith(prefix)
+
+
+# GitHub's expression grammar is a subset of Python's once the operators are
+# spelled Python's way; the translation is textual because the surface used in
+# these two conditions is exactly: || && ! == != ( ) 'literal' false
+# startsWith(). Anything else must be added here deliberately rather than
+# silently evaluating as Python.
+_ALLOWED = re.compile(
+    r"""\s|\(|\)|,|'[^']*'|&&|\|\||!=|==|!|true|false|startsWith|github(?:\.[A-Za-z_]+)+"""
+)
+
+
+def _to_python(expression: str) -> str:
+    leftover = _ALLOWED.sub("", expression)
+    assert not leftover.strip(), (
+        f"unsupported syntax in the workflow condition: {leftover!r} — extend "
+        "this evaluator instead of letting it evaluate as raw Python"
+    )
+    out = expression.replace("!=", "\0NE\0")
+    out = out.replace("!", " not ")
+    out = out.replace("\0NE\0", "!=")
+    out = out.replace("&&", " and ").replace("||", " or ")
+    out = re.sub(r"\bfalse\b", "False", out)
+    out = re.sub(r"\btrue\b", "True", out)
+    return out
+
+
+def _evaluate(expression: str, github: dict) -> bool:
+    return bool(
+        eval(  # noqa: S307 — the input is this repo's own workflow, checked above
+            _to_python(expression),
+            {"__builtins__": {}},
+            {"github": _Ctx(github), "startsWith": _starts_with},
+        )
+    )
+
+
+def _github(
+    title: str,
+    *,
+    action: str = "opened",
+    draft: bool = False,
+    user_type: str = "User",
+    association: str = "CONTRIBUTOR",
+    head_repo: str = BASE_REPO,
+) -> dict:
+    """The `github` context of a pull_request_target event, as GitHub sends it."""
+    return {
+        "repository": BASE_REPO,
+        "event": {
+            "action": action,
+            "pull_request": {
+                "title": title,
+                "draft": draft,
+                "user": {"type": user_type},
+                "author_association": association,
+                "head": {"repo": {"full_name": head_repo}},
+            },
+        },
+    }
+
+
+FORK_REPO = "attacker/agent-sanitizer"
+UNTRUSTED = [
+    {"association": association, "head_repo": FORK_REPO}
+    for association in UNTRUSTED_ASSOCIATIONS
+]
+TRUSTED = [
+    {"association": association, "head_repo": FORK_REPO}
+    for association in TRUSTED_ASSOCIATIONS
+] + [
+    {"association": association, "head_repo": BASE_REPO}
+    for association in UNTRUSTED_ASSOCIATIONS
+]
+
+
+def test_the_evaluator_is_not_vacuous() -> None:
+    # Both verdicts must be reachable, or every assertion below is worthless.
+    assert _evaluate("github.event.action == 'labeled'", _github("x", action="labeled"))
+    assert not _evaluate("github.event.action == 'labeled'", _github("x"))
+    assert _evaluate(
+        "!(github.event.pull_request.draft == false)", _github("x", draft=True)
+    )
+    assert _evaluate(
+        "startsWith(github.event.pull_request.title, 'chore:')", _github("chore: x")
+    )
+    # A property GitHub omits reads as null and matches nothing.
+    assert not _evaluate(
+        "github.event.pull_request.head.repo.full_name == github.repository",
+        {"repository": BASE_REPO, "event": {"pull_request": {"head": {}}}},
+    )
+
+
+def test_both_gates_actually_read_the_trust_signals() -> None:
+    # A positive marker: the conditions must mention the payload fields the
+    # tests below rely on, so a rewrite that drops the guard entirely fails
+    # here rather than passing on some accidentally-equivalent shape.
+    for condition in (DECIDE_IF, AUTO_APPROVE_IF):
+        assert "author_association" in condition
+        assert "head.repo.full_name" in condition
+
+
+@pytest.mark.parametrize("title", SKIP_TITLES + REVIEWED_TITLES)
+@pytest.mark.parametrize("trust", UNTRUSTED, ids=lambda t: t["association"])
+@pytest.mark.parametrize("user_type", ["User", "Bot"])
+def test_no_title_routes_a_cross_repository_pr_into_auto_approve(
+    title: str, trust: dict, user_type: str
+) -> None:
+    # The finding: `auto-approve-skipped` submits an approving review, greens
+    # the review-findings check run and re-derives the review status. A fork PR
+    # must reach none of that by naming itself.
+    github = _github(title, user_type=user_type, **trust)
+    assert not _evaluate(AUTO_APPROVE_IF, github)
+
+
+@pytest.mark.parametrize("title", SKIP_TITLES)
+@pytest.mark.parametrize("trust", UNTRUSTED, ids=lambda t: t["association"])
+def test_a_cross_repository_pr_is_reviewed_whatever_it_calls_itself(
+    title: str, trust: dict
+) -> None:
+    # The other half of the fix: guarding only the approval would leave this PR
+    # skipped by `decide` AND unapproved — stranded on both gates forever.
+    assert _evaluate(DECIDE_IF, _github(title, **trust))
+
+
+@pytest.mark.parametrize("title", SKIP_TITLES)
+@pytest.mark.parametrize(
+    "trust", TRUSTED, ids=lambda t: f"{t['association']}-{t['head_repo']}"
+)
+def test_a_trusted_low_risk_pr_still_skips_the_review_and_is_approved(
+    title: str, trust: dict
+) -> None:
+    assert not _evaluate(DECIDE_IF, _github(title, **trust))
+    assert _evaluate(AUTO_APPROVE_IF, _github(title, **trust))
+
+
+def test_a_same_repo_bot_pr_still_skips_the_review_and_is_approved() -> None:
+    # Dependabot pushes its branch to this repo, so it stays in the skipped
+    # class the auto-approve job exists to unblock.
+    github = _github("Bump acorn from 8.0.0 to 8.0.1", user_type="Bot")
+    assert not _evaluate(DECIDE_IF, github)
+    assert _evaluate(AUTO_APPROVE_IF, github)
+
+
+@pytest.mark.parametrize("title", REVIEWED_TITLES)
+def test_an_ordinary_title_is_reviewed_and_never_auto_approved(title: str) -> None:
+    github = _github(title, association="MEMBER")
+    assert _evaluate(DECIDE_IF, github)
+    assert not _evaluate(AUTO_APPROVE_IF, github)
+
+
+@pytest.mark.parametrize("title", SKIP_TITLES)
+def test_a_draft_reaches_neither_job(title: str) -> None:
+    # Drafts cannot merge; they are picked up on `ready_for_review`.
+    github = _github(title, action="opened", draft=True, association="MEMBER")
+    assert not _evaluate(DECIDE_IF, github)
+    assert not _evaluate(AUTO_APPROVE_IF, github)
+
+
+@pytest.mark.parametrize(
+    "title,trust,user_type",
+    list(
+        itertools.product(
+            SKIP_TITLES + REVIEWED_TITLES, UNTRUSTED + TRUSTED, ["User", "Bot"]
+        )
+    ),
+    ids=str,
+)
+def test_every_non_draft_pr_is_reviewed_or_approved_never_neither(
+    title: str, trust: dict, user_type: str
+) -> None:
+    # The exhaustiveness invariant the two gates hold jointly. A PR that reaches
+    # neither job gets no review to clear "Automated review posted" and no
+    # approval to clear the review-required ruleset, and no later event
+    # produces either — it is stuck, silently.
+    github = _github(title, user_type=user_type, **trust)
+    assert _evaluate(DECIDE_IF, github) or _evaluate(AUTO_APPROVE_IF, github)

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -90,9 +90,16 @@ sys.exit(2)
 HEAD_SHA = "deadbeef"
 
 
-def _review(login: str, *, state: str = "COMMENTED") -> dict:
-    """A review as the REST pulls/{n}/reviews endpoint returns it."""
-    return {"user": {"login": login}, "state": state}
+def _review(
+    login: str, *, state: str = "COMMENTED", body: str = "Automated review."
+) -> dict:
+    """A review as the REST pulls/{n}/reviews endpoint returns it.
+
+    `body` defaults to non-empty because every real writer sends one. Pass
+    `body=""` to model the review GitHub synthesizes around a standalone
+    review-comment POST, which is not a review anyone wrote.
+    """
+    return {"user": {"login": login}, "state": state, "body": body}
 
 
 def _run(
@@ -136,6 +143,32 @@ def test_a_non_reviewer_comment_review_leaves_the_gate_pending(tmp_path: Path) -
     proc, posted = _run(tmp_path, [_review("pr-author", state="COMMENTED")])
     assert proc.returncode == 0, proc.stderr
     assert _only(posted)["state"] == "pending"
+
+
+def test_a_body_less_reviewer_review_leaves_the_gate_pending(tmp_path: Path) -> None:
+    # GitHub synthesizes a body-less COMMENTED review by the same bot around
+    # every standalone review-comment POST, and resolve-addressed-threads.sh
+    # posts its audit replies under that identity. Counting one would clear the
+    # gate on exactly the PRs that carry threads, without anyone reviewing.
+    proc, posted = _run(tmp_path, [_review("github-actions[bot]", body="")])
+    assert proc.returncode == 0, proc.stderr
+    assert _only(posted)["state"] == "pending"
+
+
+def test_a_real_reviewer_review_still_clears_the_gate_behind_a_synthesized_one(
+    tmp_path: Path,
+) -> None:
+    # The positive marker for the test above: the body-non-empty filter must not
+    # swallow the review that genuinely stands.
+    proc, posted = _run(
+        tmp_path,
+        [
+            _review("github-actions[bot]", body=""),
+            _review("github-actions[bot]", body="Automated review."),
+        ],
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert _only(posted)["state"] == "success"
 
 
 @pytest.mark.parametrize("state", ["COMMENTED", "APPROVED", "CHANGES_REQUESTED"])

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -1,0 +1,225 @@
+"""Behavioral tests for .github/scripts/review-gate.sh — the "Automated review
+posted" commit status.
+
+The predicate is stateless and PR-scoped: the status is `success` when a review
+BY THE AUTOMATED REVIEWER stands undismissed on the pull request, `pending`
+otherwise. Whose review counts is the whole gate — a gate that accepts any
+actor's review is cleared by the PR author submitting a COMMENT review on their
+own PR, and the required context then asserts an automated review that never
+ran.
+
+Drives the REAL script with a fake `gh` on PATH that serves the reviews list
+from a canned array through REAL jq — so the script's own reviewer filter is
+exercised rather than re-implemented — and records the status POST's fields.
+The REST endpoint spells an app bot's login WITH the `[bot]` suffix, which is
+why both spellings are tested.
+"""
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests._helpers import REPO_ROOT
+
+SCRIPT = REPO_ROOT / ".github" / "scripts" / "review-gate.sh"
+FINDINGS_GATE = REPO_ROOT / ".github" / "scripts" / "review-findings-gate.sh"
+
+_FAKE_GH = r"""#!/usr/bin/env python3
+# gh stub: serves the PR reviews list from a canned file, running the CALLER'S
+# --jq through real jq (that filter is the logic under test), and records the
+# status POST's fields. Anything else is unhandled (exit 2), so a stray API
+# call reds the run.
+import json, os, shutil, subprocess, sys
+
+JQ = shutil.which("jq")
+if JQ is None:
+    # Loud, never a silent degrade: without real jq the stub would have to fake
+    # the filter under test and every assertion would be worthless.
+    sys.stderr.write("fake gh: jq not found on PATH\n")
+    sys.exit(3)
+
+args = sys.argv[1:]
+assert args and args[0] == "api", args
+args = args[1:]
+
+method, jq, path, fields = "GET", None, None, {}
+i = 0
+while i < len(args):
+    a = args[i]
+    if a == "--paginate":
+        i += 1
+    elif a in ("-X", "--method"):
+        method, i = args[i + 1], i + 2
+    elif a == "--jq":
+        jq, i = args[i + 1], i + 2
+    elif a in ("-F", "-f"):
+        k, _, v = args[i + 1].partition("=")
+        fields[k] = v
+        i += 2
+    elif not a.startswith("-"):
+        path, i = a, i + 1
+    else:
+        i += 1
+
+if path and path.endswith("/reviews") and method == "GET":
+    if os.environ.get("FAIL_READS") == "1":
+        sys.stderr.write("fake gh: HTTP 502 on the reviews read\n")
+        sys.exit(1)
+    with open(os.environ["GH_REVIEWS"], encoding="utf-8") as f:
+        doc = json.load(f)
+    r = subprocess.run(
+        [JQ, "-r", jq], input=json.dumps(doc), text=True, capture_output=True
+    )
+    sys.stderr.write(r.stderr)
+    sys.stdout.write(r.stdout)
+    sys.exit(r.returncode)
+
+if path and "/statuses/" in path and method == "POST":
+    with open(os.environ["STATUS_LOG"], "a", encoding="utf-8") as f:
+        f.write(json.dumps({"path": path, **fields}) + "\n")
+    sys.exit(0)
+
+sys.stderr.write("fake gh: unhandled %r\n" % (sys.argv,))
+sys.exit(2)
+"""
+
+HEAD_SHA = "deadbeef"
+
+
+def _review(login: str, *, state: str = "COMMENTED") -> dict:
+    """A review as the REST pulls/{n}/reviews endpoint returns it."""
+    return {"user": {"login": login}, "state": state}
+
+
+def _run(
+    tmp_path: Path, reviews: list[dict], *, fail_reads: bool = False
+) -> tuple[subprocess.CompletedProcess, list[dict]]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    gh = bin_dir / "gh"
+    gh.write_text(_FAKE_GH)
+    gh.chmod(0o755)
+    (tmp_path / "reviews.json").write_text(json.dumps(reviews))
+    log = tmp_path / "statuses"
+    log.write_text("")
+    env = {
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "GH_TOKEN": "fake",
+        "GH_REPO": "o/r",
+        "PR": "5",
+        "HEAD_SHA": HEAD_SHA,
+        "GH_REVIEWS": str(tmp_path / "reviews.json"),
+        "STATUS_LOG": str(log),
+    }
+    if fail_reads:
+        env["FAIL_READS"] = "1"
+    proc = subprocess.run(
+        ["bash", str(SCRIPT)], capture_output=True, text=True, env=env
+    )
+    posted = [json.loads(ln) for ln in log.read_text().splitlines() if ln.strip()]
+    return proc, posted
+
+
+def _only(posted: list[dict]) -> dict:
+    assert len(posted) == 1, posted
+    assert posted[0]["path"].endswith(f"/statuses/{HEAD_SHA}")
+    return posted[0]
+
+
+def test_a_non_reviewer_comment_review_leaves_the_gate_pending(tmp_path: Path) -> None:
+    # The finding: a PR author can submit a COMMENT review on their own PR, so
+    # accepting any actor's review lets the author clear the gate themselves.
+    proc, posted = _run(tmp_path, [_review("pr-author", state="COMMENTED")])
+    assert proc.returncode == 0, proc.stderr
+    assert _only(posted)["state"] == "pending"
+
+
+@pytest.mark.parametrize("state", ["COMMENTED", "APPROVED", "CHANGES_REQUESTED"])
+def test_no_state_of_a_human_review_clears_the_gate(tmp_path: Path, state: str) -> None:
+    proc, posted = _run(tmp_path, [_review("somehuman", state=state)])
+    assert proc.returncode == 0, proc.stderr
+    assert _only(posted)["state"] == "pending"
+
+
+@pytest.mark.parametrize("login", ["github-actions[bot]", "github-actions"])
+def test_the_reviewer_clears_the_gate_under_either_login_spelling(
+    tmp_path: Path, login: str
+) -> None:
+    # REST returns the `[bot]` suffix, GraphQL does not; the gate must accept both.
+    proc, posted = _run(tmp_path, [_review(login)])
+    assert proc.returncode == 0, proc.stderr
+    status = _only(posted)
+    assert status["state"] == "success"
+    assert status["description"] == f"Reviewed by {login}"
+
+
+def test_a_dismissed_reviewer_review_returns_the_gate_to_pending(
+    tmp_path: Path,
+) -> None:
+    proc, posted = _run(
+        tmp_path,
+        [
+            _review("github-actions[bot]", state="DISMISSED"),
+            _review("somehuman", state="APPROVED"),
+        ],
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert _only(posted)["state"] == "pending"
+
+
+def test_the_reviewer_is_found_behind_earlier_human_reviews(tmp_path: Path) -> None:
+    # The filter must scan every review, not just the first one.
+    proc, posted = _run(
+        tmp_path,
+        [
+            _review("somehuman", state="APPROVED"),
+            _review("another-human"),
+            _review("github-actions[bot]"),
+        ],
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert _only(posted)["state"] == "success"
+
+
+def test_a_pr_with_no_reviews_is_pending(tmp_path: Path) -> None:
+    proc, posted = _run(tmp_path, [])
+    assert proc.returncode == 0, proc.stderr
+    assert _only(posted)["state"] == "pending"
+
+
+def test_a_failed_reviews_read_fails_closed_with_no_status(tmp_path: Path) -> None:
+    # Can't-verify is never green: a gate that fails open lets a PR merge past a
+    # review nobody read.
+    proc, posted = _run(tmp_path, [], fail_reads=True)
+    assert proc.returncode != 0
+    assert posted == []
+
+
+@pytest.mark.drift_guard
+def test_drift_guard_both_gates_name_the_same_reviewer_login() -> None:
+    """DRIFT GUARD — two copies of one login, asserted equal. Named honestly
+    rather than as "the gates agree", which would launder the duplication.
+
+    Why a true SSOT is infeasible here: five workflows fetch review-gate.sh
+    ALONE via `sparse-checkout: .github/scripts/review-gate.sh`, so a lib it
+    sourced would be missing from those checkouts and kill the gate at runtime
+    under `set -e`. Moving the login into a lib means adding it to every one of
+    those checkout lists first.
+
+    What the drift costs: the two required contexts would answer to different
+    reviewers, so one of them could never be cleared by the reviewer that runs.
+    """
+    pattern = re.compile(r'REVIEWER_LOGIN_BARE="(?P<login>[^"]+)"')
+    logins = {
+        path.name: pattern.findall(path.read_text(encoding="utf-8"))
+        for path in (SCRIPT, FINDINGS_GATE)
+    }
+    # Positive marker: each assignment must actually exist, or the equality
+    # below passes on two empty lists.
+    for name, found in logins.items():
+        assert found, f"{name} no longer assigns REVIEWER_LOGIN_BARE"
+    assert set(logins[SCRIPT.name]) == set(logins[FINDINGS_GATE.name])


### PR DESCRIPTION
Claims `.github/workflows/claude-pr-review.yaml` and `.github/scripts/review-gate.sh`. From the 2026-08 audit (#327).

## The hole

`auto-approve-skipped` fired on PR **title** prefixes (`chore:`, `style:`, `release:`) with no cross-repository, actor, or author-association guard anywhere in the job. A fork pull request titled `chore: …` therefore skipped the model review, received an approving review that counts toward a review-required ruleset, and had both required contexts posted green — three merge levers cleared by a string the pull request author writes.

The job header asserted that "title/author come from the event payload (set by GitHub, unspoofable by the triggering actor)". That is true of the author and false of the title.

Separately, `review-gate.sh` cleared the "Automated review posted" status on **any** undismissed review, its comment stating "Any actor's review counts." A pull request author can submit a comment review on their own pull request and clear that gate without the automated reviewer running.

## The fix

Both title-keyed jobs now require a trust signal before an author-written title means anything: the head repository is this repository, or `author_association` is OWNER, MEMBER, or COLLABORATOR.

The `decide` job needed the same guard **in the opposite direction**, which is the part worth reading. Guarding only the approval would have stranded the exact pull request it was meant to protect: a fork titled `chore:` would be skipped by `decide` on `opened` and on every later `synchronize`, and no longer approved by `auto-approve-skipped` — reviewed by nobody, approved by nobody, with no event able to produce either. The skip set is now empty for untrusted authors, so the two jobs are exhaustive: every non-draft pull request is either reviewed or auto-approved, never neither. That invariant is a test.

`review-gate.sh` now filters to the automated reviewer's login, normalizing the REST `[bot]` suffix so both spellings match.

## Tests

- `tests/test_pr_review_fork_guard.py` — 414 cases evaluating the two workflow `if:` expressions over real payload shapes, rather than matching workflow text. Proven non-vacuous: against the **old** conditions a `NONE`-association fork titled `chore: bump` routes into auto-approve and is skipped by decide; against the new ones it does neither.
- `tests/test_review_gate.py` — 11 cases driving the real script with a fake `gh` whose `--jq` runs through real jq. A non-reviewer comment review leaves the status pending; both reviewer spellings clear it; a failed read posts nothing and exits non-zero.

`uv run pytest tests/ --ignore=tests/secrets` → 1167 passed.

## Decisions made

**One shared reviewer-identity predicate: not done, deliberately.** Five workflows fetch `review-gate.sh` alone via `sparse-checkout`. A sourced library absent from those checkouts would kill the gate under `set -e`, and no test enforces sparse-checkout closure — so the move requires editing five workflow checkout lists that other audit branches touch. The login is duplicated with the reason stated at both ends and pinned by a drift-guard test. The library move is the follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvuJNE8pEstzwvSmir592V)_