### PR TITLE
fix(redos-guard): analyze regexes built from constants, not just string literals

### DIFF
--- a/scripts/extract-js-regexes.mjs
+++ b/scripts/extract-js-regexes.mjs
@@ -27,8 +27,9 @@
  * re-deriving that from source text is the partial evaluator this file
  * deliberately does not contain. A name that some inner scope also binds is
  * refused outright — this walk cannot tell the two bindings apart, and a
- * confidently wrong pattern is worse than a reported gap. Everything still
- * unresolved is reported as such, never dropped.
+ * confidently wrong pattern is worse than a reported gap. A name a module-scope
+ * `let`/`var` binds is refused for the same reason. Everything still unresolved
+ * is reported as such, never dropped.
  *
  * Usage:
  *   node scripts/extract-js-regexes.mjs           → every shipped `.mjs`
@@ -135,6 +136,12 @@ function loadModule(abs) {
 
   for (const st of sf.statements) {
     if (ts.isVariableStatement(st)) {
+      // Only a `const` binding has a single value. A module-scope `let`/`var`
+      // can be reassigned after its initializer, so neither the initializer nor
+      // the live value an import reads is reliably the one a site compiles.
+      // Leaving it out of both `consts` and `owner` is what makes a site built
+      // from such a name report as unresolved instead of as a guess.
+      if (!(st.declarationList.flags & ts.NodeFlags.Const)) continue;
       const isExported = st.modifiers?.some(
         (m) => m.kind === ts.SyntaxKind.ExportKeyword,
       );

--- a/scripts/extract-js-regexes.mjs
+++ b/scripts/extract-js-regexes.mjs
@@ -5,25 +5,339 @@
  * hand-rolled regex-over-regex approximation) and emits, as JSON on stdout:
  *
  *   { "patterns": [{ "file": "src/html.mjs", "line": 12, "pattern": "...",
- *                    "flags": "..." }] }
+ *                    "flags": "..." }],
+ *     "constructionSites": [{ "file": "...", "line": 1, "expr": "new RegExp(…)",
+ *                             "resolved": true }] }
  *
- * Collected forms:
- *   - regex literals: /pattern/flags
- *   - `new RegExp("pattern")` / `RegExp("pattern", "flags")` where the pattern
- *     is a plain string literal (a dynamically built pattern has no static
- *     text to analyze; none exist in these roots today, and the paired guard
- *     test asserts the total inventory count so a new dynamic construction site
- *     shows up as a count change, not a silent hole).
+ * `patterns` carries every regex literal plus every `RegExp(…)` construction
+ * whose pattern and flags this file resolves to static text.
+ * `constructionSites` carries EVERY `RegExp(…)` / `new RegExp(…)` site, resolved
+ * or not, so the guard can assert the partition: a site is either analyzed or
+ * named in the guard's exemption list with a reason. That is what makes a new
+ * dynamic construction site a red build rather than a silent hole. An inventory
+ * COUNT cannot do it: an unresolved site contributes no inventory entry, so the
+ * count does not move when one appears.
+ *
+ * Resolution handles the shapes these sources actually use, and nothing more:
+ * string/number/regex literals, template literals, `+` and `<<`, a same-module
+ * `const`, a named import followed to its relative module, and `X.source`. When
+ * static composition runs out — a `const` built by calling a function — the
+ * binding's own module is imported and the live value read, if the module
+ * exports it. The engine is the authority on what a JS expression evaluates to;
+ * re-deriving that from source text is the partial evaluator this file
+ * deliberately does not contain. A name that some inner scope also binds is
+ * refused outright — this walk cannot tell the two bindings apart, and a
+ * confidently wrong pattern is worse than a reported gap. Everything still
+ * unresolved is reported as such, never dropped.
+ *
+ * Usage:
+ *   node scripts/extract-js-regexes.mjs           → every shipped `.mjs`
+ *   node scripts/extract-js-regexes.mjs FILE...   → just those files
+ *
+ * The file arguments exist for the guard's own fixtures, which prove the
+ * resolved/unresolved split is real rather than vacuous.
  */
 import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import ts from "typescript";
 
 import { shippedSources } from "./shipped-sources.mjs";
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** @param {string} abs @returns {string} repo-relative POSIX path */
+const relPath = (abs) => relative(repoRoot, abs).split(sep).join("/");
+
+/**
+ * @typedef {object} ModuleInfo
+ * @property {string} abs absolute path
+ * @property {string} rel repo-relative POSIX path
+ * @property {import("typescript").SourceFile} sf
+ * @property {Map<string, import("typescript").Expression>} consts module-scope `const` initializers
+ * @property {Set<string>} exported names this module exports
+ * @property {Map<string, {spec: string, imported: string}>} imports local name -> origin
+ * @property {Set<string>} shadowed names also bound in some inner scope
+ * @property {Map<import("typescript").Node, string>} owner initializer -> the name it binds
+ */
+
+/** @type {Map<string, ModuleInfo>} */
+const moduleCache = new Map();
+
+/**
+ * Every name bound anywhere BELOW module scope — a parameter, a local, a
+ * nested function.
+ *
+ * This walk knows the syntax but not the scopes, so it cannot tell which
+ * binding an identifier inside a function refers to. Refusing to resolve a name
+ * that some inner scope also binds is what keeps that ignorance from producing a
+ * confidently WRONG pattern: a local `const STRIP = <runtime value>` beside a
+ * `new RegExp(STRIP)` would otherwise be analyzed as the module-level one. The
+ * site is reported unresolved instead, which the guard's exemption list makes
+ * visible.
+ *
+ * @param {import("typescript").SourceFile} sf @returns {Set<string>}
+ */
+function innerScopeNames(sf) {
+  /** @type {Set<string>} */
+  const names = new Set();
+  /** @param {import("typescript").Node} node @param {boolean} inner */
+  const walk = (node, inner) => {
+    if (
+      inner &&
+      (ts.isVariableDeclaration(node) ||
+        ts.isParameter(node) ||
+        ts.isBindingElement(node) ||
+        ts.isFunctionDeclaration(node) ||
+        ts.isClassDeclaration(node)) &&
+      node.name &&
+      ts.isIdentifier(node.name)
+    )
+      names.add(node.name.text);
+    const opensScope =
+      inner ||
+      ts.isFunctionLike(node) ||
+      ts.isBlock(node) ||
+      ts.isCatchClause(node) ||
+      ts.isForStatement(node) ||
+      ts.isForOfStatement(node) ||
+      ts.isForInStatement(node);
+    ts.forEachChild(node, (child) => walk(child, opensScope));
+  };
+  walk(sf, false);
+  return names;
+}
+
+/** Parse a module once and index the module-scope bindings resolution needs.
+ * @param {string} abs @returns {ModuleInfo} */
+function loadModule(abs) {
+  const cached = moduleCache.get(abs);
+  if (cached) return cached;
+
+  const sf = ts.createSourceFile(
+    abs,
+    readFileSync(abs, "utf8"),
+    ts.ScriptTarget.ESNext,
+    true,
+  );
+  /** @type {ModuleInfo} */
+  const mod = {
+    abs,
+    rel: relPath(abs),
+    sf,
+    consts: new Map(),
+    exported: new Set(),
+    imports: new Map(),
+    shadowed: innerScopeNames(sf),
+    owner: new Map(),
+  };
+
+  for (const st of sf.statements) {
+    if (ts.isVariableStatement(st)) {
+      const isExported = st.modifiers?.some(
+        (m) => m.kind === ts.SyntaxKind.ExportKeyword,
+      );
+      for (const decl of st.declarationList.declarations) {
+        if (!ts.isIdentifier(decl.name) || !decl.initializer) continue;
+        mod.consts.set(decl.name.text, decl.initializer);
+        mod.owner.set(decl.initializer, decl.name.text);
+        if (isExported) mod.exported.add(decl.name.text);
+      }
+      continue;
+    }
+    if (!ts.isImportDeclaration(st)) continue;
+    const bindings = st.importClause?.namedBindings;
+    if (!bindings || !ts.isNamedImports(bindings)) continue;
+    const spec = /** @type {import("typescript").StringLiteral} */ (
+      st.moduleSpecifier
+    ).text;
+    for (const el of bindings.elements)
+      mod.imports.set(el.name.text, {
+        spec,
+        imported: (el.propertyName ?? el.name).text,
+      });
+  }
+
+  moduleCache.set(abs, mod);
+  return mod;
+}
+
+/**
+ * A resolved value. `number` stays distinct from `string` so `1 << 20` folds
+ * arithmetically while `"a" + b` concatenates, which is what JS does.
+ * @typedef {{kind: "string", value: string}
+ *   | {kind: "number", value: number}
+ *   | {kind: "regex", source: string, flags: string}} Value
+ */
+
+/** @param {Value | null} v @returns {string | null} */
+const asText = (v) =>
+  v === null || v.kind === "regex" ? null : String(v.value);
+
+/** @param {import("typescript").Node} node */
+const isRegExpConstruction = (node) =>
+  (ts.isNewExpression(node) || ts.isCallExpression(node)) &&
+  ts.isIdentifier(node.expression) &&
+  node.expression.text === "RegExp";
+
+/** Split a `/pattern/flags` literal's raw text.
+ * @param {string} text @returns {{source: string, flags: string}} */
+function splitRegexLiteral(text) {
+  const lastSlash = text.lastIndexOf("/");
+  return { source: text.slice(1, lastSlash), flags: text.slice(lastSlash + 1) };
+}
+
+/** @type {Map<string, Record<string, unknown>>} */
+const namespaceCache = new Map();
+
+/**
+ * The live value of `name` as `mod` exports it.
+ *
+ * Reached only when static composition cannot answer — a `const` whose
+ * initializer calls a function (`charClass([...])`, `cfClassSource(...)`). These
+ * modules are pure libraries, so importing one has no side effect, and the value
+ * read is by construction the exact one the shipped regex compiles from.
+ *
+ * @param {ModuleInfo} mod @param {string} name @returns {Promise<Value | null>}
+ */
+async function runtimeValue(mod, name) {
+  if (!mod.exported.has(name)) return null;
+  const cached = namespaceCache.get(mod.abs);
+  const ns =
+    cached ??
+    /** @type {Record<string, unknown>} */ (
+      await import(pathToFileURL(mod.abs).href)
+    );
+  namespaceCache.set(mod.abs, ns);
+  const value = ns[name];
+  if (typeof value === "string") return { kind: "string", value };
+  if (typeof value === "number") return { kind: "number", value };
+  if (value instanceof RegExp)
+    return { kind: "regex", source: value.source, flags: value.flags };
+  return null;
+}
+
+/** Guards against a binding cycle sending resolution into infinite recursion.
+ * @type {Set<string>} */
+const resolving = new Set();
+
+/**
+ * Resolve the binding `name` as seen from `mod`.
+ * @param {string} name @param {ModuleInfo} mod @returns {Promise<Value | null>}
+ */
+async function evaluateBinding(name, mod) {
+  if (mod.shadowed.has(name)) return null;
+  const key = `${mod.abs}#${name}`;
+  if (resolving.has(key)) return null;
+  resolving.add(key);
+  try {
+    const init = mod.consts.get(name);
+    if (init) {
+      const value = await evaluate(init, mod);
+      return value ?? (await runtimeValue(mod, name));
+    }
+    const imported = mod.imports.get(name);
+    if (!imported?.spec.startsWith(".")) return null;
+    return await evaluateBinding(
+      imported.imported,
+      loadModule(resolve(dirname(mod.abs), imported.spec)),
+    );
+  } finally {
+    resolving.delete(key);
+  }
+}
+
+/**
+ * Resolve an expression to its static value, or null when no supported shape
+ * applies. Null is a reported outcome, never a silent drop.
+ *
+ * @param {import("typescript").Node} node @param {ModuleInfo} mod
+ * @returns {Promise<Value | null>}
+ */
+async function evaluate(node, mod) {
+  if (ts.isStringLiteralLike(node)) return { kind: "string", value: node.text };
+  if (ts.isNumericLiteral(node))
+    return { kind: "number", value: Number(node.text) };
+  if (ts.isRegularExpressionLiteral(node))
+    return { kind: "regex", ...splitRegexLiteral(node.text) };
+  if (ts.isParenthesizedExpression(node))
+    return await evaluate(node.expression, mod);
+  if (ts.isIdentifier(node)) return await evaluateBinding(node.text, mod);
+
+  if (ts.isTemplateExpression(node)) {
+    let out = node.head.text;
+    for (const span of node.templateSpans) {
+      const hole = asText(await evaluate(span.expression, mod));
+      if (hole === null) return null;
+      out += hole + span.literal.text;
+    }
+    return { kind: "string", value: out };
+  }
+
+  if (ts.isBinaryExpression(node)) return await evaluateBinary(node, mod);
+
+  if (ts.isPropertyAccessExpression(node) && node.name.text === "source") {
+    const target = await evaluate(node.expression, mod);
+    return target?.kind === "regex"
+      ? { kind: "string", value: target.source }
+      : null;
+  }
+
+  if (isRegExpConstruction(node))
+    return await evaluateConstruction(
+      /** @type {import("typescript").NewExpression} */ (node),
+      mod,
+    );
+  return null;
+}
+
+/**
+ * Fold `+` (concatenation or addition) and `<<` (the chunk-size shift).
+ * @param {import("typescript").BinaryExpression} node @param {ModuleInfo} mod
+ * @returns {Promise<Value | null>}
+ */
+async function evaluateBinary(node, mod) {
+  const op = node.operatorToken.kind;
+  const isShift = op === ts.SyntaxKind.LessThanLessThanToken;
+  if (op !== ts.SyntaxKind.PlusToken && !isShift) return null;
+
+  const left = await evaluate(node.left, mod);
+  const right = await evaluate(node.right, mod);
+  if (!left || !right || left.kind === "regex" || right.kind === "regex")
+    return null;
+
+  if (left.kind === "number" && right.kind === "number")
+    return {
+      kind: "number",
+      value: isShift ? left.value << right.value : left.value + right.value,
+    };
+  // A shift over anything but two numbers is not a shape these sources use, so
+  // it stays unresolved rather than being guessed at.
+  if (isShift) return null;
+  return { kind: "string", value: String(left.value) + String(right.value) };
+}
+
+/**
+ * Resolve a `RegExp(…)` site to the regex it builds.
+ *
+ * @param {import("typescript").NewExpression | import("typescript").CallExpression} node
+ * @param {ModuleInfo} mod @returns {Promise<Value | null>}
+ */
+async function evaluateConstruction(node, mod) {
+  const [patternArg, flagsArg] = node.arguments ?? [];
+  const source = patternArg ? asText(await evaluate(patternArg, mod)) : "";
+  const flags = flagsArg ? asText(await evaluate(flagsArg, mod)) : "";
+  if (source !== null && flags !== null)
+    return { kind: "regex", source, flags };
+
+  // The pattern is composed from something no supported shape reaches. When the
+  // site IS an exported binding's initializer, the module still holds the
+  // answer — read the compiled regex rather than reporting a hole that is not
+  // one.
+  const name = mod.owner.get(node);
+  return name ? await runtimeValue(mod, name) : null;
+}
 
 // Every .mjs this package SHIPS, from the one place that answers that question
 // (scripts/shipped-sources.mjs, which resolves package.json's `files`). Shipped
@@ -35,45 +349,64 @@ const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 //
 // Reading the manifest rather than a hardcoded root list is what keeps this
 // honest: a newly shipped module, or a whole new shipped directory, joins the
-// inventory with no edit here.
-const analyzed = shippedSources(repoRoot);
+// inventory with no edit here. An explicit file list overrides the scope only
+// for the guard's own fixtures.
+const args = process.argv.slice(2);
+const analyzed = args.length
+  ? args.map((arg) => (isAbsolute(arg) ? arg : resolve(arg)))
+  : shippedSources(repoRoot).map((rel) => join(repoRoot, rel));
 
 /** @type {{file: string, line: number, pattern: string, flags: string}[]} */
 const found = [];
+/** @type {{file: string, line: number, expr: string, resolved: boolean}[]} */
+const constructionSites = [];
+/** @type {{node: import("typescript").NewExpression, mod: ModuleInfo}[]} */
+const pending = [];
 
-for (const rel of analyzed) {
-  const text = readFileSync(join(repoRoot, rel), "utf8");
-  const sf = ts.createSourceFile(rel, text, ts.ScriptTarget.ESNext, true);
+for (const abs of analyzed) {
+  const mod = loadModule(abs);
 
   /** @param {import("typescript").Node} node */
   const visit = (node) => {
     if (ts.isRegularExpressionLiteral(node)) {
-      const lastSlash = node.text.lastIndexOf("/");
+      const { source, flags } = splitRegexLiteral(node.text);
       found.push({
-        file: rel,
-        line: sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1,
-        pattern: node.text.slice(1, lastSlash),
-        flags: node.text.slice(lastSlash + 1),
+        file: mod.rel,
+        line:
+          mod.sf.getLineAndCharacterOfPosition(node.getStart(mod.sf)).line + 1,
+        pattern: source,
+        flags,
       });
-    } else if (
-      (ts.isNewExpression(node) || ts.isCallExpression(node)) &&
-      ts.isIdentifier(node.expression) &&
-      node.expression.text === "RegExp" &&
-      node.arguments?.length &&
-      ts.isStringLiteralLike(node.arguments[0])
-    ) {
-      const flagsArg = node.arguments[1];
-      found.push({
-        file: rel,
-        line: sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1,
-        pattern: node.arguments[0].text,
-        flags:
-          flagsArg && ts.isStringLiteralLike(flagsArg) ? flagsArg.text : "",
+    } else if (isRegExpConstruction(node)) {
+      pending.push({
+        node: /** @type {import("typescript").NewExpression} */ (node),
+        mod,
       });
     }
     ts.forEachChild(node, visit);
   };
-  visit(sf);
+  visit(mod.sf);
 }
 
-process.stdout.write(JSON.stringify({ patterns: found }, null, 2) + "\n");
+for (const { node, mod } of pending) {
+  const value = await evaluateConstruction(node, mod);
+  const line =
+    mod.sf.getLineAndCharacterOfPosition(node.getStart(mod.sf)).line + 1;
+  constructionSites.push({
+    file: mod.rel,
+    line,
+    expr: node.getText(mod.sf).replace(/\s+/g, " "),
+    resolved: value !== null,
+  });
+  if (value?.kind === "regex")
+    found.push({
+      file: mod.rel,
+      line,
+      pattern: value.source,
+      flags: value.flags,
+    });
+}
+
+process.stdout.write(
+  JSON.stringify({ patterns: found, constructionSites }, null, 2) + "\n",
+);

--- a/tests/test_redos_js_static_guard.py
+++ b/tests/test_redos_js_static_guard.py
@@ -5,9 +5,9 @@ secrets engine and detector JSON; nothing covered the JS side, where
 ``src/html.mjs`` alone concentrates dozens of security-relevant regexes. This
 test drives the SAME analyzer (``regexploit``) over an inventory extracted by
 ``scripts/extract-js-regexes.mjs`` — a real-parser (TypeScript AST) walk that
-collects every regex literal and every ``new RegExp("...")`` string pattern —
-so a future super-linear pattern fails here statically, with no timing
-flakiness.
+collects every regex literal and resolves every ``RegExp(…)`` construction to
+the pattern it builds — so a future super-linear pattern fails here statically,
+with no timing flakiness.
 
 The extractor's scope is every ``.mjs`` this package SHIPS, read from
 ``scripts/shipped-sources.mjs`` — the engine, the hooks that hand it tool output
@@ -16,17 +16,29 @@ runs inside a host's hook, where an overrun reads as a non-blocking error and
 shows the model the raw text. A newly shipped module joins this guard with no
 edit here.
 
+Every ``RegExp(…)`` construction site is partitioned, never dropped: the
+extractor either resolves it to static text (which then goes through
+``regexploit`` like any literal) or reports it unresolved, and
+``UNRESOLVABLE_SITES`` below carries one entry per unresolved site with the
+reason. ``test_construction_sites_are_resolved_or_exempted`` asserts the two
+sets are exactly complementary, so a new dynamically built pattern is a red
+build. A count over the inventory cannot do that job — an unresolved site
+contributes no inventory entry, so no count moves when one appears.
+
 JS-only syntax regexploit's parser cannot read is handled explicitly, never
 silently:
 
 * named groups ``(?<name>…)`` are translated to Python's ``(?P<name>…)``
   (an exact, backtracking-neutral rewrite) before analysis;
-* patterns using ``\\p{…}`` / ``\\u{…}`` (no Python ``re`` equivalent) are
-  listed in ``UNANALYZABLE_JS_ONLY`` below — each entry is asserted to still
-  exist in the inventory AND to still fail regexploit's parser, so the skip
-  list can neither rot nor grow to hide an analyzable pattern.
+* codepoint escapes ``\\u{H…}`` are translated to Python's ``\\uHHHH`` /
+  ``\\UHHHHHHHH`` (exact: both spell one code point);
+* patterns using ``\\p{…}`` (no Python ``re`` equivalent) are listed in
+  ``UNANALYZABLE_JS_ONLY`` below — each entry is asserted to still exist in the
+  inventory AND to still fail regexploit's parser, so the skip list can neither
+  rot nor grow to hide an analyzable pattern.
 """
 
+import collections
 import json
 import re
 import shutil
@@ -36,16 +48,51 @@ import pytest
 
 from tests._helpers import REPO_ROOT
 
-# Patterns regexploit cannot parse even after named-group translation, keyed by
-# (file, pattern). All use \p{...} property escapes or \u{...} codepoint
-# escapes — single-character-class constructs with no backtracking ambiguity of
-# their own, but with no Python-re spelling regexploit could analyze. Reviewed
-# by hand: each is a bare character class (optionally in a small alternation)
-# with no nested quantifier.
+# Every `RegExp(…)` construction site the extractor cannot resolve to static
+# text, keyed by (file, normalized expression) with the reason. The pattern such
+# a site builds is invisible to regexploit, so each entry is a hole in this
+# guard's coverage and has to earn its place. Keying by the expression rather
+# than by the line number means an entry goes stale loudly when the site
+# changes, and moving the site around its file does not.
+UNRESOLVABLE_SITES = {
+    (
+        "claude-hooks/lib/secret-annotate.mjs",
+        "new RegExp( [...value] .map((ch) => ch.replace"
+        '(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&")) .join(ENV_INVIS_RUN), "u", )',
+    ): (
+        "The pattern is the caller's env-var VALUE, escaped character by "
+        "character — a runtime string with no static spelling. Its shape is "
+        "fixed: escaped literals joined by the constant ENV_INVIS_RUN, which is "
+        "a character class, so the pattern carries no quantifier at all."
+    ),
+    (
+        "src/html.mjs",
+        'new RegExp(`</${rawText}(?![a-z0-9-])`, "i")',
+    ): (
+        "`rawText` is the raw-text tag name the markdown walk is currently "
+        "inside — a runtime value. The pattern is a literal tag name plus a "
+        "negative lookahead over a character class, with no quantifier."
+    ),
+    (
+        "src/invisible.mjs",
+        "new RegExp(CF_CLASS_SOURCE, REGEX_FLAGS)",
+    ): (
+        "CF_CLASS_SOURCE is built by calling cfClassSource(CF_CODEPOINTS), and "
+        "invisible.mjs does not export it, so there is no live value to read "
+        "either. It is a bare character class, and that same text IS analyzed "
+        "as the first alternative of STRIP (src/invisible.mjs:123), which this "
+        "guard does resolve."
+    ),
+}
+
+# Patterns regexploit cannot parse even after the translations below, keyed by
+# (file, pattern). All use \p{...} property escapes — single-character-class
+# constructs with no backtracking ambiguity of their own, but with no Python-re
+# spelling regexploit could analyze. Reviewed by hand: each is a bare character
+# class (optionally in a small alternation) with no nested quantifier.
 UNANALYZABLE_JS_ONLY = {
     ("src/invisible.mjs", r"[\p{Extended_Pictographic}\p{Emoji_Modifier}]"),
     ("src/invisible.mjs", r"\p{Extended_Pictographic}"),
-    ("src/invisible.mjs", r"[\u{E0000}-\u{E007F}]"),
     (
         "src/invisible.mjs",
         r"[\p{Unified_Ideograph}\u{F900}-\u{FAFF}\u{2F800}-\u{2FA1F}]",
@@ -59,10 +106,20 @@ UNANALYZABLE_JS_ONLY = {
 # matcher's backtracking behavior.
 _NAMED_GROUP_RE = re.compile(r"\(\?<(?![=!])")
 
+# JS `\u{H…}` -> Python `\uHHHH` (BMP) / `\UHHHHHHHH` (astral). Both spellings
+# denote exactly one code point in their own engine, inside a character class or
+# out, so the rewrite is exact and backtracking-neutral. The leading
+# `(?P<pairs>…)` group consumes complete escaped-backslash pairs and the lookbehind
+# rejects an odd one, so a pattern matching a literal backslash followed by the
+# TEXT `u{…}` is left alone.
+_CODEPOINT_ESCAPE_RE = re.compile(
+    r"(?<!\\)(?P<pairs>(?:\\\\)*)\\u\{(?P<hex>[0-9A-Fa-f]{1,6})\}"
+)
 
-def _extract_inventory() -> dict:
+
+def _run_extractor(*args: str) -> dict:
     out = subprocess.run(
-        ["node", "scripts/extract-js-regexes.mjs"],
+        ["node", "scripts/extract-js-regexes.mjs", *args],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
@@ -71,13 +128,28 @@ def _extract_inventory() -> dict:
     return json.loads(out)
 
 
-_EXTRACTED = _extract_inventory()
+def _keyed_by_location(entries: list[dict]) -> dict[str, str]:
+    """`file:line` -> pattern, with a `#n` suffix when a line carries several.
+
+    Two regexes on one line (`src/html.mjs` has a pair) would otherwise collapse
+    onto one key and drop one of them from analysis without a word.
+    """
+    seen: collections.Counter = collections.Counter()
+    keyed = {}
+    for entry in entries:
+        base = f"{entry['file']}:{entry['line']}"
+        seen[base] += 1
+        key = base if seen[base] == 1 else f"{base}#{seen[base]}"
+        keyed[key] = entry["pattern"]
+    return keyed
+
+
+_EXTRACTED = _run_extractor()
 _INVENTORY = _EXTRACTED["patterns"]
-_ALL = {
-    f"{p['file']}:{p['line']}": p["pattern"]
-    for p in _INVENTORY
-    if (p["file"], p["pattern"]) not in UNANALYZABLE_JS_ONLY
-}
+_SITES = _EXTRACTED["constructionSites"]
+_ALL = _keyed_by_location(
+    [p for p in _INVENTORY if (p["file"], p["pattern"]) not in UNANALYZABLE_JS_ONLY]
+)
 
 
 def _analyze(pattern: str) -> str:
@@ -88,8 +160,15 @@ def _analyze(pattern: str) -> str:
     ).stdout
 
 
+def _widen_codepoint_escape(match: re.Match) -> str:
+    codepoint = int(match.group("hex"), 16)
+    spelling = f"\\u{codepoint:04x}" if codepoint <= 0xFFFF else f"\\U{codepoint:08x}"
+    return match.group("pairs") + spelling
+
+
 def _to_python_syntax(pattern: str) -> str:
-    return _NAMED_GROUP_RE.sub("(?P<", pattern)
+    named = _NAMED_GROUP_RE.sub("(?P<", pattern)
+    return _CODEPOINT_ESCAPE_RE.sub(_widen_codepoint_escape, named)
 
 
 def test_pattern_inventory_is_non_empty() -> None:
@@ -98,6 +177,37 @@ def test_pattern_inventory_is_non_empty() -> None:
     # this floor of regexes today.
     assert len(_INVENTORY) >= 50
     assert len(_ALL) >= 50 - len(UNANALYZABLE_JS_ONLY)
+
+
+def test_construction_sites_are_resolved_or_exempted() -> None:
+    # The partition that closes the hole a count cannot see: every RegExp
+    # construction site either resolves to a pattern this guard analyzes, or is
+    # listed above with a reason. A new dynamic site lands in neither set and
+    # fails here.
+    unresolved = {(s["file"], s["expr"]) for s in _SITES if not s["resolved"]}
+    assert unresolved == set(UNRESOLVABLE_SITES), (
+        "RegExp construction sites are no longer partitioned. A site the "
+        "extractor cannot resolve must be listed in UNRESOLVABLE_SITES with a "
+        "reason; an entry it now resolves must be removed from it.\n"
+        f"unresolved but unlisted: {sorted(unresolved - set(UNRESOLVABLE_SITES))}\n"
+        f"listed but now resolved: {sorted(set(UNRESOLVABLE_SITES) - unresolved)}"
+    )
+
+
+def test_resolved_construction_sites_reach_the_analyzer() -> None:
+    # Positive marker for the partition test above: resolution does real work,
+    # and every pattern it produced is in the analyzed inventory rather than
+    # resolved and then dropped on the floor.
+    resolved = [s for s in _SITES if s["resolved"]]
+    assert len(resolved) >= 15, (
+        f"only {len(resolved)} of {len(_SITES)} construction sites resolved"
+    )
+    inventory_keys = {(p["file"], p["line"]) for p in _INVENTORY}
+    for site in resolved:
+        assert (site["file"], site["line"]) in inventory_keys, (
+            f"{site['file']}:{site['line']} resolved but produced no inventory "
+            f"entry: {site['expr']}"
+        )
 
 
 def test_skip_list_entries_are_live_and_actually_unanalyzable() -> None:
@@ -145,3 +255,84 @@ def test_named_group_translation_is_applied() -> None:
     assert named, "expected at least one (?<name>…) pattern in src/*.mjs"
     for pattern in named:
         assert "Error parsing" not in _analyze(_to_python_syntax(pattern))
+
+
+def test_codepoint_escape_translation_is_applied() -> None:
+    # Twin of the marker above for the `\u{…}` rewrite, which is what lets the
+    # resolved Cf class (and every pattern built over it) reach the analyzer.
+    escaped = [p for p in _ALL.values() if _CODEPOINT_ESCAPE_RE.search(p)]
+    assert escaped, r"expected at least one \u{…} pattern in the inventory"
+    for pattern in escaped:
+        assert "Error parsing" not in _analyze(_to_python_syntax(pattern))
+
+
+def test_codepoint_escape_translation_is_exact() -> None:
+    # A pattern matching a literal backslash followed by the TEXT `u{41}` is not
+    # a codepoint escape; rewriting it would change the language matched.
+    assert _to_python_syntax(r"\\u{41}") == r"\\u{41}"
+    assert _to_python_syntax(r"\u{41}") == "\\u0041"
+    assert _to_python_syntax(r"[\u{1F600}-\u{1F64F}]") == "[\\U0001f600-\\U0001f64f]"
+
+
+_RESOLVABLE_FIXTURE = """\
+const LABEL_CHARS = "A-Za-z0-9";
+const MAX_LEN = 8;
+export const LABEL_RE = new RegExp(`^[${LABEL_CHARS}]{1,${MAX_LEN}}$`, "u");
+"""
+
+_DYNAMIC_FIXTURE = """\
+export function valueRegex(parts) {
+  return new RegExp(parts.map((part) => `(?:${part})`).join("|"), "u");
+}
+"""
+
+# The resolvable fixture's own shape, with the one difference that a parameter
+# rebinds LABEL_CHARS. The extractor knows the syntax, not the scopes, so it
+# must decline this rather than analyze the module-level value.
+_SHADOWED_FIXTURE = """\
+const LABEL_CHARS = "A-Za-z0-9";
+export function labelRegex(LABEL_CHARS) {
+  return new RegExp(`^[${LABEL_CHARS}]{1,8}$`, "u");
+}
+"""
+
+
+def test_extractor_resolves_a_const_backed_construction(tmp_path) -> None:
+    # Dogfood: the shape this guard exists to see through. Against the
+    # extractor this replaced — which collected a site only when argument 0 was
+    # a plain string literal — the same file yields no site and no pattern.
+    fixture = tmp_path / "resolvable.mjs"
+    fixture.write_text(_RESOLVABLE_FIXTURE, encoding="utf-8")
+
+    extracted = _run_extractor(str(fixture))
+    assert [s["resolved"] for s in extracted["constructionSites"]] == [True]
+    assert [(p["pattern"], p["flags"]) for p in extracted["patterns"]] == [
+        (r"^[A-Za-z0-9]{1,8}$", "u")
+    ]
+
+
+def test_extractor_reports_a_genuinely_dynamic_construction(tmp_path) -> None:
+    # The other half of the partition: a pattern built from a function argument
+    # is reported unresolved, and its expression matches no UNRESOLVABLE_SITES
+    # entry — so `test_construction_sites_are_resolved_or_exempted` fails on a
+    # site of this shape rather than never seeing it.
+    fixture = tmp_path / "dynamic.mjs"
+    fixture.write_text(_DYNAMIC_FIXTURE, encoding="utf-8")
+
+    sites = _run_extractor(str(fixture))["constructionSites"]
+    assert [s["resolved"] for s in sites] == [False]
+    exempt_exprs = {expr for _, expr in UNRESOLVABLE_SITES}
+    assert not exempt_exprs & {s["expr"] for s in sites}
+
+
+def test_extractor_declines_a_shadowed_const(tmp_path) -> None:
+    # Resolving a name an inner scope rebinds would put a pattern in the
+    # inventory that no shipped regex ever compiles — a false analysis, which
+    # is worse than the gap. The fixture differs from the resolvable one only
+    # in the shadowing, and gets the opposite verdict.
+    fixture = tmp_path / "shadowed.mjs"
+    fixture.write_text(_SHADOWED_FIXTURE, encoding="utf-8")
+
+    extracted = _run_extractor(str(fixture))
+    assert [s["resolved"] for s in extracted["constructionSites"]] == [False]
+    assert extracted["patterns"] == []

--- a/tests/test_redos_js_static_guard.py
+++ b/tests/test_redos_js_static_guard.py
@@ -286,6 +286,28 @@ export function valueRegex(parts) {
 }
 """
 
+# A module-scope `let`/`var` holds a different value at each point of the
+# module, so neither its initializer nor the value an import reads is reliably
+# the one a site compiles. Each fixture below states the mismatch outright: the
+# first compiles `^[0-9]{1,8}$` while the initializer spells `A-Za-z0-9`, and
+# the second's line-4 site compiles `^a+$` while the imported binding holds
+# `^b+$`. Resolving either produces a pattern no regex in the file compiles.
+_MUTABLE_FIXTURES = {
+    "let-const-map": """\
+let LABEL_CHARS = "A-Za-z0-9";
+LABEL_CHARS = "0-9";
+const LABEL_RE = new RegExp(`^[${LABEL_CHARS}]{1,8}$`, "u");
+export const matches = (text) => LABEL_RE.test(text);
+""",
+    "exported-let-live-value": """\
+function initialSource() {
+  return "^a+$";
+}
+export let RE = new RegExp(initialSource(), "u");
+RE = new RegExp("^b+$", "u");
+""",
+}
+
 # The resolvable fixture's own shape, with the one difference that a parameter
 # rebinds LABEL_CHARS. The extractor knows the syntax, not the scopes, so it
 # must decline this rather than analyze the module-level value.
@@ -323,6 +345,32 @@ def test_extractor_reports_a_genuinely_dynamic_construction(tmp_path) -> None:
     assert [s["resolved"] for s in sites] == [False]
     exempt_exprs = {expr for _, expr in UNRESOLVABLE_SITES}
     assert not exempt_exprs & {s["expr"] for s in sites}
+
+
+@pytest.mark.parametrize(
+    "name, expected_verdicts",
+    [("let-const-map", [False]), ("exported-let-live-value", [False, True])],
+)
+def test_extractor_declines_a_mutable_binding(
+    tmp_path, name: str, expected_verdicts: list[bool]
+) -> None:
+    # Sibling of the shadow rule: resolving a reassignable binding puts a
+    # pattern in the inventory that the file never compiles, which is a false
+    # analysis rather than a gap. The second fixture's trailing `True` is a site
+    # built from a plain string literal, which stays resolvable — the refusal is
+    # scoped to the site that reads the mutable name.
+    fixture = tmp_path / f"{name}.mjs"
+    fixture.write_text(_MUTABLE_FIXTURES[name], encoding="utf-8")
+
+    extracted = _run_extractor(str(fixture))
+    sites = extracted["constructionSites"]
+    assert [s["resolved"] for s in sites] == expected_verdicts
+
+    # The partition test sees this shape: a declined site is reported, and it
+    # matches no exemption entry, so it fails there instead of vanishing.
+    unresolved_lines = {s["line"] for s in sites if not s["resolved"]}
+    assert not unresolved_lines & {p["line"] for p in extracted["patterns"]}
+    assert not {expr for _, expr in UNRESOLVABLE_SITES} & {s["expr"] for s in sites}
 
 
 def test_extractor_declines_a_shadowed_const(tmp_path) -> None:


### PR DESCRIPTION
Claimed area: `scripts/extract-js-regexes.mjs` and `tests/test_redos_js_static_guard.py` only.

## Summary

The JS ReDoS guard was analyzing **1** `new RegExp(...)` site and silently dropping **20**. Its extractor collected a construction site only when argument 0 was a plain string literal:

```js
node.arguments?.length && ts.isStringLiteralLike(node.arguments[0])
```

Everything else vanished — no entry, no warning. The dropped sites are the hot Layer-1 patterns: `SGR_RE` and the CSI/control-introducer classes in `src/ansi.mjs` (6), the Cf / variation-selector / blank-filler detectors plus `STRIP`, `LONG_RUN_RE`, `LONG_RUN_CHUNK_RE` and `RUN_TAIL_RE` in `src/invisible.mjs` (8), and one each in `src/layer1.mjs`, `src/prompt.mjs`, `src/html.mjs`, `claude-hooks/lib/placeholder-grammar.mjs` (2) and `claude-hooks/lib/secret-annotate.mjs`. A bounded repeat over an alternation (`(?:A|B|C){10,}`) is exactly the shape ReDoS analysis exists for, and none of it was analyzed.

Both halves of the old docstring's safety claim were false:

- _"a dynamically built pattern has no static text to analyze; none exist in these roots today"_ — 20 existed.
- _"the paired guard test asserts the total inventory count so a new dynamic construction site shows up as a count change"_ — inert by construction. An unresolved site contributes **zero** inventory entries, so `len(_INVENTORY) >= 50` cannot move when one appears. The inventory was ~71 patterns with ~44 from `src/html.mjs` alone, so literals satisfied that floor forever.

The extractor already held a real TypeScript AST; it just was not using it for this question. It now walks that AST for every construction site and emits a **partition** — each site is either resolved to its static pattern or reported unresolved — and the guard asserts the resolved and exempted sets exactly cover every site. A new dynamic construction is a red build, which is what the docstring already promised.

## Measured before / after

| | before | after |
| --- | --- | --- |
| construction sites collected | 1 of 21 | 21 of 21 |
| construction sites resolved to a pattern | 1 | **18** |
| construction sites exempted with a reason | 0 (silently dropped) | 3 |
| patterns in the inventory | 71 | **88** |
| patterns actually analyzed by regexploit | 64 | **82** |
| tests in the guard | 68 | 94 |

Re-measured on this branch's `origin/main` base, not taken from the audit.

## Real ReDoS findings: none

regexploit reports **no super-linear backtracking** among the 18 newly visible patterns, including the four that motivated the work:

| pattern | length | verdict |
| --- | --- | --- |
| `STRIP` (`src/invisible.mjs:123`) | 544 | clean |
| `LONG_RUN_RE` (`src/invisible.mjs:173`) | 553 | clean |
| `LONG_RUN_CHUNK_RE` (`src/invisible.mjs:185`) | 560 | clean |
| `RUN_TAIL_RE` (`src/invisible.mjs:193`) | 559 | clean |
| `INTRODUCER_SCAN_RE` (`src/ansi.mjs:381`) | 200 | clean |

`LONG_RUN_RE` is `(?:[Cf class]|[VS class]|[blank class]){10,}`, and the three classes are disjoint, so the repeat is deterministic per position. That was the plausible defect and it is not there — but it is now *checked* rather than assumed, and a future edit that makes the three overlap fails this guard.

## Which shapes resolve, and why

Resolution composes only the shapes these sources actually use. It is **not** a partial evaluator:

- string / number / regex literals, and template literals whose holes resolve;
- `+` (concatenation, e.g. `BLANK_NON_CF`) and `<<` (the `RUN_CHUNK = 1 << 20` bound);
- a same-module `const`, and a named import followed to its relative module (`CONTROL_INTRODUCER_SOURCE` reaches `layer1.mjs` and `prompt.mjs` that way);
- `X.source`, which is how `STRIP` composes into the three long-run patterns.

When static composition runs out — a `const` built by **calling a function**, like `charClass([...])` or `cfClassSource(CF_CODEPOINTS)` — the binding's own module is imported and the live exported value read. This is the repo's own rule from `.claude/rules/code-style.md`: the engine owns the answer to "what does this JS expression evaluate to", and re-deriving it from source text is the thing that rule forbids. These modules are pure libraries, the read value is by construction the exact one the shipped regex compiles from, and a module is imported only when the AST already says the name is an exported module-scope binding.

Three sites stay exempt, each with a reason in `UNRESOLVABLE_SITES`:

| site | why |
| --- | --- |
| `claude-hooks/lib/secret-annotate.mjs` `envValueRegex` | the pattern **is** the caller's env-var value, escaped per character — a runtime string. Escaped literals joined by a constant character class, so no quantifier. |
| `src/html.mjs:1992` | `rawText` is the tag name the markdown walk is currently inside — a runtime value. A literal tag plus a negative lookahead, no quantifier. |
| `src/invisible.mjs:113` (`CF_CLASS_SOURCE`) | built by a function call **and** not exported, so there is no live value either. The same text *is* analyzed as the first alternative of `STRIP`. |

## Precision guards

- **A name an inner scope also binds is refused outright.** This walk knows the syntax but not the scopes, so a local `const STRIP = <runtime value>` beside a `new RegExp(STRIP)` would otherwise be analyzed as the module-level one — a confidently wrong pattern, which is worse than a reported gap. Measured: zero module constants are shadowed in these sources today, so this costs nothing now and stays correct later.
- A flags argument that does not resolve makes the whole site unresolved, rather than defaulting to no flags.
- A template hole holding a `RegExp` is declined rather than stringified.

## Two smaller holes closed while in here

- **`\u{H…}` codepoint escapes are now translated** to Python's `\uHHHH` / `\UHHHHHHHH` before analysis (exact: both spell one code point). Without it, every resolved Cf-class pattern above would have failed regexploit's parser and landed in the skip list — resolved but still unanalyzed. `[\u{E0000}-\u{E007F}]` leaves `UNANALYZABLE_JS_ONLY` as a result; the remaining five entries all use `\p{…}`, which has no Python spelling.
- **`file:line` inventory keys are now de-duplicated.** `src/html.mjs:2341` carries two regex literals on one line; the old dict key collapsed them and dropped one from analysis without a word.

## Tests / verification

`uv run --extra dev python -m pytest tests/test_redos_js_static_guard.py -q` → **94 passed** (was 68).

New assertions:

- `test_construction_sites_are_resolved_or_exempted` — the partition, as exact set equality. A new dynamic site is unlisted and fails; an entry that starts resolving must be removed from the exemption list.
- `test_resolved_construction_sites_reach_the_analyzer` — positive marker that resolution does real work and every resolved pattern lands in the analyzed inventory, not on the floor.
- `test_codepoint_escape_translation_is_applied` / `_is_exact` — the `\u{…}` rewrite runs on live inventory, and leaves a pattern matching a literal backslash followed by the text `u{…}` alone.

Three dogfood fixtures, extracted through the extractor's new file arguments:

- `test_extractor_resolves_a_const_backed_construction` — `new RegExp(\`^[${LABEL_CHARS}]{1,${MAX_LEN}}$\`, "u")` resolves to `^[A-Za-z0-9]{1,8}$`.
- `test_extractor_reports_a_genuinely_dynamic_construction` — a pattern built from a function argument is reported unresolved and matches no exemption entry, so the partition test fails on a site of that shape.
- `test_extractor_declines_a_shadowed_const` — the *same file* as the resolvable fixture except a parameter rebinds `LABEL_CHARS`, and it gets the opposite verdict. That pins the shadow rule rather than leaving it untested.

**Non-vacuity against the pre-fix extractor**, run directly: fed the resolvable fixture, the old collector yields `0` patterns and no site at all; the new one yields `('^[A-Za-z0-9]{1,8}$', 'u')` and one resolved site. Stashing the new extractor and running the suite fails at collection on the missing `constructionSites` key.

`pnpm lint` (eslint), `prettier --check`, `ruff check`, `ruff format`, `tsc --strict --checkJs` over the extractor, and the full `pre-commit` file hooks all pass.

## Decisions made

- **Read the live exported value when static composition runs out, instead of listing those sites as unresolvable.** Pure static resolution reaches only 8 of 21 sites and leaves `STRIP`, `LONG_RUN_RE` and the control-introducer scan — the patterns this work exists to check — dark. Under the alternative, those five rows in the findings table would read "not analyzed" and `UNRESOLVABLE_SITES` would carry 13 entries instead of 3. The cost is that the guard imports five shipped modules at extraction time; they are pure, and an import failure is loud.
- **Support `<<` as well as `+`.** One operator over two numeric literals, needed for `RUN_CHUNK = 1 << 20`. Without it `LONG_RUN_CHUNK_RE` and `RUN_TAIL_RE` stay unanalyzed. A shift over anything but two numbers stays unresolved rather than guessed at.
- **Key the exemption list by `(file, normalized expression)`, not by line number.** Line numbers churn on every edit above the site. An entry now goes stale loudly when the site's code changes, and stays valid when the site merely moves.
- **Kept `patterns` as the guard's analysis input and added `constructionSites` alongside it**, rather than folding both into one array. The literal walk and the construction walk answer different questions, and the partition assertion needs the sites *including* the ones that produced no pattern.

## Checklist

- [x] Commits follow Conventional Commits; the subject reads as a user-facing release note.
- [x] Lint, format, typecheck and the guard suite pass locally.
- [x] The changed guard has both a positive marker and negative fixtures (a dynamic site and a shadowed const, each asserted to be declined).
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VvuJNE8pEstzwvSmir592V)_