### PR TITLE
fix(hooks): report a slow hook's CPU time and stop blaming the sanitizer for a busy host

### DIFF
--- a/claude-hooks/lib/control-plane.mjs
+++ b/claude-hooks/lib/control-plane.mjs
@@ -170,8 +170,8 @@ export async function runJudgeCli(
   // on the success path hides exactly the case where the hook is both slow and
   // broken. Null until stdin arrives — a read that throws measured nothing, and
   // an invented number is worse than none.
-  /** @type {(() => number) | null} */
-  let elapsed = null;
+  /** @type {ReturnType<typeof startHookTimer> | null} */
+  let timer = null;
   /** @type {number | null} */
   let payloadBytes = null;
   /** @type {string | null} */
@@ -185,18 +185,19 @@ export async function runJudgeCli(
     // Timed from HERE, not from process start: the wait for the harness to hand
     // over stdin is not this hook's cost, and blaming it for one would send
     // operators chasing a bug report that is not theirs to fix.
-    elapsed = startHookTimer();
+    timer = startHookTimer();
     const { claudeAdapter: adapter } = controlPlane();
     const event = adapter.parse(transformInput(input));
     tool = event.tool ?? null;
-    // Awaited into its own binding first: as an inline argument, `elapsed()`
+    // Awaited into its own binding first: as an inline argument, the timer read
     // would be evaluated BEFORE the judge it is supposed to be timing.
     const judged = await judge(event);
     const out = nativeStdout(
       adapter.render(
-        withSlowHookNotice(hookName, elapsed(), judged, undefined, {
+        withSlowHookNotice(hookName, timer.wallMs(), judged, undefined, {
           payloadBytes,
           tool,
+          cpuMs: timer.cpuMs(),
         }),
         event,
       ),
@@ -208,10 +209,11 @@ export async function runJudgeCli(
     // must act on first, and the timing is context for it. stderr only — the
     // model-facing channel here belongs to onError's fail-closed message, and a
     // performance aside must not dilute a "this output was never vetted".
-    if (elapsed !== null)
-      writeSlowHookNotice(hookName, elapsed(), undefined, {
+    if (timer !== null)
+      writeSlowHookNotice(hookName, timer.wallMs(), undefined, {
         payloadBytes,
         tool,
+        cpuMs: timer.cpuMs(),
       });
     onError(err, input);
   }

--- a/claude-hooks/lib/hook-timing.mjs
+++ b/claude-hooks/lib/hook-timing.mjs
@@ -1,24 +1,24 @@
 /**
- * The one place a hook's own wall-clock cost is measured and reported.
+ * The one place a hook's own cost is measured and reported — one threshold, one
+ * message, one merge rule, shared by every hook.
  *
- * These hooks sit on the critical path of every tool call, every prompt and
- * every session start: whatever they spend, the user waits. That cost is also
- * the hardest kind of bug to notice from inside — a hook that got slow looks
- * exactly like an agent that got slow, so it goes unreported for weeks (one
- * SessionStart scan blocked startup for 30 SECONDS before anyone traced it back
- * here). A hook past the budget therefore says so IN BAND, in the model's
- * context, where it cannot be missed and can be relayed to the operator.
+ * These hooks sit on the critical path of every tool call, prompt and session
+ * start: whatever they spend, the user waits. A slow hook is also the hardest
+ * bug to notice from inside — it looks exactly like a slow agent, so it goes
+ * unreported for weeks (one SessionStart scan blocked startup for 30 SECONDS
+ * before anyone traced it back here). A hook past the budget therefore says so
+ * IN BAND, in the model's context, where it can be relayed to the operator.
  *
- * One threshold, one message, one merge rule, shared by every hook — the
- * measurement is worthless if each hook words it differently or picks its own
- * bar for "slow".
+ * TWO numbers, because wall-clock alone cannot say whose cost it is: a hook on
+ * a contended host waits far longer than it computes (a 1.1 KB payload and a
+ * 235 KB one both reported 7.2s on a loaded 2-vCPU box, against 0.3s of work).
+ * So the notice prints CPU beside the clock — the share every affected call
+ * repeats — and never GATES on it: a hook wedged on a dead redactor socket
+ * burns no CPU and is exactly the sanitizer's fault.
  *
- * What it deliberately does NOT count is ONE-TIME PROVISIONING (see
- * {@link excludeProvisioning}). A dependency-install wait or a cold redactor
- * spawn is wall-clock the user really waits, but it is not a cost this hook
- * pays per call and it is not a bug worth a report — charging it would make the
- * FIRST call of every session cry wolf, which is precisely the alert fatigue
- * this notice exists to avoid.
+ * ONE-TIME PROVISIONING is excluded (see {@link excludeProvisioning}): charging
+ * an install to the hook that merely waited it out would make the FIRST call of
+ * every session cry wolf, which is the alert fatigue this notice fights.
  *
  * Dependency-free on purpose: everything imports this, including hook-io, so a
  * back-import would close a cycle. The one emitter it needs is passed in.
@@ -29,8 +29,9 @@
  *
  * A second is far above anything these hooks do when healthy (Layer 1 is a few
  * regex passes; the redactor daemon answers in tens of milliseconds once warm)
- * and far below the point where a human is merely impatient — so crossing it
- * means something is actually wrong, not that the machine is busy.
+ * and far below the point where a human is merely impatient. Crossing it means
+ * the user waited that long, which is worth saying either way; whether the
+ * sanitizer or a busy machine spent it is what the CPU figure answers.
  */
 export const SLOW_HOOK_THRESHOLD_MS = 1000;
 
@@ -89,13 +90,22 @@ export function formatBytes(bytes) {
  * that made this specific latency report take a manual multi-step
  * investigation to characterize (which tool call, how large a payload) before
  * anyone could act on it.
- * @typedef {{ payloadBytes?: number | null, tool?: string | null }} SlowHookContext
+ * `cpuMs` is the run's own processor time (see {@link startHookTimer}); absent
+ * when the caller has no way to measure it, which is what the shell port of
+ * this module reports.
+ * @typedef {{
+ *   payloadBytes?: number | null,
+ *   tool?: string | null,
+ *   cpuMs?: number | null,
+ * }} SlowHookContext
  */
 
 /**
- * The parenthetical clause naming `context`'s known fields, or `""` when
- * `context` is absent or carries neither — so a caller with no context to give
- * gets the exact same notice text as before this existed.
+ * The parenthetical clause naming `context`'s payload size and tool, or `""`
+ * when neither is known — so a caller with nothing to name gets the same notice
+ * text as one that passes no context at all. `cpuMs` is deliberately not here:
+ * it needs the sentence {@link slowHookNotice} gives it, not a bare number in a
+ * list of what was slow.
  * @param {SlowHookContext | undefined} [context]
  * @returns {string}
  */
@@ -108,10 +118,25 @@ function formatContextSuffix(context) {
   return parts.length > 0 ? ` (${parts.join(", ")})` : "";
 }
 
-// Process-wide total of milliseconds spent in one-time provisioning. A running
-// total rather than a flag because a single hook run can pay more than one (a
-// dependency wait AND a cold daemon spawn), and they may not nest.
+/**
+ * This process's own user+system processor time so far, in milliseconds.
+ *
+ * `process.cpuUsage()` is RUSAGE_SELF: it counts what this node process
+ * computed and excludes both idle waiting and any child process. That is
+ * exactly the split the notice needs — a hook blocked on a socket, a lock or a
+ * loaded scheduler adds wall-clock here and no CPU.
+ * @returns {number}
+ */
+function processCpuMs() {
+  const { user, system } = process.cpuUsage();
+  return (user + system) / 1000;
+}
+
+// Process-wide totals of wall-clock and CPU spent in one-time provisioning. A
+// running total rather than a flag because a single hook run can pay more than
+// one (a dependency wait AND a cold daemon spawn), and they may not nest.
 let provisioningMs = 0;
+let provisioningCpuMs = 0;
 
 /**
  * Run `work`, charging its whole duration to provisioning so no timer running
@@ -119,53 +144,85 @@ let provisioningMs = 0;
  * that FAILS is still excluded — the wait happened either way, and a hook that
  * then fails is reported through its fault posture, not as "slow".
  *
+ * Its CPU is charged too, not just its wall-clock: the lazy dependency import
+ * this wraps is real in-process work, so leaving it in would hand the first
+ * call of every session a CPU figure it did not spend.
+ *
  * Wrap only genuinely one-time, per-session setup: waiting out a dependency
  * install, waiting for a cold redactor daemon to bind. Never wrap the hook's
  * actual work — that is exactly what this measurement is for.
  * @template T
  * @param {() => Promise<T>} work
  * @param {() => number} [now]  injectable clock, for tests
+ * @param {() => number} [cpuNow]  injectable CPU clock, for tests
  * @returns {Promise<T>}
  */
-export async function excludeProvisioning(work, now = Date.now) {
+export async function excludeProvisioning(
+  work,
+  now = Date.now,
+  cpuNow = processCpuMs,
+) {
   const started = now();
+  const cpuStarted = cpuNow();
   try {
     return await work();
   } finally {
     provisioningMs += Math.max(0, now() - started);
+    provisioningCpuMs += Math.max(0, cpuNow() - cpuStarted);
   }
 }
 
 /**
- * Start measuring; the returned function reports the milliseconds elapsed so
- * far MINUS any provisioning charged in the meantime, and may be called more
+ * Start measuring; each reader on the returned object reports what has elapsed
+ * so far MINUS any provisioning charged in the meantime, and may be called more
  * than once.
+ *
+ * `wallMs` is what the user waited and `cpuMs` is what this process actually
+ * computed. Both are needed to say whose cost a slow run is — see the module
+ * header for the report that read a contended host as a sanitizer bug.
  *
  * Only provisioning charged since this timer started is subtracted, so an
  * earlier run's cold start cannot pay down a later run's real cost. A
  * provisioning window that straddles the timer's start would otherwise be able
- * to subtract more than the timer has measured, so the result is floored at 0.
+ * to subtract more than the timer has measured, so both results are floored
+ * at 0.
  * @param {() => number} [now]  injectable clock, for tests
- * @returns {() => number}
+ * @param {() => number} [cpuNow]  injectable CPU clock, for tests
+ * @returns {{ wallMs: () => number, cpuMs: () => number }}
  */
-export function startHookTimer(now = Date.now) {
+export function startHookTimer(now = Date.now, cpuNow = processCpuMs) {
   const started = now();
+  const cpuStarted = cpuNow();
   const provisionedBefore = provisioningMs;
-  return () =>
-    Math.max(0, now() - started - (provisioningMs - provisionedBefore));
+  const provisionedCpuBefore = provisioningCpuMs;
+  return {
+    wallMs: () =>
+      Math.max(0, now() - started - (provisioningMs - provisionedBefore)),
+    cpuMs: () =>
+      Math.max(
+        0,
+        cpuNow() - cpuStarted - (provisioningCpuMs - provisionedCpuBefore),
+      ),
+  };
 }
 
 /**
  * The model-facing line for a hook that overran the budget, or null when it did
  * not. Addressed to the model because the model is the only party that reliably
  * reads this channel — stderr from a non-blocking hook is easy to miss — and it
- * is asked to relay the number, since the operator is the one who can file it.
+ * is asked to relay the numbers, since the operator is the one who can file it.
+ *
+ * With `context.cpuMs` in hand the line says which share of the wait was the
+ * sanitizer computing. Without it the line says that it cannot tell, rather
+ * than asserting an attribution nothing measured: a wall-clock overrun on a
+ * loaded host is the common case, and blaming it on the sanitizer sends the
+ * operator hunting a per-call cost that does not exist.
  * @param {string} hookName
  * @param {number} elapsedMs
  * @param {number} [thresholdMs]
- * @param {SlowHookContext} [context]  known payload size / triggering tool, so
- *   the notice is self-diagnosing rather than requiring the next reader to
- *   reconstruct what was slow by hand
+ * @param {SlowHookContext} [context]  known CPU time / payload size /
+ *   triggering tool, so the notice is self-diagnosing rather than requiring the
+ *   next reader to reconstruct what was slow by hand
  * @returns {string | null}
  */
 export function slowHookNotice(
@@ -175,11 +232,17 @@ export function slowHookNotice(
   context,
 ) {
   if (elapsedMs <= thresholdMs) return null;
+  const cpuMs = context?.cpuMs;
+  const attribution =
+    typeof cpuMs === "number"
+      ? `, and used ${formatSeconds(cpuMs)}s of CPU. ` +
+        "Only the CPU share is work every affected call repeats; the rest was waiting on a busy machine."
+      : ". Wall-clock alone cannot separate the sanitizer's own work from a busy machine.";
   return (
     `agent-sanitizer PERFORMANCE: the ${hookName} hook took ` +
-    `${formatSeconds(elapsedMs)}s${formatContextSuffix(context)}, over its ${formatSeconds(thresholdMs)}s budget — ` +
-    "this delay is the sanitizer's, not the model's, and every affected call pays it. " +
-    `Tell the user, and suggest they report it at ${ISSUE_URL} with the hook name and timing.`
+    `${formatSeconds(elapsedMs)}s${formatContextSuffix(context)}, over its ${formatSeconds(thresholdMs)}s budget${attribution} ` +
+    `Tell the user, and suggest they report it at ${ISSUE_URL} with the hook name and ` +
+    `${typeof cpuMs === "number" ? "both timings" : "timing"}.`
   );
 }
 
@@ -188,11 +251,11 @@ export function slowHookNotice(
  * {@link SLOW_PROVISION_THRESHOLD_MS}, or null when it did not.
  *
  * Deliberately NOT {@link slowHookNotice} with a bigger threshold: that message
- * says "every affected call pays it", which is false here and would send the
- * reader hunting a per-call cost that does not exist. What is actionable about a
- * slow install is the installer (uv resolves in a fraction of pip's time) and
- * the fact that a repeat means the idempotence check is broken — so this asks
- * for a report only on the repeat, which is the version of this that is a bug.
+ * splits the wait into a per-call share and machine contention, and neither
+ * reading is the one to take away here. What is actionable about a slow install
+ * is the installer (uv resolves in a fraction of pip's time) and the fact that a
+ * repeat means the idempotence check is broken — so this asks for a report only
+ * on the repeat, which is the version of this that is a bug.
  *
  * The one caller is the shell provisioner, whose port of this module
  * (plugin/scripts/lib/hook-timing.sh) must emit this exact string; that port and
@@ -294,6 +357,7 @@ export function withSlowHookNotice(
  *   stdout envelope writer (hook-io's emitHookResponse); passed in rather than
  *   imported so this module stays dependency-free — see the module doc
  * @param {(chunk: string) => void} [writeErr]  injectable stderr sink, for tests
+ * @param {SlowHookContext} [context]  see {@link slowHookNotice}
  * @returns {boolean}  whether a notice was emitted
  */
 export function reportSlowHook(
@@ -302,8 +366,9 @@ export function reportSlowHook(
   hookEventName,
   emit,
   writeErr = (chunk) => process.stderr.write(chunk),
+  context,
 ) {
-  const notice = writeSlowHookNotice(hookName, elapsedMs, writeErr);
+  const notice = writeSlowHookNotice(hookName, elapsedMs, writeErr, context);
   if (notice === null) return false;
   emit(hookEventName, { additionalContext: notice });
   return true;

--- a/claude-hooks/scan-invisible-chars.mjs
+++ b/claude-hooks/scan-invisible-chars.mjs
@@ -412,15 +412,17 @@ export async function cliMain(opts = {}) {
   // inside — it reads as "Claude is slow to start". Timing the whole body and
   // reporting an overrun in band is what turned a 30-second scan from a rumor
   // into a bug report (see lib/hook-timing.mjs).
-  const elapsed = startHookTimer();
+  const timer = startHookTimer();
   try {
     await runScanCli(opts);
   } finally {
     reportSlowHook(
       HOOK_NAME,
-      elapsed(),
+      timer.wallMs(),
       HookEvent.SESSION_START,
       emitHookResponse,
+      undefined,
+      { cpuMs: timer.cpuMs() },
     );
   }
 }

--- a/claude-hooks/scan-loaded-instructions.mjs
+++ b/claude-hooks/scan-loaded-instructions.mjs
@@ -257,7 +257,7 @@ export { HOOK_NAME };
  * @returns {Promise<void>}
  */
 export async function cliMain({ trace: sink = trace } = {}) {
-  const elapsed = startHookTimer();
+  const timer = startHookTimer();
   const emitTrace = bestEffortTrace(sink);
   try {
     const payload = await readStdinJson();
@@ -310,9 +310,11 @@ export async function cliMain({ trace: sink = trace } = {}) {
   } finally {
     reportSlowHook(
       HOOK_NAME,
-      elapsed(),
+      timer.wallMs(),
       HookEvent.INSTRUCTIONS_LOADED,
       emitHookResponse,
+      undefined,
+      { cpuMs: timer.cpuMs() },
     );
   }
 }

--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=b24050bdbce5ecee6c85c3e3a5f71b8124964462f2627f5fcd65bd2540acd749
-ca855921f165867e73696e6b614dd9bd5f573b993d5d2e6c576013ca7992aac0  agent-sanitizer-hooks-darwin-arm64
-d527b879872161cca0f9c21da0d139c94a10999609fccd033442bbfe46d5a13d  agent-sanitizer-hooks-darwin-x64
-be96ac09af5c515df0d27d21f7fd37e5c91427484b24c11639c2e68fece69a2e  agent-sanitizer-hooks-linux-arm64
-0b1395a23d2c84757cc4c4191dccb6cc3360ee9fd0c8ecc049b9eba87f5adc88  agent-sanitizer-hooks-linux-x64
+# bundle=e981a6af405d515205b5c79c6b12ff5bcb548301b53a3be25ab1fe604ca891cc
+545544465c2f6d8ed8c46cfd0d44d03d4c0603474328a23ce93f9cc08e98a4aa  agent-sanitizer-hooks-darwin-arm64
+66afe47c1e44dd98a3e57a489f02eeda73659d3e01109395e2436fe30fb3d3c2  agent-sanitizer-hooks-darwin-x64
+1788f88bf45c27762a409adf67ad2b982e462928cebf05aac0b7003c5bf80fe4  agent-sanitizer-hooks-linux-arm64
+1ed5bdf47dc584e356707bf72eb111f6f35939c15e5f21904bc7a58e2cf7c4f7  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -61,22 +61,38 @@ function formatContextSuffix(context) {
   if (context.tool) parts2.push(`tool ${context.tool}`);
   return parts2.length > 0 ? ` (${parts2.join(", ")})` : "";
 }
-async function excludeProvisioning(work, now = Date.now) {
+function processCpuMs() {
+  const { user, system } = process.cpuUsage();
+  return (user + system) / 1e3;
+}
+async function excludeProvisioning(work, now = Date.now, cpuNow = processCpuMs) {
   const started = now();
+  const cpuStarted = cpuNow();
   try {
     return await work();
   } finally {
     provisioningMs += Math.max(0, now() - started);
+    provisioningCpuMs += Math.max(0, cpuNow() - cpuStarted);
   }
 }
-function startHookTimer(now = Date.now) {
+function startHookTimer(now = Date.now, cpuNow = processCpuMs) {
   const started = now();
+  const cpuStarted = cpuNow();
   const provisionedBefore = provisioningMs;
-  return () => Math.max(0, now() - started - (provisioningMs - provisionedBefore));
+  const provisionedCpuBefore = provisioningCpuMs;
+  return {
+    wallMs: () => Math.max(0, now() - started - (provisioningMs - provisionedBefore)),
+    cpuMs: () => Math.max(
+      0,
+      cpuNow() - cpuStarted - (provisioningCpuMs - provisionedCpuBefore)
+    )
+  };
 }
 function slowHookNotice(hookName, elapsedMs, thresholdMs = SLOW_HOOK_THRESHOLD_MS, context) {
   if (elapsedMs <= thresholdMs) return null;
-  return `agent-sanitizer PERFORMANCE: the ${hookName} hook took ${formatSeconds(elapsedMs)}s${formatContextSuffix(context)}, over its ${formatSeconds(thresholdMs)}s budget \u2014 this delay is the sanitizer's, not the model's, and every affected call pays it. Tell the user, and suggest they report it at ${ISSUE_URL} with the hook name and timing.`;
+  const cpuMs = context?.cpuMs;
+  const attribution = typeof cpuMs === "number" ? `, and used ${formatSeconds(cpuMs)}s of CPU. Only the CPU share is work every affected call repeats; the rest was waiting on a busy machine.` : ". Wall-clock alone cannot separate the sanitizer's own work from a busy machine.";
+  return `agent-sanitizer PERFORMANCE: the ${hookName} hook took ${formatSeconds(elapsedMs)}s${formatContextSuffix(context)}, over its ${formatSeconds(thresholdMs)}s budget${attribution} Tell the user, and suggest they report it at ${ISSUE_URL} with the hook name and ${typeof cpuMs === "number" ? "both timings" : "timing"}.`;
 }
 function writeSlowHookNotice(hookName, elapsedMs, writeErr = (chunk) => process.stderr.write(chunk), context) {
   const notice = slowHookNotice(hookName, elapsedMs, void 0, context);
@@ -92,19 +108,20 @@ function withSlowHookNotice(hookName, elapsedMs, verdict, writeErr = (chunk) => 
     additional_context: verdict.additional_context ? `${verdict.additional_context} ${notice}` : notice
   };
 }
-function reportSlowHook(hookName, elapsedMs, hookEventName, emit, writeErr = (chunk) => process.stderr.write(chunk)) {
-  const notice = writeSlowHookNotice(hookName, elapsedMs, writeErr);
+function reportSlowHook(hookName, elapsedMs, hookEventName, emit, writeErr = (chunk) => process.stderr.write(chunk), context) {
+  const notice = writeSlowHookNotice(hookName, elapsedMs, writeErr, context);
   if (notice === null) return false;
   emit(hookEventName, { additionalContext: notice });
   return true;
 }
-var SLOW_HOOK_THRESHOLD_MS, ISSUE_URL, provisioningMs;
+var SLOW_HOOK_THRESHOLD_MS, ISSUE_URL, provisioningMs, provisioningCpuMs;
 var init_hook_timing = __esm({
   "claude-hooks/lib/hook-timing.mjs"() {
     "use strict";
     SLOW_HOOK_THRESHOLD_MS = 1e3;
     ISSUE_URL = "https://github.com/AlexanderMattTurner/agent-sanitizer/issues/new";
     provisioningMs = 0;
+    provisioningCpuMs = 0;
   }
 });
 
@@ -66112,22 +66129,23 @@ async function runJudgeCli(hookName, judge, {
   write = (chunk) => process.stdout.write(chunk)
 }) {
   let input;
-  let elapsed = null;
+  let timer = null;
   let payloadBytes = null;
   let tool = null;
   try {
     input = await readInput();
     payloadBytes = readInput === readStdinJson ? lastStdinByteLength() : null;
-    elapsed = startHookTimer();
+    timer = startHookTimer();
     const { claudeAdapter: adapter } = controlPlane();
     const event = adapter.parse(transformInput(input));
     tool = event.tool ?? null;
     const judged = await judge(event);
     const out = nativeStdout(
       adapter.render(
-        withSlowHookNotice(hookName, elapsed(), judged, void 0, {
+        withSlowHookNotice(hookName, timer.wallMs(), judged, void 0, {
           payloadBytes,
-          tool
+          tool,
+          cpuMs: timer.cpuMs()
         }),
         event
       )
@@ -66136,10 +66154,11 @@ async function runJudgeCli(hookName, judge, {
   } catch (err) {
     process.stderr.write(`${hookName} hook error: ${errMessage(err)}
 `);
-    if (elapsed !== null)
-      writeSlowHookNotice(hookName, elapsed(), void 0, {
+    if (timer !== null)
+      writeSlowHookNotice(hookName, timer.wallMs(), void 0, {
         payloadBytes,
-        tool
+        tool,
+        cpuMs: timer.cpuMs()
       });
     onError(err, input);
   }
@@ -68910,15 +68929,17 @@ function formatSkipped(skipped) {
   ].join("\n");
 }
 async function cliMain3(opts = {}) {
-  const elapsed = startHookTimer();
+  const timer = startHookTimer();
   try {
     await runScanCli(opts);
   } finally {
     reportSlowHook(
       HOOK_NAME4,
-      elapsed(),
+      timer.wallMs(),
       HookEvent.SESSION_START,
-      emitHookResponse
+      emitHookResponse,
+      void 0,
+      { cpuMs: timer.cpuMs() }
     );
   }
 }
@@ -69128,7 +69149,7 @@ function loadedFileMessage({ report, cleaned, reason }, filePath) {
 ${tail}`;
 }
 async function cliMain4({ trace: sink = trace } = {}) {
-  const elapsed = startHookTimer();
+  const timer = startHookTimer();
   const emitTrace = bestEffortTrace(sink);
   try {
     const payload = await readStdinJson();
@@ -69171,9 +69192,11 @@ async function cliMain4({ trace: sink = trace } = {}) {
   } finally {
     reportSlowHook(
       HOOK_NAME5,
-      elapsed(),
+      timer.wallMs(),
       HookEvent.INSTRUCTIONS_LOADED,
-      emitHookResponse
+      emitHookResponse,
+      void 0,
+      { cpuMs: timer.cpuMs() }
     );
   }
 }

--- a/plugin/scripts/lib/hook-timing.sh
+++ b/plugin/scripts/lib/hook-timing.sh
@@ -63,10 +63,16 @@ hook_timing_format_seconds() {
 
 # The line for a hook that overran its budget, or nothing when it did not.
 # $1 hook name, $2 elapsed ms, $3 threshold ms (optional).
+#
+# This is the node module's NO-CPU wording, and it is the honest one here. The
+# node timer splits the wait with process.cpuUsage(); bash's nearest equivalent
+# is `times`, and reading it the obvious way — inside a command substitution —
+# forks first and so reports the child's zero. A silently-zero CPU figure is
+# worse than none, so this port says it cannot attribute the wait.
 slow_hook_notice() {
   local name="$1" elapsed="$2" threshold="${3:-$SLOW_HOOK_THRESHOLD_MS}"
   ((elapsed > threshold)) || return 0
-  printf '%s' "agent-sanitizer PERFORMANCE: the ${name} hook took $(hook_timing_format_seconds "$elapsed")s, over its $(hook_timing_format_seconds "$threshold")s budget — this delay is the sanitizer's, not the model's, and every affected call pays it. Tell the user, and suggest they report it at ${HOOK_TIMING_ISSUE_URL} with the hook name and timing."
+  printf '%s' "agent-sanitizer PERFORMANCE: the ${name} hook took $(hook_timing_format_seconds "$elapsed")s, over its $(hook_timing_format_seconds "$threshold")s budget. Wall-clock alone cannot separate the sanitizer's own work from a busy machine. Tell the user, and suggest they report it at ${HOOK_TIMING_ISSUE_URL} with the hook name and timing."
 }
 
 # The line for a ONE-TIME provisioning step that overran its (much larger)

--- a/test/claude-hooks-timing.test.mjs
+++ b/test/claude-hooks-timing.test.mjs
@@ -489,9 +489,17 @@ describe("runJudgeCli times every judge hook", () => {
     assert.match(stdout, /PERFORMANCE/);
     assert.match(stdout, /pretooluse-sanitize/);
     // A judge that SLEPT past the budget is the contended-host case in
-    // miniature: the wall-clock is real and the CPU behind it is nil, and the
+    // miniature: the wall-clock is real, most of it bought no work, and the
     // notice has to say so rather than call the whole second sanitizer work.
-    assert.match(stdout, /used 0\.0s of CPU/);
+    // Compared, not pinned to 0.0s: the same window really does load the
+    // control plane, and on a cold runner that is a tenth of a second of CPU.
+    const timings = stdout.match(/took (\d+\.\d)s .*?used (\d+\.\d)s of CPU/u);
+    assert.ok(timings, stdout);
+    const [, wall, cpu] = timings;
+    assert.ok(
+      Number(cpu) < Number(wall),
+      `a sleeping judge must report CPU (${cpu}s) below wall (${wall}s)`,
+    );
     assert.ok(
       errs.some((line) => line.includes("PERFORMANCE")),
       "the timing must also reach stderr",

--- a/test/claude-hooks-timing.test.mjs
+++ b/test/claude-hooks-timing.test.mjs
@@ -36,9 +36,36 @@ function fakeClock(...deltas) {
 
 describe("startHookTimer", () => {
   it("reports the elapsed milliseconds, and can be read more than once", () => {
-    const elapsed = startHookTimer(fakeClock(250, 400));
-    assert.equal(elapsed(), 250);
-    assert.equal(elapsed(), 650);
+    const timer = startHookTimer(fakeClock(250, 400));
+    assert.equal(timer.wallMs(), 250);
+    assert.equal(timer.wallMs(), 650);
+  });
+
+  it("reports CPU separately from wall-clock", () => {
+    // The split the notice is built on: a run that waited 7.2s while computing
+    // 0.3s of it is a busy machine, not a slow sanitizer.
+    const timer = startHookTimer(fakeClock(7200), fakeClock(300));
+    assert.equal(timer.wallMs(), 7200);
+    assert.equal(timer.cpuMs(), 300);
+  });
+
+  it("measures real CPU through the default clock", () => {
+    // Non-vacuity for the production path: the injected-clock cases above
+    // would all pass if process.cpuUsage() were never wired in at all.
+    const timer = startHookTimer();
+    let sink = 0;
+    for (let i = 0; i < 5_000_000; i++) sink += i % 7;
+    assert.ok(sink > 0);
+    assert.ok(timer.cpuMs() > 0, "a busy loop must show up as CPU");
+  });
+
+  it("charges a hook that WAITS no CPU it did not spend", async () => {
+    // The false positive this whole split closes: a hook parked on a loaded
+    // scheduler or a slow socket burns wall-clock and no processor time.
+    const timer = startHookTimer();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.ok(timer.wallMs() >= 45, `wall was ${timer.wallMs()}`);
+    assert.ok(timer.cpuMs() < 40, `sleeping cost ${timer.cpuMs()}ms of CPU`);
   });
 });
 
@@ -51,20 +78,43 @@ describe("provisioning is not the hook's cost", () => {
   it("subtracts a provisioning window that runs inside the timer", async () => {
     let t = 0;
     const clock = () => t;
-    const elapsed = startHookTimer(clock);
+    const timer = startHookTimer(clock);
     t += 50; // real hook work
     await excludeProvisioning(async () => {
       t += 30_000; // a dependency install we merely waited out
     }, clock);
     t += 20; // more real work
-    assert.equal(elapsed(), 70);
-    assert.equal(slowHookNotice("h", elapsed()), null);
+    assert.equal(timer.wallMs(), 70);
+    assert.equal(slowHookNotice("h", timer.wallMs()), null);
+  });
+
+  it("subtracts the CPU a provisioning step spent, not just its wait", async () => {
+    // awaitLazyDependency imports the engine INSIDE a provisioning window, and
+    // that import is real in-process work — charged, it would hand the first
+    // call of every session a CPU figure it never spent.
+    let t = 0;
+    let cpu = 0;
+    const clock = () => t;
+    const cpuClock = () => cpu;
+    const timer = startHookTimer(clock, cpuClock);
+    t += 50;
+    cpu += 40; // real hook work
+    await excludeProvisioning(
+      async () => {
+        t += 3_000;
+        cpu += 900; // importing the engine
+      },
+      clock,
+      cpuClock,
+    );
+    assert.equal(timer.wallMs(), 50);
+    assert.equal(timer.cpuMs(), 40);
   });
 
   it("charges provisioning that FAILED, so a failed wait is not reported as slow", async () => {
     let t = 0;
     const clock = () => t;
-    const elapsed = startHookTimer(clock);
+    const timer = startHookTimer(clock);
     await assert.rejects(
       excludeProvisioning(async () => {
         t += 5_000;
@@ -72,26 +122,35 @@ describe("provisioning is not the hook's cost", () => {
       }, clock),
       /install died/u,
     );
-    assert.equal(elapsed(), 0);
+    assert.equal(timer.wallMs(), 0);
   });
 
   it("never lets one run's provisioning pay down a later run's real cost", async () => {
     let t = 0;
+    let cpu = 0;
     const clock = () => t;
-    await excludeProvisioning(async () => {
-      t += 30_000;
-    }, clock);
+    const cpuClock = () => cpu;
+    await excludeProvisioning(
+      async () => {
+        t += 30_000;
+        cpu += 900;
+      },
+      clock,
+      cpuClock,
+    );
     // A LATER timer sees none of that credit: its window starts clean.
-    const elapsed = startHookTimer(clock);
+    const timer = startHookTimer(clock, cpuClock);
     t += 2_000;
-    assert.equal(elapsed(), 2_000);
-    assert.match(slowHookNotice("h", elapsed()), /2\.0s/u);
+    cpu += 1_500;
+    assert.equal(timer.wallMs(), 2_000);
+    assert.equal(timer.cpuMs(), 1_500);
+    assert.match(slowHookNotice("h", timer.wallMs()), /2\.0s/u);
   });
 
   it("excuses the cold-start dependency wait (awaitLazyDependency)", async () => {
     let t = 0;
     const clock = () => t;
-    const elapsed = startHookTimer(clock);
+    const timer = startHookTimer(clock);
     let polls = 0;
     const loaded = await awaitLazyDependency({
       // Resolves only after the install "finishes" — three polls of waiting.
@@ -105,13 +164,13 @@ describe("provisioning is not the hook's cost", () => {
       intervalMs: 10_000,
     });
     assert.deepEqual(loaded, { ok: true });
-    assert.equal(elapsed(), 0, "30s of install wait must not be charged");
+    assert.equal(timer.wallMs(), 0, "30s of install wait must not be charged");
   });
 
   it("excuses the cold redactor-daemon spawn", async () => {
     let t = 0;
     const clock = () => t;
-    const elapsed = startHookTimer(clock);
+    const timer = startHookTimer(clock);
     const dead = Object.assign(new Error("no socket"), { code: "ENOENT" });
     let dialled = 0;
     const result = await redactViaDaemon("some text", {
@@ -128,7 +187,11 @@ describe("provisioning is not the hook's cost", () => {
       now: clock,
     });
     assert.deepEqual(result, { text: "some text", found: [] });
-    assert.equal(elapsed(), 0, "the daemon cold start must not be charged");
+    assert.equal(
+      timer.wallMs(),
+      0,
+      "the daemon cold start must not be charged",
+    );
   });
 });
 
@@ -150,6 +213,39 @@ describe("slowHookNotice", () => {
     assert.match(notice, /30\.0s/);
     assert.match(notice, /1\.0s budget/);
     assert.match(notice, /github\.com\/.*\/issues/);
+  });
+
+  it("names the CPU share, and blames the sanitizer for only that", () => {
+    // The measured case this wording exists for: 7.2s of wall against 0.3s of
+    // work, on a box running three other jobs. The old line asserted the whole
+    // 7.2s was the sanitizer's and that every call repeated it — both false.
+    const notice = slowHookNotice("sanitize-output", 7_200, undefined, {
+      cpuMs: 300,
+    });
+    assert.match(notice, /took 7\.2s/);
+    assert.match(notice, /used 0\.3s of CPU/);
+    assert.match(notice, /Only the CPU share is work every affected call/);
+    assert.match(notice, /waiting on a busy machine/);
+    assert.match(notice, /hook name and both timings/);
+  });
+
+  it("admits it cannot attribute the wait when no CPU figure is given", () => {
+    // The shell port's case. Silence about the split beats a claim nothing
+    // measured — see plugin/scripts/lib/hook-timing.sh.
+    const notice = slowHookNotice("safe-launch PreToolUse", 7_200);
+    assert.match(notice, /Wall-clock alone cannot separate/);
+    assert.doesNotMatch(notice, /CPU share/);
+    assert.match(notice, /hook name and timing\./);
+  });
+
+  it("claims no per-call cost it has not measured, in either form", () => {
+    // Non-vacuity for the two cases above: the retracted sentence is gone from
+    // BOTH forms, not merely reworded in the one the shell does not emit.
+    for (const context of [undefined, { cpuMs: 300 }])
+      assert.doesNotMatch(
+        slowHookNotice("h", 7_200, undefined, context),
+        /this delay is the sanitizer's/,
+      );
   });
 
   it("honors an explicit threshold", () => {
@@ -320,6 +416,23 @@ describe("reportSlowHook (no-verdict events)", () => {
     assert.equal(event, "SessionStart");
     assert.match(fields.additionalContext, /scan-invisible-chars/);
   });
+
+  it("carries the caller's CPU figure into both channels", () => {
+    // The SessionStart scanners have no verdict to fold a notice into, so this
+    // is the only route their CPU reading takes to the model.
+    const errs = [];
+    const emitted = [];
+    reportSlowHook(
+      "scan-invisible-chars",
+      7_200,
+      "SessionStart",
+      (event, fields) => emitted.push([event, fields]),
+      (chunk) => errs.push(chunk),
+      { cpuMs: 700 },
+    );
+    assert.match(emitted[0][1].additionalContext, /used 0\.7s of CPU/);
+    assert.match(errs[0], /used 0\.7s of CPU/);
+  });
 });
 
 describe("runJudgeCli times every judge hook", () => {
@@ -375,6 +488,10 @@ describe("runJudgeCli times every judge hook", () => {
     const stdout = written.join("");
     assert.match(stdout, /PERFORMANCE/);
     assert.match(stdout, /pretooluse-sanitize/);
+    // A judge that SLEPT past the budget is the contended-host case in
+    // miniature: the wall-clock is real and the CPU behind it is nil, and the
+    // notice has to say so rather than call the whole second sanitizer work.
+    assert.match(stdout, /used 0\.0s of CPU/);
     assert.ok(
       errs.some((line) => line.includes("PERFORMANCE")),
       "the timing must also reach stderr",

--- a/test/hook-timing-shell-parity.test.mjs
+++ b/test/hook-timing-shell-parity.test.mjs
@@ -114,6 +114,21 @@ describe("hook timing: the shell port matches the node module", () => {
     );
   });
 
+  it("ports the no-CPU wording, which is the only one it can measure", () => {
+    // The shell has no per-process CPU reading to give, so what it must match
+    // is the node line for a caller that knows none. Pinning the CPU form as
+    // DIFFERENT is what fails here if the node default ever starts carrying a
+    // number the shell cannot produce.
+    const shell = sh(["slow_hook_notice", "safe-launch PreToolUse", "7200"]);
+    assert.equal(shell, slowHookNotice("safe-launch PreToolUse", 7200));
+    assert.notEqual(
+      shell,
+      slowHookNotice("safe-launch PreToolUse", 7200, undefined, {
+        cpuMs: 300,
+      }),
+    );
+  });
+
   it("honors an explicit threshold argument, as the node signature does", () => {
     assert.equal(
       sh(["slow_hook_notice", "h", "500", "100"]),
@@ -157,7 +172,7 @@ describe("hook timing: the shell port matches the node module", () => {
     const hook = sh(["slow_hook_notice", "x", "90000"]);
     const provision = sh(["slow_provision_notice", "x", "90000"]);
     assert.notEqual(hook, provision);
-    assert.match(hook, /every affected call pays it/);
+    assert.match(hook, /Wall-clock alone cannot separate/);
     assert.match(provision, /paid once per install/);
   });
 


### PR DESCRIPTION
## Summary

The slow-hook notice measures wall-clock, then asserts a cause that measurement cannot support: _"this delay is the sanitizer's, not the model's, and every affected call pays it."_ `startHookTimer` now reads `process.cpuUsage()` beside the clock, and the notice prints both numbers, attributing to per-call sanitizer work only the CPU share.

The reported case: `pretooluse-sanitize` on a 1.1 KB payload and `sanitize-output` on a 235 KB one both reported **7.1s / 7.2s**. Payloads 213× apart costing the same second means the cost was never the payload. Measured on the same host, idle, the two hooks cost **293–300 ms** and **239–248 ms** — a fixed cost (node startup, bundle load), against `sanitize()` itself at 0.016 ms and 0.77 ms. The remaining ~6.9s was contention: this container was running `background-py-check.sh`, a mutation session and pytest concurrently, and `/tmp/glovebox-hook-latency/records.tsv` shows a sibling hook at 1161 ms wall / 700 ms CPU / load 1.50 per core.

## Changes

- `startHookTimer(now, cpuNow)` returns `{ wallMs, cpuMs }` instead of a bare elapsed reader. `process.cpuUsage()` is RUSAGE_SELF, so it counts what this process computed and excludes idle waiting — exactly the split the notice needs.
- `excludeProvisioning` charges provisioning **CPU** as well as its wait. `awaitLazyDependency` imports the engine inside a provisioning window; left in, that import would bill the first call of every session for CPU it did not spend.
- `slowHookNotice` prints `and used <C>s of CPU. Only the CPU share is work every affected call repeats; the rest was waiting on a busy machine.` The CPU figure is **reported, never gated on** — a hook wedged on a dead redactor socket burns no CPU and is exactly the sanitizer's fault, so a CPU threshold would silence the case worth hearing about.
- With no CPU figure the line now says it cannot attribute the wait, instead of asserting an attribution nothing measured. `plugin/scripts/lib/hook-timing.sh` carries that wording byte-identically, so the parity test still compares the shipped default.
- `reportSlowHook` takes a context, which is how the two SessionStart scanners (no verdict channel) get their CPU reading to the model.

**Both notice strings change.** Anything matching the old text needs updating; `plugin/dist/hooks/plugin-hooks.bundle.mjs` and `hook-binaries.sha256` are regenerated in this commit.

## Review focus

Read `claude-hooks/lib/hook-timing.mjs` first — `startHookTimer` and `slowHookNotice` carry the whole change. The invariant spanning files is that `plugin/scripts/lib/hook-timing.sh` must emit the node module's **no-CPU** wording byte-for-byte; `test/hook-timing-shell-parity.test.mjs` runs both over 33 durations and now also pins the CPU form as the one the shell must *not* match.

Least sure of: the wording. `formatSeconds` rounds to tenths, so a hook that computed 40 ms prints "used 0.0s of CPU" — true and, for the contended case, the point, but it reads oddly next to a 7.2s wall figure.

## Tests / verification

- `node --test test/claude-hooks-timing.test.mjs test/hook-timing-shell-parity.test.mjs plugin/test/plugin-bundle.test.mjs` — 237 pass.
- `node --test test/claude-hooks-*.test.mjs test/hook-latency.test.mjs` — 603 pass.
- Non-vacuity for the production path: `measures real CPU through the default clock` burns a busy loop and asserts `cpuMs() > 0`, so every injected-clock case would still fail if `process.cpuUsage()` were never wired in. Its counterpart sleeps 50 ms and asserts the CPU stays near zero — the contended-host case in miniature.
- `claims no per-call cost it has not measured, in either form` asserts the retracted sentence is gone from **both** branches, not merely reworded in the one the shell does not emit.
- `pnpm exec tsc --noEmit && pnpm exec tsc -p tsconfig.hooks.json --noEmit`, `pnpm exec eslint`, `prettier --check`, `shellcheck` and `shfmt -d` on the shell port: clean.

## Decisions made

- **The shell port gets no CPU number.** bash's nearest equivalent is `times`, and reading it the obvious way — inside a command substitution — forks first and reports the child's zero (verified: a 200k-iteration loop reports `0m0.321s` directly and `0m0.000s` through `$(times)`). A silently-zero CPU figure is worse than none, so the shell emits the no-CPU wording. Under the alternative, `safe-launch`'s preflight would also split its wait, at the cost of a fragile delta across a fork.
- **`startHookTimer` returns an object rather than a function with a `cpuMs` property.** Three call sites and their tests change; the alternative types badly under `checkJs` and reads as cleverness in a module that ships. `claude-hooks/lib/hook-timing` is not in `package.json`'s `exports`, so no consumer can import it — this is not a breaking API change.
- **No CPU threshold.** See the third bullet above; the wedged-socket case is the reason.

<details>
<summary>Author checklist</summary>

- [x] Commits follow Conventional Commits; the subject names the observable message change.
- [x] `pnpm lint` and `pnpm check` pass locally; `pnpm test` running.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version untouched.

</details>


---
_Generated by [Claude Code](https://claude.ai/code/session_01KJC5hp8oV2H4DrJZDKJN1D)_