### PR TITLE
fix(layer3): scan plain-text URLs, and read CSS values by shape not position

### DIFF
--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=98375b5bab48547deb370b3ee93b28afd23ea2ae399fc23ebbd40aa3c8da8985
-d7587b001c9e7113d68f8e77cfa14a87a913445de5997f263488aa89ce26cdf8  agent-sanitizer-hooks-darwin-arm64
-3ef221a9ffe42116de90df7b8f4db0344b94cb80c85d7578a611bbe5c231ab1b  agent-sanitizer-hooks-darwin-x64
-386ceeca8a61b48e83f53ad6c62214dfa4b0009846b25c75f1366154be82be8e  agent-sanitizer-hooks-linux-arm64
-38afe6936c42bc88af63c68240c71550f4e2587dbf9c3bf5f8f55a09083b2edf  agent-sanitizer-hooks-linux-x64
+# bundle=e3be4b0647c2f1c054522920d25ff692af4537e6bf05f8fde2fedcda25d5a931
+b0458a68f9733099496772616809811c9b21ef072d9f59dd75b07769f6f9114e  agent-sanitizer-hooks-darwin-arm64
+044c31c1bc96dc719a383813b10fcd3950d0e2f6191f860dabdfa18134b15d9d  agent-sanitizer-hooks-darwin-x64
+86be340e82c7f3d7effbdffda9159a769713020f04fe82a5f9498fe82d08a6d1  agent-sanitizer-hooks-linux-arm64
+d727a38a5acafabc67fc050bb74a76ebba89f64919da4673fd1578e12dca141f  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=e3be4b0647c2f1c054522920d25ff692af4537e6bf05f8fde2fedcda25d5a931
-b0458a68f9733099496772616809811c9b21ef072d9f59dd75b07769f6f9114e  agent-sanitizer-hooks-darwin-arm64
-044c31c1bc96dc719a383813b10fcd3950d0e2f6191f860dabdfa18134b15d9d  agent-sanitizer-hooks-darwin-x64
-86be340e82c7f3d7effbdffda9159a769713020f04fe82a5f9498fe82d08a6d1  agent-sanitizer-hooks-linux-arm64
-d727a38a5acafabc67fc050bb74a76ebba89f64919da4673fd1578e12dca141f  agent-sanitizer-hooks-linux-x64
+# bundle=b24050bdbce5ecee6c85c3e3a5f71b8124964462f2627f5fcd65bd2540acd749
+ca855921f165867e73696e6b614dd9bd5f573b993d5d2e6c576013ca7992aac0  agent-sanitizer-hooks-darwin-arm64
+d527b879872161cca0f9c21da0d139c94a10999609fccd033442bbfe46d5a13d  agent-sanitizer-hooks-darwin-x64
+be96ac09af5c515df0d27d21f7fd37e5c91427484b24c11639c2e68fece69a2e  agent-sanitizer-hooks-linux-arm64
+0b1395a23d2c84757cc4c4191dccb6cc3360ee9fd0c8ecc049b9eba87f5adc88  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -3864,15 +3864,19 @@ var init_invisible = __esm({
 function needsMarkdownPipeline(text5) {
   return HTML_TAG_PRESENT.test(text5) || MD_LINK_HINT.test(text5);
 }
+function needsUrlScan(text5) {
+  return URL_PRESENT.test(text5) || needsMarkdownPipeline(text5);
+}
 function matchesSecretHint(text5) {
   return SECRET_HINT.test(text5) || SECRET_HINT_EXT.test(text5);
 }
-var HTML_TAG_PRESENT, MD_LINK_HINT, SECRET_HINT, SECRET_HINT_EXT;
+var HTML_TAG_PRESENT, MD_LINK_HINT, URL_PRESENT, SECRET_HINT, SECRET_HINT_EXT;
 var init_gates = __esm({
   "src/gates.mjs"() {
     "use strict";
     HTML_TAG_PRESENT = /<[a-zA-Z/!?][^<>]*>/;
     MD_LINK_HINT = /\]\(|!\[|^[ \t]*\[[^[\]\n]+\]:\s/m;
+    URL_PRESENT = /https?:\/\//i;
     SECRET_HINT = /secret|token|password|passwd|pwd|bearer|credential|authorization|contrase[nñ]a|-----BEGIN|(?:api|auth|service|account|db|database|priv|private|client|access)[_-]?key|(?:db|database|key)[_-]?pass|(?:A3T|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}|gh[pousr]_[A-Za-z0-9]|github_pat_|gl[a-z]{2,12}-[0-9A-Za-z_-]{20}|sk-ant-|AIza[0-9A-Za-z_-]{35}|sk_live_|sk_test_|rk_live_|rk_test_|xox[bpasr]-|eyJ[A-Za-z0-9]|do[opr]_v1_[a-f0-9]{16}|v1\.0-[a-f0-9]{24}-|hv[sb]\.[A-Za-z0-9_-]{20}|(?<![a-z0-9])[a-z0-9]{14}\.atlasv1\.|sk-or-v1-[0-9a-f]{16}|gsk_[A-Za-z0-9]{16}|xai-[A-Za-z0-9]{16}|r8_[A-Za-z0-9]{16}/i;
     SECRET_HINT_EXT = /(?:AC|SK)[a-z0-9]{32}|SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}|sq0csp-[0-9A-Za-z_-]{43}|(?<![0-9])[0-9]{8,10}:[0-9A-Za-z_-]{35}|(?<![0-9a-z])[0-9a-z]{32}-us[0-9]{1,2}|(?<![A-Za-z0-9_-])[MNO][A-Za-z0-9_-]{23,25}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27}|T3BlbkFJ|pypi-AgE|(?<![A-Za-z0-9])AKC[A-Za-z0-9]{10}|(?<![A-Za-z0-9])AP[0-9A-Fa-f][A-Za-z0-9]{8}|:\/\/[^\s:/@]{1,64}:[^\s:/@]{1,64}@|(?:key|pw|pass)["']?[\s:=>]+["']?[A-Za-z0-9_/+-]{20}/i;
   }
@@ -63327,13 +63331,12 @@ function isHidingTransform(node2) {
     const name50 = fn.name;
     const args = valueTokens(fn);
     if (/^(?:scale|scale3d|scalex|scaley|matrix|matrix3d)$/.test(name50)) {
-      const numbers = args.filter(
-        (a) => a.type === "Number"
-      );
+      const groups = functionArgs(fn);
       const factorIdx = name50 === "matrix" ? [0, 3] : name50 === "matrix3d" ? [0, 5] : [0, 1];
       if (factorIdx.some((i) => {
-        const f = numbers[i];
-        return f && Math.abs(parseFloat(f.value)) < NEAR_ZERO_EPSILON;
+        const group = groups[i];
+        const factor = group && group.length === 1 ? group[0] : null;
+        return factor !== null && factor.type === "Number" && Math.abs(parseFloat(factor.value)) < NEAR_ZERO_EPSILON;
       }))
         return true;
     } else if (name50 === "rotatex" || name50 === "rotatey") {
@@ -63462,14 +63465,17 @@ function canonicalizeColorFunction(value) {
   if (h2 === null || s2 === null || l === null) return null;
   return hslToHex(h2, s2, l);
 }
+function canonicalizeHex(digits) {
+  const expanded = digits.length <= 4 ? [...digits].map((digit) => digit + digit).join("") : digits;
+  if (expanded.slice(6) === "00") return "transparent";
+  return `#${expanded.slice(0, 6)}`;
+}
 function canonicalizeColor(raw) {
   const value = raw.trim().toLowerCase();
   if (!value) return "";
   if (Object.hasOwn(NAMED_COLORS, value)) return NAMED_COLORS[value];
-  const shortHex = value.match(/^#([0-9a-f])([0-9a-f])([0-9a-f])$/);
-  if (shortHex)
-    return `#${shortHex[1]}${shortHex[1]}${shortHex[2]}${shortHex[2]}${shortHex[3]}${shortHex[3]}`;
-  if (/^#[0-9a-f]{6}$/.test(value)) return value;
+  const hex = value.match(/^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/);
+  if (hex) return canonicalizeHex(hex[1]);
   return canonicalizeColorFunction(value) ?? value;
 }
 function paintsImageLayer(node2) {
@@ -64032,7 +64038,8 @@ function rawParams(qs) {
     if (!pair) continue;
     const eq = pair.indexOf("=");
     const name50 = eq === -1 ? pair : pair.slice(0, eq);
-    const value = eq === -1 ? "" : pair.slice(eq + 1);
+    const afterEq = eq === -1 ? "" : pair.slice(eq + 1);
+    const value = afterEq === "" ? pair : afterEq;
     pairs.push([name50.toLowerCase(), value]);
   }
   return pairs;
@@ -64230,7 +64237,7 @@ function collectUrls(text5) {
   return urls;
 }
 function detectExfil(text5) {
-  if (!MD_LINK_HINT.test(text5) && !HTML_TAG_PRESENT.test(text5)) return null;
+  if (!needsUrlScan(text5)) return null;
   const threats = [];
   try {
     for (const { url, isImage, autoFetched, context } of collectUrls(text5)) {
@@ -64253,7 +64260,7 @@ function detectExfil(text5) {
   return threats.length > 0 ? threats : null;
 }
 function detectConfusableHosts(text5) {
-  if (!MD_LINK_HINT.test(text5) && !HTML_TAG_PRESENT.test(text5)) return null;
+  if (!needsUrlScan(text5)) return null;
   const threats = [];
   const seen = /* @__PURE__ */ new Set();
   try {
@@ -64580,7 +64587,7 @@ var init_html4 = __esm({
     DATA_URI_LENGTH_THRESHOLD = 4096;
     SCRIPT_URI_RE = /^\s*(?:javascript|vbscript):/i;
     RELATIVE_URL_BASE = "http://relative.invalid";
-    BENIGN_BLOB_PARAM_RE = /^(?:x-(?:amz|goog|ms|oss|obs)-[a-z0-9-]+|amz-[a-z0-9-]+|utm_[a-z]+|sig|signature|hmac|policy|credential|expires|key-pair-id|se|sp|sr|sv|st|spr|si|skoid|sktid|cursor|after|before|continuation|continuationtoken|continuation_token|pagetoken|page_token|nexttoken|next_token|gclid|fbclid|dclid|msclkid|gbraid|wbraid|_ga|_gl|mc_eid|mc_cid)$/i;
+    BENIGN_BLOB_PARAM_RE = /^(?:x-(?:amz|goog|ms|oss|obs)-[a-z0-9-]+|amz-[a-z0-9-]+|utm_[a-z]+|sig|signature|hmac|policy|credential|expires|key-pair-id|se|sp|sr|sv|st|spr|si|skoid|sktid|code|state|cursor|after|before|continuation|continuationtoken|continuation_token|pagetoken|page_token|nexttoken|next_token|gclid|fbclid|dclid|msclkid|gbraid|wbraid|_ga|_gl|mc_eid|mc_cid)$/i;
     OPAQUE_TOKEN_RE = /[A-Za-z0-9_]{20,}/g;
     VALUE_HAS_DIGIT_RE = /\d/;
     BLOB_VALUE_B64_RE = /^[A-Za-z0-9+/]{40,}={0,2}$/;
@@ -64701,8 +64708,9 @@ async function applyMarkdownPipeline(state, { html: html4, exfilScan, deadline }
   const inputText = state.text;
   let reveal;
   const splices = [];
-  if (!html4 && !exfilScan || !needsMarkdownPipeline(inputText))
-    return { reveal: void 0, splices };
+  const runLayer2 = Boolean(html4) && needsMarkdownPipeline(inputText);
+  const runLayer3 = Boolean(exfilScan) && needsUrlScan(inputText);
+  if (!runLayer2 && !runLayer3) return { reveal: void 0, splices };
   const refuseIfSpent = () => {
     if (deadline && deadline.remainingMs() <= 0)
       throw new Error(
@@ -64719,7 +64727,7 @@ async function applyMarkdownPipeline(state, { html: html4, exfilScan, deadline }
       { cause: importErr }
     );
   }
-  if (html4) {
+  if (runLayer2) {
     const layer2 = sanitizeHtml2(state.text);
     if (layer2) {
       if (layer2.text !== state.text) {
@@ -64740,7 +64748,7 @@ async function applyMarkdownPipeline(state, { html: html4, exfilScan, deadline }
       if (preserved) state.findings.push(note(preserved));
     }
   }
-  if (exfilScan) {
+  if (runLayer3) {
     refuseIfSpent();
     const threats = detectExfil2(inputText);
     if (threats) {

--- a/src/gates.mjs
+++ b/src/gates.mjs
@@ -44,6 +44,27 @@ export function needsMarkdownPipeline(text) {
   return HTML_TAG_PRESENT.test(text) || MD_LINK_HINT.test(text);
 }
 
+/**
+ * Matches an absolute http(s) URL anywhere in the text. Gate for the Layer-3
+ * URL detectors, which read the URLs a GFM autolink literal yields and so find
+ * a look-alike host or an exfil-shaped query in bare prose — no tag and no
+ * link syntax required.
+ */
+export const URL_PRESENT = /https?:\/\//i;
+
+/**
+ * True when Layer 3 (exfil + confusable-host detection) can find something.
+ * A superset of {@link needsMarkdownPipeline}: a markup-bearing document can
+ * carry a relative exfil target (`[x](/collect?d=…)`), and a plain-prose one
+ * can carry an absolute URL with no markup at all. Layer 2 keeps the narrower
+ * gate — it can only splice what a tag delimits.
+ * @param {string} text
+ * @returns {boolean}
+ */
+export function needsUrlScan(text) {
+  return URL_PRESENT.test(text) || needsMarkdownPipeline(text);
+}
+
 // ─── Secret-shape pre-gate (Layer 3 URL-param reuse) ─────────────────────────
 // Cheap shape match that decides whether a URL parameter value carries a
 // credential (Layer 3). This hand-duplicates credential-shape knowledge that

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -2387,12 +2387,9 @@ function rawParams(qs) {
     const eq = pair.indexOf("=");
     const name = eq === -1 ? pair : pair.slice(0, eq);
     // A VALUELESS param carries its payload in the only token it has, so that
-    // token is its candidate value as well as its name — `?<blob>` and
-    // `?d=<blob>` are one channel, and so is `?<blob>=`, whose sole `=` is
-    // base64 padding the split reads as the separator. Reporting `""` here made
-    // every shape test (all of which read only the value) blind to the shorter
-    // spellings. The name still goes through BENIGN_BLOB_PARAM_RE, so no
-    // allowlisted param gains a value it did not have.
+    // token is its candidate value too — `?<blob>`, `?d=<blob>`, and `?<blob>=`
+    // (whose sole `=` is base64 padding) are one channel. The name alone still
+    // goes through BENIGN_BLOB_PARAM_RE.
     const afterEq = eq === -1 ? "" : pair.slice(eq + 1);
     const value = afterEq === "" ? pair : afterEq;
     pairs.push([name.toLowerCase(), value]);

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -43,6 +43,7 @@ import {
   SECRET_HINT,
   SECRET_HINT_EXT,
   matchesSecretHint,
+  needsUrlScan,
 } from "./gates.mjs";
 import { confusableHost, describeConfusableHost } from "./confusable-host.mjs";
 import { SEVERITY } from "./severity.mjs";
@@ -231,26 +232,34 @@ function isHidingTransform(node) {
     const name = fn.name;
     const args = valueTokens(fn);
     if (/^(?:scale|scale3d|scalex|scaley|matrix|matrix3d)$/.test(name)) {
-      // scale/matrix collapse to nothing when EITHER axis factor is (near-)zero —
-      // `scale(1,0)` / `scale3d(1,0,1)` collapse the Y axis, `matrix(1,0,0,0,…)`
-      // sets scaleY (d) to 0 — so testing only the first factor missed the
-      // multi-arg Y-collapse forms. css-tree reads the exponent form (`1e-3`) at
-      // full value; scale()/matrix() factors are <number>s (never lengths). For
-      // `matrix(a,b,c,d,…)` the two scale factors are a (index 0) and d (index 3).
-      // The two scale factors' positions differ per function: scale/scale3d/
-      // scaleX/scaleY carry them first (a single scaleX(0)/scaleY(0) sits at 0);
-      // `matrix(a,b,c,d,…)` puts scaleX=a (0) and scaleY=d (3); `matrix3d` puts
-      // scaleX=m11 (0) and scaleY=m22 (5). Do NOT use index 3 for matrix3d — that
-      // is m14, which is legitimately 0 on the identity matrix (false positive).
-      const numbers = args.filter(
-        (/** @type {any} */ a) => a.type === "Number",
-      );
+      // scale/matrix collapse to nothing when EITHER axis factor is (near-)zero:
+      // `scale(1,0)` collapses the Y axis, as does `matrix(1,0,0,0,…)` (d=0).
+      // A factor sits at a fixed ARGUMENT position, so the comma-separated
+      // argument list is what carries it — indexing a Number-filtered token list
+      // instead drops an unresolvable `var()`/`calc()` argument and slides a
+      // later benign 0 into a factor slot, splicing VISIBLE text.
+      // Factor positions per function:
+      //   scale/scale3d/scaleX/scaleY: scaleX=0, scaleY=1 (a lone scaleX(0) or
+      //     scaleY(0) argument sits at 0)
+      //   matrix(a,b,c,d,…): scaleX=a (0), scaleY=d (3)
+      //   matrix3d(m11,…): scaleX=m11 (0), scaleY=m22 (5) — index 3 is m14,
+      //     which the identity matrix leaves at 0 (a false positive)
+      const groups = functionArgs(fn);
       const factorIdx =
         name === "matrix" ? [0, 3] : name === "matrix3d" ? [0, 5] : [0, 1];
+      // css-tree reads the exponent form (`1e-3`) at full value; scale()/matrix()
+      // factors are <number>s (never lengths). An argument that is not one Number
+      // token — `var(--x)`, `calc(…)`, a missing slot — is unresolvable and fails
+      // OPEN: it yields no hidden verdict.
       if (
         factorIdx.some((/** @type {number} */ i) => {
-          const f = numbers[i];
-          return f && Math.abs(parseFloat(f.value)) < NEAR_ZERO_EPSILON;
+          const group = groups[i];
+          const factor = group && group.length === 1 ? group[0] : null;
+          return (
+            factor !== null &&
+            factor.type === "Number" &&
+            Math.abs(parseFloat(factor.value)) < NEAR_ZERO_EPSILON
+          );
         })
       )
         return true;
@@ -680,12 +689,37 @@ function canonicalizeColorFunction(value) {
 }
 
 /**
- * Canonicalize a CSS color to lowercase `#rrggbb` so `white`, `#FFF`,
- * `#ffffff`, `rgb(255, 255, 255)`, `rgb(255 255 255)`, `rgb(100% 100% 100%)`,
- * and `hsl(0 0% 100%)` all compare equal. Returns the trimmed lowercased input
- * unchanged when it is not a form we recognize; callers gate the same-color
- * compare on isConcreteColor so an unresolved token (`var()`, `inherit`) never
- * falsely reads as a same-color hide.
+ * Fold one hex color body — 3, 4, 6 or 8 digits, `#` already stripped — to
+ * `#rrggbb`, or to `transparent` when its alpha byte is zero. `#RGB`/`#RGBA`
+ * expand by doubling each digit, exactly as a browser reads them.
+ *
+ * A PARTIAL alpha (neither `00` nor `ff`) drops out and leaves the color, which
+ * is what {@link canonicalizeColorFunction} already does with `rgba(…, .5)`:
+ * the caller compares this color against the backdrop it is painted on, and a
+ * color blended over its own value renders that value at every alpha. Keeping
+ * the two spellings apart here would leave `#ffffff80` a bypass of a hide that
+ * `rgba(255,255,255,.5)` is caught for.
+ * @param {string} digits
+ * @returns {string}
+ */
+function canonicalizeHex(digits) {
+  const expanded =
+    digits.length <= 4
+      ? [...digits].map((digit) => digit + digit).join("")
+      : digits;
+  if (expanded.slice(6) === "00") return "transparent";
+  return `#${expanded.slice(0, 6)}`;
+}
+
+/**
+ * Canonicalize a CSS color to lowercase `#rrggbb` (or the `transparent`
+ * sentinel) so `white`, `#FFF`, `#ffffff`, `#ffffffff`, `rgb(255, 255, 255)`,
+ * `rgb(255 255 255)`, `rgb(100% 100% 100%)`, and `hsl(0 0% 100%)` all compare
+ * equal — as do `transparent`, `#0000`, `#00000000` and `rgba(0,0,0,0)`.
+ * Returns the trimmed lowercased input unchanged when it is not a form we
+ * recognize; callers gate the same-color compare on isConcreteColor so an
+ * unresolved token (`var()`, `inherit`) never falsely reads as a same-color
+ * hide.
  * @param {string} raw
  * @returns {string}
  */
@@ -697,10 +731,11 @@ function canonicalizeColor(raw) {
   // (poisoning isHiddenStyle's return) instead of falling through as a plain
   // string.
   if (Object.hasOwn(NAMED_COLORS, value)) return NAMED_COLORS[value];
-  const shortHex = value.match(/^#([0-9a-f])([0-9a-f])([0-9a-f])$/);
-  if (shortHex)
-    return `#${shortHex[1]}${shortHex[1]}${shortHex[2]}${shortHex[2]}${shortHex[3]}${shortHex[3]}`;
-  if (/^#[0-9a-f]{6}$/.test(value)) return value;
+  // All four hex notations in one match: reading only #RGB and #RRGGBB left
+  // `#0000` and `#00000000` — exact synonyms of `transparent`, which IS a hide —
+  // unresolved, so invisible text reached the model.
+  const hex = value.match(/^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/);
+  if (hex) return canonicalizeHex(hex[1]);
   return canonicalizeColorFunction(value) ?? value;
 }
 
@@ -2237,9 +2272,13 @@ const RELATIVE_URL_BASE = "http://relative.invalid";
 // would only widen the rename-dodge surface. A blob or credential-shaped value
 // in any OTHER parameter still fires — this allowlist trades a narrow dodge
 // (`?sig=<stolen>`) for not drowning the model in false positives on ordinary
-// fetched pages.
+// fetched pages. The OAuth callback pair (`code`, `state`) is listed for that
+// same trade: a redirect URL is one of the most common things a fetched page or
+// a browser tool prints, and both values are opaque by design (an authorization
+// code, a signed CSRF nonce), so the value shape cannot separate them from a
+// payload.
 const BENIGN_BLOB_PARAM_RE =
-  /^(?:x-(?:amz|goog|ms|oss|obs)-[a-z0-9-]+|amz-[a-z0-9-]+|utm_[a-z]+|sig|signature|hmac|policy|credential|expires|key-pair-id|se|sp|sr|sv|st|spr|si|skoid|sktid|cursor|after|before|continuation|continuationtoken|continuation_token|pagetoken|page_token|nexttoken|next_token|gclid|fbclid|dclid|msclkid|gbraid|wbraid|_ga|_gl|mc_eid|mc_cid)$/i;
+  /^(?:x-(?:amz|goog|ms|oss|obs)-[a-z0-9-]+|amz-[a-z0-9-]+|utm_[a-z]+|sig|signature|hmac|policy|credential|expires|key-pair-id|se|sp|sr|sv|st|spr|si|skoid|sktid|code|state|cursor|after|before|continuation|continuationtoken|continuation_token|pagetoken|page_token|nexttoken|next_token|gclid|fbclid|dclid|msclkid|gbraid|wbraid|_ga|_gl|mc_eid|mc_cid)$/i;
 
 // matchesSecretHint is a deliberately broad PRE-gate whose bare-keyword arms
 // (`token`, `secret`, `authorization`, …) also match ordinary hyphen/word
@@ -2347,7 +2386,15 @@ function rawParams(qs) {
     if (!pair) continue;
     const eq = pair.indexOf("=");
     const name = eq === -1 ? pair : pair.slice(0, eq);
-    const value = eq === -1 ? "" : pair.slice(eq + 1);
+    // A VALUELESS param carries its payload in the only token it has, so that
+    // token is its candidate value as well as its name — `?<blob>` and
+    // `?d=<blob>` are one channel, and so is `?<blob>=`, whose sole `=` is
+    // base64 padding the split reads as the separator. Reporting `""` here made
+    // every shape test (all of which read only the value) blind to the shorter
+    // spellings. The name still goes through BENIGN_BLOB_PARAM_RE, so no
+    // allowlisted param gains a value it did not have.
+    const afterEq = eq === -1 ? "" : pair.slice(eq + 1);
+    const value = afterEq === "" ? pair : afterEq;
     pairs.push([name.toLowerCase(), value]);
   }
   return pairs;
@@ -2773,7 +2820,7 @@ function collectUrls(text) {
  * @returns {Array<{ isImage: boolean, autoFetched: boolean, reason: string, target: string }> | null}
  */
 export function detectExfil(text) {
-  if (!MD_LINK_HINT.test(text) && !HTML_TAG_PRESENT.test(text)) return null;
+  if (!needsUrlScan(text)) return null;
 
   /** @type {Array<{ isImage: boolean, autoFetched: boolean, reason: string, target: string }>} */
   const threats = [];
@@ -2820,7 +2867,7 @@ export function detectExfil(text) {
  * @returns {Array<{ severity: string, description: string }> | null}
  */
 export function detectConfusableHosts(text) {
-  if (!MD_LINK_HINT.test(text) && !HTML_TAG_PRESENT.test(text)) return null;
+  if (!needsUrlScan(text)) return null;
 
   /** @type {Array<{ severity: string, description: string }>} */
   const threats = [];

--- a/src/output.mjs
+++ b/src/output.mjs
@@ -29,7 +29,7 @@ import {
   describeStripped,
   isIncidentalInvisible,
 } from "./invisible.mjs";
-import { needsMarkdownPipeline } from "./gates.mjs";
+import { needsMarkdownPipeline, needsUrlScan } from "./gates.mjs";
 import {
   applyLayer1,
   INERT_ANSI_NOTE,
@@ -418,8 +418,13 @@ async function applyMarkdownPipeline(state, { html, exfilScan, deadline }) {
   let reveal;
   /** @type {Array<{ placeholder: string, original: string }>} */
   const splices = [];
-  if ((!html && !exfilScan) || !needsMarkdownPipeline(inputText))
-    return { reveal: undefined, splices };
+  // Each layer carries its OWN pre-gate: Layer 2 can only splice what a tag
+  // delimits, while Layer 3's detectors read a bare `https://…` in prose that
+  // holds no markup at all. Gating both on the markup test hid every plain-text
+  // look-alike host and exfil URL from the scan.
+  const runLayer2 = Boolean(html) && needsMarkdownPipeline(inputText);
+  const runLayer3 = Boolean(exfilScan) && needsUrlScan(inputText);
+  if (!runLayer2 && !runLayer3) return { reveal: undefined, splices };
   // INVARIANT: this refusal stops a layer below from STARTING with no budget
   // left. Each parses the whole document in ONE synchronous call, so nothing
   // interrupts it, and a host that kills the overrun hook shows the RAW text.
@@ -455,7 +460,7 @@ async function applyMarkdownPipeline(state, { html, exfilScan, deadline }) {
   // Layer 2 — strips what a rendered page would not show (comments, hidden
   // elements); scripting/resource tags preserved+reported. Each cut leaves a
   // keyed placeholder whose original bytes ride out in `splices`.
-  if (html) {
+  if (runLayer2) {
     const layer2 = sanitizeHtml(state.text);
     if (layer2) {
       if (layer2.text !== state.text) {
@@ -494,7 +499,7 @@ async function applyMarkdownPipeline(state, { html, exfilScan, deadline }) {
   // use them. Scan the ORIGINAL text, not the Layer-2 splice output: a beacon
   // URL hidden inside a display:none element or an HTML comment is MORE
   // suspicious, not less, yet Layer 2 has already removed it from `cleaned`.
-  if (exfilScan) {
+  if (runLayer3) {
     refuseIfSpent();
     const threats = detectExfil(inputText);
     // Severity tracks who does the fetching. An auto-fetched target — an image,

--- a/test/html.test.mjs
+++ b/test/html.test.mjs
@@ -243,6 +243,13 @@ const HIDDEN_STYLE_CASES = [
   // matrix3d IDENTITY must NOT read as hidden: m14 (index 3) is legitimately 0,
   // so a naive "index 3 is scaleY" check would false-positive here.
   ["transform:matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1)", false],
+  // An unresolvable ARGUMENT is not a missing one: reading the factors out of a
+  // Number-filtered token list dropped the var() and slid the benign `c` zero
+  // into the scaleY slot, splicing visible text.
+  ["transform:matrix(1,var(--x),0,1,0,0)", false],
+  ["transform:matrix(1,calc(1 - 1),0,1,0,0)", false],
+  ["transform:scale(1,var(--y))", false], // the factor slot itself is unresolvable
+  ["transform:scale(var(--x),0)", true], // the OTHER factor still resolves to 0
   ["transform:rotateY(90deg)", true], // edge-on (bug: not detected)
   ["transform:rotateX(90deg)", true],
   ["transform:rotateY(-90deg)", true],
@@ -315,6 +322,16 @@ const HIDDEN_STYLE_CASES = [
   ["color:rgb(0 0 0 / 0);background:white", true], // zero alpha = transparent text
   ["color:rgba(1,2,3,0);background:white", true], // legacy comma 4th-channel zero alpha
   ["color:rgba(255,255,255,0.5);background-color:white", true], // non-zero alpha ignored for the hex compare
+  // ── hex notations WITH alpha: #RGBA and #RRGGBBAA are as much CSS as #RGB is,
+  //    and a zero alpha is a spelling of `transparent` ──
+  ["color:#0000", true], // 4-digit zero alpha === transparent
+  ["color:#00000000", true], // 8-digit zero alpha === transparent
+  ["color:#ffffffff;background:white", true], // opaque alpha === #ffffff on white
+  ["color:#ffff;background:#fff", true], // 4-digit opaque white on white
+  ["color:#ffffff80;background:white", true], // partial alpha, same as the rgba() spelling above
+  ["color:#0000ff;background:white", false], // 6 digits: blue on white, not a zero-alpha read
+  ["color:#abcde", false], // 5 digits is not a hex color — fail open
+  ["color:#000000000", false], // 9 digits is not a hex color — fail open
   ["color:hsl(0 0% 100%);background:hsl(0 0% 50%)", false], // distinct hsl lightness
   // hsl hue sectors (each 60° arc of the conversion) as same-color hides.
   ["color:hsl(90 100% 50%);background-color:hsl(90 100% 50%)", true],
@@ -523,6 +540,129 @@ describe("unit: isHiddenStyle exact verdicts", () => {
   ])
     it(`returns false (not a poisoned non-boolean) for color:${proto}`, () =>
       assert.equal(isHiddenStyle(`background:${proto}`), false));
+});
+
+// ─── invariant: one rendered color, one verdict ──────────────────────────────
+//
+// A browser renders every spelling of a color identically, so isHiddenStyle
+// owes them one verdict. Asserting the INVARIANT rather than "#0000 is hidden"
+// fails for the next notation the canonicalizer forgets, not just for the two
+// hex-with-alpha forms that reached the model as invisible text.
+
+describe("invariant: every spelling of one rendered color gets one verdict", () => {
+  // Each group is one rendered color, spelled every way CSS allows.
+  const COLOR_SPELLINGS = {
+    transparent: [
+      "transparent",
+      "#0000",
+      "#00000000",
+      "rgba(0,0,0,0)",
+      "rgb(0 0 0 / 0%)",
+    ],
+    white: [
+      "white",
+      "#fff",
+      "#ffff",
+      "#ffffff",
+      "#ffffffff",
+      "rgb(255,255,255)",
+      "rgb(100% 100% 100%)",
+      "hsl(0 0% 100%)",
+    ],
+    black: ["black", "#000", "#000f", "#000000", "#000000ff", "rgb(0,0,0)"],
+  };
+  // Two frames per group: one where the color hides the text and one where it
+  // does not. Without the visible frame a canonicalizer that mapped every
+  // spelling to the same WRONG color would still pass.
+  const FRAMES = [
+    [
+      "hidden on a matching backdrop",
+      (color) => `color:${color};background:${color}`,
+      true,
+    ],
+    [
+      "visible on a contrasting backdrop",
+      (color) => `color:${color};background:#7f3a1d`,
+      false,
+    ],
+  ];
+  for (const [group, spellings] of Object.entries(COLOR_SPELLINGS))
+    for (const [frameLabel, frame, expected] of FRAMES)
+      it(`${group}: every spelling reads ${expected} — ${frameLabel}`, () => {
+        /** @type {Record<string, boolean>} */
+        const verdicts = {};
+        for (const spelling of spellings)
+          verdicts[spelling] = isHiddenStyle(frame(spelling));
+        // `transparent` hides on ANY backdrop, so its "visible" frame is the
+        // one place the expectation flips — pin the group's own expectation.
+        const want = group === "transparent" ? true : expected;
+        assert.deepEqual(
+          verdicts,
+          Object.fromEntries(spellings.map((s) => [s, want])),
+        );
+      });
+  it("the corpus is not vacuous: the frames disagree for a concrete color", () => {
+    // If both frames returned the same verdict for `white`, every assertion
+    // above would hold for a canonicalizer that resolved nothing at all.
+    assert.equal(isHiddenStyle("color:white;background:white"), true);
+    assert.equal(isHiddenStyle("color:white;background:#7f3a1d"), false);
+  });
+});
+
+// ─── invariant: an unresolvable transform factor never hides ─────────────────
+//
+// The module's doctrine is fail-OPEN on CSS it cannot resolve: a splice removes
+// text the model needed, so an unresolved value must never produce a hidden
+// verdict. Reading scale factors out of a Number-FILTERED token list broke that
+// in the one direction that matters — an argument css-tree could not resolve
+// vanished from the list and a later benign 0 took its slot.
+
+describe("invariant: an unresolvable transform argument never yields a hidden verdict", () => {
+  // Every transform whose verdict this repo pins as hidden through a scale
+  // factor, with the argument INDEX of each factor.
+  const SCALED = [
+    ["scale(1,1)", [0, 1]],
+    ["scale3d(1,1,1)", [0, 1]],
+    ["matrix(1,0,0,1,0,0)", [0, 3]],
+    ["matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1)", [0, 5]],
+  ];
+  const UNRESOLVABLE = ["var(--x)", "calc(1 - 1)", "attr(data-s)"];
+
+  /** Replace argument `index` of a one-function transform value. */
+  const withArg = (fn, index, replacement) => {
+    const open = fn.indexOf("(");
+    const args = fn.slice(open + 1, -1).split(",");
+    args[index] = replacement;
+    return `${fn.slice(0, open)}(${args.join(",")})`;
+  };
+
+  it("substituting one argument is not a no-op (the mutator works)", () => {
+    assert.equal(
+      withArg("matrix(1,0,0,1,0,0)", 3, "var(--x)"),
+      "matrix(1,0,0,var(--x),0,0)",
+    );
+    assert.equal(withArg("scale(1,1)", 0, "0"), "scale(0,1)");
+  });
+
+  for (const [fn, factorIdx] of SCALED) {
+    const argCount = fn.slice(fn.indexOf("(") + 1, -1).split(",").length;
+    for (const token of UNRESOLVABLE)
+      for (let index = 0; index < argCount; index++)
+        it(`transform:${fn} with argument ${index} = ${token} is not hidden`, () =>
+          assert.equal(
+            isHiddenStyle(`transform:${withArg(fn, index, token)}`),
+            false,
+          ));
+    // Non-vacuity: the same functions DO report hidden when a factor genuinely
+    // resolves to zero, so the assertions above are about the unresolvable
+    // token and not about a detector that never fires.
+    for (const index of factorIdx)
+      it(`transform:${fn} with factor ${index} = 0 IS hidden`, () =>
+        assert.equal(
+          isHiddenStyle(`transform:${withArg(fn, index, "0")}`),
+          true,
+        ));
+  }
 });
 
 // ─── metamorphic: ident spelling never changes the verdict ───────────────────
@@ -790,11 +930,16 @@ describe("unit: checkExfilUrl exact verdicts", () => {
       "embedded credentials",
     ));
   it("flags a fragment past the threshold (201), not at it (200)", () => {
+    // A hyphenated slug, so the LENGTH branch is what this measures: a run of
+    // 200 unbroken alphanumerics is blob-shaped and the value-shape test claims
+    // it first, whichever side of the threshold it sits on.
+    const slug = "a-".repeat(100);
+    assert.equal(slug.length, 200);
     assert.equal(
-      checkExfilUrl("https://e.com/p#" + "A".repeat(200)),
+      checkExfilUrl("https://e.com/p#" + slug),
       "unusually long fragment",
     );
-    assert.equal(checkExfilUrl("https://e.com/p#" + "A".repeat(199)), null);
+    assert.equal(checkExfilUrl("https://e.com/p#" + slug.slice(0, 199)), null);
   });
   it("flags an active-content data: URI even with leading whitespace (\\s, not \\S)", () =>
     assert.equal(
@@ -978,6 +1123,89 @@ describe("unit: checkExfilUrl exact verdicts", () => {
     assert.equal(checkExfilUrl(`https://api.x/items?cursor=${b64url}`), null));
   it("leaves a utm_* param carrying a base64url value alone (allowlisted)", () =>
     assert.equal(checkExfilUrl(`https://x.com/p?utm_content=${b64url}`), null));
+  // An OAuth redirect is one of the commonest URLs a fetched page prints, and
+  // its authorization code is opaque by design — the value shape cannot tell it
+  // from a payload, so the name carries the verdict (precision doctrine).
+  it("leaves an OAuth callback's code/state alone (allowlisted)", () => {
+    assert.equal(
+      checkExfilUrl(
+        "https://app.example.com/callback?code=4%2F0AWtgzh5AbCdEfGhIjKlMnOpQrStUvWxYz1234567890&state=xyz",
+      ),
+      null,
+    );
+    assert.equal(
+      checkExfilUrl(`https://app.example.com/cb?state=${b64url}`),
+      null,
+    );
+    // Non-vacuous: the same value in a non-allowlisted param still fires.
+    assert.equal(
+      checkExfilUrl(`https://app.example.com/cb?c=${b64url}`),
+      "suspicious query parameter",
+    );
+  });
+});
+
+// ─── invariant: the `=` is not a hiding place ────────────────────────────────
+//
+// `?<payload>`, `?<payload>=` and `?d=<payload>` are one exfil channel: the
+// server reads the query string either way. Splitting on `=` and keeping only
+// the right-hand side gave the shortest spelling an empty value, and every
+// shape test reads the value — so dropping two characters bought silence.
+
+describe("invariant: a parameter's exfil verdict ignores whether it carries an `=`", () => {
+  // Each payload as a named value, as a bare query token, and in the fragment,
+  // which carries the same `key=value` channel. The base64 payload's trailing
+  // `=` padding also covers the case where the split reads the padding as the
+  // separator and leaves an empty right-hand side.
+  const spellings = (payload) => ({
+    "named value": `?d=${payload}`,
+    "bare token": `?${payload}`,
+    "in the fragment": `#${payload}`,
+  });
+  const PAYLOADS = [
+    ["a base64 blob", "QUtJQVJPT1RTRUNSRVRLRVkxMjM0NTY3ODkwYWJjZGVmZ2hpams="],
+    ["a hex blob", "a".repeat(16) + "b3c4d5e6f7081920"],
+    ["an ordinary word", "guide"],
+  ];
+  for (const [label, payload] of PAYLOADS) {
+    const forms = spellings(payload);
+    it(`agrees across every spelling of ${label}`, () => {
+      const verdicts = Object.fromEntries(
+        Object.entries(forms).map(([form, suffix]) => [
+          form,
+          checkExfilUrl(`https://e.com/p${suffix}`),
+        ]),
+      );
+      const [first] = Object.values(verdicts);
+      assert.deepEqual(
+        verdicts,
+        Object.fromEntries(Object.keys(forms).map((form) => [form, first])),
+      );
+    });
+  }
+  // Non-vacuity: the payloads above must not ALL be null, or the agreement
+  // holds for a detector that never fires.
+  it("flags the blob spellings and clears the word (the corpus separates them)", () => {
+    assert.equal(
+      checkExfilUrl(`https://e.com/p?${PAYLOADS[0][1]}`),
+      "suspicious query parameter",
+    );
+    assert.equal(
+      checkExfilUrl(`https://e.com/p?${PAYLOADS[1][1]}`),
+      "suspicious query parameter",
+    );
+    assert.equal(checkExfilUrl(`https://e.com/p?${PAYLOADS[2][1]}`), null);
+  });
+  // Precision: the allowlist is keyed on the NAME, and a valueless param's
+  // token is its name — so an allowlisted param stays silent, and a benign
+  // valueless flag never becomes a finding.
+  for (const [label, url] of [
+    ["an allowlisted signing param", "https://cdn.x/a?sig"],
+    ["a bare feature flag", "https://x.com/app?debug"],
+    ["an empty value", "https://x.com/app?flag="],
+    ["a section anchor", "https://x.com/guide#installation-on-linux"],
+  ])
+    it(`leaves ${label} alone`, () => assert.equal(checkExfilUrl(url), null));
 });
 
 describe("unit: urlHost exact verdicts", () => {

--- a/test/output.test.mjs
+++ b/test/output.test.mjs
@@ -26,6 +26,9 @@ import {
   REDACTION_DOCTRINE,
 } from "../src/output.mjs";
 import { INERT_ANSI_NOTE } from "../src/layer1.mjs";
+// Not re-exported from ./output.mjs: `needsUrlScan` is an internal Layer-3
+// pre-gate, so the published surface stays what engine-exports.test.mjs pins.
+import { needsUrlScan } from "../src/gates.mjs";
 import { layer2Placeholder } from "../src/html.mjs";
 import { cp } from "./test-helpers.mjs";
 
@@ -60,6 +63,21 @@ describe("needsMarkdownPipeline", () => {
     assert.equal(needsMarkdownPipeline("plain prose, nothing here"), false));
   it("stays false for bare comparison operators (precision)", () =>
     assert.equal(needsMarkdownPipeline("a < b and c > d, x<3"), false));
+});
+
+// ─── needsUrlScan ────────────────────────────────────────────────────────────
+
+describe("needsUrlScan", () => {
+  it("is true for a bare http(s) URL in prose with no markup", () =>
+    assert.equal(needsUrlScan("visit https://example.com/a today"), true));
+  it("is a superset of needsMarkdownPipeline (markup with a relative target)", () => {
+    assert.equal(needsMarkdownPipeline("see [x](/collect?d=1)"), true);
+    assert.equal(needsUrlScan("see [x](/collect?d=1)"), true);
+  });
+  it("is false for prose carrying neither a URL nor markup", () =>
+    assert.equal(needsUrlScan("plain prose, nothing here"), false));
+  it("stays false for a scheme-less host mention (precision)", () =>
+    assert.equal(needsUrlScan("ask paypal.com about it"), false));
 });
 
 // ─── describeRemoved ─────────────────────────────────────────────────────────
@@ -330,7 +348,7 @@ describe("sanitizeText: Layer 2/3 markdown pipeline gating", () => {
     assert.deepEqual(r.warnings, []);
   });
 
-  it("skips the pipeline when needsMarkdownPipeline is false (no tag/link)", async () => {
+  it("skips the pipeline when neither gate matches (no tag/link/URL)", async () => {
     const r = await sanitizeText("plain prose, no markup", {
       html: true,
       exfilScan: true,
@@ -338,6 +356,41 @@ describe("sanitizeText: Layer 2/3 markdown pipeline gating", () => {
     assert.equal(r.cleaned, "plain prose, no markup");
     assert.equal(r.modified, false);
     assert.deepEqual(r.warnings, []);
+  });
+
+  // INVARIANT: Layer 3 reads URLs, so its verdict depends on the URL and not on
+  // the markup around it. Gating the whole pipeline on the MARKUP test made a
+  // payload invisible to the scan simply by not wrapping it in a link — the
+  // plain-text spelling is the one an attacker reaches for first.
+  describe("Layer 3's verdict does not depend on surrounding markup", () => {
+    const WRAPPERS = [
+      ["bare prose", (url) => `visit ${url} now`],
+      ["a markdown link", (url) => `visit [here](${url}) now`],
+      ["an HTML anchor", (url) => `visit <a href="${url}">here</a> now`],
+    ];
+    const CASES = [
+      ["a confusable host", "https://pаypal.com/login", ["confusable-host"]],
+      [
+        "an exfil-shaped query",
+        "https://evil.example/b?d=QUtJQVJPT1RTRUNSRVRLRVkxMjM0NTY3ODkwYWJjZGVmZ2hpams=",
+        ["exfil-urls"],
+      ],
+      ["an ordinary URL", "https://example.com/docs/guide", []],
+    ];
+    for (const [urlLabel, url, expected] of CASES)
+      for (const [wrapperLabel, wrap] of WRAPPERS)
+        it(`reports ${JSON.stringify(expected)} for ${urlLabel} in ${wrapperLabel}`, async () => {
+          const r = await sanitizeText(wrap(url), { exfilScan: true });
+          assert.deepEqual(r.found, expected);
+          // Layer 3 never rewrites: the URL must survive byte-identical.
+          assert.equal(r.cleaned, wrap(url));
+        });
+    // Non-vacuity: the positive cases above are the proof the scan RAN, and
+    // this pins that the two findings are distinguishable rather than one
+    // catch-all code.
+    it("distinguishes the two Layer-3 findings", () => {
+      assert.notDeepEqual(CASES[0][2], CASES[1][2]);
+    });
   });
 
   it("html=true splices an HTML comment to its keyed placeholder and warns", async () => {


### PR DESCRIPTION
Claims `src/gates.mjs`, `src/html.mjs`, `src/output.mjs` and their tests. From the 2026-08 audit (#327).

Four detector bypasses, each reproduced against the live engine before the fix.

## Layer 3 never ran on a plain-text URL

The confusable-host and exfil-URL detectors sat behind `needsMarkdownPipeline`, a gate that asks whether the text holds an HTML tag or a markdown link. Those detectors read raw text and need no markdown parse, so a look-alike domain in ordinary prose was never scanned — and it failed silently, with no finding and no warning.

`sanitizeText` on `visit https://pаypal.com/login now` (Cyrillic а) returned nothing. Wrap that same URL in a markdown link, an autolink, or merely put a stray HTML tag elsewhere in the text, and it was detected. The detector was always correct in isolation; only the gate was wrong.

A bare URL in prose is the most common shape this library sees, which is what makes this the highest-reachability finding of the audit.

`gates.mjs` gains `needsUrlScan`, a superset of `needsMarkdownPipeline`. `applyMarkdownPipeline` now gates each layer separately: Layer 2 on the markup test, Layer 3 on the URL scan. That input now returns `found:["confusable-host"]`.

## A query parameter with no usable value was invisible

`rawParams` put a valueless token in the `name` slot and an empty string in `value`, and every downstream shape test reads only `value`. A 52-character base64 blob passed as a bare parameter returned nothing, while the byte-identical `?d=<blob>` returned `suspicious query parameter`.

The parameter's own token is now the candidate value whenever the right-hand side is empty. That covers a case the narrower fix would have missed: in `?<blob>=`, the sole `=` is base64 padding, which the split reads as the separator — and that is exactly the audit's own example.

## Hex colours with an alpha channel bypassed the hidden-text detectors

`canonicalizeColor` read two of CSS's four hex notations. `color:#0000` and `color:#00000000` are exact synonyms of `transparent`, which **is** flagged, so hidden text in either spelling reached the model verbatim.

| style | hidden before | hidden after |
| --- | --- | --- |
| `color:transparent` | yes | yes |
| `color:rgba(0,0,0,0)` | yes | yes |
| `color:#00000000` | **no** | yes |
| `color:#0000` | **no** | yes |

All four notations now fold in one match.

## Transform scale factors were read by position out of a filtered list

`isHidingTransform` filtered arguments to number tokens and then indexed by position, so a `var()` or `calc()` factor was dropped and a benign `0` shifted into a scale slot. `transform: matrix(1, var(--x), 0, 1, 0, 0)` reported hidden, and Layer 2 spliced **visible** text — failing closed on ambiguous input, against the module's own precision-over-recall doctrine, under a comment asserting an invariant that is false.

Factors are now read by argument position through the existing `functionArgs` helper, and a slot whose sole token is not a number fails open. The false comment is corrected.

## Decisions made

**Partial hex alpha resolves; it does not fail open.** The plan said it should stay unresolved, "matching how `canonicalizeColorFunction` treats a partial alpha". That premise was wrong, and execution proved it: `rgba(255,255,255,0.5)` already canonicalizes to `#ffffff`, is flagged, and is pinned by an existing corpus case. Failing open on hex would have made `#ffffff80` a bypass of a hide the `rgba()` spelling catches, and would have broken the very invariant this PR asserts. So `#ffffff80` canonicalizes to `#ffffff`, the same as its function-form twin.

**`code` and `state` joined the benign-parameter allowlist.** Scanning plain-text URLs exposed a verdict the gate had been hiding: the benign `oauth-callback` entry in `test/injection-corpus.test.mjs` fired `exfil-urls`. On the unmodified tree the same URL inside a markdown link already flagged, so this is pre-existing, not new. Rather than weaken a benign corpus that exists to hold precision, the OAuth callback pair is allowlisted — the same class as `sig` and `X-Amz-*`. The cost is that `?code=<blob>` and `?state=<blob>` no longer flag.

**One existing assertion moved.** The `checkExfilUrl` fragment-threshold test now uses a hyphenated 200-character slug rather than 200 `A`s, because an unbroken alphanumeric run is blob-shaped and the value-shape test claims it first. The length branch is still measured on both sides of the boundary.

## Tests

Four invariant suites, each with an explicit non-vacuity assertion: one verdict per rendered colour across every spelling; an unresolvable transform argument never hides; a parameter's verdict ignores the `=`; Layer 3's verdict ignores surrounding markup.

`node --test test/html.test.mjs test/output.test.mjs test/confusables.test.mjs` → **1078 pass, 0 fail**. Also green: `injection-corpus`, `mutation-guards`, `html-corpus`, `html-property`, `html-exfil-semantic-fuzz`, `entry-warning-parity`, `engine-exports`, `types-consumer`, `gates-mutation-kill`, `shipped-gates`, `hook-latency`. `tsc --noEmit` and `eslint` clean.

## Unrelated flake worth a separate fix

`test/hook-latency.test.mjs` fails intermittently under the pre-commit guard-pair runner: it measures wall-clock budgets while the hook runs ~1800 tests in one parallel process. The identical failure reproduces on a pristine `origin/main` worktree, and the suite passes standalone. The fix belongs in `.hooks/run-guard-pairs.mjs` — run that suite serially, or list it in `tooSlowForCommit` — which is outside this PR's file claim.