### PR TITLE
fix(bundle): parse the bundle to find its runtime require() calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@stryker-mutator/tap-runner": "^9.6.1",
     "@types/node": "25.9.1",
     "acorn": "^8.18.0",
+    "acorn-walk": "^8.3.5",
     "agent-sanitizer": "link:.",
     "bun": "1.3.11",
     "c8": "11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       acorn:
         specifier: ^8.18.0
         version: 8.18.0
+      acorn-walk:
+        specifier: ^8.3.5
+        version: 8.3.5
       agent-sanitizer:
         specifier: link:.
         version: 'link:'
@@ -897,6 +900,10 @@ packages:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
 
   acorn@8.18.0:
     resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
@@ -2927,6 +2934,10 @@ snapshots:
       eslint-visitor-keys: 5.0.1
 
   acorn-jsx@5.3.2(acorn@8.18.0):
+    dependencies:
+      acorn: 8.18.0
+
+  acorn-walk@8.3.5:
     dependencies:
       acorn: 8.18.0
 

--- a/scripts/lib/bundle-esbuild.mjs
+++ b/scripts/lib/bundle-esbuild.mjs
@@ -22,12 +22,15 @@
  *      the build rather than by a user.
  *
  * `BUNDLE_TARGETS` is the single list of shipped entries; add an entry here and
- * the contract test in `test/bundle-hardening.test.mjs` covers it automatically.
+ * the contract test in `bundle-hardening.test.mjs` beside it covers that entry
+ * automatically.
  */
 import { readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { parse } from "acorn";
+import { simple } from "acorn-walk";
 import { build } from "esbuild";
 
 /** Repo root (this module lives at scripts/lib/). */
@@ -70,6 +73,14 @@ const inlineRuntimeJsonRequires = {
 };
 
 /**
+ * Reported in place of a specifier whose value the bundle decides at runtime.
+ * No allowlist may contain it, so such a call always fails the build: a
+ * specifier the build cannot read is a specifier the build cannot prove
+ * resolvable in a deployment that has no node_modules.
+ */
+export const COMPUTED_SPECIFIER = "<computed>";
+
+/**
  * Fail the build on any runtime require the shipped artifact could not resolve.
  * This is the general guard: the rewrite above handles the shape we know, and
  * this refuses to ship the shape we do not.
@@ -79,26 +90,69 @@ const inlineRuntimeJsonRequires = {
 export function assertNoRuntimeRequires(text, allowedRuntimeRequires) {
   const allowed = new Set(allowedRuntimeRequires);
   const survivors = runtimeRequires(text).filter((spec) => !allowed.has(spec));
-  if (survivors.length > 0)
-    throw new Error(
-      `bundle keeps runtime require() of: ${survivors.join(", ")}. ` +
-        "A shipped bundle has no node_modules and no sibling data files, so " +
-        "these throw on first use. Inline them at build time.",
-    );
+  if (survivors.length === 0) return;
+  const computed = survivors.includes(COMPUTED_SPECIFIER)
+    ? ` ${COMPUTED_SPECIFIER} means the call's argument is not a string literal, so the build cannot prove what it resolves to.`
+    : "";
+  throw new Error(
+    `bundle keeps runtime require() of: ${survivors.join(", ")}. ` +
+      "A shipped bundle has no node_modules and no sibling data files, so " +
+      "these throw on first use. Inline them at build time." +
+      computed,
+  );
+}
+
+/** esbuild renames the require shim (`require2(…)`), hence the digit suffix. */
+const RUNTIME_REQUIRE_CALLEE = /^require\d*$/;
+
+/**
+ * The specifier a `require()` call names, or `COMPUTED_SPECIFIER` when the
+ * argument is anything other than a single string literal — a variable, a
+ * template literal, a concatenation, or no argument at all.
+ * @param {import("acorn").CallExpression} node
+ * @returns {string}
+ */
+function requireSpecifier(node) {
+  const [arg, ...rest] = node.arguments;
+  if (
+    rest.length === 0 &&
+    arg?.type === "Literal" &&
+    typeof arg.value === "string"
+  )
+    return arg.value;
+  return COMPUTED_SPECIFIER;
 }
 
 /**
  * The distinct specifiers the artifact still hands to a runtime `require()`.
- * esbuild renames the shim (`require2(…)`), hence the digit suffix.
+ *
+ * Parses the bundle rather than scanning it, because "is this a call" is a
+ * question about JavaScript structure. A text scan answers it wrong in both
+ * directions on inputs this build produces: `inlineRuntimeJsonRequires` splices
+ * dependency JSON into the bundle and `legalComments: "eof"` appends third-party
+ * comments to it, so a `require("x")` mentioned inside a string or a comment
+ * reads as a real call; and `minify: false` lets esbuild wrap a long argument
+ * list onto its own line, so a real call reads as nothing at all.
+ *
+ * A parse error propagates: a bundle that is not valid ESM is a build failure,
+ * not a bundle with no requires.
+ *
  * @param {string} text
  * @returns {string[]}
  */
 export function runtimeRequires(text) {
-  return [
-    ...new Set(
-      [...text.matchAll(/\brequire\d*\((['"])([^'"]+)\1\)/g)].map((m) => m[2]),
-    ),
-  ];
+  /** @type {Set<string>} */
+  const found = new Set();
+  simple(parse(text, { sourceType: "module", ecmaVersion: "latest" }), {
+    CallExpression(node) {
+      if (
+        node.callee.type === "Identifier" &&
+        RUNTIME_REQUIRE_CALLEE.test(node.callee.name)
+      )
+        found.add(requireSpecifier(node));
+    },
+  });
+  return [...found];
 }
 
 /**

--- a/scripts/lib/bundle-hardening.test.mjs
+++ b/scripts/lib/bundle-hardening.test.mjs
@@ -30,6 +30,7 @@ import { layer2Placeholder } from "../../src/html.mjs";
 
 import {
   BUNDLE_TARGETS,
+  COMPUTED_SPECIFIER,
   assertNoRuntimeRequires,
   bundleHardened,
   bundleTarget,
@@ -214,6 +215,86 @@ for (const target of BUNDLE_TARGETS) {
     assert.equal(SMOKE_DRIVERS[target.name](t, artifact), expected);
   });
 }
+
+/**
+ * What `runtimeRequires` must answer on the shapes this build actually emits.
+ * Each case is a source form a text scan gets wrong in one direction or the
+ * other; naming which one it is here is what keeps the case from being
+ * redundant with its neighbours.
+ * @type {readonly [string, string, readonly string[]][]}
+ */
+const REQUIRE_SHAPES = [
+  // esbuild pretty-prints (`minify: false`), so it wraps a long argument list
+  // onto its own line. This is the reachable false negative: a wrapped require
+  // in a future dependency would pass the guard and ship.
+  [
+    "wrapped across lines",
+    'require2(\n  "./data/patch.json"\n)',
+    ["./data/patch.json"],
+  ],
+  // The positive control: the one shape a text scan already got right, so a
+  // table that failed on every row would be visible as a bug in the table.
+  [
+    "single line",
+    'var patch = require2("./data/patch.json");',
+    ["./data/patch.json"],
+  ],
+  // The three computed shapes. None can be allowlisted, so each fails the build.
+  [
+    "variable specifier",
+    'const p = "./data/patch.json"; require2(p);',
+    [COMPUTED_SPECIFIER],
+  ],
+  [
+    "template literal",
+    "require2(`./data/${name}.json`);",
+    [COMPUTED_SPECIFIER],
+  ],
+  [
+    "concatenation",
+    'require2("./data/" + name + ".json");',
+    [COMPUTED_SPECIFIER],
+  ],
+  // The two probes every text scanner must survive. `inlineRuntimeJsonRequires`
+  // splices dependency JSON into the bundle and `legalComments: "eof"` appends
+  // third-party comments to it, so both shapes are present in shipped bytes.
+  [
+    "inside a string literal",
+    'var json = {"note": "require(\'left-pad\')"};',
+    [],
+  ],
+  ["inside a comment", '// TODO: require("left-pad") here\n', []],
+];
+
+for (const [shape, source, expected] of REQUIRE_SHAPES)
+  test(`runtimeRequires reads a require ${shape}`, () => {
+    assert.deepEqual(runtimeRequires(source), [...expected]);
+  });
+
+test("a computed specifier fails the build", () => {
+  // The whole point of reporting `<computed>`: an allowlist cannot contain it,
+  // so a require whose target the build cannot read is refused rather than
+  // passed. The wide allowlist proves the refusal is not an allowlist miss.
+  assert.throws(
+    () =>
+      assertNoRuntimeRequires('const p = "./data/patch.json"; require2(p);', [
+        "./data/patch.json",
+        "namespace-guard",
+      ]),
+    /runtime require\(\) of: <computed>.*not a string literal/s,
+  );
+  // The explanation of `<computed>` stays out of a message that has no computed
+  // survivor to explain.
+  assert.throws(
+    () => assertNoRuntimeRequires('require2("../data/patch.json");', []),
+    (err) => !/not a string literal/.test(err.message),
+  );
+});
+
+test("a bundle that is not valid ESM fails loud", () => {
+  // A parse error must not read as "this bundle has no runtime requires".
+  assert.throws(() => runtimeRequires("const = ;"), SyntaxError);
+});
 
 test("the require guard rejects a survivor and accepts the allowlist", () => {
   // The guard is what makes a would-be-broken bundle unwritable, so prove it


### PR DESCRIPTION
Claimed area: `scripts/lib/bundle-esbuild.mjs` + `scripts/lib/bundle-hardening.test.mjs` (plus `package.json`/`pnpm-lock.yaml` for one dev dependency).

## Summary

`runtimeRequires` is the reader behind the build gate that refuses to ship a bundle keeping an unresolvable runtime `require()` — the guard that exists because css-tree's `createRequire(...)("../data/patch.json")` once shipped and killed Layer 2 for every WebFetch result. It answered a question about JavaScript structure with a regex over the bundle text, and was wrong in **both** directions on bytes this build actually emits.

It missed real calls, so a broken bundle could pass and ship:

| input | before | after |
| --- | --- | --- |
| `require2(\n  "./data/patch.json"\n)` | `[]` | `["./data/patch.json"]` |
| `const p="./data/patch.json"; require2(p)` | `[]` | `["<computed>"]` |
| `` require2(`./data/${name}.json`) `` | `[]` | `["<computed>"]` |
| `require2("./data/" + name + ".json")` | `[]` | `["<computed>"]` |

It also invented calls that do not exist, so a correct bundle could fail:

| input | before | after |
| --- | --- | --- |
| `var json = {"note": "require('left-pad')"};` | `["left-pad"]` | `[]` |
| `// TODO: require("left-pad") here` | `["left-pad"]` | `[]` |

Every row is reachable, not hypothetical. `bundleHardened` sets `minify: false`, so esbuild pretty-prints and wraps a long argument list onto its own line — that is the first row, and it is the one that would let the next dependency reship the css-tree defect with a green build. `inlineRuntimeJsonRequires` splices dependency JSON **into** the bundle text and `legalComments: "eof"` appends third-party comments to it, which is where the last two rows come from.

## Changes

- `runtimeRequires` parses with `acorn` (`sourceType: "module"`, `ecmaVersion: "latest"`) and walks with `acorn-walk` for a `CallExpression` whose callee is an `Identifier` matching `/^require\d*$/`. Strings and comments are not call expressions, so both false positives disappear by construction rather than by a widened matcher.
- A literal specifier is reported as before. A **non-literal** argument — a variable, a template literal, a concatenation, no argument at all — is reported as the new exported `COMPUTED_SPECIFIER` (`"<computed>"`). No allowlist can contain it, so a require the build cannot resolve fails the build **loudly**. This is what makes the docstring's promise to "refuse the shape we do not know" true.
- A parse error propagates: a bundle that is not valid ESM is a build failure, not a bundle with no requires.
- `acorn-walk` added as a dev dependency (`acorn` was already one).

## Tests / verification

New cases in `scripts/lib/bundle-hardening.test.mjs`:

- A table over the seven source shapes above, including the two probes every text scanner must survive — the idiom inside a string literal and inside a comment — each asserting zero findings.
- `a computed specifier fails the build`: `assertNoRuntimeRequires` throws on `require2(p)` even when the allowlist contains the string the variable holds, so the refusal is proven to come from the computed shape and not from an allowlist miss.
- `a bundle that is not valid ESM fails loud`.

**Non-vacuity, measured rather than asserted.** I restored the pre-fix regex body (keeping the new export so the file still imported) and re-ran the suite: 8 of the 9 new assertions failed. The ninth, `single line`, is a deliberate positive control — it is the one shape the regex already got right, so a table failing on every row would be visible as a bug in the table. Its comment says so.

**Parse cost.** Measured on the two real artifacts, median of 5 runs:

| target | bundle | esbuild run | parse + walk |
| --- | --- | --- | --- |
| `plugin-hooks` | 2.41 MB | ~990 ms | ~300 ms |
| `python-cli` | 2.16 MB | ~550 ms | ~240 ms |

Roughly a third of the esbuild run it already guards, on a build step. Not a problem.

**Suites run:**

- `node --test scripts/lib/bundle-hardening.test.mjs` — 18/18 pass.
- `node --test plugin/test/plugin-bundle.test.mjs` — 100/100 pass.
- `node --test test/*.test.mjs` — 4125/4132 pass. The 7 reds are the wall-clock latency and 256 KB budget gates; they fail identically on a clean checkout of this branch's base in the same sandbox, the failing subset changes between runs, and PR #333 is fixing exactly that class. `test/` does not import this module.
- `pnpm lint`, `pnpm check`, `prettier --check` all clean.
- `node plugin/scripts/build-plugin.mjs` and `node scripts/bundle-python-cli.mjs` both succeed end to end and report the artifacts already current — the guard does not falsely trip, and neither `plugin/dist/**` nor the wheel's bundled CLI was dirtied, so nothing regenerated is committed here.

## Decisions made

- **`acorn-walk` added rather than a hand-rolled walker.** The first draft walked the tree with its own explicit stack. That is a reimplementation of a library that already owns the job, and it failed `tsc --noEmit` on the untyped node values it had to carry. `acorn-walk` is smaller, ~5x faster on these bundles, and typed. Cost: it touches `package.json` and `pnpm-lock.yaml`, which sibling branches may also touch. Under the alternative the diff stays inside the two files I own, at the price of a hand-rolled walker plus casts to satisfy the type checker.
- **A computed specifier reports one opaque token rather than the source text of the argument.** `"<computed>"` cannot collide with a real specifier and cannot be allowlisted. Under the alternative the message names the exact expression, which reads better in a build log but invites someone to allowlist it.

## Checklist

- [x] Commits follow Conventional Commits; the subject reads as a user-facing release note.
- [x] `pnpm lint` and `pnpm check` pass locally; the bundle suites pass (see above for the pre-existing latency reds).
- [x] The new detector has negative tests — the string-literal and comment probes assert zero findings on legitimate bundle content.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json`'s version are untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VvuJNE8pEstzwvSmir592V)_