### PR TITLE
test(fuzz-coverage): run the obligation gate on acorn's AST and close its one-directional lists

### DIFF
--- a/test/confusable-host-property.test.mjs
+++ b/test/confusable-host-property.test.mjs
@@ -1,0 +1,233 @@
+/**
+ * Property/fuzz tests for Layer 3's confusable-host detector.
+ *
+ * `detectConfusableHosts` eats attacker-controlled documents: it runs a
+ * markdown parser and the WHATWG URL parser over untrusted text, decodes every
+ * punycode label it finds, and owns its own `found` category and model-facing
+ * warning. confusable-host.test.mjs scores the RULE against a benign/attack
+ * corpus of isolated labels; this file pins the DETECTOR's invariants over
+ * whole generated documents, where extraction, neighbouring links and filler
+ * prose could bleed one URL's verdict into another's.
+ *
+ * The precision invariant is the one that matters most here. A false positive
+ * rewrites the operator's own content out of the channel, so the headline
+ * property is stated in that direction: a document whose hosts hold no `xn--`
+ * label cannot produce a finding, because the WHATWG parser returns the A-label
+ * form and a host with no A-label held no non-ASCII code point to begin with.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import fc from "fast-check";
+
+import { detectConfusableHosts } from "../src/html.mjs";
+import { SEVERITY } from "../src/severity.mjs";
+import { fcRunOptions } from "./test-helpers.mjs";
+
+const runOptions = fcRunOptions({ numRuns: 300 });
+
+const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+  encoding: "utf8",
+}).trim();
+const CORPUS = JSON.parse(
+  readFileSync(path.join(repoRoot, "test/data/confusable-hosts.json"), "utf8"),
+);
+
+const SEVERITIES = new Set(Object.values(SEVERITY));
+
+/** Prose that carries no URL of its own, so only the seeded hosts are judged. */
+const filler = fc
+  .array(
+    fc.constantFrom(
+      "see the notes",
+      "step 2",
+      "# heading",
+      "- bullet",
+      "`code`",
+      "**bold** text",
+      "a paragraph, with punctuation.",
+      "",
+    ),
+    { minLength: 0, maxLength: 6 },
+  )
+  .map((lines) => lines.join("\n"));
+
+/** An ASCII host that can never decode to a non-ASCII label. */
+const asciiHost = fc
+  .array(
+    fc
+      .stringMatching(/^[a-z][a-z0-9-]{0,10}$/)
+      .filter((l) => !l.includes("xn")),
+    { minLength: 2, maxLength: 3 },
+  )
+  .map((labels) => labels.join("."));
+
+const attackLabel = fc.constantFrom(...CORPUS.attacks.map((a) => a.label));
+
+/** A markdown link, an image, a bare autolink, or a link reference definition. */
+const linkTo = (host) =>
+  fc
+    .tuple(
+      fc.constantFrom("link", "image", "autolink", "definition"),
+      fc.constantFrom("", "/path", "/a?q=1#frag"),
+    )
+    .map(([shape, tail]) => {
+      const url = `https://${host}${tail}`;
+      if (shape === "image") return `![alt](${url})`;
+      if (shape === "autolink") return `<${url}>`;
+      if (shape === "definition") return `[ref]: ${url}`;
+      return `[text](${url})`;
+    });
+
+const documentOf = (hosts) =>
+  fc
+    .tuple(filler, fc.tuple(...hosts.map(linkTo)), filler)
+    .map(([head, links, tail]) => [head, ...links, tail].join("\n\n"));
+
+/** Every finding's shape, asserted wherever a result is inspected. */
+const assertFindingShape = (findings) => {
+  assert.ok(findings === null || Array.isArray(findings));
+  if (findings === null) return;
+  assert.ok(findings.length > 0, "an empty array must be reported as null");
+  for (const finding of findings) {
+    assert.ok(
+      SEVERITIES.has(finding.severity),
+      `bad severity: ${finding.severity}`,
+    );
+    assert.equal(typeof finding.description, "string");
+    assert.ok(finding.description.length > 0);
+  }
+};
+
+describe("property: detectConfusableHosts never throws and reports a legal shape", () => {
+  it("survives arbitrary text", () => {
+    fc.assert(
+      fc.property(fc.string({ maxLength: 400 }), (text) => {
+        assertFindingShape(detectConfusableHosts(text));
+      }),
+      runOptions,
+    );
+  });
+
+  it("survives arbitrary documents built from real link shapes", () => {
+    fc.assert(
+      fc.property(
+        fc
+          .array(
+            fc.oneof(
+              asciiHost,
+              attackLabel.map((l) => `${l}.com`),
+            ),
+            {
+              minLength: 1,
+              maxLength: 4,
+            },
+          )
+          .chain((hosts) => documentOf(hosts)),
+        (document) => {
+          assertFindingShape(detectConfusableHosts(document));
+        },
+      ),
+      runOptions,
+    );
+  });
+});
+
+describe("property: precision — an all-ASCII document is never flagged", () => {
+  it("no finding when no host carries a punycode label", () => {
+    fc.assert(
+      fc.property(
+        fc
+          .array(asciiHost, { minLength: 1, maxLength: 4 })
+          .chain((hosts) => documentOf(hosts)),
+        (document) => {
+          assert.ok(
+            !document.toLowerCase().includes("xn--"),
+            "the generator leaked a punycode label, so this property is vacuous",
+          );
+          assert.equal(detectConfusableHosts(document), null);
+        },
+      ),
+      runOptions,
+    );
+  });
+});
+
+describe("property: recall — a corpus attack host is found wherever it sits", () => {
+  it("a deceptive host embedded in ordinary prose is reported", () => {
+    assert.ok(
+      CORPUS.attacks.length > 0,
+      "the attack corpus is empty, so this property would pass over nothing",
+    );
+    fc.assert(
+      fc.property(
+        attackLabel.chain((label) =>
+          fc
+            .array(asciiHost, { minLength: 0, maxLength: 3 })
+            .chain((benign) => documentOf([`${label}.com`, ...benign])),
+        ),
+        (document) => {
+          const findings = detectConfusableHosts(document);
+          assert.ok(
+            findings !== null,
+            `a corpus attack host went unreported in:\n${document}`,
+          );
+          assertFindingShape(findings);
+        },
+      ),
+      runOptions,
+    );
+  });
+});
+
+describe("property: one deception is one finding, however often it is written", () => {
+  it("repeating a host does not multiply its finding", () => {
+    fc.assert(
+      fc.property(
+        attackLabel,
+        fc.integer({ min: 2, max: 5 }),
+        (label, repeats) => {
+          const host = `${label}.com`;
+          const once = detectConfusableHosts(`[a](https://${host})`);
+          const many = detectConfusableHosts(
+            Array.from(
+              { length: repeats },
+              (_unused, i) => `[a${i}](https://${host}/p${i})`,
+            ).join("\n\n"),
+          );
+          assert.notEqual(once, null, "the single-link case reported nothing");
+          assert.deepEqual(many, once);
+        },
+      ),
+      runOptions,
+    );
+  });
+
+  it("is deterministic over the same document", () => {
+    fc.assert(
+      fc.property(
+        fc
+          .array(
+            fc.oneof(
+              asciiHost,
+              attackLabel.map((l) => `${l}.org`),
+            ),
+            {
+              minLength: 1,
+              maxLength: 4,
+            },
+          )
+          .chain((hosts) => documentOf(hosts)),
+        (document) => {
+          assert.deepEqual(
+            detectConfusableHosts(document),
+            detectConfusableHosts(document),
+          );
+        },
+      ),
+      runOptions,
+    );
+  });
+});

--- a/test/fuzz-coverage.test.mjs
+++ b/test/fuzz-coverage.test.mjs
@@ -11,11 +11,11 @@
  * invariant. A percentage can't catch "this parser has no security invariant";
  * requiring a named fuzz target for each one can.
  *
- * Each obligation list is one half of a PARTITION over the population it draws
- * from: FUZZ_REQUIRED + FUZZ_EXEMPT cover every exported function,
+ * Each obligation list is one part of a PARTITION over the population it draws
+ * from: FUZZ_REQUIRED + FUZZ_EXEMPT + FUZZ_TODO cover every exported function,
  * SEMANTIC_FUZZ_REQUIRED + SEMANTIC_FUZZ_EXEMPT cover every required name, and
  * IN_SCOPE + OUT_OF_SCOPE cover every discovered suite. A required list on its
- * own proves only what it names; the exempt half is what makes a new export or
+ * own proves only what it names; the other parts are what make a new export or
  * a new suite impossible to land without a human choosing a side.
  */
 import { describe, it } from "node:test";
@@ -93,25 +93,13 @@ const FUZZ_REQUIRED = [
 ];
 
 /**
- * The other half of the export partition: every exported function that owes no
- * fuzz target, and the one-line reason it owes none. A `TODO:` reason marks a
- * genuine gap that is tracked rather than denied — the name still cannot be
- * deleted or renamed without this gate noticing, and the next reader sees it.
+ * The DENIAL part of the export partition: every exported function that owes no
+ * fuzz target, and the one-line reason it owes none. Every entry here is a
+ * settled "no" — a name that owes a suite it does not have belongs in
+ * {@link FUZZ_TODO}, so a deferral cannot ride in as a reason string.
  * @type {Readonly<Record<string, string>>}
  */
 const FUZZ_EXEMPT = Object.freeze({
-  // ── genuine gaps, tracked ────────────────────────────────────────────────
-  anchorSpans:
-    "TODO: owes a property suite — it anchors a prefix/suffix over untrusted Write content",
-  matchesSecretHint:
-    "TODO: owes a property suite — a fail-open pre-gate for the secret scan",
-  needsMarkdownPipeline:
-    "TODO: owes a property suite — a fail-open pre-gate for Layers 2 and 3",
-  overlapAwareCount:
-    "TODO: owes a property suite — it decides Edit ambiguity over untrusted needles",
-  pairDiskSpans:
-    "TODO: owes a property suite — it maps redaction pairs onto on-disk spans",
-
   // ── predicates and lookups: no parse or transform step of their own ──────
   closingTagName: "reads one tag name out of an already-tokenized HTML value",
   contextScopeContradiction:
@@ -173,6 +161,25 @@ const FUZZ_EXEMPT = Object.freeze({
   toUtf16View:
     "converts a view between offset spaces, validated at construction",
   viewMapDefect: "self-check over a view the pipeline built",
+});
+
+/**
+ * The DEFERRAL part of the export partition: every exported function that owes
+ * a property suite but does not have one yet, and the untrusted input it takes.
+ *
+ * A named list rather than a reason-string convention inside FUZZ_EXEMPT,
+ * because both edits a deferral allows must be visible. Growing the deferred
+ * set adds a line here; and demoting a name out of FUZZ_REQUIRED deletes its
+ * suite obligation, which the partition forces to read as a deletion from one
+ * list and an addition to another.
+ * @type {Readonly<Record<string, string>>}
+ */
+const FUZZ_TODO = Object.freeze({
+  anchorSpans: "anchors a prefix/suffix over untrusted Write content",
+  matchesSecretHint: "a fail-open pre-gate for the secret scan",
+  needsMarkdownPipeline: "a fail-open pre-gate for Layers 2 and 3",
+  overlapAwareCount: "decides Edit ambiguity over untrusted needles",
+  pairDiskSpans: "maps redaction pairs onto on-disk spans",
 });
 
 // Entry points that owe SEMANTIC-CORRECTNESS fuzzing, not just structural
@@ -705,24 +712,28 @@ for (const [name, mod] of [
 }
 
 /**
- * Assert `required` and `exempt` partition `population` exactly, so a member
- * of the population cannot exist without a human having classified it.
+ * Assert `parts` partition `population` exactly, so a member of the population
+ * cannot exist without a human having classified it into exactly ONE part. The
+ * concatenation is compared element-wise, so a name listed in two parts fails
+ * here as loudly as a name listed in none.
  * @param {string[]} population
- * @param {string[]} required
- * @param {string[]} exempt
+ * @param {string[][]} parts
  * @param {string} hint  what the reader must do about a mismatch
  */
-const assertPartition = (population, required, exempt, hint) => {
+const assertPartition = (population, parts, hint) => {
   assert.ok(
     population.length > 0,
     "empty population — the partition would hold vacuously",
   );
-  assert.deepEqual(
-    [...population].sort(),
-    [...required, ...exempt].sort(),
-    hint,
-  );
+  assert.deepEqual([...population].sort(), parts.flat().sort(), hint);
 };
+
+/** The three parts of the export partition, in classification order. */
+const exportParts = [
+  FUZZ_REQUIRED,
+  Object.keys(FUZZ_EXEMPT),
+  Object.keys(FUZZ_TODO),
+];
 
 describe("fuzz-coverage obligation gate", () => {
   it("discovers at least one fast-check suite (gate is not vacuous)", () => {
@@ -749,35 +760,85 @@ describe("fuzz-coverage obligation gate", () => {
     );
   });
 
-  it("every exported function is either fuzz-required or exempt with a reason", () => {
+  it("every exported function is fuzz-required, exempt, or deferred with a reason", () => {
     assertPartition(
       [...exportedFunctions.keys()],
-      FUZZ_REQUIRED,
-      Object.keys(FUZZ_EXEMPT),
+      exportParts,
       "a new export must be classified: add it to FUZZ_REQUIRED and give it a " +
-        "property suite, or to FUZZ_EXEMPT with the one-line reason it owes none",
+        "property suite, to FUZZ_EXEMPT with the one-line reason it owes none, " +
+        "or to FUZZ_TODO with the untrusted input it takes",
+    );
+    for (const map of [FUZZ_EXEMPT, FUZZ_TODO])
+      for (const [name, reason] of Object.entries(map))
+        assert.ok(reason.length > 0, `${name} carries an empty reason`);
+  });
+
+  it("no FUZZ_EXEMPT reason reads as a deferral", () => {
+    // FUZZ_EXEMPT is a denial; a promise written into a reason string is the
+    // escape hatch FUZZ_TODO exists to make visible instead.
+    const readsAsDeferral = (reason) => /^(todo|fixme)\b/i.test(reason);
+    assert.ok(
+      readsAsDeferral("TODO: owes a property suite"),
+      "the deferral shape matches nothing — this assertion would pass vacuously",
+    );
+    assert.ok(
+      Object.keys(FUZZ_TODO).length > 0,
+      "FUZZ_TODO is empty, so no deferral has anywhere honest to go",
     );
     for (const [name, reason] of Object.entries(FUZZ_EXEMPT))
-      assert.ok(reason.length > 0, `${name} carries an empty exemption reason`);
+      assert.ok(
+        !readsAsDeferral(reason),
+        `${name}'s exemption reads as a deferral — move it to FUZZ_TODO`,
+      );
   });
 
   it("the export partition rejects an unclassified name (assertion is not vacuous)", () => {
+    const [required, exempt, todo] = exportParts;
     const population = [...exportedFunctions.keys(), "syntheticNewExport"];
     assert.throws(
       () =>
         assertPartition(
           population,
-          FUZZ_REQUIRED,
-          Object.keys(FUZZ_EXEMPT),
+          exportParts,
           "an unclassified export must fail the partition",
+        ),
+      assert.AssertionError,
+    );
+    // Any ONE of the three classifications satisfies it, so a genuinely new or
+    // undecided export has a side to be put on.
+    for (const parts of [
+      [[...required, "syntheticNewExport"], exempt, todo],
+      [required, [...exempt, "syntheticNewExport"], todo],
+      [required, exempt, [...todo, "syntheticNewExport"]],
+    ])
+      assertPartition(
+        population,
+        parts,
+        "classifying the synthetic export must satisfy the same partition",
+      );
+  });
+
+  it("the export partition rejects a name that is both required and deferred", () => {
+    // The demotion this partition exists to make visible: moving a name out of
+    // FUZZ_REQUIRED into FUZZ_TODO deletes its property-suite obligation, so a
+    // copy that leaves the FUZZ_REQUIRED entry behind must fail rather than
+    // read as a green no-op.
+    const [required, exempt, todo] = exportParts;
+    const population = [...exportedFunctions.keys()];
+    const [demoted, ...stillRequired] = required;
+    assert.throws(
+      () =>
+        assertPartition(
+          population,
+          [required, exempt, [...todo, demoted]],
+          "a name in two parts must fail the partition",
         ),
       assert.AssertionError,
     );
     assertPartition(
       population,
-      FUZZ_REQUIRED,
-      [...Object.keys(FUZZ_EXEMPT), "syntheticNewExport"],
-      "classifying the synthetic export must satisfy the same partition",
+      [stillRequired, exempt, [...todo, demoted]],
+      "an honest demotion — one name moved, not copied — must still partition",
     );
   });
 
@@ -924,8 +985,7 @@ describe("semantic-fuzz obligation gate", () => {
     // neither list is an obligation nobody decided.
     assertPartition(
       FUZZ_REQUIRED,
-      SEMANTIC_FUZZ_REQUIRED,
-      Object.keys(SEMANTIC_FUZZ_EXEMPT),
+      [SEMANTIC_FUZZ_REQUIRED, Object.keys(SEMANTIC_FUZZ_EXEMPT)],
       "every FUZZ_REQUIRED name must be in SEMANTIC_FUZZ_REQUIRED or in " +
         "SEMANTIC_FUZZ_EXEMPT with the reason its precision is asserted elsewhere",
     );
@@ -1046,8 +1106,7 @@ describe("threat-alphabet domain coverage", () => {
   it("every discovered fast-check suite is in scope or out of scope", () => {
     assertPartition(
       fuzzFiles.map((file) => file.name),
-      Object.keys(IN_SCOPE_MEMBERS),
-      Object.keys(OUT_OF_SCOPE),
+      [Object.keys(IN_SCOPE_MEMBERS), Object.keys(OUT_OF_SCOPE)],
       "a new fast-check suite must be classified in test/threat-codepoints.mjs: " +
         "add it to IN_SCOPE with the alphabet members it owes, or to " +
         "OUT_OF_SCOPE with the one-line reason it ingests none",

--- a/test/fuzz-coverage.test.mjs
+++ b/test/fuzz-coverage.test.mjs
@@ -17,6 +17,7 @@ import { execFileSync } from "node:child_process";
 import { readFileSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
+import { parse } from "acorn";
 
 import * as invisible from "../src/invisible.mjs";
 import * as html from "../src/html.mjs";
@@ -134,184 +135,281 @@ const testDir = path.join(repoRoot, "test");
 // the "fc.assert(" sentinel itself), so scanning it would pass vacuously.
 const selfName = path.basename(fileURLToPath(import.meta.url));
 
-// Strip import statements and comments so a required name only counts when it
-// appears in actual test code — a function listed in an `import {…}` or named
-// in a comment is NOT evidence that a property exercises it.
-const stripImportsAndComments = (source) =>
-  source
-    .replace(/^import\b[\s\S]*?from\s+["'][^"']+["'];?[ \t]*$/gm, "")
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+// ─── JS structure, answered by the grammar ───────────────────────────────────
+// Every question in this section is about the JS GRAMMAR — is this identifier
+// inside a property invocation, where does this arrow body end, is this token
+// code or the inside of a string — so acorn answers it. A depth counter over
+// the text cannot: 69 string, template and regex literals in this repo's
+// fast-check suites hold unbalanced parens, and one of them inside a property
+// body moves the captured span off its real end in either direction.
 
-// A name appearing ANYWHERE in a file that merely CONTAINS an `fc.assert(`/
-// `fc.property(` call somewhere is not evidence that a PROPERTY exercises
-// that name — this repo mixes a handful of property tests into files that
-// are otherwise hundreds of lines of ordinary example-based `it(...)` tests
-// (test/cli.test.mjs, test/html.test.mjs, test/invisible.test.mjs), so an
-// ordinary example test calling e.g. `sanitize(...)` would otherwise satisfy
-// "coverage" for `sanitize` even after its actual property test was deleted.
-// Narrow the match to only the source WITHIN each `fc.assert(...)` /
-// `fc.property(...)` call (balanced-paren scan from the callee's opening
-// paren to its matching close) so a name only counts when it is textually
-// inside a real property/fuzz invocation.
+const FC_PROPERTY_METHODS = new Set(["assert", "property", "asyncProperty"]);
 
-// Several suites (confusables-property, html-property, prompt-property,
-// view-map-property) factor the boilerplate into a one-line local wrapper —
-// e.g. `const check = (arbitrary, predicate) =>\n  fc.assert(fc.property(arbitrary, predicate), runOptions);`
-// — and drive every property through `check(arb, (x) => ...)`. The predicate
-// closure (where a required name actually gets referenced) then sits inside
-// the WRAPPER's call, not literally inside `fc.assert(...)`, so a matcher
-// that only recognizes the literal fc.* callees would false-negative on
-// every one of those suites. Detect such local wrappers by their definition
-// (a same-line-or-wrapped arrow whose body directly calls fc.assert/
-// fc.property/fc.asyncProperty) and treat calls to them as property
-// invocations too.
-const WRAPPER_DEF_RE =
-  /\bconst\s+(\w+)\s*=\s*\([^)]*\)\s*=>\s*fc\.(?:assert|property|asyncProperty)\(/g;
+const FUNCTION_TYPES = new Set([
+  "ArrowFunctionExpression",
+  "FunctionDeclaration",
+  "FunctionExpression",
+]);
 
-// Other suites (html-property's containsForbiddenNode/isHiddenElement,
-// rehydrate-semantic-fuzz's editCall/rehydrateRedacted and
-// ioFor->mkView->occurrences) call the required name only from INSIDE a
-// locally-defined helper function's own body, one or more indirection
-// levels away from the fc.assert/property call site itself. A name used
-// only via such a helper is exercised by the fuzz run exactly as much as one
-// referenced directly, so its OWN definition body is pulled in transitively
-// below (extractDefinitions + the fixpoint loop in extractFcCallSpans).
-const FUNCTION_DEF_RE =
-  /\bfunction\s+(\w+)\s*\(|\b(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s*)?\(/g;
+// A `var` hoists to the nearest of these; everything else binds where it sits.
+const FUNCTION_SCOPE_TYPES = new Set([...FUNCTION_TYPES, "Program"]);
 
-const escapeRegExp = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-
-/** @returns {number} index of the matching close paren, or -1 */
-const findMatchingParen = (code, openIdx) => {
-  let depth = 0;
-  for (let i = openIdx; i < code.length; i++) {
-    if (code[i] === "(") depth++;
-    else if (code[i] === ")") {
-      depth--;
-      if (depth === 0) return i;
-    }
-  }
-  return -1;
-};
-
-/** @returns {number} index of the matching close brace, or -1 */
-const findMatchingBrace = (code, openIdx) => {
-  let depth = 0;
-  for (let i = openIdx; i < code.length; i++) {
-    if (code[i] === "{") depth++;
-    else if (code[i] === "}") {
-      depth--;
-      if (depth === 0) return i;
-    }
-  }
-  return -1;
-};
+const BLOCK_SCOPE_TYPES = new Set([
+  "BlockStatement",
+  "CatchClause",
+  "ClassDeclaration",
+  "ClassExpression",
+  "ForInStatement",
+  "ForOfStatement",
+  "ForStatement",
+  "StaticBlock",
+  "SwitchStatement",
+]);
 
 /**
- * Finds every named `function NAME(...) {...}` and
- * `const/let/var NAME = (...) => ...` (block- or expression-bodied)
- * definition in `code` and returns a Map from name to its full [start, end)
- * source span (declaration keyword through the body's end).
- * @param {string} code
- * @returns {Map<string, [number, number]>}
+ * Parse one ES module, collecting its comment ranges.
+ * @param {string} source
+ * @returns {{ ast: any, comments: {start: number, end: number}[] }}
  */
-const extractDefinitions = (code) => {
-  const defs = new Map();
-  for (const match of code.matchAll(FUNCTION_DEF_RE)) {
-    const name = match[1] ?? match[2];
-    const isFunctionKeyword = match[1] !== undefined;
-    const parenOpen = match.index + match[0].length - 1;
-    const parenClose = findMatchingParen(code, parenOpen);
-    if (parenClose === -1) continue;
-    let i = parenClose + 1;
-    while (i < code.length && /\s/.test(code[i])) i++;
-    if (isFunctionKeyword) {
-      if (code[i] !== "{") continue;
-      const braceClose = findMatchingBrace(code, i);
-      if (braceClose === -1) continue;
-      defs.set(name, [match.index, braceClose + 1]);
-      continue;
-    }
-    // const/let/var NAME = (...) — only a function definition if an arrow
-    // follows the params; `const x = (a + b) * c;` must NOT match.
-    if (code.slice(i, i + 2) !== "=>") continue;
-    i += 2;
-    while (i < code.length && /\s/.test(code[i])) i++;
-    if (code[i] === "{") {
-      const braceClose = findMatchingBrace(code, i);
-      if (braceClose === -1) continue;
-      defs.set(name, [match.index, braceClose + 1]);
-      continue;
-    }
-    // Expression-bodied arrow: scan to the top-level (depth-0) terminating
-    // semicolon so a body containing its own (), {}, [] doesn't cut short.
-    let depth = 0;
-    let j = i;
-    for (; j < code.length; j++) {
-      const c = code[j];
-      if (c === "(" || c === "{" || c === "[") depth++;
-      else if (c === ")" || c === "}" || c === "]") depth--;
-      else if (c === ";" && depth === 0) break;
-    }
-    defs.set(name, [match.index, Math.min(j + 1, code.length)]);
+const parseModule = (source) => {
+  /** @type {{start: number, end: number}[]} */
+  const comments = [];
+  const ast = parse(source, {
+    ecmaVersion: "latest",
+    sourceType: "module",
+    onComment: comments,
+  });
+  return { ast, comments };
+};
+
+/** Every child node of `node`. */
+function* childNodes(node) {
+  for (const key of Object.keys(node)) {
+    const value = node[key];
+    if (Array.isArray(value)) {
+      for (const item of value)
+        if (item && typeof item.type === "string") yield item;
+    } else if (value && typeof value.type === "string") yield value;
   }
-  return defs;
+}
+
+/** `node` and every node beneath it. */
+const subtree = (node, out = []) => {
+  out.push(node);
+  for (const child of childNodes(node)) subtree(child, out);
+  return out;
+};
+
+/** Every name a binding pattern introduces. */
+function* patternNames(pattern) {
+  if (pattern === null || pattern === undefined) return;
+  if (pattern.type === "Identifier") yield pattern.name;
+  else if (pattern.type === "ObjectPattern")
+    for (const property of pattern.properties)
+      yield* patternNames(
+        property.type === "RestElement" ? property.argument : property.value,
+      );
+  else if (pattern.type === "ArrayPattern")
+    for (const element of pattern.elements) yield* patternNames(element);
+  else if (pattern.type === "AssignmentPattern")
+    yield* patternNames(pattern.left);
+  else if (pattern.type === "RestElement")
+    yield* patternNames(pattern.argument);
+}
+
+/**
+ * Resolve identifiers to the binding they name, so a call is matched by what it
+ * REFERS to rather than by how it is spelled.
+ * @param {any} ast
+ * @returns {(name: string, node: any) => any} the local function a name is
+ *   bound to, or null when the name is unbound, imported, or a parameter
+ */
+const identifierBindings = (ast) => {
+  const scopeOf = new Map();
+  const declare = (scope, name, definition) => {
+    if (!scope.bindings.has(name)) scope.bindings.set(name, definition);
+  };
+  const enclosingFunction = (scope) =>
+    scope.isFunction ? scope : enclosingFunction(scope.parent);
+
+  const visit = (node, outer) => {
+    scopeOf.set(node, outer);
+    const isFunction = FUNCTION_SCOPE_TYPES.has(node.type);
+    const scope =
+      isFunction || BLOCK_SCOPE_TYPES.has(node.type)
+        ? { parent: outer, isFunction, bindings: new Map() }
+        : outer;
+    if (node.type === "FunctionDeclaration" || node.type === "ClassDeclaration")
+      declare(outer, node.id.name, node);
+    if (isFunction && node.params)
+      for (const param of node.params)
+        for (const name of patternNames(param)) declare(scope, name, null);
+    if (node.type === "CatchClause")
+      for (const name of patternNames(node.param)) declare(scope, name, null);
+    if (node.type === "VariableDeclaration")
+      for (const declarator of node.declarations)
+        for (const name of patternNames(declarator.id))
+          declare(
+            node.kind === "var" ? enclosingFunction(outer) : outer,
+            name,
+            declarator.init,
+          );
+    if (node.type === "ImportDeclaration")
+      for (const specifier of node.specifiers)
+        declare(outer, specifier.local.name, null);
+    for (const child of childNodes(node)) visit(child, scope);
+  };
+  visit(ast, { parent: null, isFunction: true, bindings: new Map() });
+
+  return (name, node) => {
+    for (let scope = scopeOf.get(node); scope; scope = scope.parent)
+      if (scope.bindings.has(name)) return scope.bindings.get(name);
+    return null;
+  };
+};
+
+/** True for a direct `fc.assert(…)` / `fc.property(…)` / `fc.asyncProperty(…)`. */
+const isFcPropertyCall = (node) =>
+  node.type === "CallExpression" &&
+  node.callee.type === "MemberExpression" &&
+  !node.callee.computed &&
+  node.callee.object.type === "Identifier" &&
+  node.callee.object.name === "fc" &&
+  node.callee.property.type === "Identifier" &&
+  FC_PROPERTY_METHODS.has(node.callee.property.name);
+
+/**
+ * True when `node` invokes `fc.assert`/`fc.property`/`fc.asyncProperty` in its
+ * OWN body. A nested function is not descended into: a helper that merely
+ * builds `it(…, () => fc.assert(…))` registers a test rather than running a
+ * property, so calling it is not itself a property invocation.
+ * @param {any} node
+ * @returns {boolean}
+ */
+const callsFcDirectly = (node) => {
+  if (isFcPropertyCall(node)) return true;
+  for (const child of childNodes(node)) {
+    if (FUNCTION_TYPES.has(child.type)) continue;
+    if (callsFcDirectly(child)) return true;
+  }
+  return false;
 };
 
 /**
- * Concatenates the source spanned by every `fc.assert(...)`, `fc.property(...)`,
- * `fc.asyncProperty(...)` call, every call to a local wrapper function whose
- * own body directly invokes one of those (WRAPPER_DEF_RE), AND — by
- * fixpoint — the full definition body of any locally-defined helper
- * function called from within source already pulled in (so a name used only
- * inside a helper-of-a-helper, e.g. an `editCall(...)` invoked inside a
- * property that itself calls `rehydrateRedacted(...)`, still counts). Each
- * direct call span runs from the callee's opening paren to its balanced
- * closing paren.
- * @param {string} code
+ * The identifier names a suite references from inside a property invocation.
+ *
+ * A name appearing anywhere in a file that merely CONTAINS a property call is
+ * not evidence that a PROPERTY exercises it: this repo mixes a handful of
+ * property tests into files that are otherwise hundreds of lines of ordinary
+ * example-based `it(...)` tests, so an example test calling `sanitize(...)`
+ * would otherwise satisfy the obligation after its property test was deleted.
+ *
+ * Three shapes count as a property invocation. A direct `fc.*` call; a call to
+ * a LOCAL WRAPPER whose own body invokes one (several suites factor the
+ * boilerplate into `const check = (arb, pred) => fc.assert(fc.property(…))`,
+ * putting the predicate closure inside the wrapper's call rather than fc's);
+ * and, transitively, the body of any local helper called from source already
+ * included, since a name reached through a helper is exercised by the fuzz run
+ * exactly as much as one referenced directly.
+ * @param {any} ast
+ * @returns {{ names: Set<string>, spanLength: number }}
+ */
+const propertyReferences = (ast) => {
+  const definitionOf = identifierBindings(ast);
+  const nodes = subtree(ast);
+
+  const wrapperCache = new Map();
+  const isWrapper = (definition) => {
+    if (definition === null || !FUNCTION_TYPES.has(definition.type))
+      return false;
+    if (!wrapperCache.has(definition))
+      wrapperCache.set(definition, callsFcDirectly(definition.body));
+    return wrapperCache.get(definition);
+  };
+  const calledDefinition = (node) =>
+    node.type === "CallExpression" && node.callee.type === "Identifier"
+      ? definitionOf(node.callee.name, node.callee)
+      : null;
+
+  const roots = nodes.filter(
+    (node) => isFcPropertyCall(node) || isWrapper(calledDefinition(node)),
+  );
+  // A nested root (fc.property inside fc.assert) already sits inside its
+  // parent's span; counting only the outermost keeps spanLength a real
+  // character count rather than one that double-counts.
+  const outermost = roots.filter(
+    (root) =>
+      !roots.some(
+        (other) =>
+          other !== root && other.start <= root.start && root.end <= other.end,
+      ),
+  );
+
+  const names = new Set();
+  const visited = new Set();
+  const queue = [...outermost];
+  while (queue.length > 0) {
+    const region = queue.pop();
+    if (visited.has(region)) continue;
+    visited.add(region);
+    for (const node of subtree(region)) {
+      if (node.type === "Identifier") names.add(node.name);
+      const definition = calledDefinition(node);
+      if (definition !== null && FUNCTION_TYPES.has(definition.type))
+        queue.push(definition);
+    }
+  }
+  return {
+    names,
+    spanLength: outermost.reduce(
+      (sum, node) => sum + (node.end - node.start),
+      0,
+    ),
+  };
+};
+
+/** Every identifier a module references outside its own import statements. */
+const referencedIdentifiers = (ast) => {
+  const names = new Set();
+  const visit = (node) => {
+    if (node.type === "ImportDeclaration") return;
+    if (node.type === "Identifier") names.add(node.name);
+    for (const child of childNodes(node)) visit(child);
+  };
+  visit(ast);
+  return names;
+};
+
+/**
+ * `source` with each `[start, end)` range blanked and every other offset
+ * unmoved. Split by UTF-16 code UNIT, the space acorn's offsets index: an
+ * astral character in a suite (this repo's tests are full of emoji) is two
+ * units, and walking code points instead shifts every range after the first one.
+ * @param {string} source
+ * @param {{start: number, end: number}[]} ranges
  * @returns {string}
  */
-const extractFcCallSpans = (code) => {
-  const wrapperNames = new Set(
-    [...code.matchAll(WRAPPER_DEF_RE)].map((m) => m[1]),
-  );
-  const calleeAlternation = [
-    "fc\\.assert",
-    "fc\\.property",
-    "fc\\.asyncProperty",
-    ...[...wrapperNames].map(escapeRegExp),
-  ].join("|");
-  const callStartRe = new RegExp(`\\b(?:${calleeAlternation})\\(`, "g");
-
-  /** @type {[number, number][]} */
-  const included = [];
-  for (const match of code.matchAll(callStartRe)) {
-    const start = match.index;
-    const parenOpen = start + match[0].length - 1;
-    const parenClose = findMatchingParen(code, parenOpen);
-    if (parenClose === -1) continue;
-    included.push([start, parenClose + 1]);
-  }
-
-  const defs = extractDefinitions(code);
-  const pulledIn = new Set();
-  let changed = true;
-  while (changed) {
-    changed = false;
-    const currentText = included.map(([s, e]) => code.slice(s, e)).join("\n");
-    for (const [name, span] of defs) {
-      if (pulledIn.has(name)) continue;
-      if (new RegExp(`\\b${escapeRegExp(name)}\\s*\\(`).test(currentText)) {
-        pulledIn.add(name);
-        included.push(span);
-        changed = true;
-      }
-    }
-  }
-
-  return included.map(([s, e]) => code.slice(s, e)).join("\n");
+const blankRanges = (source, ranges) => {
+  const units = source.split("");
+  for (const { start, end } of ranges)
+    for (let i = start; i < end; i++) if (units[i] !== "\n") units[i] = " ";
+  return units.join("");
 };
+
+/**
+ * `source` with its comments and import statements blanked, so a name surviving
+ * here is a real use — a function listed in an `import {…}` or named in a
+ * comment is NOT evidence that a property exercises it.
+ * @param {string} source
+ * @param {any} ast
+ * @param {{start: number, end: number}[]} comments
+ * @returns {string}
+ */
+const strippedSource = (source, ast, comments) =>
+  blankRanges(source, [
+    ...comments,
+    ...ast.body.filter((node) => node.type === "ImportDeclaration"),
+  ]);
 
 // The shared arbitraries in test-helpers.mjs (unicodeChar / loneSurrogate)
 // carry their seed literals — the surrogate bounds 0xd800/0xdfff — in the
@@ -327,66 +425,93 @@ const extractFcCallSpans = (code) => {
 // satisfy that obligation transitively without ever fuzzing it.
 const SHARED_ARBITRARIES = ["unicodeChar", "loneSurrogate"];
 
-const helperSource = stripImportsAndComments(
-  readFileSync(path.join(testDir, "test-helpers.mjs"), "utf8"),
+const helperText = readFileSync(path.join(testDir, "test-helpers.mjs"), "utf8");
+const helperParse = parseModule(helperText);
+const helperSource = strippedSource(
+  helperText,
+  helperParse.ast,
+  helperParse.comments,
 );
 
 /**
- * The source span of a single `export … <name> …` declaration in `code`: from
- * the `export` keyword to just before the next top-level `export ` (or EOF).
- * @param {string} code
+ * The `[start, end)` range of the `export … <name> …` declaration in `ast`.
+ * @param {any} ast
  * @param {string} name
- * @returns {string|null} null when no such declaration exists
+ * @returns {{start: number, end: number}|null} null when no such export exists
  */
-const extractExportSpan = (code, name) => {
-  const decl = new RegExp(
-    `^export\\s+(?:async\\s+)?(?:const|let|var|function)\\s+${escapeRegExp(name)}\\b`,
-    "m",
-  );
-  const match = decl.exec(code);
-  if (!match) return null;
-  const bodyStart = match.index + match[0].length;
-  const next = code.slice(bodyStart).search(/^export\s/m);
-  return next === -1
-    ? code.slice(match.index)
-    : code.slice(match.index, bodyStart + next);
+const exportRange = (ast, name) => {
+  for (const node of ast.body) {
+    if (node.type !== "ExportNamedDeclaration" || !node.declaration) continue;
+    const declaration = node.declaration;
+    const declared =
+      declaration.type === "VariableDeclaration"
+        ? declaration.declarations.flatMap((one) => [...patternNames(one.id)])
+        : [declaration.id.name];
+    if (declared.includes(name)) return { start: node.start, end: node.end };
+  }
+  return null;
 };
 
 /**
- * `.filter(...)` clauses removed. A filter can only REMOVE values from an
- * arbitrary's domain, so a code point named inside one is evidence of an
- * EXCLUSION, never of seeding: `unicodeChar` spells the surrogate bounds
- * 0xd800/0xdfff precisely because it cannot generate them, and crediting its
- * importers for the lone-surrogate class was the false negative this guard
- * exists to prevent. Dropping a narrowing filter can only lose credit (a false
- * negative), which is the direction CLAUDE.md asks these heuristics to fail.
- * @param {string} span
+ * The source of one export declaration with its `.filter(…)` calls removed.
+ *
+ * A filter can only REMOVE values from an arbitrary's domain, so a code point
+ * named inside one is evidence of an EXCLUSION, never of seeding: `unicodeChar`
+ * spells the surrogate bounds 0xd800/0xdfff precisely because it cannot
+ * generate them, and crediting its importers for the lone-surrogate class was
+ * the false negative this guard exists to prevent. Dropping a narrowing filter
+ * can only lose credit, which is the direction CLAUDE.md asks these heuristics
+ * to fail.
+ * @param {string} source  the comment-blanked module text
+ * @param {any} ast
+ * @param {{start: number, end: number}} range
  * @returns {string}
  */
-const stripFilterClauses = (span) => {
-  let out = span;
-  for (;;) {
-    const idx = out.indexOf(".filter(");
-    if (idx === -1) return out;
-    const close = findMatchingParen(out, idx + ".filter".length);
-    if (close === -1)
-      throw new Error(`unbalanced .filter( in shared-arbitrary span: ${out}`);
-    out = out.slice(0, idx) + out.slice(close + 1);
+const seedingSource = (source, ast, range) => {
+  const declaration = subtree(ast).find(
+    (node) => node.start === range.start && node.end === range.end,
+  );
+  const dropped = subtree(declaration)
+    .filter(
+      (node) =>
+        node.type === "CallExpression" &&
+        node.callee.type === "MemberExpression" &&
+        !node.callee.computed &&
+        node.callee.property.type === "Identifier" &&
+        node.callee.property.name === "filter",
+    )
+    .map((node) => ({ start: node.callee.object.end, end: node.end }));
+  // Outermost-first: a filter nested inside another goes with it.
+  const outermost = dropped
+    .filter(
+      (one) =>
+        !dropped.some(
+          (other) =>
+            other !== one && other.start <= one.start && one.end <= other.end,
+        ),
+    )
+    .sort((a, b) => a.start - b.start);
+  let kept = "";
+  let cursor = range.start;
+  for (const { start, end } of outermost) {
+    kept += source.slice(cursor, start);
+    cursor = end;
   }
+  return (kept + source.slice(cursor, range.end)).trim();
 };
 
 /** Shared arbitrary name → the source that evidences what it SEEDS. */
 const seedingSpans = new Map(
   SHARED_ARBITRARIES.map((name) => {
-    const span = extractExportSpan(helperSource, name);
-    if (span === null)
+    const range = exportRange(helperParse.ast, name);
+    if (range === null)
       throw new Error(
         `test-helpers.mjs has no 'export … ${name}' declaration — the ` +
           `shared-arbitrary extraction is stale. Fix it (or drop the name from ` +
           `SHARED_ARBITRARIES): silently appending nothing would re-create the ` +
           `false negative this credit exists to prevent.`,
       );
-    const seeding = stripFilterClauses(span).trim();
+    const seeding = seedingSource(helperSource, helperParse.ast, range);
     if (seeding === "")
       throw new Error(
         `the extracted span for ${name} is empty after removing .filter(…) clauses`,
@@ -397,30 +522,33 @@ const seedingSpans = new Map(
 
 const fuzzFiles = readdirSync(testDir)
   .filter((name) => name.endsWith(".test.mjs") && name !== selfName)
-  .map((name) => {
-    const source = readFileSync(path.join(testDir, name), "utf8");
-    const stripped = stripImportsAndComments(source);
-    // The import line itself is stripped, so a name surviving in `stripped` is
-    // a real use; requiring the helper import too keeps a same-named local
-    // arbitrary from claiming the shared one's credit.
+  .map((name) => ({
+    name,
+    source: readFileSync(path.join(testDir, name), "utf8"),
+  }))
+  .filter((file) => file.source.includes("fc.assert("))
+  .map(({ name, source }) => {
+    const { ast, comments } = parseModule(source);
+    // Requiring the helper import too keeps a same-named local arbitrary from
+    // claiming the shared one's credit.
+    const identifiers = referencedIdentifiers(ast);
     const referencedArbitraries = source.includes('from "./test-helpers.mjs"')
-      ? SHARED_ARBITRARIES.filter((arb) =>
-          new RegExp(`\\b${escapeRegExp(arb)}\\b`).test(stripped),
-        )
+      ? SHARED_ARBITRARIES.filter((arb) => identifiers.has(arb))
       : [];
     const code = [
-      stripped,
+      strippedSource(source, ast, comments),
       ...referencedArbitraries.map((arb) => seedingSpans.get(arb)),
     ].join("\n");
+    const { names, spanLength } = propertyReferences(ast);
     return {
       name,
-      source,
       code,
+      identifiers,
       referencedArbitraries,
-      fcCode: extractFcCallSpans(code),
+      fcNames: names,
+      fcSpanLength: spanLength,
     };
-  })
-  .filter((file) => file.source.includes("fc.assert("));
+  });
 
 // A "semantic-fuzz suite" is a fuzz file following the `*-semantic-fuzz.
 // test.mjs` naming convention this repo uses for precision fuzzing (fast-check
@@ -478,17 +606,17 @@ describe("fuzz-coverage obligation gate", () => {
   });
 
   it("the fc-call span extractor actually finds spans (gate is not vacuous)", () => {
-    // Guards against the extractor silently matching nothing (e.g. a
-    // refactor to a callee spelling FC_CALL_START_RE no longer matches),
-    // which would make every "is referenced by a fast-check suite" check
-    // below fail closed for the wrong reason instead of proving coverage.
+    // Guards against the extractor silently matching nothing (e.g. a callee
+    // spelling isFcPropertyCall no longer recognizes), which would make every
+    // "is referenced by a fast-check suite" check below fail closed for the
+    // wrong reason instead of proving coverage.
     const totalSpanLength = fuzzFiles.reduce(
-      (sum, file) => sum + file.fcCode.length,
+      (sum, file) => sum + file.fcSpanLength,
       0,
     );
     assert.ok(
       totalSpanLength > 0,
-      "extractFcCallSpans found no fc.assert/fc.property spans in any " +
+      "propertyReferences found no fc.assert/fc.property spans in any " +
         "discovered fuzz file — the span-narrowed match would pass vacuously",
     );
   });
@@ -503,11 +631,7 @@ describe("fuzz-coverage obligation gate", () => {
     });
 
     it(`'${name}' is referenced by a fast-check suite`, () => {
-      const wordRe = new RegExp(`\\b${name}\\b`);
-      // Match only within the text spans of actual fc.assert(...)/
-      // fc.property(...) calls, not anywhere in a file that merely contains
-      // such a call elsewhere (see extractFcCallSpans above).
-      const hits = fuzzFiles.filter((file) => wordRe.test(file.fcCode));
+      const hits = fuzzFiles.filter((file) => file.fcNames.has(name));
       assert.ok(
         hits.length > 0,
         `${name} handles untrusted input but no property/fuzz suite's ` +
@@ -515,6 +639,113 @@ describe("fuzz-coverage obligation gate", () => {
       );
     });
   }
+});
+
+describe("property-span extraction runs on the grammar", () => {
+  // A fixture whose property body carries every literal shape a paren-depth
+  // scan mis-reads: a lone ")", a lone "(", a template holding a brace, and a
+  // regex literal holding a paren. `insideProperty` sits AFTER the ")" (a
+  // depth scan closes the call early and loses it) and `notFuzzed` sits after
+  // the whole property (an over-long span hands it the credit it never earned).
+  const FIXTURE = [
+    'import fc from "fast-check";',
+    'import { insideProperty, viaHelper, notFuzzed } from "../src/x.mjs";',
+    "",
+    "const check = (arbitrary, predicate) =>",
+    "  fc.assert(fc.property(arbitrary, predicate), {});",
+    "",
+    "const helper = (value) => viaHelper(value);",
+    "",
+    "check(fc.string(), (text) => {",
+    '  const closer = ")";',
+    '  const opener = "look ![alt](";',
+    "  const braced = `${text} { unmatched`;",
+    "  const pattern = /\\(/;",
+    "  return insideProperty(text, closer, opener, braced, pattern) && helper(text);",
+    "});",
+    "",
+    'it("an ordinary example test", () => {',
+    "  notFuzzed(inComment);",
+    "});",
+    "",
+    "// a comment naming insideProperty is not a reference",
+  ].join("\n");
+
+  const wrapperCallStart = FIXTURE.indexOf("check(fc.string()");
+  const { names, spanLength } = propertyReferences(parseModule(FIXTURE).ast);
+
+  it("a paren-depth scan of the fixture closes early (fixture has teeth)", () => {
+    // The discredited approximation, kept as the negative control this fixture
+    // is aimed at: a depth counter cannot see string or regex literals.
+    let depth = 0;
+    let end = -1;
+    for (
+      let i = FIXTURE.indexOf("(", wrapperCallStart);
+      i < FIXTURE.length;
+      i++
+    ) {
+      if (FIXTURE[i] === "(") depth++;
+      else if (FIXTURE[i] === ")" && --depth === 0) {
+        end = i;
+        break;
+      }
+    }
+    assert.ok(end > wrapperCallStart, "the depth scan found no close paren");
+    assert.ok(
+      !FIXTURE.slice(wrapperCallStart, end).includes("insideProperty"),
+      "the depth scan now reaches insideProperty — the fixture lost its teeth, " +
+        "so it no longer discriminates the grammar from a text scan",
+    );
+  });
+
+  it("resolves a name that follows an unbalanced literal", () => {
+    assert.ok(names.has("insideProperty"));
+  });
+
+  it("resolves a name reached only through a local helper", () => {
+    assert.ok(names.has("viaHelper"));
+  });
+
+  it("gives no credit to a name outside every property call", () => {
+    assert.equal(names.has("notFuzzed"), false);
+    assert.equal(names.has("inComment"), false);
+  });
+
+  it("blanks imports and comments past an astral character", () => {
+    // The emoji is two UTF-16 units and one code point. Walking code points
+    // shifts every range after it by one, so the import survives and real code
+    // is blanked in its place — and this repo's suites are full of emoji.
+    const source = [
+      'const flag = "\u{1f3f4}";',
+      'import fc from "fast-check";',
+      "// insideProperty in a comment",
+      "const kept = flag;",
+    ].join("\n");
+    const { ast, comments } = parseModule(source);
+    const lines = strippedSource(source, ast, comments).split("\n");
+    // Exact line equality, not `includes`: a one-unit shift still blanks most
+    // of the import, and only the boundary characters show which way it moved.
+    assert.equal(lines[0], 'const flag = "\u{1f3f4}";');
+    assert.equal(lines[1].trim(), "", "the import line is not fully blanked");
+    assert.equal(lines[2].trim(), "", "the comment line is not fully blanked");
+    assert.equal(lines[3], "const kept = flag;");
+  });
+
+  it("captures both property invocations in full and no more", () => {
+    // The fixture holds exactly two: the wrapper CALL, and the `fc.assert` in
+    // the wrapper's own definition. A short span loses the tail of the first.
+    const wrapperCall = FIXTURE.slice(
+      wrapperCallStart,
+      FIXTURE.indexOf("});", wrapperCallStart) + 2,
+    );
+    const wrapperBody = "fc.assert(fc.property(arbitrary, predicate), {})";
+    assert.ok(
+      wrapperCall.endsWith("})"),
+      "the wrapper call slice is cut short",
+    );
+    assert.ok(FIXTURE.includes(wrapperBody));
+    assert.equal(spanLength, wrapperCall.length + wrapperBody.length);
+  });
 });
 
 describe("semantic-fuzz obligation gate", () => {
@@ -539,8 +770,7 @@ describe("semantic-fuzz obligation gate", () => {
 
   for (const name of SEMANTIC_FUZZ_REQUIRED) {
     it(`'${name}' is referenced by a *-semantic-fuzz.test.mjs suite`, () => {
-      const wordRe = new RegExp(`\\b${name}\\b`);
-      const hits = semanticFuzzFiles.filter((file) => wordRe.test(file.fcCode));
+      const hits = semanticFuzzFiles.filter((file) => file.fcNames.has(name));
       assert.ok(
         hits.length > 0,
         `${name} is a precision-sensitive entry point (structural fuzzing alone ` +
@@ -627,8 +857,7 @@ describe("shared-arbitrary seeding credit", () => {
         "non-arbitrary export or delete it",
     );
     for (const file of fuzzFiles) {
-      if (stripImportsAndComments(file.source).includes("keptOutsideNeedles"))
-        continue;
+      if (file.identifiers.has("keptOutsideNeedles")) continue;
       assert.ok(
         !file.code.includes("keptOutsideNeedles"),
         `${file.name} inherited keptOutsideNeedles' body from test-helpers.mjs`,

--- a/test/fuzz-coverage.test.mjs
+++ b/test/fuzz-coverage.test.mjs
@@ -10,6 +10,13 @@
  * because a passthrough executes the line without violating any asserted
  * invariant. A percentage can't catch "this parser has no security invariant";
  * requiring a named fuzz target for each one can.
+ *
+ * Each obligation list is one half of a PARTITION over the population it draws
+ * from: FUZZ_REQUIRED + FUZZ_EXEMPT cover every exported function,
+ * SEMANTIC_FUZZ_REQUIRED + SEMANTIC_FUZZ_EXEMPT cover every required name, and
+ * IN_SCOPE + OUT_OF_SCOPE cover every discovered suite. A required list on its
+ * own proves only what it names; the exempt half is what makes a new export or
+ * a new suite impossible to land without a human choosing a side.
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
@@ -37,23 +44,13 @@ import { CHECKS } from "../src/invisible.mjs";
 import {
   THREAT_CODEPOINTS,
   IN_SCOPE_MEMBERS,
+  OUT_OF_SCOPE,
   acceptedSpellings,
   spellingMatches,
   threat,
 } from "./threat-codepoints.mjs";
 
 // Functions that ingest untrusted text/URLs/ranges and so owe a fuzz target.
-// Intentionally excluded (documented so the omission is a choice, not a miss):
-//   - isSgrOnly, isHiddenOpen, closingTagName: pure short-string predicates
-//     with no transform/parse step, covered by example tests and indirectly
-//     through their callers.
-//   - looksLikeHtmlSource: parses, but returns a verdict rather than a
-//     transform, so it has no fuzzable invariant of its own; the verdict is
-//     pinned by the exact-verdict corpus in html.test.mjs and both branches it
-//     selects are fuzzed through sanitizeHtml.
-//   - scanHtmlFragment: has no invariant of its own beyond what the
-//     sanitizeHtml round-trip / splice-fidelity properties already assert on
-//     its output.
 const FUZZ_REQUIRED = [
   "stripInvisible",
   "stripInvisibleWithReport",
@@ -95,18 +92,94 @@ const FUZZ_REQUIRED = [
   "rehydrateLayer2",
 ];
 
+/**
+ * The other half of the export partition: every exported function that owes no
+ * fuzz target, and the one-line reason it owes none. A `TODO:` reason marks a
+ * genuine gap that is tracked rather than denied — the name still cannot be
+ * deleted or renamed without this gate noticing, and the next reader sees it.
+ * @type {Readonly<Record<string, string>>}
+ */
+const FUZZ_EXEMPT = Object.freeze({
+  // ── genuine gaps, tracked ────────────────────────────────────────────────
+  anchorSpans:
+    "TODO: owes a property suite — it anchors a prefix/suffix over untrusted Write content",
+  matchesSecretHint:
+    "TODO: owes a property suite — a fail-open pre-gate for the secret scan",
+  needsMarkdownPipeline:
+    "TODO: owes a property suite — a fail-open pre-gate for Layers 2 and 3",
+  overlapAwareCount:
+    "TODO: owes a property suite — it decides Edit ambiguity over untrusted needles",
+  pairDiskSpans:
+    "TODO: owes a property suite — it maps redaction pairs onto on-disk spans",
+
+  // ── predicates and lookups: no parse or transform step of their own ──────
+  closingTagName: "reads one tag name out of an already-tokenized HTML value",
+  contextScopeContradiction:
+    "maps a host-supplied load reason through a table, with no parse",
+  excludeFromContextScan: "path-prefix predicate over one scan entry name",
+  hasNonAscii: "code-unit range predicate over one string",
+  isBenignAnsiKinds:
+    "set membership over the TOKEN_KIND values Layer 1 removed",
+  isHiddenOpen: "short-string predicate over one open tag",
+  isIncidentalInvisible:
+    "threshold read over counts the invisible analysis produced",
+  isSgrOnly: "predicate over the tokens scanAnsi produced",
+  isWalkableContainer: "shape predicate over one JSON value",
+  looksLikeHtmlSource:
+    "returns a verdict rather than a transform, and both branches it selects are fuzzed through sanitizeHtml",
+  scopeFor: "looks a tool name up in the fold-scope table",
+
+  // ── operator-facing prose built from an already-classified finding ───────
+  composeContext: "assembles the context block from a computed warning list",
+  describeExfil: "formats Layer 3's classified threats into prose",
+  describeRemoved: "formats Layer 2's removal counts into prose",
+  describeStripped: "formats Layer 1's CATEGORY codes into prose",
+  describeWarned: "formats Layer 2's preserved-tag counts into prose",
+  formatReason: "formats the prompt gate's block reason into prose",
+  normalizeContext: "formats the folded field names into a model-facing note",
+  withheldWarning:
+    "formats one noun phrase into the withheld-artifact sentence",
+
+  // ── filesystem entry points whose only parse is an already-required one ──
+  ancestorInstructionFiles: "pure parent-path arithmetic over a directory path",
+  atomicReplaceFile: "write primitive over text a required scan produced",
+  cleanFile: "reads a file and delegates the parse to scanText",
+  findInstructionFiles: "enumerates paths and reads no file content",
+  scanInstructionFiles: "reads files and delegates the parse to scanText",
+
+  // ── compositions and views fuzzed through the entry point above them ─────
+  applyLayer1:
+    "the Layer-1 composition, fuzzed through sanitize and sanitizeText",
+  countEffectiveInvisible: "reads the analysis stripInvisible already ran",
+  countPayloadInvisible: "reads the analysis stripInvisible already ran",
+  findLongRuns: "one anchored scan, fuzzed through stripInvisibleWithReport",
+  hasLongRun: "the yes/no of findLongRuns, over the same anchored scan",
+  isBenignAnsi: "runs applyLayer1 and reads its kinds",
+  layer2Placeholder:
+    "derives a keyed placeholder by sha256; the round-trip fuzz oracle pins its grammar",
+  makeFileView:
+    "freezes a text and pair list into a view, validated at construction",
+  orderedMatches:
+    "orders what occurrences found, and spliceOrdered consumes that order",
+  pairsToUtf16:
+    "converts pair offsets between spaces, fuzzed through resolveSpan",
+  payloadInvisibleView:
+    "the view the long-run probe reads, pinned by invisible-fast-path",
+  payloadLongRunSample: "reads that same view, pinned by invisible-fast-path",
+  scanHtmlFragment:
+    "has no invariant of its own beyond what the sanitizeHtml round-trip and splice-fidelity properties assert on its output",
+  stripAnsiFully: "the ANSI half of applyLayer1, fuzzed through layer1-ansi",
+  suppressToolOutput: "substitutes a sentinel for a subtree and parses nothing",
+  toUtf16View:
+    "converts a view between offset spaces, validated at construction",
+  viewMapDefect: "self-check over a view the pipeline built",
+});
+
 // Entry points that owe SEMANTIC-CORRECTNESS fuzzing, not just structural
 // fuzzing: a structural property (never-throws, idempotent, shape-preserved)
 // can hold in aggregate while a detector corrupts the wrong leaf or misses a
 // specific payload shape — exactly the class of false positive that shipped
-// in scanText's scatter floor (fixed alongside this gate). A subset of
-// FUZZ_REQUIRED: named internal helpers (isHiddenStyle, decodeRun,
-// resolveSpan, alignDeletions, rehydrateNewString, stripInvisibleWithReport,
-// deleteVerbatimSpans; urlHost's sibling checkExfilUrl is kept since it's
-// independently callable) are exercised only THROUGH their public entry
-// point in these suites, so requiring their own name to appear here would be
-// a false negative, not a stronger check — the precision property is
-// asserted at the entry point.
+// in scanText's scatter floor (fixed alongside this gate).
 const SEMANTIC_FUZZ_REQUIRED = [
   "stripInvisible",
   "sanitizeHtml",
@@ -123,6 +196,40 @@ const SEMANTIC_FUZZ_REQUIRED = [
   "rehydrateRedacted",
   "occurrences",
 ];
+
+/**
+ * The other half of the semantic partition, over FUZZ_REQUIRED. Most entries
+ * are named internal helpers a semantic suite drives only THROUGH their public
+ * entry point, where the precision property is asserted: requiring their own
+ * name here would be a false negative, not a stronger check.
+ * @type {Readonly<Record<string, string>>}
+ */
+const SEMANTIC_FUZZ_EXEMPT = Object.freeze({
+  alignDeletions:
+    "driven through rehydrateRedacted, where precision is asserted",
+  buildPreToolUseResponse:
+    "a whole-process composition; each layer's precision is asserted at its own entry point",
+  decodeRun: "driven through scanText, where precision is asserted",
+  deleteVerbatimSpans:
+    "driven through sanitizeText, where precision is asserted",
+  detectConfusableHosts:
+    "its precision is pinned exactly by the benign/attack corpus in confusable-host.test.mjs",
+  evaluateToolOutput:
+    "a whole-process composition; each layer's precision is asserted at its own entry point",
+  isHiddenElement: "driven through sanitizeHtml, where precision is asserted",
+  isHiddenStyle: "driven through sanitizeHtml, where precision is asserted",
+  rehydrateLayer2:
+    "a whole-process composition; each layer's precision is asserted at its own entry point",
+  rehydrateNewString:
+    "driven through rehydrateRedacted, where precision is asserted",
+  resolveSpan: "driven through rehydrateRedacted, where precision is asserted",
+  sanitize:
+    "the top-level composition over layers that each carry their own semantic suite",
+  spliceOrdered: "driven through sanitizeText, where precision is asserted",
+  spliceRanges: "driven through sanitizeHtml, where precision is asserted",
+  stripInvisibleWithReport:
+    "driven through stripInvisible, where precision is asserted",
+});
 
 const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
   encoding: "utf8",
@@ -597,6 +704,26 @@ for (const [name, mod] of [
   exportedFunctions.set(name, mod[name]);
 }
 
+/**
+ * Assert `required` and `exempt` partition `population` exactly, so a member
+ * of the population cannot exist without a human having classified it.
+ * @param {string[]} population
+ * @param {string[]} required
+ * @param {string[]} exempt
+ * @param {string} hint  what the reader must do about a mismatch
+ */
+const assertPartition = (population, required, exempt, hint) => {
+  assert.ok(
+    population.length > 0,
+    "empty population — the partition would hold vacuously",
+  );
+  assert.deepEqual(
+    [...population].sort(),
+    [...required, ...exempt].sort(),
+    hint,
+  );
+};
+
 describe("fuzz-coverage obligation gate", () => {
   it("discovers at least one fast-check suite (gate is not vacuous)", () => {
     assert.ok(
@@ -619,6 +746,38 @@ describe("fuzz-coverage obligation gate", () => {
       totalSpanLength > 0,
       "propertyReferences found no fc.assert/fc.property spans in any " +
         "discovered fuzz file — the span-narrowed match would pass vacuously",
+    );
+  });
+
+  it("every exported function is either fuzz-required or exempt with a reason", () => {
+    assertPartition(
+      [...exportedFunctions.keys()],
+      FUZZ_REQUIRED,
+      Object.keys(FUZZ_EXEMPT),
+      "a new export must be classified: add it to FUZZ_REQUIRED and give it a " +
+        "property suite, or to FUZZ_EXEMPT with the one-line reason it owes none",
+    );
+    for (const [name, reason] of Object.entries(FUZZ_EXEMPT))
+      assert.ok(reason.length > 0, `${name} carries an empty exemption reason`);
+  });
+
+  it("the export partition rejects an unclassified name (assertion is not vacuous)", () => {
+    const population = [...exportedFunctions.keys(), "syntheticNewExport"];
+    assert.throws(
+      () =>
+        assertPartition(
+          population,
+          FUZZ_REQUIRED,
+          Object.keys(FUZZ_EXEMPT),
+          "an unclassified export must fail the partition",
+        ),
+      assert.AssertionError,
+    );
+    assertPartition(
+      population,
+      FUZZ_REQUIRED,
+      [...Object.keys(FUZZ_EXEMPT), "syntheticNewExport"],
+      "classifying the synthetic export must satisfy the same partition",
     );
   });
 
@@ -758,15 +917,20 @@ describe("semantic-fuzz obligation gate", () => {
     assert.ok(SEMANTIC_FUZZ_REQUIRED.length > 0);
   });
 
-  it("every SEMANTIC_FUZZ_REQUIRED name is also in FUZZ_REQUIRED", () => {
+  it("every fuzz-required name is either semantic-required or exempt with a reason", () => {
     // Semantic-fuzz coverage is a stricter obligation layered on top of the
-    // structural one; a name here that isn't in FUZZ_REQUIRED is a drifted
-    // entry, not a real additional target.
-    for (const name of SEMANTIC_FUZZ_REQUIRED)
-      assert.ok(
-        FUZZ_REQUIRED.includes(name),
-        `${name} is in SEMANTIC_FUZZ_REQUIRED but not FUZZ_REQUIRED`,
-      );
+    // structural one, so its population is FUZZ_REQUIRED itself: a name here
+    // that isn't in FUZZ_REQUIRED is a drifted entry, and a required name in
+    // neither list is an obligation nobody decided.
+    assertPartition(
+      FUZZ_REQUIRED,
+      SEMANTIC_FUZZ_REQUIRED,
+      Object.keys(SEMANTIC_FUZZ_EXEMPT),
+      "every FUZZ_REQUIRED name must be in SEMANTIC_FUZZ_REQUIRED or in " +
+        "SEMANTIC_FUZZ_EXEMPT with the reason its precision is asserted elsewhere",
+    );
+    for (const [name, reason] of Object.entries(SEMANTIC_FUZZ_EXEMPT))
+      assert.ok(reason.length > 0, `${name} carries an empty exemption reason`);
   });
 
   for (const name of SEMANTIC_FUZZ_REQUIRED) {
@@ -879,11 +1043,19 @@ describe("threat-alphabet domain coverage", () => {
       );
   });
 
-  it("every IN_SCOPE suite file actually exists and drives fast-check", () => {
-    for (const name of Object.keys(IN_SCOPE_MEMBERS))
+  it("every discovered fast-check suite is in scope or out of scope", () => {
+    assertPartition(
+      fuzzFiles.map((file) => file.name),
+      Object.keys(IN_SCOPE_MEMBERS),
+      Object.keys(OUT_OF_SCOPE),
+      "a new fast-check suite must be classified in test/threat-codepoints.mjs: " +
+        "add it to IN_SCOPE with the alphabet members it owes, or to " +
+        "OUT_OF_SCOPE with the one-line reason it ingests none",
+    );
+    for (const [name, reason] of Object.entries(OUT_OF_SCOPE))
       assert.ok(
-        fuzzFileByName.has(name),
-        `IN_SCOPE names '${name}' but no such fast-check suite was discovered — stale entry or renamed file`,
+        reason.length > 0,
+        `${name} carries an empty out-of-scope reason`,
       );
   });
 

--- a/test/fuzz-coverage.test.mjs
+++ b/test/fuzz-coverage.test.mjs
@@ -65,6 +65,7 @@ const FUZZ_REQUIRED = [
   "detectExfil",
   "checkExfilUrl",
   "urlHost",
+  "detectConfusableHosts",
   // Agent-pipeline transforms/parsers over untrusted input (one named fuzz
   // target each — the same obligation extended to the new entry points).
   "normalizeConfusables",

--- a/test/threat-codepoints.mjs
+++ b/test/threat-codepoints.mjs
@@ -148,6 +148,8 @@ export const OUT_OF_SCOPE = Object.freeze({
   // ── post-Layer-1 consumers: Layer 1 strips every invisible and ANSI byte
   // before these layers run, so seeding the alphabet here tests a state the
   // layer never sees. Surrogate/astral totality rides in on fc.string().
+  "confusable-host-property.test.mjs":
+    "Layer 3 reads link destinations in documents Layer 1 has already cleaned",
   "exfil-property.test.mjs":
     "Layer 3 reads URL and markdown link destinations, which Layer 1 has already cleaned",
   "html-exfil-semantic-fuzz.test.mjs":
@@ -165,8 +167,6 @@ export const OUT_OF_SCOPE = Object.freeze({
     "folds against an injected scanner over a confusable glyph table",
   "confusables-semantic-fuzz.test.mjs":
     "fold precision over genuine non-Latin words versus confusable lookalikes",
-  "confusable-host-property.test.mjs":
-    "reads hostnames the WHATWG URL parser already resolved, not raw text",
   "splice-property.test.mjs":
     "splices ranges and needle matches an earlier layer resolved",
   "view-map-property.test.mjs":

--- a/test/threat-codepoints.mjs
+++ b/test/threat-codepoints.mjs
@@ -107,9 +107,8 @@ const INVISIBLE_MEMBERS = THREAT_CODEPOINTS.filter(
  * fuzz suite must seed. `"all"` means the whole alphabet; an array names the
  * in-scope subset. Every exclusion (a member present in the alphabet but absent
  * from a suite's list) is justified inline — a carve-out is a choice, not a miss.
- * A suite NOT listed here is not gated for domain coverage (it does not ingest
- * the threat alphabet — e.g. confusables/splice/view-map operate on already-
- * mapped offsets or a confusable glyph table, not raw invisible/ANSI bytes).
+ * A suite absent from here must appear in {@link OUT_OF_SCOPE} with its reason;
+ * the gate asserts the two together cover every discovered fast-check suite.
  * @type {Readonly<Record<string, number[] | "all">>}
  */
 export const IN_SCOPE = Object.freeze({
@@ -131,18 +130,83 @@ export const IN_SCOPE = Object.freeze({
   // its unicodeChar arbitrary. It owes every invisible member plus the surrogate
   // totality probe.
   "instructions-property.test.mjs": [...INVISIBLE_MEMBERS, 0xd800],
+});
 
-  // NOT gated for the threat alphabet (and so deliberately absent):
-  //   - exfil-property.test.mjs: Layer 3 inspects URL/markdown link destinations,
-  //     which run AFTER Layer 1 has already stripped every invisible/ANSI byte —
-  //     seeding those here would test a state the layer never sees. Its totality
-  //     (never-throw on lone surrogates / astral) is already covered by its
-  //     fc.string() URL arbitraries, not a hard-coded code-point literal.
-  //   - html-property.test.mjs: same boundary — the HTML parser runs post-Layer-1
-  //     and invisible/ANSI/joiner/TAG members carry no markup meaning; surrogate/
-  //     astral totality rides in on its fc.string() fragments.
-  //   - confusables / splice / view-map / rehydrate: operate on a confusable
-  //     glyph table or already-mapped offsets, not raw invisible/ANSI input.
+/**
+ * The other half of the same partition: every fast-check suite that is NOT
+ * gated for domain coverage, and the reason it owes nothing.
+ *
+ * IN_SCOPE alone is one-directional. It proves each listed suite seeds what it
+ * owes, and says nothing about a suite nobody listed — so a new fuzz target for
+ * a raw-byte entry point can land with an input domain that never reaches the
+ * dangerous bytes, which is the U+009B trap this module exists to close. The
+ * gate asserts IN_SCOPE and OUT_OF_SCOPE together cover the discovered suites,
+ * so a new suite forces a human to pick a side.
+ * @type {Readonly<Record<string, string>>}
+ */
+export const OUT_OF_SCOPE = Object.freeze({
+  // ── post-Layer-1 consumers: Layer 1 strips every invisible and ANSI byte
+  // before these layers run, so seeding the alphabet here tests a state the
+  // layer never sees. Surrogate/astral totality rides in on fc.string().
+  "exfil-property.test.mjs":
+    "Layer 3 reads URL and markdown link destinations, which Layer 1 has already cleaned",
+  "html-exfil-semantic-fuzz.test.mjs":
+    "Layer 3 precision over whole documents, downstream of the same strip",
+  "html-property.test.mjs":
+    "the HTML parser runs post-Layer-1, and no alphabet member carries markup meaning",
+  "html-semantic-fuzz.test.mjs":
+    "hidden-element splice precision, downstream of the same strip",
+  "html.test.mjs":
+    "exact-verdict HTML unit tests, downstream of the same strip",
+
+  // ── offset and table engines: their input is a resolved offset, a needle or
+  // a confusable glyph table, never raw untrusted bytes.
+  "confusables-property.test.mjs":
+    "folds against an injected scanner over a confusable glyph table",
+  "confusables-semantic-fuzz.test.mjs":
+    "fold precision over genuine non-Latin words versus confusable lookalikes",
+  "confusable-host-property.test.mjs":
+    "reads hostnames the WHATWG URL parser already resolved, not raw text",
+  "splice-property.test.mjs":
+    "splices ranges and needle matches an earlier layer resolved",
+  "view-map-property.test.mjs":
+    "offset algebra between the disk, cleaned and redacted views",
+  "rehydrate-property.test.mjs":
+    "re-anchors an Edit against a view the pipeline already produced",
+  "rehydrate-semantic-fuzz.test.mjs":
+    "re-anchoring precision over the same already-produced views",
+
+  // ── differentials and fast paths: each pins one implementation against
+  // another over the alphabet its own subject defines.
+  "ansi-pattern-parity.test.mjs":
+    "differentials the shipped escape regex against the scanner over the ANSI grammar",
+  "invisible-differential.test.mjs":
+    "differentials the optimized carve analysis against the slow one",
+  "invisible-fast-path.test.mjs":
+    "pins each counting short-circuit against the analysis it replaces",
+  "invisible-property.test.mjs":
+    "fuzzes the ZWNJ/ZWJ carve-out over its own joiner and emoji alphabet",
+  "invisible-semantic-fuzz.test.mjs":
+    "carve-out precision over that same joiner alphabet",
+  "invisible.test.mjs":
+    "unit tests driven from the CHECKS/VS/BLANK_NON_CF SSOT",
+  "layer1-ansi.test.mjs":
+    "Layer 1's own idempotence and containment invariants over the ANSI grammar",
+
+  // ── precision suites whose structural sibling carries the domain gate.
+  "instructions-semantic-fuzz.test.mjs":
+    "instructions-property.test.mjs is the gated suite for this entry point",
+  "output-semantic-fuzz.test.mjs":
+    "output-property.test.mjs is the gated suite for this entry point",
+  "prompt-semantic-fuzz.test.mjs":
+    "prompt-property.test.mjs is the gated suite for this entry point",
+
+  // ── whole-process compositions over text the gated entry points produce.
+  "claude-hooks-layer-pipeline.test.mjs":
+    "asserts the PreToolUse layer ORDER on what the hook emits",
+  "claude-hooks-roundtrip.fuzz.test.mjs":
+    "fuzzes the sanitize to edit to rehydrate loop, whose input is sanitized text",
+  "cli.test.mjs": "pins the CLI I/O envelope against sanitize as its oracle",
 });
 
 // Round-trip guard data: every cp named in IN_SCOPE must be a real alphabet


### PR DESCRIPTION
Claimed area: `test/fuzz-coverage.test.mjs`, `test/threat-codepoints.mjs`, and one new `test/confusable-host-property.test.mjs`. Nothing under `.github/`, `plugin/`, `python/` or `src/` is touched.

## Summary

The fuzz-obligation gate decides which exported functions owe a property/fuzz suite. It had two defects, and they compound: the first makes its evidence unreliable, the second means it never looks at most of the surface it is supposed to guard.

1. **It hand-rolled a JS parser** while `acorn` was already a devDependency and `.hooks/lib/guarded-data-scan.mjs` in this same repo already walked `CallExpression` nodes for the same class of question.
2. **It was proven in one direction only.** `exportedFunctions` was built and never compared back against `FUZZ_REQUIRED`. `SEMANTIC_FUZZ_REQUIRED` and `IN_SCOPE` had the same shape.

Three commits, one per piece.

## Changes

### 1. `refactor(test)`: the extractor runs on the grammar

Deleted `stripImportsAndComments`, `findMatchingParen`, `findMatchingBrace`, `extractDefinitions`, `extractFcCallSpans`, `extractExportSpan`, `stripFilterClauses`, `WRAPPER_DEF_RE`, `FUNCTION_DEF_RE` and `escapeRegExp`. Each suite is now parsed once with acorn:

- property invocations are `CallExpression` nodes whose callee is `fc.assert` / `fc.property` / `fc.asyncProperty`, or a local wrapper resolved by **identifier binding** — a real scope chain (function and block scopes, `var` hoisting, params, imports, destructuring patterns), not a name-regex fixpoint;
- the span is `[node.start, node.end)`;
- the transitive helper pull-in follows resolved bindings of *called* identifiers instead of a `\bname\s*\(` regex over accumulated text;
- comments come from `onComment` and imports from the `ImportDeclaration` nodes, so the stripping regexes are gone;
- the shared-arbitrary extraction (`export const unicodeChar = …` minus its `.filter(…)` clauses) is AST-driven too.

The gate now answers "is this name referenced by a property" with a `Set` of identifiers rather than a word regex over concatenated text, so a name that appears only inside a string literal no longer counts.

**Measured harm, reproduced before the fix.** Across the tree's fast-check suites there are **69** paren-unbalanced string, template and regex literals (`"^(?:"`, `"look [alt]("`, `/(?:\p{Cf}|[…]/`). Injecting one extra `")"` inside the string `"^(?:"` in the first `fc.assert(` of `test/splice-property.test.mjs`:

| injection | true span (acorn) | text-scan span | total captured `fcCode` |
| --------- | ----------------- | -------------- | ----------------------- |
| none | 1164 | 1164 | 12124 |
| `)` | 1165 | 1140 (−25) | 11754 (**−370**) |
| `((` | 1166 | 1775 (+609) | 12768 (**+644**) |

Short is a false RED — a genuinely fuzzed detector reports as unfuzzed. Long is a false GREEN — the span runs past its real end into neighbouring code, so an ordinary example test hands a name the credit the span-narrowing exists to deny.

**Every existing verdict is preserved**: all 29 required names still resolve, all 14 semantic-required names still resolve, and the shared-arbitrary and threat-alphabet assertions are unchanged.

### 2. `test(confusable-host)`: fuzz `detectConfusableHosts`, then require it

`detectConfusableHosts` is a Layer-3 detector over attacker-controlled documents — it runs a markdown parser and the WHATWG URL parser, decodes every punycode label, and owns its own `found` category and model-facing warning — and no property suite referenced it. New `test/confusable-host-property.test.mjs` fuzzes it over whole generated documents (link, image, autolink and reference-definition shapes, benign filler prose):

- **totality and shape** — never throws; the result is `null` or a non-empty array whose every entry carries a known `SEVERITY` and a non-empty description;
- **precision** — a document whose hosts hold no `xn--` label is never flagged (the false-positive direction, which is the one that rewrites the operator's own content out of the channel);
- **recall** — a host from the attack corpus is reported wherever it sits among benign links;
- **dedup** — one host repeated N times is still one finding;
- **determinism**.

### 3. `test(fuzz-coverage)`: exempt halves close all three lists

Each required list now has an exempt half, one reason per entry, and the gate asserts `required + exempt == population` exactly:

| population | required | exempt | lives in |
| --- | --- | --- | --- |
| 75 exported functions | 29 | 46 (`FUZZ_EXEMPT`) | `fuzz-coverage.test.mjs` |
| 29 `FUZZ_REQUIRED` names | 14 | 15 (`SEMANTIC_FUZZ_EXEMPT`) | `fuzz-coverage.test.mjs` |
| 30 discovered fast-check suites | 5 (`IN_SCOPE`) | 25 (`OUT_OF_SCOPE`) | `threat-codepoints.mjs` |

A new export or a new fuzz suite can no longer land without a human choosing a side.

## What I measured

Re-measured on this tree rather than trusting the audit's figures:

- **72** exported engine functions plus 3 hook entry points = **75**; 28 were in `FUZZ_REQUIRED`, so **47 owed nothing** that anyone had decided. The module comment named four deliberate exclusions.
- **31** of those 47 were referenced by no property/fuzz suite at all — not the 6 the audit named, though all 6 are in the 31.
- **69** paren-unbalanced literals in fc suites (the audit said ~47; the tree has moved).
- **29** fast-check suites before this PR, 5 of them gated for domain coverage.

## Genuinely uncovered names — follow-up work

These five carry a `TODO:` reason (now in a dedicated `FUZZ_TODO` map — see Decisions made below) rather than a denial. They still cannot be deleted or renamed without the gate noticing, and each owes a property suite in a later PR:

| name | why it matters |
| --- | --- |
| `needsMarkdownPipeline` | fail-open pre-gate; a wrong `false` silently disables Layers 2 and 3 |
| `matchesSecretHint` | fail-open pre-gate; a wrong `false` silently disables the secret scan |
| `anchorSpans` | anchors a prefix/suffix over untrusted Write content |
| `overlapAwareCount` | decides Edit ambiguity over untrusted needles |
| `pairDiskSpans` | maps redaction pairs onto on-disk spans |

The other 41 exemptions are predicates with no parse step, prose formatters over already-classified findings, filesystem entry points that delegate their only parse to `scanText`, and compositions fuzzed through the entry point above them.

## Tests / verification

Both original defects have non-vacuity proof in the file itself.

**Defect 1** — a fixture whose property body carries a lone `")"`, a lone `"("`, a template literal with a brace and a regex `/\(/`, with a required name *after* the `")"` and an ordinary example test *after* the whole property. Five assertions: the extractor resolves the name past the unbalanced literal, resolves a name reached only through a local helper, gives no credit to the name outside every property call or to one named only in a comment, and captures both property invocations to the exact character. The sixth is the negative control — a paren-depth scan of that same fixture is run inline and asserted to close **early**, so the fixture cannot quietly lose its teeth.

A sixth test pins an offset bug found during self-review: comment and import ranges are blanked by UTF-16 code **unit**, the space acorn's offsets index. Walking code points (`[...source]`) shifts every range after the first astral character, and this repo's suites are full of emoji. Reverting that one line reds the test.

**Defect 2** — the partition assertion is run against the real population plus a synthetic `syntheticNewExport`: it must throw, and must pass once the synthetic name is classified.

Runs:

- `node --test test/fuzz-coverage.test.mjs test/confusable-host-property.test.mjs` — 106/106 pass
- `node --test test/*.test.mjs` — 4150/4150 pass (repeated 5 clean runs)
- `pnpm check` (both tsconfigs) and `eslint`/`prettier` clean

## Review follow-up (two findings, both fixed)

**`TODO:` exemptions were an unbounded escape hatch.** The gate only asserted `reason.length > 0` for a `FUZZ_EXEMPT` entry, so a `TODO:`-prefixed reason passed as a valid denial — the deferred set could grow silently, and a name could be *demoted* out of `FUZZ_REQUIRED` into a TODO exemption (deleting its property suite) with CI green. Fixed by making the deferral structural: a third frozen map `FUZZ_TODO` now holds the five entries above, `assertPartition` takes an array of parts and asserts `parts.flat()` covers the population with no duplicates, and a new test rejects a name that is both required and deferred.

**The out-of-scope reason for `confusable-host-property.test.mjs` was inaccurate.** It read "reads hostnames the WHATWG URL parser already resolved, not raw text" — that describes `confusableHost`, a different function. This suite's first property feeds raw `fc.string` output straight into `detectConfusableHosts`, which runs `needsUrlScan` and a markdown parse over that raw text. Fixed to "Layer 3 reads link destinations in documents Layer 1 has already cleaned," and the entry moved out of the "offset and table engines" group (whose header claims "never raw untrusted bytes" — false for this suite) into "post-Layer-1 consumers," where reason and group now agree.

**Non-vacuity for the structural fix**, mutations applied to the real file:

| Mutation | Result |
|---|---|
| A: a required name added to `FUZZ_TODO` while still in `FUZZ_REQUIRED` (demotion-with-leftover) | 3 tests fail |
| B: a name deleted from `FUZZ_EXEMPT` (in none of the three buckets) | 3 tests fail |
| C: a reason rewritten to `"TODO: owes a property suite"` inside `FUZZ_EXEMPT` | 1 test fails |
| D: an honest demotion — moved out of `FUZZ_REQUIRED` into `FUZZ_TODO` | passes (legal, as designed), but the semantic partition catches the now-stale `SEMANTIC_FUZZ_EXEMPT` entry — a demotion cannot land as a one-line edit |
| Unmutated | 100/100 pass |

## Unrelated flake, not this PR's

`test/hook-latency.test.mjs` fails intermittently under CPU contention (wall-clock budget assertions land on different cases each run); it passes standalone and imports nothing this PR touches. PR #333 (`fix(test): charge the hook latency gates in CPU time, not wall clock`) is already open against that exact class of failure.

## Decisions made

- **The acorn walk stays inside `test/fuzz-coverage.test.mjs`** rather than moving to a shared `test/helpers/js-ast.mjs`. It has exactly one consumer, and the existing `.hooks/lib/guarded-data-scan.mjs` answers a different question (import graph and path resolution, for scheduling guard tests) — sharing would mean an abstraction with one caller plus a second caller that wants none of it. If a second consumer appears, that is the moment to lift it. *Alternative:* extract now, and pay a shared module whose only caller is this gate.
- **`IN_SCOPE` got the same treatment as `FUZZ_REQUIRED`.** The argument holds: a new fuzz suite for a raw-byte entry point can land with an input domain that never reaches the dangerous bytes, which is exactly the U+009B trap. The cost is 25 reasons, each written from the suite's own file header. *Alternative:* leave `IN_SCOPE` one-directional and accept that a new suite is gated by nothing.
- **`detectConfusableHosts` is `SEMANTIC_FUZZ_EXEMPT`.** Its precision is already pinned exactly by the 52-label benign / 11-label attack corpus in `confusable-host.test.mjs`; a `*-semantic-fuzz` suite would restate that corpus.
- **The threat-alphabet `IN_SCOPE` set is unchanged.** `invisible-property.test.mjs` seeds 6 of the 14 alphabet members and arguably owes the invisible half, but adding it would mean editing a suite this PR does not own. It is in `OUT_OF_SCOPE` with an honest reason naming the alphabet it does fuzz (the ZWNJ/ZWJ carve-out's own).
- **Added a fourth assertion beyond the review's spec**: `no FUZZ_EXEMPT reason reads as a deferral` (`/^(todo|fixme)\b/i`). The structural `FUZZ_TODO` map alone leaves nothing mechanically stopping the same `TODO:` prose from reappearing inside `FUZZ_EXEMPT` itself. It is a validity check on the list's own data, in the same family as the neighbouring `reason.length > 0`, not a copies-agree drift guard. Kept non-vacuous with two positive markers: the shape must match a synthetic `"TODO: …"` reason, and `FUZZ_TODO` must be non-empty. *Alternative:* drop it and rely on the structural map alone, which mutation C above shows is insufficient.
- **Regrouped the `confusable-host-property.test.mjs` entry** in `OUT_OF_SCOPE` rather than only rewriting its reason, since the old group's header comment asserts the very thing the finding disproves.

## Checklist

- [x] Commits follow Conventional Commits; each subject reads as a user-facing release note.
- [x] `pnpm test`, `pnpm lint`, and `pnpm check` pass locally (see the hook-latency note above).
- [x] New or changed detectors have negative tests (zero findings on legitimate input) and pin their invariants with property/fuzz tests.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version are left untouched.
