### PR TITLE
fix(claude-hooks): stop the slow-hook notice naming a cause for the wait

### DIFF
--- a/claude-hooks/lib/hook-timing.mjs
+++ b/claude-hooks/lib/hook-timing.mjs
@@ -217,6 +217,10 @@ export function startHookTimer(now = Date.now, cpuNow = processCpuMs) {
  * than asserting an attribution nothing measured: a wall-clock overrun on a
  * loaded host is the common case, and blaming it on the sanitizer sends the
  * operator hunting a per-call cost that does not exist.
+ *
+ * The wait clause names candidates and picks none, for the same reason. A hook
+ * that blocks on a dead socket inside a HOST extension spends no CPU and no
+ * machine load, so naming either as the cause would be a second wrong guess.
  * @param {string} hookName
  * @param {number} elapsedMs
  * @param {number} [thresholdMs]
@@ -236,7 +240,7 @@ export function slowHookNotice(
   const attribution =
     typeof cpuMs === "number"
       ? `, and used ${formatSeconds(cpuMs)}s of CPU. ` +
-        "Only the CPU share is work every affected call repeats; the rest was waiting on a busy machine."
+        "Only the CPU share is work every affected call repeats; the rest was spent waiting, on a busy machine or on something this hook called."
       : ". Wall-clock alone cannot separate the sanitizer's own work from a busy machine.";
   return (
     `agent-sanitizer PERFORMANCE: the ${hookName} hook took ` +

--- a/claude-hooks/lib/hook-timing.mjs
+++ b/claude-hooks/lib/hook-timing.mjs
@@ -162,8 +162,8 @@ export function startHookTimer(now = Date.now) {
  * is asked to relay the number, since the operator is the one who can file it.
  *
  * It says "the hook's" and never "the sanitizer's": the measured span covers the
- * whole hook run, host extensions included, so naming this package as the culprit
- * sends a report about someone else's code to this issue tracker.
+ * whole hook run, host extensions included, so naming this package as the
+ * culprit blames it for time it may not have spent.
  * @param {string} hookName
  * @param {number} elapsedMs
  * @param {number} [thresholdMs]

--- a/claude-hooks/lib/hook-timing.mjs
+++ b/claude-hooks/lib/hook-timing.mjs
@@ -160,6 +160,10 @@ export function startHookTimer(now = Date.now) {
  * not. Addressed to the model because the model is the only party that reliably
  * reads this channel — stderr from a non-blocking hook is easy to miss — and it
  * is asked to relay the number, since the operator is the one who can file it.
+ *
+ * It says "the hook's" and never "the sanitizer's": the measured span covers the
+ * whole hook run, host extensions included, so naming this package as the culprit
+ * sends a report about someone else's code to this issue tracker.
  * @param {string} hookName
  * @param {number} elapsedMs
  * @param {number} [thresholdMs]
@@ -178,7 +182,7 @@ export function slowHookNotice(
   return (
     `agent-sanitizer PERFORMANCE: the ${hookName} hook took ` +
     `${formatSeconds(elapsedMs)}s${formatContextSuffix(context)}, over its ${formatSeconds(thresholdMs)}s budget — ` +
-    "this delay is the sanitizer's, not the model's, and every affected call pays it. " +
+    "this delay is the hook's, not the model's, and every affected call pays it. " +
     `Tell the user, and suggest they report it at ${ISSUE_URL} with the hook name and timing.`
   );
 }

--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=b24050bdbce5ecee6c85c3e3a5f71b8124964462f2627f5fcd65bd2540acd749
-ca855921f165867e73696e6b614dd9bd5f573b993d5d2e6c576013ca7992aac0  agent-sanitizer-hooks-darwin-arm64
-d527b879872161cca0f9c21da0d139c94a10999609fccd033442bbfe46d5a13d  agent-sanitizer-hooks-darwin-x64
-be96ac09af5c515df0d27d21f7fd37e5c91427484b24c11639c2e68fece69a2e  agent-sanitizer-hooks-linux-arm64
-0b1395a23d2c84757cc4c4191dccb6cc3360ee9fd0c8ecc049b9eba87f5adc88  agent-sanitizer-hooks-linux-x64
+# bundle=1ec95d466b72422a4dd9a1ddb2fbc69be3c662ffc9d4b6cb0f2357b2350121c6
+f43e23fda2a59892e332b3d20a0fe7020db7dc8a384cdbd293469750536bc73f  agent-sanitizer-hooks-darwin-arm64
+88aa6b1ca912d45757197603a5c96e1fcf56584e4e217caac7bb79dd82c66871  agent-sanitizer-hooks-darwin-x64
+4400dc6414c1c311c446d949698001a215ac0ac5064d7d49a09b7bae76a3ed82  agent-sanitizer-hooks-linux-arm64
+47f2410e049c483877142d69528635d4036e468c500b523dff2bea352c93e572  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=e981a6af405d515205b5c79c6b12ff5bcb548301b53a3be25ab1fe604ca891cc
-545544465c2f6d8ed8c46cfd0d44d03d4c0603474328a23ce93f9cc08e98a4aa  agent-sanitizer-hooks-darwin-arm64
-66afe47c1e44dd98a3e57a489f02eeda73659d3e01109395e2436fe30fb3d3c2  agent-sanitizer-hooks-darwin-x64
-1788f88bf45c27762a409adf67ad2b982e462928cebf05aac0b7003c5bf80fe4  agent-sanitizer-hooks-linux-arm64
-1ed5bdf47dc584e356707bf72eb111f6f35939c15e5f21904bc7a58e2cf7c4f7  agent-sanitizer-hooks-linux-x64
+# bundle=caf5bd8b31ab966897fe7a8288e736cafc90d81575454eb53918aa5677988adf
+f6ba3d669bcea01c3399928fd7a19a3ec5101db3d1fbeba45526eee1450edc77  agent-sanitizer-hooks-darwin-arm64
+fdbb004587f16437322983a7651d92f3b46edcc6a0066aa1d8f8b2601922831e  agent-sanitizer-hooks-darwin-x64
+6179a16a04f69925f1bca366dc85fe462426be1a3dc47a2b429a15b39dfa0cd4  agent-sanitizer-hooks-linux-arm64
+aab296fb505194b41601076849e76366b3aacff7b8e2b5d3cb7296e11d751993  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -91,7 +91,7 @@ function startHookTimer(now = Date.now, cpuNow = processCpuMs) {
 function slowHookNotice(hookName, elapsedMs, thresholdMs = SLOW_HOOK_THRESHOLD_MS, context) {
   if (elapsedMs <= thresholdMs) return null;
   const cpuMs = context?.cpuMs;
-  const attribution = typeof cpuMs === "number" ? `, and used ${formatSeconds(cpuMs)}s of CPU. Only the CPU share is work every affected call repeats; the rest was waiting on a busy machine.` : ". Wall-clock alone cannot separate the sanitizer's own work from a busy machine.";
+  const attribution = typeof cpuMs === "number" ? `, and used ${formatSeconds(cpuMs)}s of CPU. Only the CPU share is work every affected call repeats; the rest was spent waiting, on a busy machine or on something this hook called.` : ". Wall-clock alone cannot separate the sanitizer's own work from a busy machine.";
   return `agent-sanitizer PERFORMANCE: the ${hookName} hook took ${formatSeconds(elapsedMs)}s${formatContextSuffix(context)}, over its ${formatSeconds(thresholdMs)}s budget${attribution} Tell the user, and suggest they report it at ${ISSUE_URL} with the hook name and ${typeof cpuMs === "number" ? "both timings" : "timing"}.`;
 }
 function writeSlowHookNotice(hookName, elapsedMs, writeErr = (chunk) => process.stderr.write(chunk), context) {

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -76,7 +76,7 @@ function startHookTimer(now = Date.now) {
 }
 function slowHookNotice(hookName, elapsedMs, thresholdMs = SLOW_HOOK_THRESHOLD_MS, context) {
   if (elapsedMs <= thresholdMs) return null;
-  return `agent-sanitizer PERFORMANCE: the ${hookName} hook took ${formatSeconds(elapsedMs)}s${formatContextSuffix(context)}, over its ${formatSeconds(thresholdMs)}s budget \u2014 this delay is the sanitizer's, not the model's, and every affected call pays it. Tell the user, and suggest they report it at ${ISSUE_URL} with the hook name and timing.`;
+  return `agent-sanitizer PERFORMANCE: the ${hookName} hook took ${formatSeconds(elapsedMs)}s${formatContextSuffix(context)}, over its ${formatSeconds(thresholdMs)}s budget \u2014 this delay is the hook's, not the model's, and every affected call pays it. Tell the user, and suggest they report it at ${ISSUE_URL} with the hook name and timing.`;
 }
 function writeSlowHookNotice(hookName, elapsedMs, writeErr = (chunk) => process.stderr.write(chunk), context) {
   const notice = slowHookNotice(hookName, elapsedMs, void 0, context);

--- a/plugin/scripts/lib/hook-timing.sh
+++ b/plugin/scripts/lib/hook-timing.sh
@@ -66,7 +66,7 @@ hook_timing_format_seconds() {
 slow_hook_notice() {
   local name="$1" elapsed="$2" threshold="${3:-$SLOW_HOOK_THRESHOLD_MS}"
   ((elapsed > threshold)) || return 0
-  printf '%s' "agent-sanitizer PERFORMANCE: the ${name} hook took $(hook_timing_format_seconds "$elapsed")s, over its $(hook_timing_format_seconds "$threshold")s budget — this delay is the sanitizer's, not the model's, and every affected call pays it. Tell the user, and suggest they report it at ${HOOK_TIMING_ISSUE_URL} with the hook name and timing."
+  printf '%s' "agent-sanitizer PERFORMANCE: the ${name} hook took $(hook_timing_format_seconds "$elapsed")s, over its $(hook_timing_format_seconds "$threshold")s budget — this delay is the hook's, not the model's, and every affected call pays it. Tell the user, and suggest they report it at ${HOOK_TIMING_ISSUE_URL} with the hook name and timing."
 }
 
 # The line for a ONE-TIME provisioning step that overran its (much larger)

--- a/test/claude-hooks-timing.test.mjs
+++ b/test/claude-hooks-timing.test.mjs
@@ -225,8 +225,21 @@ describe("slowHookNotice", () => {
     assert.match(notice, /took 7\.2s/);
     assert.match(notice, /used 0\.3s of CPU/);
     assert.match(notice, /Only the CPU share is work every affected call/);
-    assert.match(notice, /waiting on a busy machine/);
+    assert.match(notice, /spent waiting/);
     assert.match(notice, /hook name and both timings/);
+  });
+
+  it("names candidates for the wait and commits to none", () => {
+    // A hook blocked on a dead socket inside a HOST extension spends no CPU and
+    // adds no machine load, so a clause asserting "waiting on a busy machine"
+    // states a cause nothing measured — the same overreach the CPU split closed
+    // one sentence earlier. Observed: 5.25s of wall, ~0 CPU, one unanswered
+    // TCP connect issued by a host extension.
+    const notice = slowHookNotice("sanitize-output", 5_250, undefined, {
+      cpuMs: 0,
+    });
+    assert.match(notice, /on a busy machine or on something this hook called/);
+    assert.doesNotMatch(notice, /the rest was waiting on a busy machine/);
   });
 
   it("admits it cannot attribute the wait when no CPU figure is given", () => {

--- a/test/claude-hooks-timing.test.mjs
+++ b/test/claude-hooks-timing.test.mjs
@@ -152,6 +152,16 @@ describe("slowHookNotice", () => {
     assert.match(notice, /github\.com\/.*\/issues/);
   });
 
+  it("blames the HOOK, never this package", () => {
+    // The measured span covers the whole hook run, host extensions included, so
+    // naming this package is a claim the timer cannot support. The shell-parity
+    // test cannot catch a reword — it only proves the two copies agree — so this
+    // is the only thing pinning WHICH party the notice accuses.
+    const notice = slowHookNotice("sanitize-output", 5_250);
+    assert.match(notice, /this delay is the hook's/);
+    assert.doesNotMatch(notice, /the sanitizer's/);
+  });
+
   it("honors an explicit threshold", () => {
     assert.equal(slowHookNotice("x", 50, 100), null);
     assert.match(slowHookNotice("x", 300, 100), /0\.3s/);


### PR DESCRIPTION
The slow-hook notice reports how long a hook took. With a CPU figure in hand it now says the non-CPU share "was waiting on a busy machine" — but nothing measures machine load, so that names a cause the timer cannot know.

The clause now names both candidates and commits to neither: "the rest was spent waiting, on a busy machine or on something this hook called."

Auto-merge was enabled on this PR by alexander-turner (merge method: merge), so it lands itself once the required checks pass. Nobody merges it by hand.

<details>
<summary>Why this case is not covered by the CPU split</summary>

This branch opened as a one-word reword of the older `this delay is the sanitizer's` claim. PR #339 landed that fix more thoroughly while this sat open, splitting wall-clock from CPU, so every conflicted file here resolves to main and only the residual below remains.

The residual is the same overreach one sentence later. A hook blocked on a dead socket inside a HOST extension spends no CPU and adds no machine load, so "a busy machine" is a second wrong guess. Observed on a glovebox host: 5.25s of wall, ~0 CPU, one unanswered TCP connect issued by that host's own PostToolUse extension. The CPU split correctly reports 0.0s of CPU; the wait clause then misattributes the remaining 5.25s.

Scope: the no-CPU branch is untouched, so `plugin/scripts/lib/hook-timing.sh` and its byte-parity test need no edit — the shell port never emits a CPU figure.

Generated artifacts, both REBUILT rather than merge-picked, answering the merge-delta review: `plugin/dist/hooks/plugin-hooks.bundle.mjs` via `node plugin/scripts/build-plugin.mjs`, and `plugin/dist/hooks/hook-binaries.sha256` via `node plugin/scripts/build-hook-binaries.mjs` (bun 1.3.11). `plugin/test/plugin-bundle.test.mjs` is the check that compares committed bytes to a fresh build, including `committed hook-binary manifest is fresh for this tree`: 100 pass, 0 fail on the current head, and `git status` is clean after both rebuilds.

Verification: `node --test test/claude-hooks-timing.test.mjs test/hook-timing-shell-parity.test.mjs` — 138 pass, 0 fail. Non-vacuity: with the old clause restored, `names candidates for the wait and commits to none` fails (0 pass, 1 fail); restored, it passes.

</details>

## Review focus

`claude-hooks/lib/hook-timing.mjs` — the CPU-present arm of `attribution` only. Confirm the no-CPU arm is byte-identical to main, since that is the one the shell port mirrors and the parity test compares.
