### PR TITLE
fix(ci): scope git's auth header to github.com and fail an empty path gate

### DIFF
--- a/.github/scripts/auto-resolve/lib.sh
+++ b/.github/scripts/auto-resolve/lib.sh
@@ -36,19 +36,8 @@ protected_matches() {
   return 0
 }
 
-# Authenticates git over HTTPS with TOKEN for the rest of this process, without
-# writing the token into .git/config (every checkout here is
-# persist-credentials: false). It RESETS GIT_CONFIG_COUNT rather than appending:
-# re-authenticating with a second token must replace the first token's header,
-# and starting from 1 also discards any GIT_CONFIG_* transport override an
-# earlier step left in the environment.
-git_auth_header() {
-  local basic
-  basic="$(printf 'x-access-token:%s' "${1:?token required}" | base64 | tr -d '\n')"
-  export GIT_CONFIG_COUNT=1
-  export GIT_CONFIG_KEY_0="http.https://github.com/.extraheader"
-  export GIT_CONFIG_VALUE_0="AUTHORIZATION: basic ${basic}"
-}
+# shellcheck source=.github/scripts/lib-git-auth.sh disable=SC1091
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/lib-git-auth.sh"
 
 # Marks the PR as one auto-resolve must not spend on again until a human acts.
 # discover excludes the label, so a permanent blocker (a missing push token, a

--- a/.github/scripts/decide-reusable-diff.sh
+++ b/.github/scripts/decide-reusable-diff.sh
@@ -10,6 +10,8 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$HERE/lib-decide-range.sh"
 # shellcheck source=lib-path-match.sh disable=SC1091
 . "$HERE/lib-path-match.sh"
+# shellcheck source=lib-git-auth.sh disable=SC1091
+. "$HERE/lib-git-auth.sh"
 # Normalize every input to defined-possibly-empty so `set -u` catches a future
 # reference to a genuinely-unset variable (a real bug) without crashing on an
 # intentionally-omitted optional trigger. BASE_SHA/HEAD_SHA absent keeps its
@@ -85,8 +87,9 @@ fi
 # no BASE_REF and keep their exact ranges. Fail-open: any fetch/resolve failure leaves
 # BASE_SHA at the webhook value — today's safe over-run, never an under-run.
 if [[ -n "${BASE_REF:-}" && -n "${GH_TOKEN:-}" ]]; then
-  auth="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
-  if git -c "http.extraheader=AUTHORIZATION: basic $auth" \
+  auth="" # assigned by name below; shellcheck cannot follow printf -v
+  git_auth_header_value auth "$GH_TOKEN"
+  if git -c "$GIT_AUTH_HEADER_KEY=$auth" \
     fetch --no-tags --quiet origin "$BASE_REF" 2>/dev/null; then
     live_base="$(git rev-parse FETCH_HEAD 2>/dev/null || true)"
     # Only advance the base FORWARD along history: require the live tip to be a

--- a/.github/scripts/lib-git-auth.sh
+++ b/.github/scripts/lib-git-auth.sh
@@ -1,0 +1,39 @@
+# shellcheck shell=bash
+# The one construction of git's HTTPS credential in this repo (sourced, not run).
+#
+# The key is scoped to `http.https://github.com/.extraheader`, never the bare
+# `http.extraheader`: an unscoped key is a repo-wide default, so git sends the
+# token to whatever host the operation ends up talking to — a redirect, an
+# `insteadOf` rewrite, a submodule URL elsewhere. Scoping is what keeps the
+# token on github.com.
+# shellcheck disable=SC2034  # read by the scripts that source this file, which shellcheck lints separately
+GIT_AUTH_HEADER_KEY="http.https://github.com/.extraheader"
+
+# git_auth_header_value VAR TOKEN — sets VAR to the header value that
+# authenticates as TOKEN, for `git -c "$GIT_AUTH_HEADER_KEY=$VAR" <one command>`.
+#
+# It assigns by name rather than printing, because a `$(…)` caller would swallow
+# the `:?` abort below into an empty string and then authenticate as nobody — a
+# 404 on a private ref, blamed on anything but the missing token.
+git_auth_header_value() {
+  local _git_auth_var="${1:?target variable name required}" _git_auth_basic
+  _git_auth_basic="$(printf 'x-access-token:%s' "${2:?token required}" | base64 | tr -d '\n')"
+  printf -v "$_git_auth_var" 'AUTHORIZATION: basic %s' "$_git_auth_basic"
+}
+
+# git_auth_header TOKEN — authenticates git over HTTPS for the REST OF THIS
+# PROCESS, without writing the token into .git/config (every checkout here is
+# persist-credentials: false). For a multi-step flow that runs many git commands
+# under one credential; a script that needs auth on a single command passes
+# `-c` per-command instead and leaves the environment alone.
+#
+# It RESETS GIT_CONFIG_COUNT rather than appending: re-authenticating with a
+# second token must replace the first token's header, and starting from 1 also
+# discards any GIT_CONFIG_* transport override an earlier step left behind.
+git_auth_header() {
+  local _git_auth_value
+  git_auth_header_value _git_auth_value "${1:?token required}"
+  export GIT_CONFIG_COUNT=1
+  export GIT_CONFIG_KEY_0="$GIT_AUTH_HEADER_KEY"
+  export GIT_CONFIG_VALUE_0="$_git_auth_value"
+}

--- a/.github/scripts/lib-path-match.sh
+++ b/.github/scripts/lib-path-match.sh
@@ -44,11 +44,18 @@ path_gate_matching_lines() {
 # newline-separated list of whole-line literals (a derived file closure) instead
 # of a regex. Same posture, and it is the reason this exists: the fixed-string
 # arm reads the same grep status and must not spell it `|| true`.
+#
+# A blank PATTERNS list skips grep and keeps the whole list, because a derivation
+# that produced nothing is a derivation that failed: grep answers a blank pattern
+# list with a clean exit 1, and reading that as "no watched path changed" is the
+# silent skip this file exists to prevent.
 path_gate_matching_fixed_lines() {
-  local rc=0 out=""
-  out=$(grep -Fxf <(printf '%s\n' "$1") <<<"$2") || rc=$?
-  if ((rc > 1)); then
-    out="$2"
+  local rc=0 out="$2"
+  if [[ -n "${1//[[:space:]]/}" ]]; then
+    out=$(grep -Fxf <(printf '%s\n' "$1") <<<"$2") || rc=$?
+    if ((rc > 1)); then
+      out="$2"
+    fi
   fi
   if [[ -n "$out" ]]; then
     printf '%s\n' "$out"

--- a/.github/scripts/prepare-merge-delta-input.sh
+++ b/.github/scripts/prepare-merge-delta-input.sh
@@ -19,8 +19,13 @@
 #   merge-delta.report.txt     — what the sanitizer neutralized (if anything)
 set -euo pipefail
 
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib-git-auth.sh disable=SC1091
+. "$HERE/lib-git-auth.sh"
+
 : "${PR:?PR number required}"
 : "${PR_INPUT_DIR:?PR_INPUT_DIR required}"
+: "${GH_TOKEN:?GH_TOKEN required}"
 
 mkdir -p "$PR_INPUT_DIR"
 
@@ -39,8 +44,9 @@ trap 'rm -f "$raw" "$err"' EXIT
 # diff, not code to run. A fetch or merge-base failure is a can't-verify, not a
 # no-op: fail loud rather than skip the review (a PR head always has a
 # refs/pull/N/head, so a failure here is a real problem, not "no merges").
-auth="AUTHORIZATION: basic $(printf 'x-access-token:%s' "${GH_TOKEN:-}" | base64 | tr -d '\n')"
-if ! git -c "http.https://github.com/.extraheader=${auth}" \
+auth="" # assigned by name below; shellcheck cannot follow printf -v
+git_auth_header_value auth "$GH_TOKEN"
+if ! git -c "$GIT_AUTH_HEADER_KEY=$auth" \
   fetch --no-tags --quiet origin "+refs/pull/${PR}/head:refs/remotes/pr/head"; then
   echo "::error::could not fetch refs/pull/${PR}/head as data — cannot review this PR's merge deltas" >&2
   exit 1

--- a/tests/test_git_auth.py
+++ b/tests/test_git_auth.py
@@ -1,0 +1,212 @@
+"""Behavior tests for .github/scripts/lib-git-auth.sh.
+
+The guarantee under test: the credential git is handed reaches github.com and
+nothing else. `http.extraheader` written without a URL scope is a repo-wide
+default, so git sends it to whatever host the operation ends up talking to — a
+redirect, an `insteadOf` rewrite, a submodule URL. `git config --get-urlmatch`
+is git's own resolver for that question, so these tests ask it rather than
+inspecting the key's spelling.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests._helpers import (
+    REPO_ROOT,
+    commit_all,
+    env_without_git_location,
+    git_env,
+    init_test_repo,
+)
+
+LIB = REPO_ROOT / ".github" / "scripts" / "lib-git-auth.sh"
+DECIDE = REPO_ROOT / ".github" / "scripts" / "decide-reusable-diff.sh"
+
+GITHUB_URL = "https://github.com/owner/repo.git"
+OTHER_HOST_URL = "https://attacker.example/owner/repo.git"
+
+#: The bare key the helper replaces, kept as the control case below.
+UNSCOPED_KEY = "http.extraheader"
+
+
+def without_git_config(env: dict[str, str]) -> dict[str, str]:
+    """`env` with git's own config injection removed.
+
+    A caller can already have GIT_CONFIG_COUNT and friends set (an agent
+    sandbox does), and those settings both answer `--get-urlmatch` and survive
+    into the scripts under test — so a test that asks what the helper put there
+    must start from a known-empty baseline.
+    """
+    return {k: v for k, v in env.items() if not k.startswith("GIT_CONFIG_")}
+
+
+def clean_env() -> dict[str, str]:
+    return without_git_config(env_without_git_location())
+
+
+def bash(script: str, *args: str, cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", "-euo", "pipefail", "-c", script, "bash", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        env=clean_env(),
+    )
+
+
+def urlmatch(repo: Path, config: str, url: str) -> subprocess.CompletedProcess:
+    """What git resolves `http.extraheader` to for `url`, given one `-c` setting."""
+    return subprocess.run(
+        ["git", "-c", config, "config", "--get-urlmatch", "http.extraheader", url],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env=clean_env(),
+    )
+
+
+def auth_config(repo: Path, token: str = "s3cret") -> str:
+    """The `-c` argument the helper builds, as the scripts assemble it."""
+    built = bash(
+        f'. "{LIB}"; git_auth_header_value auth "$1"; '
+        "printf '%s\\n' \"$GIT_AUTH_HEADER_KEY=$auth\"",
+        token,
+        cwd=repo,
+    )
+    assert built.returncode == 0, built.stderr
+    return built.stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    sandbox = tmp_path / "repo"
+    init_test_repo(sandbox)
+    return sandbox
+
+
+def test_the_header_reaches_github(repo: Path) -> None:
+    resolved = urlmatch(repo, auth_config(repo), GITHUB_URL)
+    assert resolved.returncode == 0, resolved.stderr
+    assert resolved.stdout.strip().startswith("AUTHORIZATION: basic ")
+
+
+def test_the_header_does_not_reach_another_host(repo: Path) -> None:
+    """The property the scoped key buys, asked of git's own resolver."""
+    resolved = urlmatch(repo, auth_config(repo), OTHER_HOST_URL)
+    assert resolved.returncode != 0
+    assert resolved.stdout == ""
+
+
+def test_an_unscoped_header_would_reach_every_host(repo: Path) -> None:
+    """Non-vacuity control: the bare `http.extraheader` spelling this helper
+    replaces hands the same token to an unrelated host, so the assertion above
+    is a real constraint rather than a property git gives away for free."""
+    resolved = urlmatch(
+        repo, f"{UNSCOPED_KEY}=AUTHORIZATION: basic leak", OTHER_HOST_URL
+    )
+    assert resolved.returncode == 0, resolved.stderr
+    assert resolved.stdout.strip() == "AUTHORIZATION: basic leak"
+
+
+def test_the_per_command_helper_leaves_the_environment_alone(repo: Path) -> None:
+    """A caller that needs auth on ONE command must not re-point git's config for
+    whatever else the job runs afterwards, so the value-builder exports nothing."""
+    built = bash(
+        f'. "{LIB}"; git_auth_header_value auth "$1"; '
+        'printf \'%s\\n\' "${GIT_CONFIG_COUNT:-unset}" "${GIT_CONFIG_KEY_0:-unset}"',
+        "s3cret",
+        cwd=repo,
+    )
+    assert built.returncode == 0, built.stderr
+    assert built.stdout == "unset\nunset\n"
+
+
+def test_the_process_wide_helper_scopes_the_same_key(repo: Path) -> None:
+    """The multi-step flows keep the exported form; it must be the same scope."""
+    built = bash(
+        f'. "{LIB}"; git_auth_header "$1"; '
+        'printf \'%s\\n\' "$GIT_CONFIG_COUNT" "$GIT_CONFIG_KEY_0"',
+        "s3cret",
+        cwd=repo,
+    )
+    assert built.returncode == 0, built.stderr
+    assert built.stdout == "1\nhttp.https://github.com/.extraheader\n"
+
+
+@pytest.mark.parametrize(
+    "call", ("git_auth_header_value auth ''", 'git_auth_header ""')
+)
+def test_a_missing_token_is_loud(repo: Path, call: str) -> None:
+    """An empty token must abort, never authenticate as nobody: the header would
+    still be sent, and the failure would surface as an unrelated 404."""
+    result = bash(f'. "{LIB}"; {call}', cwd=repo)
+    assert result.returncode != 0
+    assert "token required" in result.stderr
+
+
+def stub_git(bin_dir: Path, record: Path) -> None:
+    """A `git` that records one fetch's argv and auth environment, then stops.
+
+    Every other subcommand runs the real git, so the script under test keeps
+    diffing the local history it was given.
+    """
+    real = shutil.which("git")
+    assert real, "git must be on PATH"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    stub = bin_dir / "git"
+    stub.write_text(
+        "#!/bin/bash\n"
+        'if [[ " $* " == *" fetch "* ]]; then\n'
+        f'  printf "argv:%s\\n" "$*" >>"{record}"\n'
+        f'  printf "key0:%s\\n" "${{GIT_CONFIG_KEY_0:-none}}" >>"{record}"\n'
+        "  exit 1\n"
+        "fi\n"
+        f'exec {real} "$@"\n'
+    )
+    stub.chmod(0o755)
+
+
+def test_the_base_reanchor_fetch_scopes_its_header(tmp_path: Path) -> None:
+    """decide-reusable-diff.sh re-anchors to the live base tip over the network.
+
+    Before this fix it passed `-c http.extraheader=…` on that fetch, which is
+    the repo-wide default the control case above shows reaches any host. The
+    stub reports what the fetch was actually handed.
+    """
+    sandbox = tmp_path / "repo"
+    init_test_repo(sandbox)
+    (sandbox / "src").mkdir()
+    (sandbox / "src" / "app.mjs").write_text("export const x = 1;\n")
+    base = commit_all(sandbox, "chore: base")
+    (sandbox / "src" / "app.mjs").write_text("export const x = 2;\n")
+    head = commit_all(sandbox, "fix: edit")
+
+    record = tmp_path / "fetch.log"
+    stub_git(tmp_path / "bin", record)
+    env = without_git_config(git_env())
+    result = subprocess.run(
+        ["bash", str(DECIDE)],
+        cwd=sandbox,
+        capture_output=True,
+        text=True,
+        env={
+            **env,
+            "PATH": f"{tmp_path / 'bin'}:{env['PATH']}",
+            "GITHUB_OUTPUT": str(tmp_path / "out"),
+            "BASE_SHA": base,
+            "HEAD_SHA": head,
+            "BASE_REF": "main",
+            "GH_TOKEN": "s3cret",
+            "PATHS_REGEX": "^src/",
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    recorded = record.read_text()
+    assert "-c http.https://github.com/.extraheader=AUTHORIZATION: basic " in recorded
+    assert f"-c {UNSCOPED_KEY}=" not in recorded, recorded
+    # Per-command, so the fetch's own environment must carry no auth override —
+    # whatever else the job runs after this step keeps git's config unchanged.
+    assert "key0:none\n" in recorded, recorded

--- a/tests/test_path_match.py
+++ b/tests/test_path_match.py
@@ -73,3 +73,34 @@ def test_grep_failure_widens_to_every_changed_file(tmp_path: Path, fn: str) -> N
     result = run_helper(fn, HELPERS[fn], path=f"{stub_dir}:/usr/bin:/bin")
     assert result.returncode == 0, result.stderr
     assert result.stdout == CHANGED + "\n"
+
+
+#: What a caller's derivation hands the fixed-line helper when it produced no
+#: paths. `""` is the derivation that printed nothing; `"\n"` is that same answer
+#: after the caller appended its record separator, which is the shape
+#: decide-reusable-diff.sh actually builds.
+EMPTY_DERIVATIONS = ("", "\n", "  \n\t\n")
+
+
+@pytest.mark.parametrize("derived", EMPTY_DERIVATIONS)
+def test_an_empty_derived_list_widens_to_every_changed_file(derived: str) -> None:
+    """A derivation that produced nothing is a derivation that failed.
+
+    grep answers a blank pattern list with a clean exit 1, which is
+    indistinguishable from "no watched path changed" — and reading it that way
+    skips the gated job and greens its always() reporter, the exact false green
+    this library exists to prevent. Widening is the same fail-open posture the
+    exit-2 case takes.
+    """
+    result = run_helper("path_gate_matching_fixed_lines", derived)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == CHANGED + "\n"
+
+
+@pytest.mark.parametrize("fn", sorted(HELPERS))
+def test_widening_an_empty_changed_list_emits_no_path(fn: str) -> None:
+    """Widening means "every changed file", and with nothing changed that is no
+    file at all — a blank line here would reach the caller as a path to diff."""
+    result = run_helper(fn, "", changed="")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""


### PR DESCRIPTION
Claimed area: `.github/scripts/` git auth construction + `lib-path-match.sh`. No overlap with the reviewer-identity SSOT work in `review-gate.sh` and friends.

## Summary

Two independent CI-script gaps, one commit each.

**1. Unscoped credential (`decide-reusable-diff.sh`).** Its base re-anchor fetch passed the token under the bare `http.extraheader` key. That key is a repo-wide default, so git attaches the header to whatever host the operation ends up talking to — a redirect, an `insteadOf` rewrite, a submodule URL. Every other auth site in the repo already scopes it to `http.https://github.com/.extraheader`; this was the one that did not. The construction now lives in one place, `.github/scripts/lib-git-auth.sh`, so the scope cannot drift between sites.

**2. Empty derived path list read as "nothing matched" (`lib-path-match.sh`).** `path_gate_matching_fixed_lines` handed grep a blank pattern list and got a clean exit 1 back — indistinguishable from "no watched path changed". The gated job then skips and its `always()` reporter greens the skip, which is the exact false green this file exists to prevent. A derivation that produced nothing is a derivation that failed, so the helper widens to every changed file, matching the fail-open posture it already takes when grep itself fails. Ported from `agent-glovebox`'s `path_gate_matching_members`, adapted to this repo's function name and callers.

## Changes

- **new** `.github/scripts/lib-git-auth.sh` — `GIT_AUTH_HEADER_KEY` plus two builders: `git_auth_header_value VAR TOKEN` for a single command's `-c` argument, and `git_auth_header TOKEN` (moved here unchanged from `auto-resolve/lib.sh`) for a multi-step flow that runs many git commands under one credential.
- `decide-reusable-diff.sh` — the re-anchor fetch uses the scoped key.
- `prepare-merge-delta-input.sh` — drops its inline copy of the header construction, and `GH_TOKEN` joins the `:?` guards at the top instead of degrading to an empty-token header through `${GH_TOKEN:-}`.
- `auto-resolve/lib.sh` — sources the shared lib in place of its own copy; behavior unchanged.
- `lib-path-match.sh` — the blank-list case skips grep and falls through to the shared "print when non-empty" tail, so widening an empty changed-file list still emits no path.

## Review focus

`.github/scripts/lib-git-auth.sh` first. The cross-file invariant a single screen cannot show: two shapes of auth coexist on purpose. A script that needs a credential for **one** command builds the `-c` argument and leaves the environment alone; `auto-resolve`'s multi-step flow keeps the exported `GIT_CONFIG_*` form. Both spell the same key, and `tests/test_git_auth.py::test_the_process_wide_helper_scopes_the_same_key` pins that.

The part I am least sure of is `git_auth_header_value` assigning by name rather than printing. A `$(…)` caller would swallow the `:?` abort into an empty string and then authenticate as nobody, which is why it is written this way — but shellcheck cannot follow `printf -v`, so each caller carries an `auth=""` initializer and a one-line note. If you would rather see a `# shellcheck disable=SC2154` at the use site, say so.

## Tests / verification

`tests/test_git_auth.py` (new) asks git's own resolver, `git config --get-urlmatch`, which hosts the header reaches — not what the key is spelled:

- the header resolves for `https://github.com/owner/repo.git` and does not resolve for `https://attacker.example/owner/repo.git`;
- a control case shows the bare `http.extraheader` spelling **does** resolve for the attacker host, so the assertion above is a real constraint rather than something git gives away for free;
- an end-to-end case runs `decide-reusable-diff.sh` against a sandbox repo with a recording `git` on PATH, and asserts the fetch was handed the scoped `-c` argument, no bare `http.extraheader=`, and no `GIT_CONFIG_KEY_0` in its environment;
- an empty token aborts loudly, for both builders.

`tests/test_path_match.py` gains two cases: a parametrized one over the three shapes a caller's empty derivation takes (`""`, `"\n"` — what `decide-reusable-diff.sh` actually builds after appending its record separator — and whitespace-only), asserting the whole changed-file list comes back; and one over both helpers asserting that widening an empty changed list emits nothing, since a blank line would reach the caller as a path to diff.

Non-vacuity, measured rather than asserted: reverting each fix in place and re-running turns the new tests red and leaves the rest green — 4 failed / 13 passed, then all green after restoring.

Commands run:

- `pytest tests/test_git_auth.py tests/test_path_match.py tests/test_decide_reusable_diff.py tests/test_template_sync.py` — all passed.
- Full suite: 3182 passed, 5 skipped. Three modules (`test_python_client.py`, `test_hook_fail_closed.py`, `test_hook_issue_prompts.py`) failed before `pnpm install` on a missing `acorn`/node worker and pass on the provisioned tree; none touch `.github/scripts/`.
- `shellcheck -x -P .claude/hooks:.github/scripts` and `shfmt -i 2 -d` clean on all five touched shell files plus the three other `git_auth_header` callers.

## Decisions made

- **Where the shared construction lives.** `prepare-merge-delta-input.sh` cannot practically source `auto-resolve/lib.sh`: that file reads `lib/shared-names.json` through four `jq` passes at source time and pulls in `gh`-dependent helpers, none of which a merge-delta render needs. A minimal `lib-git-auth.sh` that both sides source avoids the dependency without leaving two copies of the credential. The alternative — importing `auto-resolve/lib.sh` — would have made a `jq` failure break the merge-delta review.
- **Per-command `-c`, not the exported form, for the two single-fetch scripts.** `decide-reusable-diff.sh` and `prepare-merge-delta-input.sh` each authenticate exactly one fetch, so they leave git's configuration untouched for whatever else runs in the same job. Only `auto-resolve`'s multi-step flow exports.
- **`git_auth_header` moved rather than duplicated.** It now sits beside the per-command builder and reuses it, so `auto-resolve/lib.sh` sources one file instead of owning a second base64 construction. `auto-resolve`'s callers see no behavior change.
- **`GH_TOKEN` is now required by `prepare-merge-delta-input.sh`.** The workflow that calls it sets `GH_TOKEN` at job level, so this converts a silent empty-token 404 into a named failure. If some caller is meant to run token-less, this is the line to revert.
