### PR TITLE
fix(test): charge the hook latency gates in CPU time, not wall clock

### DIFF
--- a/.github/workflows/node-tests.yaml
+++ b/.github/workflows/node-tests.yaml
@@ -87,9 +87,10 @@ jobs:
 
       # `pnpm test` runs this suite under c8, and c8 multiplies wall clock
       # several-fold — so the one gate that promises the hooks answer a
-      # realistic input in under 100ms stands down there and would be checked
-      # nowhere. Uninstrumented it is the only latency assertion that speaks in
-      # milliseconds rather than ratios; the ratio gates simply pass twice.
+      # realistic 256 KB input in a bounded number of milliseconds stands down
+      # there and would be checked nowhere. Uninstrumented it is the only
+      # latency assertion that speaks in wall-clock milliseconds rather than
+      # ratios of CPU time; the ratio gates simply pass twice.
       - name: Run the hook latency gates uninstrumented
         run: node --test test/hook-latency.test.mjs
 

--- a/test/hook-latency.test.mjs
+++ b/test/hook-latency.test.mjs
@@ -200,17 +200,23 @@ const SHAPES = {
  * every other character is real work for the prompt classifier's scatter count
  * and almost none for the strip the output path runs.
  *
- * This and every `budget` entry below is 1.3x the DEAREST reading across three
- * environments: standalone, under the parallel coverage run, and standalone
- * against four workers of competing CPU and allocation load. The instrumented
- * run reads LOWER on every heavy cell, since c8 charges this file's calibration
- * harder than the code under test, so the ceilings come from the two
- * uninstrumented ones. Across those runs no case reads more than 1.12x its
- * own median, so 1.3x covers run-to-run variation and nothing more — every
- * ceiling here sits under twice its case's median, which is the standard: a
- * doubling is red, and anything looser is a ceiling nothing is under.
+ * This and every `budget` entry below is 1.3x the DEAREST reading across four
+ * environments: standalone, under the parallel coverage run, standalone against
+ * four workers of competing CPU and allocation load, and the GitHub runner. The
+ * instrumented run reads LOWER on every heavy cell, since c8 charges this file's
+ * calibration harder than the code under test, so the ceilings come from the
+ * uninstrumented ones. Within one machine no case reads more than 1.12x its own
+ * median, so 1.3x covers run-to-run variation and nothing more.
+ *
+ * Between machines the same ratio moves further: `sanitizeText/payload-scattered`
+ * costs 9.9ms of CPU on the runner against 6.5ms here for the same ~0.89ms unit,
+ * so the ceiling has to be the dearest microarchitecture's, not the developer's.
+ * Every ceiling still sits under twice its case's median on the environment that
+ * set it, which is the standard: a doubling is red, and anything looser is a
+ * ceiling nothing is under. The per-case diagnostic each gate emits is what makes
+ * a runner's numbers readable, so this table can be re-derived from CI.
  */
-const CHEAP_BUDGET = 11;
+const CHEAP_BUDGET = 15;
 
 /**
  * The blocking entry points, each with the shapes it must answer cheaply.
@@ -546,11 +552,17 @@ describe("hook-path latency", () => {
   });
 
   for (const { entry, shape, name } of CASES)
-    timed(`${name}: 256 KB stays inside its budget`, () => {
+    timed(`${name}: 256 KB stays inside its budget`, (t) => {
       const { cheap, budget: heavy } = ENTRIES[entry];
       // `cheap` is the only declaration of which shapes an entry answers
       // cheaply; a shape in neither list yields undefined and fails loud.
       const budget = cheap.includes(shape) ? CHEAP_BUDGET : heavy[shape];
+      // Emitted on the green path too: the table above is derived from the
+      // dearest reading across machines, and a passing run is the only place a
+      // machine this file has never been measured on reports its numbers.
+      t.diagnostic(
+        `${name}: ${timing.units[name].toFixed(1)}/${budget} units (${timing.large[name].toFixed(1)}ms CPU, unit ${timing.unit.toFixed(3)}ms)`,
+      );
       assert.ok(
         timing.units[name] <= budget,
         `${name} ran in ${timing.units[name].toFixed(1)} units (${timing.large[name].toFixed(1)}ms CPU), budget ${budget}`,

--- a/test/hook-latency.test.mjs
+++ b/test/hook-latency.test.mjs
@@ -10,12 +10,33 @@
  *
  * Every budget is a RATIO against a calibration measured in this same process:
  * one code-point-by-code-point pass over a fixed 256 KB input, which is the
- * cheapest full read of a text anything here can do. Machine speed, CPU
- * contention and the coverage instrumentation scale both sides, so the ratios
- * survive a loaded CI runner in a way wall-clock milliseconds do not — the
- * calibration is written in this file, rather than reaching for a native
- * builtin, precisely so it pays the same instrumentation tax as the code it
- * normalizes.
+ * cheapest full read of a text anything here can do. Machine speed and the
+ * coverage instrumentation scale both sides, so the ratios survive a slow or
+ * instrumented runner in a way wall-clock milliseconds do not — the calibration
+ * is written in this file, rather than reaching for a native builtin, precisely
+ * so it pays the same instrumentation tax as the code it normalizes.
+ *
+ * CONTENTION is a different problem, and the ratio does not solve it. A ratio
+ * cancels a slower machine because both sides run at that speed; it cannot
+ * cancel a BUSY one, because the two sides are timed over blocks of very
+ * different length. A calibration pass takes about a millisecond, so
+ * {@link measure}'s fastest-of-N estimator reliably catches a quiet slot for it,
+ * while a 256 KB parse5 run takes hundreds of milliseconds and on a loaded
+ * runner gets no quiet slot in any sample. The divisor stays flat while the
+ * numerator inflates, and the ratio reports the load as a regression. So every
+ * timed block here is charged in the CPU time the process actually spent
+ * (`process.cpuUsage`) rather than the wall clock it occupied: time spent
+ * descheduled behind another test worker is not time this code spent. Measured
+ * on the dearest cell, four workers of competing load move the wall clock 1.9x
+ * and the CPU time 1.06x.
+ *
+ * The calibration is allocation-free for the same reason. Reading the text with
+ * `for (const ch of text)` materializes a string per code point, which makes the
+ * pass a measure of the collector's current disposition — and the young
+ * generation's size is set by whatever ran before, so the same pass cost 3.0ms
+ * in a fresh process and 1.4ms once a parse5 run had grown the heap. A
+ * calibration that halves for a reason unrelated to the machine doubles every
+ * ratio read against it.
  */
 import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
@@ -56,17 +77,31 @@ const cp = (n) => String.fromCodePoint(n);
 const grow = (unit, n) => unit.repeat(Math.ceil(n / unit.length)).slice(0, n);
 
 /**
- * The FASTEST of {@link SAMPLES} timed runs after a warm-up call, in ms.
+ * The FASTEST of {@link SAMPLES} timed runs after a warm-up call.
  *
- * Contention and collector pauses only ever ADD time, so the minimum is the
- * closest any of the samples got to the cost of the code itself, and it is what
- * keeps these gates readable on a two-core shared runner that is also running
- * the rest of the suite. A median still carries whatever noise landed on the
- * middle sample, which on such a runner is most of them. The estimator loses
- * nothing the gates are for: a path that got an order of magnitude slower is an
- * order of magnitude slower in its fastest run too.
+ * Collector pauses and the scheduling the CPU clock still sees only ever ADD
+ * time, so the minimum is the closest any of the samples got to the cost of the
+ * code itself. A median still carries whatever noise landed on the middle
+ * sample, which on a shared runner is most of them. The estimator loses nothing
+ * the gates are for: a path that got an order of magnitude slower is an order of
+ * magnitude slower in its fastest run too.
  */
 const SAMPLES = 4;
+
+/**
+ * A timed block, in ms: the CPU time the process spent, and the wall clock it
+ * occupied.
+ * @typedef {{cpu: number, wall: number}} Timing
+ */
+
+/** The CPU time a block charged the process, in ms. `process.cpuUsage` counts
+ * every thread, so a collector pass or a background compile the block provoked
+ * is charged to it — which is the intent, since the hook pays for those too. */
+const cpuSince = (mark) => {
+  const spent = process.cpuUsage(mark);
+  return (spent.user + spent.system) / 1000;
+};
+
 /**
  * Each call gets its own document from `input(attempt)`. Handing every call the
  * same string measures a memo hit rather than the work: the HTML layer
@@ -76,37 +111,59 @@ const SAMPLES = 4;
  * The inputs differ in length by one code point, so the shape is unchanged.
  * @param {(attempt: number) => string} input
  * @param {(text: string) => unknown | Promise<unknown>} fn
+ * @returns {Promise<Timing>}
  */
 async function measure(input, fn) {
   await fn(input(0));
-  let best = Infinity;
+  const best = { cpu: Infinity, wall: Infinity };
   for (let i = 1; i <= SAMPLES; i++) {
     const text = input(i);
+    const mark = process.cpuUsage();
     const started = performance.now();
     await fn(text);
-    best = Math.min(best, performance.now() - started);
+    // Each estimator takes its own minimum: the quietest sample by wall clock
+    // need not be the cheapest by CPU, and taking the pair from one sample would
+    // charge the CPU figure for whatever made that sample the quietest.
+    best.wall = Math.min(best.wall, performance.now() - started);
+    best.cpu = Math.min(best.cpu, cpuSince(mark));
   }
   return best;
 }
 
 /** A timed block has to last at least this long to be a measurement rather than
- * timer noise. */
+ * timer noise, however cheap the call it is made of. */
 const MIN_BLOCK_MS = 5;
 /** How many distinct documents a timed block cycles through. */
 const BLOCK_RING = 8;
 
 /**
- * The per-call cost of `fn`, timed over as many calls as it takes to be a
- * measurement.
+ * The per-call CPU cost of `fn`, timed over as many calls as it takes to fill a
+ * block of `blockMs`.
  *
  * One 32 KB pass costs a fraction of a millisecond on a fast machine, and that
  * is the number the scaling gate divides by. Timing a batch and dividing keeps
  * the small end meaningful at any machine speed, so the gate covers every case
  * instead of losing the cheap ones to the timer's resolution.
+ *
+ * `blockMs` is what makes the two sides of a scaling ratio comparable, and the
+ * caller passes the cost of the side it will be divided into. Fastest-of-N is
+ * only a fair estimator between blocks of similar length: a 12 ms call can
+ * finish entirely between two collections and four tries usually find one that
+ * does, while a 250 ms call always pays a share of the collector, so the short
+ * side reads low and the ratio reads high. Matching the block lengths amortizes
+ * the collector equally over both. Measured on `sanitizeText/html-prose`, a
+ * fixed 5 ms block put the 8x ratio at 14.1x–22.2x against a 24x limit; matched
+ * blocks put it at 13.4x–17.4x.
+ * @param {(attempt: number) => string} input
+ * @param {(text: string) => unknown | Promise<unknown>} fn
+ * @param {number} blockMs
+ * @returns {Promise<number>}
  */
-async function measurePerCall(input, fn) {
-  const single = await measure(input, fn);
-  const repeats = Math.ceil(MIN_BLOCK_MS / Math.max(single, Number.EPSILON));
+async function measurePerCall(input, fn, blockMs) {
+  const single = (await measure(input, fn)).cpu;
+  const repeats = Math.ceil(
+    Math.max(MIN_BLOCK_MS, blockMs) / Math.max(single, Number.EPSILON),
+  );
   if (repeats <= 1) return single;
   // The block cycles a ring of distinct documents for the same reason `measure`
   // varies its input, and a ring rather than one document per call because
@@ -122,7 +179,7 @@ async function measurePerCall(input, fn) {
       for (let i = 0; i < repeats; i++) await fn(ring[i % ring.length]);
     },
   );
-  return block / repeats;
+  return block.cpu / repeats;
 }
 
 // Text shapes with materially different cost profiles. The clean ones answer
@@ -147,20 +204,23 @@ const SHAPES = {
 };
 
 // Ceilings in calibration units for the shapes an entry does real work on. Each
-// is sized off the DEARER of two measurements — standalone, and under the
-// parallel coverage run, where the ratios move because c8 instruments the code
-// under test harder than it instruments this file's calibration — with 1.6x on
-// top. The two environments disagree by up to ~40% on the same case, so 1.6x is
-// what covers that disagreement and nothing more: enough that a green run means
-// the path is where it was left, tight enough that a doubling is red. Anything
-// with more slack than that is a ceiling nothing is under. CHEAP_BUDGET is
-// tighter, and each entry's `cheap` list names the shapes that entry has no
-// per-code-point work to do on: past ten passes' worth of work, such an input is
-// being analyzed for something it does not contain. The lists differ per entry
-// because the entries read different things — a soft hyphen every other
-// character is real work for the prompt classifier's scatter count and almost
-// none for the strip the output path runs.
-const CHEAP_BUDGET = 9;
+// is 1.3x the DEAREST reading across three environments: standalone, under the
+// parallel coverage run, and standalone against four workers of competing CPU
+// and allocation load. The instrumented run reads LOWER on every heavy cell,
+// because c8 charges this file's calibration harder than it charges the code
+// under test, so the ceilings are set by the two uninstrumented environments.
+// The dearest reading already contains a loaded run's collector spikes — up to
+// 1.7x that case's median — so 1.3x on top covers run-to-run variation and
+// nothing more: enough that a green run means the path is where it was left,
+// tight enough that a doubling is red. Anything with more slack than that is a
+// ceiling nothing is under. CHEAP_BUDGET is tighter, and each entry's `cheap`
+// list names the shapes that entry has no per-code-point work to do on: past a
+// dozen passes' worth of work, such an input is being analyzed for something it
+// does not contain. The lists differ per entry because the entries read
+// different things — a soft hyphen every other character is real work for the
+// prompt classifier's scatter count and almost none for the strip the output
+// path runs.
+const CHEAP_BUDGET = 11;
 
 /**
  * The blocking entry points, each with the shapes it must answer cheaply.
@@ -174,12 +234,12 @@ const ENTRIES = {
     // ANSI, and HTML-shaped text carries neither.
     cheap: ["ascii-prose", "cjk-prose", "emoji-prose", "html-prose"],
     budget: {
-      "joiner-dense": 37,
-      "vs-dense": 37,
-      "payload-run": 100,
+      "joiner-dense": 47,
+      "vs-dense": 42,
+      "payload-run": 84,
       "payload-scattered": 29,
-      "emoji-zwj": 36,
-      "run-dense": 53,
+      "emoji-zwj": 52,
+      "run-dense": 44,
     },
   },
   sanitizeText: {
@@ -200,12 +260,12 @@ const ENTRIES = {
       // for: it is parse5 building a 256 KB fragment, so it moves with the
       // parser rather than with anything here. SUPERLINEAR below is what
       // actually holds this path.
-      "html-prose": 168,
-      "joiner-dense": 65,
-      "vs-dense": 45,
-      "payload-run": 58,
-      "emoji-zwj": 45,
-      "run-dense": 32,
+      "html-prose": 467,
+      "joiner-dense": 45,
+      "vs-dense": 39,
+      "payload-run": 57,
+      "emoji-zwj": 39,
+      "run-dense": 41,
     },
   },
   scanText: {
@@ -215,15 +275,15 @@ const ENTRIES = {
     run: (text) => scanText(text),
     cheap: ["ascii-prose", "cjk-prose", "emoji-prose", "html-prose"],
     budget: {
-      "joiner-dense": 37,
-      "vs-dense": 21,
+      "joiner-dense": 22,
+      "vs-dense": 17,
       // One 256 KB run decodes as a single payload, so this case is dominated by
       // one large allocation and swings with the collector — the widest budget
       // here buys tolerance for that rather than for a slower machine.
-      "payload-run": 55,
-      "payload-scattered": 25,
-      "emoji-zwj": 24,
-      "run-dense": 28,
+      "payload-run": 87,
+      "payload-scattered": 16,
+      "emoji-zwj": 19,
+      "run-dense": 39,
     },
   },
 };
@@ -267,7 +327,7 @@ const SUPERLINEAR = {
  */
 const FOLD_GLYPH = "\u0430";
 const foldText = (n) => grow(FOLD_GLYPH + "bcdefghijklmn ", n);
-const FOLD_BUDGET = 23;
+const FOLD_BUDGET = 17;
 
 /**
  * The one gate that promises a NUMBER rather than a ratio.
@@ -275,7 +335,10 @@ const FOLD_BUDGET = 23;
  * Every budget above is machine-relative on purpose, and a table of ratios can
  * stay green while each hook takes a second, so the thing a user actually
  * notices \u2014 the wait before a session starts, the wait before a prompt goes \u2014
- * needs a ceiling in milliseconds. The input is ordinary text at 256 KB, which
+ * needs a ceiling in milliseconds — and, alone here, in WALL-CLOCK
+ * milliseconds: a user waiting on a hook waits through the time it spends
+ * descheduled too, so the CPU clock the ratios use would understate exactly the
+ * thing this gate promises. The input is ordinary text at 256 KB, which
  * is several times any real instruction set and larger than most pastes; the
  * adversarial shapes keep their ratio budgets, because a ceiling wide enough for
  * 256 KB of nothing but zero-width space on a slow runner would not be a
@@ -308,30 +371,44 @@ function foldFindings(text) {
 
 const CALIBRATION_TEXT = SHAPES["ascii-prose"](LARGE);
 
-/** One pass over the input, a code point at a time — the unit every budget is
+/**
+ * One pass over the input, a code point at a time — the unit every budget is
  * quoted in. Deliberately trivial: it must not get faster or slower for any
- * reason except the machine it runs on. */
+ * reason except the machine it runs on.
+ *
+ * Indexing rather than iterating is what keeps that promise. `for (const ch of
+ * text)` reads the same code points but materializes a string for each one, so
+ * its cost tracks the young generation's size — which the rest of the process
+ * sets, not the machine. This loop allocates nothing.
+ */
 function calibrationPass(text) {
   let seen = 0;
-  for (const ch of text) seen += ch.length;
+  for (let i = 0; i < text.length;) {
+    const point = text.codePointAt(i);
+    seen += point;
+    i += point > 0xffff ? 2 : 1;
+  }
   return seen;
 }
 
-const calibrate = () => measure(() => CALIBRATION_TEXT, calibrationPass);
+/** The unit, in CPU ms per pass. */
+const calibrate = async () =>
+  (await measure(() => CALIBRATION_TEXT, calibrationPass)).cpu;
 
 /**
- * `fn`'s cost in calibration units, calibrating on BOTH sides of the
+ * `fn`'s CPU cost in calibration units, calibrating on BOTH sides of the
  * measurement and taking the larger unit. The test runner runs files in
- * parallel, so the load on the machine drifts during a run; a single calibration
- * taken up front can be read against a case measured under quite different
- * contention. Bracketing the measurement keeps the two comparable, and taking
- * the larger unit resolves a drift in the direction that does not manufacture a
- * failure.
+ * parallel, so the machine's clock speed and cache pressure drift during a run;
+ * a single calibration taken up front can be read against a case measured in
+ * quite different conditions. Bracketing the measurement keeps the two
+ * comparable, and taking the larger unit resolves a drift in the direction that
+ * does not manufacture a failure.
+ * @returns {Promise<{cost: Timing, units: number}>}
  */
 async function unitsFor(input, fn) {
   const opening = await calibrate();
   const cost = await measure(input, fn);
-  return { cost, units: cost / Math.max(opening, await calibrate()) };
+  return { cost, units: cost.cpu / Math.max(opening, await calibrate()) };
 }
 
 /** Every entry x shape pair the gates below speak about. */
@@ -343,7 +420,10 @@ const CASES = Object.keys(ENTRIES).flatMap((entry) =>
   })),
 );
 
-/** @type {{unit: number, large: Record<string, number>, small: Record<string, number>,
+/**
+ * Every figure here is CPU ms except `realistic`, which is the wall clock the
+ * millisecond ceiling is about.
+ * @type {{unit: number, large: Record<string, number>, small: Record<string, number>,
  *   units: Record<string, number>, superlinear: Record<string, number>,
  *   realistic: Record<string, number>,
  *   fold: Record<string, number>, foldUnits: number, foldChanged: boolean}} */
@@ -368,26 +448,31 @@ before(async () => {
       (attempt) => SHAPES[shape](LARGE - attempt),
       (text) => run(text, shape),
     );
-    timing.large[name] = measured.cost;
+    timing.large[name] = measured.cost.cpu;
     timing.units[name] = measured.units;
     timing.small[name] = await measurePerCall(
       (attempt) => SHAPES[shape](SMALL - attempt),
       (text) => run(text, shape),
+      measured.cost.cpu,
     );
   }
   for (const [entry, { run }] of Object.entries(ENTRIES))
     // Not "html-prose", so `sanitizeText` takes the Layer-1 path the majority of
     // tool results take rather than the markup path only web ingress reaches.
-    timing.realistic[entry] = await measure(
-      (attempt) => REALISTIC_TEXT.slice(0, REALISTIC_TEXT.length - attempt),
-      (text) => run(text, "realistic-prose"),
-    );
+    timing.realistic[entry] = (
+      await measure(
+        (attempt) => REALISTIC_TEXT.slice(0, REALISTIC_TEXT.length - attempt),
+        (text) => run(text, "realistic-prose"),
+      )
+    ).wall;
   const { run } = ENTRIES[SUPERLINEAR.entry];
   for (const end of ["from", "to"]) {
-    timing.superlinear[end] = await measure(
-      (attempt) => SHAPES[SUPERLINEAR.shape](SUPERLINEAR[end] - attempt),
-      (text) => run(text, SUPERLINEAR.shape),
-    );
+    timing.superlinear[end] = (
+      await measure(
+        (attempt) => SHAPES[SUPERLINEAR.shape](SUPERLINEAR[end] - attempt),
+        (text) => run(text, SUPERLINEAR.shape),
+      )
+    ).cpu;
   }
   for (const [size, key] of [
     [SMALL, "small"],
@@ -402,7 +487,7 @@ before(async () => {
     // The fold takes no parse and holds no memo, so every run may share one
     // input; the offsets `findings` carries are only valid for this one.
     const measured = await unitsFor(() => text, fold);
-    timing.fold[key] = measured.cost;
+    timing.fold[key] = measured.cost.cpu;
     if (key === "large") {
       timing.foldUnits = measured.units;
       timing.foldChanged = fold() !== text;
@@ -424,12 +509,13 @@ const timed = (name, fn) =>
 
 describe("hook-path latency", () => {
   timed("the calibration is a measurement, not timer noise", () => {
-    // Every ratio below divides by this. A machine that materializes 256 KB in
-    // under a third of a millisecond is not one these gates can speak about, so
-    // say so loudly rather than passing on a division by noise.
+    // Every ratio below divides by this. `process.cpuUsage` accounts in whole
+    // microseconds, so a pass under a tenth of a millisecond is quantized to
+    // within a percent of itself and the ratios stop meaning anything — say so
+    // loudly rather than passing on a division by noise.
     assert.ok(
-      timing.unit > 0.3,
-      `calibration ran in ${timing.unit.toFixed(3)}ms — too fast to divide by`,
+      timing.unit > 0.1,
+      `calibration ran in ${timing.unit.toFixed(3)}ms of CPU — too fast to divide by`,
     );
   });
 
@@ -441,7 +527,7 @@ describe("hook-path latency", () => {
       const budget = cheap.includes(shape) ? CHEAP_BUDGET : heavy[shape];
       assert.ok(
         timing.units[name] <= budget,
-        `${name} ran in ${timing.units[name].toFixed(1)} units (${timing.large[name].toFixed(1)}ms), budget ${budget}`,
+        `${name} ran in ${timing.units[name].toFixed(1)} units (${timing.large[name].toFixed(1)}ms CPU), budget ${budget}`,
       );
     });
 
@@ -467,7 +553,7 @@ describe("hook-path latency", () => {
       for (const shape of Object.keys(SHAPES).filter((s) => !cheap.includes(s)))
         assert.ok(
           timing.large[`${entry}/${shape}`] > dearest,
-          `${entry}/${shape} (${timing.large[`${entry}/${shape}`].toFixed(1)}ms) no longer costs more than the dearest cheap shape (${dearest.toFixed(1)}ms) — it is not exercising the path it was written for`,
+          `${entry}/${shape} (${timing.large[`${entry}/${shape}`].toFixed(1)}ms CPU) no longer costs more than the dearest cheap shape (${dearest.toFixed(1)}ms CPU) — it is not exercising the path it was written for`,
         );
     });
 
@@ -510,7 +596,7 @@ describe("hook-path latency", () => {
       );
       assert.ok(
         units <= CHEAP_BUDGET,
-        `the hook judged a clean 256 KB prompt in ${units.toFixed(1)} units (${cost.toFixed(1)}ms), budget ${CHEAP_BUDGET}`,
+        `the hook judged a clean 256 KB prompt in ${units.toFixed(1)} units (${cost.cpu.toFixed(1)}ms CPU), budget ${CHEAP_BUDGET}`,
       );
     },
   );
@@ -525,7 +611,7 @@ describe("hook-path latency", () => {
     () => {
       assert.ok(
         superlinearGrowth() <= SUPERLINEAR.limit,
-        `${superlinearName} cost ${superlinearGrowth().toFixed(1)}x for ${sizeStep}x the input (${timing.superlinear.from.toFixed(1)}ms → ${timing.superlinear.to.toFixed(1)}ms), limit ${SUPERLINEAR.limit}x`,
+        `${superlinearName} cost ${superlinearGrowth().toFixed(1)}x for ${sizeStep}x the input (${timing.superlinear.from.toFixed(1)}ms → ${timing.superlinear.to.toFixed(1)}ms CPU), limit ${SUPERLINEAR.limit}x`,
       );
     },
   );
@@ -541,7 +627,7 @@ describe("hook-path latency", () => {
       );
       assert.ok(
         timing.foldUnits <= FOLD_BUDGET,
-        `folding 256 KB of look-alikes took ${timing.foldUnits.toFixed(1)} units (${timing.fold.large.toFixed(1)}ms), budget ${FOLD_BUDGET}`,
+        `folding 256 KB of look-alikes took ${timing.foldUnits.toFixed(1)} units (${timing.fold.large.toFixed(1)}ms CPU), budget ${FOLD_BUDGET}`,
       );
     },
   );

--- a/test/hook-latency.test.mjs
+++ b/test/hook-latency.test.mjs
@@ -9,34 +9,14 @@
  * scan sat in the carve analysis charging ~250 ms per megabyte.
  *
  * Every budget is a RATIO against a calibration measured in this same process:
- * one code-point-by-code-point pass over a fixed 256 KB input, which is the
- * cheapest full read of a text anything here can do. Machine speed and the
- * coverage instrumentation scale both sides, so the ratios survive a slow or
- * instrumented runner in a way wall-clock milliseconds do not — the calibration
- * is written in this file, rather than reaching for a native builtin, precisely
- * so it pays the same instrumentation tax as the code it normalizes.
- *
- * CONTENTION is a different problem, and the ratio does not solve it. A ratio
- * cancels a slower machine because both sides run at that speed; it cannot
- * cancel a BUSY one, because the two sides are timed over blocks of very
- * different length. A calibration pass takes about a millisecond, so
- * {@link measure}'s fastest-of-N estimator reliably catches a quiet slot for it,
- * while a 256 KB parse5 run takes hundreds of milliseconds and on a loaded
- * runner gets no quiet slot in any sample. The divisor stays flat while the
- * numerator inflates, and the ratio reports the load as a regression. So every
- * timed block here is charged in the CPU time the process actually spent
- * (`process.cpuUsage`) rather than the wall clock it occupied: time spent
- * descheduled behind another test worker is not time this code spent. Measured
- * on the dearest cell, four workers of competing load move the wall clock 1.9x
- * and the CPU time 1.06x.
- *
- * The calibration is allocation-free for the same reason. Reading the text with
- * `for (const ch of text)` materializes a string per code point, which makes the
- * pass a measure of the collector's current disposition — and the young
- * generation's size is set by whatever ran before, so the same pass cost 3.0ms
- * in a fresh process and 1.4ms once a parse5 run had grown the heap. A
- * calibration that halves for a reason unrelated to the machine doubles every
- * ratio read against it.
+ * {@link calibrationPass} over a fixed 256 KB input, the cheapest full read of a
+ * text anything here can do. Machine speed and the coverage instrumentation
+ * scale both sides, so the ratios survive a slow or instrumented runner in a way
+ * milliseconds do not — the calibration lives in this file, rather than reaching
+ * for a native builtin, so it pays the same instrumentation tax as the code it
+ * normalizes. A ratio does not cancel a BUSY machine, though, so every timed
+ * block is charged in CPU time rather than wall clock (see {@link measure}).
+ * {@link REALISTIC_MS} is the lone exception.
  */
 import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
@@ -79,14 +59,17 @@ const grow = (unit, n) => unit.repeat(Math.ceil(n / unit.length)).slice(0, n);
 /**
  * The FASTEST of {@link SAMPLES} timed runs after a warm-up call.
  *
- * Collector pauses and the scheduling the CPU clock still sees only ever ADD
+ * Collector pauses, and the descheduling the CPU clock still sees, only ever ADD
  * time, so the minimum is the closest any of the samples got to the cost of the
  * code itself. A median still carries whatever noise landed on the middle
  * sample, which on a shared runner is most of them. The estimator loses nothing
  * the gates are for: a path that got an order of magnitude slower is an order of
- * magnitude slower in its fastest run too.
+ * magnitude slower in its fastest run too. Eight rather than four because four
+ * tries are not enough on a loaded runner for the collector to miss one: at four
+ * the dearest cells read up to 1.7x their own median, at eight up to 1.1x, which
+ * is what lets the budgets below stay tight enough to catch a doubling.
  */
-const SAMPLES = 4;
+const SAMPLES = 8;
 
 /**
  * A timed block, in ms: the CPU time the process spent, and the wall clock it
@@ -103,6 +86,14 @@ const cpuSince = (mark) => {
 };
 
 /**
+ * A block's cost, in both clocks. `cpu` is what every ratio below reads: a ratio
+ * cancels a slower machine because both sides run at that speed, but not a busy
+ * one, because the two sides are timed over blocks of very different length — a
+ * 1 ms calibration pass reliably catches a quiet slot for its fastest sample and
+ * a 250 ms parse5 run never does, so the divisor stays flat while the numerator
+ * inflates. Time descheduled behind another test worker is not time this code
+ * spent, and the CPU clock does not charge it.
+ *
  * Each call gets its own document from `input(attempt)`. Handing every call the
  * same string measures a memo hit rather than the work: the HTML layer
  * remembers its last parse, so the warm-up builds the tree the timed runs then
@@ -142,18 +133,14 @@ const BLOCK_RING = 8;
  *
  * One 32 KB pass costs a fraction of a millisecond on a fast machine, and that
  * is the number the scaling gate divides by. Timing a batch and dividing keeps
- * the small end meaningful at any machine speed, so the gate covers every case
- * instead of losing the cheap ones to the timer's resolution.
+ * the small end meaningful at any machine speed.
  *
- * `blockMs` is what makes the two sides of a scaling ratio comparable, and the
- * caller passes the cost of the side it will be divided into. Fastest-of-N is
- * only a fair estimator between blocks of similar length: a 12 ms call can
- * finish entirely between two collections and four tries usually find one that
- * does, while a 250 ms call always pays a share of the collector, so the short
- * side reads low and the ratio reads high. Matching the block lengths amortizes
- * the collector equally over both. Measured on `sanitizeText/html-prose`, a
- * fixed 5 ms block put the 8x ratio at 14.1x–22.2x against a 24x limit; matched
- * blocks put it at 13.4x–17.4x.
+ * `blockMs` is what makes the two sides of a scaling ratio comparable: the
+ * caller passes the cost of the side it will be divided into, since
+ * fastest-of-N is fair only between blocks of similar length (see
+ * {@link measure}). Under {@link MIN_BLOCK_MS} the floor wins and the bias runs
+ * the other way — those cells sit an order of magnitude clear of
+ * {@link SCALING_LIMIT}.
  * @param {(attempt: number) => string} input
  * @param {(text: string) => unknown | Promise<unknown>} fn
  * @param {number} blockMs
@@ -161,9 +148,11 @@ const BLOCK_RING = 8;
  */
 async function measurePerCall(input, fn, blockMs) {
   const single = (await measure(input, fn)).cpu;
-  const repeats = Math.ceil(
-    Math.max(MIN_BLOCK_MS, blockMs) / Math.max(single, Number.EPSILON),
-  );
+  // A zero would divide into a repeat count no loop finishes. The resolution
+  // probe in `before` is what normally catches a clock too coarse to measure
+  // these calls; this refuses to hang if one gets past it.
+  assert.ok(single > 0, "the CPU clock reported no time for a timed call");
+  const repeats = Math.ceil(Math.max(MIN_BLOCK_MS, blockMs) / single);
   if (repeats <= 1) return single;
   // The block cycles a ring of distinct documents for the same reason `measure`
   // varies its input, and a ring rather than one document per call because
@@ -203,23 +192,24 @@ const SHAPES = {
     grow("ordinary instruction text " + cp(0x200b).repeat(12) + "\n", n),
 };
 
-// Ceilings in calibration units for the shapes an entry does real work on. Each
-// is 1.3x the DEAREST reading across three environments: standalone, under the
-// parallel coverage run, and standalone against four workers of competing CPU
-// and allocation load. The instrumented run reads LOWER on every heavy cell,
-// because c8 charges this file's calibration harder than it charges the code
-// under test, so the ceilings are set by the two uninstrumented environments.
-// The dearest reading already contains a loaded run's collector spikes — up to
-// 1.7x that case's median — so 1.3x on top covers run-to-run variation and
-// nothing more: enough that a green run means the path is where it was left,
-// tight enough that a doubling is red. Anything with more slack than that is a
-// ceiling nothing is under. CHEAP_BUDGET is tighter, and each entry's `cheap`
-// list names the shapes that entry has no per-code-point work to do on: past a
-// dozen passes' worth of work, such an input is being analyzed for something it
-// does not contain. The lists differ per entry because the entries read
-// different things — a soft hyphen every other character is real work for the
-// prompt classifier's scatter count and almost none for the strip the output
-// path runs.
+/**
+ * The ceiling, in calibration units, for a shape an entry has no per-code-point
+ * work to do on: past a dozen passes' worth of work, such an input is being
+ * analyzed for something it does not contain. Each entry's `cheap` list names
+ * its own such shapes, because the entries read different things — a soft hyphen
+ * every other character is real work for the prompt classifier's scatter count
+ * and almost none for the strip the output path runs.
+ *
+ * This and every `budget` entry below is 1.3x the DEAREST reading across three
+ * environments: standalone, under the parallel coverage run, and standalone
+ * against four workers of competing CPU and allocation load. The instrumented
+ * run reads LOWER on every heavy cell, since c8 charges this file's calibration
+ * harder than the code under test, so the ceilings come from the two
+ * uninstrumented ones. Across those runs no case reads more than 1.12x its
+ * own median, so 1.3x covers run-to-run variation and nothing more — every
+ * ceiling here sits under twice its case's median, which is the standard: a
+ * doubling is red, and anything looser is a ceiling nothing is under.
+ */
 const CHEAP_BUDGET = 11;
 
 /**
@@ -234,12 +224,12 @@ const ENTRIES = {
     // ANSI, and HTML-shaped text carries neither.
     cheap: ["ascii-prose", "cjk-prose", "emoji-prose", "html-prose"],
     budget: {
-      "joiner-dense": 47,
-      "vs-dense": 42,
+      "joiner-dense": 31,
+      "vs-dense": 34,
       "payload-run": 84,
       "payload-scattered": 29,
-      "emoji-zwj": 52,
-      "run-dense": 44,
+      "emoji-zwj": 31,
+      "run-dense": 48,
     },
   },
   sanitizeText: {
@@ -260,12 +250,12 @@ const ENTRIES = {
       // for: it is parse5 building a 256 KB fragment, so it moves with the
       // parser rather than with anything here. SUPERLINEAR below is what
       // actually holds this path.
-      "html-prose": 467,
-      "joiner-dense": 45,
-      "vs-dense": 39,
-      "payload-run": 57,
-      "emoji-zwj": 39,
-      "run-dense": 41,
+      "html-prose": 365,
+      "joiner-dense": 43,
+      "vs-dense": 38,
+      "payload-run": 59,
+      "emoji-zwj": 38,
+      "run-dense": 32,
     },
   },
   scanText: {
@@ -280,10 +270,10 @@ const ENTRIES = {
       // One 256 KB run decodes as a single payload, so this case is dominated by
       // one large allocation and swings with the collector — the widest budget
       // here buys tolerance for that rather than for a slower machine.
-      "payload-run": 87,
-      "payload-scattered": 16,
+      "payload-run": 64,
+      "payload-scattered": 17,
       "emoji-zwj": 19,
-      "run-dense": 39,
+      "run-dense": 34,
     },
   },
 };
@@ -327,7 +317,7 @@ const SUPERLINEAR = {
  */
 const FOLD_GLYPH = "\u0430";
 const foldText = (n) => grow(FOLD_GLYPH + "bcdefghijklmn ", n);
-const FOLD_BUDGET = 17;
+const FOLD_BUDGET = 16;
 
 /**
  * The one gate that promises a NUMBER rather than a ratio.
@@ -335,14 +325,12 @@ const FOLD_BUDGET = 17;
  * Every budget above is machine-relative on purpose, and a table of ratios can
  * stay green while each hook takes a second, so the thing a user actually
  * notices \u2014 the wait before a session starts, the wait before a prompt goes \u2014
- * needs a ceiling in milliseconds — and, alone here, in WALL-CLOCK
- * milliseconds: a user waiting on a hook waits through the time it spends
- * descheduled too, so the CPU clock the ratios use would understate exactly the
- * thing this gate promises. The input is ordinary text at 256 KB, which
- * is several times any real instruction set and larger than most pastes; the
- * adversarial shapes keep their ratio budgets, because a ceiling wide enough for
- * 256 KB of nothing but zero-width space on a slow runner would not be a
- * guarantee about anything.
+ * needs a ceiling in milliseconds — and, alone here, in WALL-CLOCK milliseconds,
+ * since a user waits through descheduling too and the CPU clock the ratios use
+ * would understate the very thing this gate promises. The input is ordinary text
+ * at 256 KB, larger than most pastes; the adversarial shapes keep their ratio
+ * budgets, because a ceiling wide enough for 256 KB of nothing but zero-width
+ * space on a slow runner would not be a guarantee about anything.
  *
  * c8 multiplies wall clock by roughly seven here, which is a fact about the
  * instrumentation and not about the hook, so this half stands down under
@@ -395,6 +383,33 @@ function calibrationPass(text) {
 const calibrate = async () =>
   (await measure(() => CALIBRATION_TEXT, calibrationPass)).cpu;
 
+/** How long a probe block busy-waits, and how many it runs. */
+const PROBE_MS = 0.2;
+const PROBE_BLOCKS = 40;
+
+/**
+ * The finest CPU-time reading this clock resolves, in ms.
+ *
+ * `process.cpuUsage` reports microseconds, but a kernel that accumulates rusage
+ * at tick granularity only ever reports whole ticks — 1 ms, or 4 ms — and the
+ * calibration pass costs about one millisecond, so on such a kernel the unit is
+ * quantized to within its own size and no ratio here means anything. Busy-wait
+ * blocks well under a tick and keep the smallest non-zero reading: it comes back
+ * near {@link PROBE_MS} on a microsecond clock and at a whole tick otherwise.
+ */
+function clockResolutionMs() {
+  let finest = Infinity;
+  for (let i = 0; i < PROBE_BLOCKS; i++) {
+    const mark = process.cpuUsage();
+    const until = performance.now() + PROBE_MS;
+    let spin = 0;
+    while (performance.now() < until) spin += Math.sqrt(spin + 1);
+    const spent = cpuSince(mark);
+    if (spent > 0 && spent < finest) finest = spent;
+  }
+  return finest;
+}
+
 /**
  * `fn`'s CPU cost in calibration units, calibrating on BOTH sides of the
  * measurement and taking the larger unit. The test runner runs files in
@@ -439,8 +454,19 @@ const timing = {
   foldChanged: false,
 };
 
+/** The coarsest clock these gates can be read on. A reading no finer than this
+ * cannot resolve the calibration pass, and `measurePerCall` would divide a
+ * matched block by a zero. Checked here rather than in a test body: every
+ * measurement below is downstream of it. */
+const RESOLUTION_CEILING_MS = 0.5;
+
 before(async () => {
   if (MUTATION_RUN) return;
+  const resolution = clockResolutionMs();
+  assert.ok(
+    resolution <= RESOLUTION_CEILING_MS,
+    `process.cpuUsage resolves no finer than ${resolution.toFixed(3)}ms on this kernel, so the calibration pass is quantized to within its own size`,
+  );
   timing.unit = await calibrate();
   for (const { entry, shape, name } of CASES) {
     const { run } = ENTRIES[entry];
@@ -651,7 +677,7 @@ describe("hook-path latency", () => {
       );
       return;
     }
-    // The other half of the ratchet. A ceiling of 12x on a path that grew
+    // The other half of the ratchet. SUPERLINEAR.limit on a path that grew
     // linearly would gate nothing at all, so this fails the moment the HTML
     // layer stops being super-linear — and the fix is to delete SUPERLINEAR and
     // let the ordinary scaling gate own it.


### PR DESCRIPTION
Claimed area: the estimator and budget table in `test/hook-latency.test.mjs`.

## Summary

Make the latency gates measure the code rather than the machine's mood. Every timed block is charged in the CPU time the process actually spent, the calibration allocates nothing, both sides of a scaling ratio are timed over blocks of matching length, and the fastest-of-N estimator gets enough samples to find the collector missing. Budgets are re-derived, since the unit's definition changed.

`sanitizeText/html-prose` reds on a busy machine rather than on a regression — reported in #325 with ~5% headroom on its 168-unit budget, reproduced on unmodified `main`. Three causes:

**A ratio cancels a slower machine, not a busier one.** The two sides are timed over blocks of very different length. A calibration pass takes ~1 ms, so `measure`'s fastest-of-N estimator reliably catches a quiet slot for it; a 256 KB parse5 run takes hundreds of ms and gets no quiet slot in any sample. The divisor stays flat while the numerator inflates. Four workers of competing load move that cell 1.9x on the wall clock and 1.06x on the CPU clock.

**The calibration was not the trivial thing it claimed to be.** `for (const ch of text)` materializes a string per code point, so the pass measured the collector's disposition — and the young generation's size is set by whatever ran before it: 3.0 ms in a fresh process, 1.4 ms once a parse5 run had grown the heap. A calibration that halves for a reason unrelated to the machine doubles every ratio read against it.

**Four samples were too few.** A minimum over four tries still lands on a collector pass often enough that the dearest cells read up to 1.7x their own median on a loaded runner. Budgets derived from that spread cannot also be tight enough to fail on a doubling. At eight samples no case reads more than 1.12x its median.

The scaling gates carry the same short-block-versus-long-block asymmetry as the ratios: a 12 ms call can finish entirely between two collections and a few tries usually find one that does, while a 250 ms call always pays a share of the collector, so the short side reads low and the 8x ratio reads high.

## Changes

- `measure` returns `{cpu, wall}`, each its own minimum over the samples. `unitsFor`, `measurePerCall`, the scaling gates, `SUPERLINEAR` and the fold gate read `cpu`; `REALISTIC_MS` reads `wall`, because a user waiting on a hook waits through descheduling too.
- `calibrationPass` indexes by code point instead of iterating, so it allocates nothing.
- `SAMPLES` 4 → 8.
- `measurePerCall` takes a `blockMs` floor, and the caller passes the cost of the measurement it will be divided into. Its per-call cost is asserted non-zero rather than floored at `Number.EPSILON` — against a CPU clock a zero is a real reading, and the floor would have built a block of ~1e18 calls instead of failing.
- `before` probes the clock's resolution and fails with a diagnosis if `process.cpuUsage` turns out to be tick-accounted, since every measurement is downstream of it. The unit gate's floor drops from 0.3 ms to 0.1 ms, which is where microsecond accounting stops resolving the unit; the old floor was sized for a 3 ms allocating pass.
- Every budget re-derived: `CHEAP_BUDGET` 9 → 15, `FOLD_BUDGET` 23 → 16, and the per-shape table throughout. `SCALING_LIMIT`, `SUPERLINEAR.limit` and `REALISTIC_MS` are untouched — the first two are cpu/cpu ratios that cancel the unit, the third is wall-clock ms in both designs.
- Each budget gate emits its measured units, raw CPU cost and the unit it divided by as a TAP diagnostic, on the green path as well as the red one.
- `node-tests.yaml`: the comment on the uninstrumented step promised "under 100ms" when `REALISTIC_MS` is 40, and now names which clock each half reads.

## Review focus

Read `measure` and `unitsFor` first — they decide which clock every gate downstream speaks in, and the `cpu`/`wall` split is the one place a mix-up would be silent (a gate reading `wall` would keep the old flakiness; the millisecond ceiling reading `cpu` would stop measuring what it names). The cross-file invariant the diff can't show: `node-tests.yaml`'s uninstrumented step is the only place `REALISTIC_MS` is ever read, since `pnpm test` runs under c8 and that gate stands down there.

The judgment I'd most like scrutinized is the resolution probe in `before`: it busy-waits 40 blocks of 0.2 ms and keeps the smallest non-zero CPU reading, which comes back at ~0.2 ms on a microsecond clock and at a whole tick on a tick-accounted one. It costs 8 ms and it is the only thing standing between a coarse kernel and a table of meaningless ratios.

## Decisions made

- **`process.cpuUsage` counts every thread, and that is left as-is.** A collector pass or a background compile the block provoked is charged to the block. Under the alternative — main-thread user time only — a regression that shifts work onto the collector would be invisible to these gates, which is worse than charging a block for parallel GC it caused.
- **The spread was attacked at the estimator, not absorbed into the budgets.** The first derivation set two cells (`classifyPrompt/emoji-zwj`, `scanText/payload-run`) wide enough that a doubling would have passed, because a single loaded run spiked them. More samples removed the spikes instead. Under the alternative those two ceilings stay at 52 and 87 against medians of 24 and 46, and the table's own non-vacuity claim is false for two rows.
- **`CHEAP_BUDGET` is set from the GitHub runner, not from this machine.** The first derivation used one machine and CI red at `sanitizeText/payload-scattered`: 11.1 units against the ceiling of 11. The unit reads the same on both machines (~0.89 ms), but that path's raw cost is 9.9 ms on the runner against ~6.5 ms here, so it is the code-to-calibration ratio that moves with microarchitecture — the ratio cancels clock speed, not instruction mix. The ceiling is now 15, which is still under twice the runner's reading, so a doubling stays red there. Under the alternative — keeping 11 and calling the runner's cell an outlier — the gate reds on every PR.
- **Every gate now prints its numbers on the green path too.** The table's whole method is "1.3x the dearest reading across environments", and CI was an environment whose numbers nobody could read: a green run said nothing and a red one printed one cell. Under the alternative the table stays derivable only from a developer machine, which is what produced the failure above.
- **The millisecond ceiling stays on the wall clock.** It exists to promise a bounded wait to a user, and a user waits through descheduling. Under the alternative it would stop measuring the thing it names — at the cost that it is the one gate here still load-sensitive, which is why it runs only in the uninstrumented CI step.

## How it was tested

`pnpm test`, `pnpm lint`, `pnpm check` pass. The file itself runs in 22s standalone, up from 12s — the cost of eight samples.

**The reported flake, before and after.** Against four workers of competing CPU and allocation load, `main` reds `sanitizeText/html-prose` in 3 of 3 runs — 237.1, 224.3 and 294.3 units against its budget of 168. The same load leaves this branch green in 3 of 3.

**The gates still bite.** Injecting a per-code-point pass into `sanitizeText` that doubles the HTML path's CPU cost reds all ten of its budget cells, `html-prose` included.

**Budget derivation.** Seven runs across three local environments — standalone, under the parallel `pnpm test` coverage run, and standalone against the synthetic load — plus the GitHub runner. The instrumented run reads *lower* on every heavy cell, because c8 charges the calibration harder than the code under test, so the ceilings come from the uninstrumented ones. Within one machine no case reads more than 1.12x its own median; each budget is 1.3x its dearest reading, which puts every ceiling under twice its median — so a doubling reds everywhere, which is the standard the table's comment claims.

**The scaling gate.** `sanitizeText/html-prose` was the tightest cell in the file after the budget one: 14.1x–22.2x against a 24x limit, and its 21.9x maximum landed in a *quiet* run, so widening the limit would have treated the symptom. With matched block lengths and eight samples it reads at most 16.5x.

**Propagated.** The same estimator defects were present in `agent-glovebox`'s `.claude/hooks/sanitize-output.fuzz.test.mjs` growth-exponent gate — fixed in AlexanderMattTurner/agent-glovebox#4327.

## Lessons Learned

- **What**: state that a RATIO against an in-process calibration does not make a timing gate load-proof — the ratio cancels machine speed, and only CPU-time accounting (`process.cpuUsage`, `time.process_time`, `getrusage`) cancels contention. Add the corollary that fastest-of-N is a fair estimator only between blocks of similar duration, so any gate dividing a long measurement by a short one is biased upward under load.
- **Where**: `.claude/skills/writing-tests/SKILL.md`, alongside the existing non-vacuity guidance.
- **Why**: the ratio framing reads as the load-proof answer, so a gate written that way looks finished; the failure surfaces only as an intermittent red on a busy runner and gets attributed to flakiness rather than to the estimator. It cost a blocked commit here.
- **What**: require a calibration loop to be allocation-free, and name `for (const ch of text)` as the trap.
- **Where**: same file.
- **Why**: it is the obvious way to write "one pass, a code point at a time", and it silently makes the unit a function of the heap's history rather than the machine — a 2x swing that moves every budget read against it.
- **What**: require a machine-relative timing budget to print its measured value on the PASSING path, not only in the failure message.
- **Where**: same file.
- **Why**: such a table is derived from the dearest reading across environments, and CI is an environment whose numbers are otherwise invisible — a green run reports nothing and a red one reports the single cell that broke, so the table can only ever be re-derived from whichever developer machine wrote it. That is exactly how the ceiling shipped here too low for the runner.

## Checklist

- [x] Commits follow Conventional Commits; each subject reads as a user-facing release note.
- [x] `pnpm test`, `pnpm lint`, and `pnpm check` pass locally.
- [x] No detector changed; the estimator's non-vacuity is pinned by the injected-regression runs above.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version are left untouched.