### PR TITLE
fix(html): catch two-padding-char base64 in bare exfil query params

### DIFF
--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=caf5bd8b31ab966897fe7a8288e736cafc90d81575454eb53918aa5677988adf
-f6ba3d669bcea01c3399928fd7a19a3ec5101db3d1fbeba45526eee1450edc77  agent-sanitizer-hooks-darwin-arm64
-fdbb004587f16437322983a7651d92f3b46edcc6a0066aa1d8f8b2601922831e  agent-sanitizer-hooks-darwin-x64
-6179a16a04f69925f1bca366dc85fe462426be1a3dc47a2b429a15b39dfa0cd4  agent-sanitizer-hooks-linux-arm64
-aab296fb505194b41601076849e76366b3aacff7b8e2b5d3cb7296e11d751993  agent-sanitizer-hooks-linux-x64
+# bundle=ec16fa63eb1922e3b7e4518055f25b2dbf183211ee42a373969fa21c151ad2ef
+a1e11b050080eed839e2b820b00c58572eb323b2e8858deee5a51169506c19d2  agent-sanitizer-hooks-darwin-arm64
+c25a458e0cb3ac622f9f4bef28957b99c75a861da10824f58b64c0561a18d089  agent-sanitizer-hooks-darwin-x64
+89c43abea1700083a94e88bcc2365b1f8f4d762d099b6fa9e9bc89e5f0912d0c  agent-sanitizer-hooks-linux-arm64
+66dfff0e51c58b7ef71ac11cced9a0c9dba1382bc971c21f4ff13952e06a5640  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=ec16fa63eb1922e3b7e4518055f25b2dbf183211ee42a373969fa21c151ad2ef
-a1e11b050080eed839e2b820b00c58572eb323b2e8858deee5a51169506c19d2  agent-sanitizer-hooks-darwin-arm64
-c25a458e0cb3ac622f9f4bef28957b99c75a861da10824f58b64c0561a18d089  agent-sanitizer-hooks-darwin-x64
-89c43abea1700083a94e88bcc2365b1f8f4d762d099b6fa9e9bc89e5f0912d0c  agent-sanitizer-hooks-linux-arm64
-66dfff0e51c58b7ef71ac11cced9a0c9dba1382bc971c21f4ff13952e06a5640  agent-sanitizer-hooks-linux-x64
+# bundle=3750de31cf8ae340f7dd18021a009de3b78e439cfd509ff46484fdfa71cf4b07
+b8c4d59ce0a85e774256c2eb2102f7f35c791f5d00ef37f2aa7d06ccdd654ea1  agent-sanitizer-hooks-darwin-arm64
+ec5e4876c16f84147669a98b375ea2403bd848ffa0828643d76ff330edd85f58  agent-sanitizer-hooks-darwin-x64
+14a25ae735932859b39751acfec7f4a43f2ed0be6a30c1e8979ee7808118dba0  agent-sanitizer-hooks-linux-arm64
+ac5b2b65da1a888d89009255647b1cc26b32dae984979e8e30c29b32c97af494  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -64103,7 +64103,7 @@ function rawParams(qs) {
     const eq = pair.indexOf("=");
     const name50 = eq === -1 ? pair : pair.slice(0, eq);
     const afterEq = eq === -1 ? "" : pair.slice(eq + 1);
-    const value = afterEq === "" ? pair : afterEq;
+    const value = /^=*$/.test(afterEq) ? pair : afterEq;
     pairs.push([name50.toLowerCase(), value]);
   }
   return pairs;

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -64101,31 +64101,33 @@ function rawParams(qs) {
   for (const pair of qs.split(/[&;]/)) {
     if (!pair) continue;
     const eq = pair.indexOf("=");
-    const name50 = eq === -1 ? pair : pair.slice(0, eq);
-    const afterEq = eq === -1 ? "" : pair.slice(eq + 1);
-    const value = /^=*$/.test(afterEq) ? pair : afterEq;
-    pairs.push([name50.toLowerCase(), value]);
+    const rawName = eq === -1 ? pair : pair.slice(0, eq);
+    const value = eq === -1 ? "" : pair.slice(eq + 1);
+    pairs.push([rawName.toLowerCase(), value, rawName]);
   }
   return pairs;
 }
-function paramExfilReason(name50, value) {
+function paramExfilReason(name50, value, rawName) {
   if (BENIGN_BLOB_PARAM_RE.test(name50)) return null;
-  const opaqueRuns = value.match(OPAQUE_TOKEN_RE);
-  if (opaqueRuns?.some(
-    (run) => VALUE_HAS_DIGIT_RE.test(run) && matchesSecretHint(run)
-  ))
-    return "credential-shaped token in URL parameter";
-  if (isBlobValue(value) || decodedBlobMatch(value))
-    return "suspicious query parameter";
+  for (const candidate of [rawName, value]) {
+    if (!candidate) continue;
+    const opaqueRuns = candidate.match(OPAQUE_TOKEN_RE);
+    if (opaqueRuns?.some(
+      (run) => VALUE_HAS_DIGIT_RE.test(run) && matchesSecretHint(run)
+    ))
+      return "credential-shaped token in URL parameter";
+    if (isBlobValue(candidate) || decodedBlobMatch(candidate))
+      return "suspicious query parameter";
+  }
   return null;
 }
 function rawUrlKeywordExfil(url) {
   const qIdx = url.search(/[?#]/);
   if (qIdx === -1) return null;
   for (const segment of url.slice(qIdx + 1).split("#")) {
-    for (const [name50, value] of rawParams(segment)) {
+    for (const [name50, value, rawName] of rawParams(segment)) {
       if (!KEYWORD_PARAM_NAME_RE.test(name50)) continue;
-      const reason = paramExfilReason(name50, value);
+      const reason = paramExfilReason(name50, value, rawName);
       if (reason) return reason;
     }
   }
@@ -64137,12 +64139,12 @@ function allParamsBenign(parsed) {
   );
 }
 function checkUrlParams(parsed) {
-  for (const [name50, value] of rawParams(parsed.search.slice(1))) {
-    const reason = paramExfilReason(name50, value);
+  for (const [name50, value, rawName] of rawParams(parsed.search.slice(1))) {
+    const reason = paramExfilReason(name50, value, rawName);
     if (reason) return reason;
   }
-  for (const [name50, value] of rawParams(parsed.hash.slice(1))) {
-    const reason = paramExfilReason(name50, value);
+  for (const [name50, value, rawName] of rawParams(parsed.hash.slice(1))) {
+    const reason = paramExfilReason(name50, value, rawName);
     if (reason) return reason;
   }
   return null;

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -2491,11 +2491,11 @@ function rawParams(qs) {
     const eq = pair.indexOf("=");
     const name = eq === -1 ? pair : pair.slice(0, eq);
     // A VALUELESS param carries its payload in the only token it has, so that
-    // token is its candidate value too — `?<blob>`, `?d=<blob>`, and `?<blob>=`
-    // (whose sole `=` is base64 padding) are one channel. The name alone still
-    // goes through BENIGN_BLOB_PARAM_RE.
+    // token is its candidate value too — `?<blob>`, `?d=<blob>`, and
+    // `?<blob>=`/`?<blob>==` (whose trailing `=`s are base64 padding) are one
+    // channel. The name alone still goes through BENIGN_BLOB_PARAM_RE.
     const afterEq = eq === -1 ? "" : pair.slice(eq + 1);
-    const value = afterEq === "" ? pair : afterEq;
+    const value = /^=*$/.test(afterEq) ? pair : afterEq;
     pairs.push([name.toLowerCase(), value]);
   }
   return pairs;

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -2481,52 +2481,55 @@ function decodedBlobMatch(value) {
  * values, turning a `+`-bearing base64 blob into a space-broken string that the
  * anchored blob regexes would miss.
  * @param {string} qs
- * @returns {Array<[string, string]>}
+ * @returns {Array<[string, string, string]>} [lowercased name, value, RAW (case-preserved) name]
  */
 function rawParams(qs) {
-  /** @type {Array<[string, string]>} */
+  /** @type {Array<[string, string, string]>} */
   const pairs = [];
   for (const pair of qs.split(/[&;]/)) {
     if (!pair) continue;
     const eq = pair.indexOf("=");
-    const name = eq === -1 ? pair : pair.slice(0, eq);
-    // A VALUELESS param carries its payload in the only token it has, so that
-    // token is its candidate value too — `?<blob>`, `?d=<blob>`, and
-    // `?<blob>=`/`?<blob>==` (whose trailing `=`s are base64 padding) are one
-    // channel. The name alone still goes through BENIGN_BLOB_PARAM_RE.
-    const afterEq = eq === -1 ? "" : pair.slice(eq + 1);
-    const value = /^=*$/.test(afterEq) ? pair : afterEq;
-    pairs.push([name.toLowerCase(), value]);
+    const rawName = eq === -1 ? pair : pair.slice(0, eq);
+    const value = eq === -1 ? "" : pair.slice(eq + 1);
+    pairs.push([rawName.toLowerCase(), value, rawName]);
   }
   return pairs;
 }
 
 /**
- * Exfil reason for one URL parameter, or null. A credential-shaped value in any
- * non-allowlisted parameter (reusing the secret-shape gate), or a long
- * base64/hex blob in one. Allowlisted signing/pagination/analytics parameters
- * are skipped entirely (see BENIGN_BLOB_PARAM_RE).
- * @param {string} name  lowercased parameter name
- * @param {string} value RAW (un-decoded) value
+ * Exfil reason for one URL parameter, or null. A credential-shaped or
+ * blob-shaped run in EITHER half of the pair — the value, or the name — in any
+ * non-allowlisted parameter. Testing the name too (not just the value) is what
+ * catches a payload that lands on the wrong side of the `=`: `?<blob>`,
+ * `?<blob>=`, `?<blob>==` (trailing `=`s read as padding) and `?<blob>=x` (any
+ * non-padding tail) are one channel, since the server reads the query string
+ * either way. Allowlisted signing/pagination/analytics parameters are skipped
+ * entirely (see BENIGN_BLOB_PARAM_RE).
+ * @param {string} name    lowercased parameter name, for the allowlist gate
+ * @param {string} value   RAW (un-decoded) value
+ * @param {string} rawName RAW (case-preserved, un-decoded) name
  * @returns {string | null}
  */
-function paramExfilReason(name, value) {
+function paramExfilReason(name, value, rawName) {
   if (BENIGN_BLOB_PARAM_RE.test(name)) return null;
-  // A leaked credential is an OPAQUE, separator-free token. Gate the
-  // secret-shape/digit test on the CONTIGUOUS opaque run(s) of the value, not on
-  // the whole prose value: a benign path-like value (`?redirect=/authorization-
-  // service/…abcdefghij1234567890`) otherwise matches "authorization" in one
-  // place and a 20-char run in another and false-fires. Requiring both on the
-  // SAME run keeps `ghp_…`-style contiguous tokens firing while dropping prose.
-  const opaqueRuns = value.match(OPAQUE_TOKEN_RE);
-  if (
-    opaqueRuns?.some(
-      (run) => VALUE_HAS_DIGIT_RE.test(run) && matchesSecretHint(run),
+  for (const candidate of [rawName, value]) {
+    if (!candidate) continue;
+    // A leaked credential is an OPAQUE, separator-free token. Gate the
+    // secret-shape/digit test on the CONTIGUOUS opaque run(s), not on the whole
+    // prose candidate: a benign path-like value (`?redirect=/authorization-
+    // service/…abcdefghij1234567890`) otherwise matches "authorization" in one
+    // place and a 20-char run in another and false-fires. Requiring both on the
+    // SAME run keeps `ghp_…`-style contiguous tokens firing while dropping prose.
+    const opaqueRuns = candidate.match(OPAQUE_TOKEN_RE);
+    if (
+      opaqueRuns?.some(
+        (run) => VALUE_HAS_DIGIT_RE.test(run) && matchesSecretHint(run),
+      )
     )
-  )
-    return "credential-shaped token in URL parameter";
-  if (isBlobValue(value) || decodedBlobMatch(value))
-    return "suspicious query parameter";
+      return "credential-shaped token in URL parameter";
+    if (isBlobValue(candidate) || decodedBlobMatch(candidate))
+      return "suspicious query parameter";
+  }
   return null;
 }
 
@@ -2547,9 +2550,9 @@ function rawUrlKeywordExfil(url) {
   const qIdx = url.search(/[?#]/);
   if (qIdx === -1) return null;
   for (const segment of url.slice(qIdx + 1).split("#")) {
-    for (const [name, value] of rawParams(segment)) {
+    for (const [name, value, rawName] of rawParams(segment)) {
       if (!KEYWORD_PARAM_NAME_RE.test(name)) continue;
-      const reason = paramExfilReason(name, value);
+      const reason = paramExfilReason(name, value, rawName);
       if (reason) return reason;
     }
   }
@@ -2577,14 +2580,14 @@ function allParamsBenign(parsed) {
  * @returns {string | null}
  */
 function checkUrlParams(parsed) {
-  for (const [name, value] of rawParams(parsed.search.slice(1))) {
-    const reason = paramExfilReason(name, value);
+  for (const [name, value, rawName] of rawParams(parsed.search.slice(1))) {
+    const reason = paramExfilReason(name, value, rawName);
     if (reason) return reason;
   }
   // The fragment carries the same `key=value` channel (`#token=…`); a bare
   // anchor (`#section-2`) yields one empty-value param that trips nothing.
-  for (const [name, value] of rawParams(parsed.hash.slice(1))) {
-    const reason = paramExfilReason(name, value);
+  for (const [name, value, rawName] of rawParams(parsed.hash.slice(1))) {
+    const reason = paramExfilReason(name, value, rawName);
     if (reason) return reason;
   }
   return null;

--- a/test/html.test.mjs
+++ b/test/html.test.mjs
@@ -1147,38 +1147,46 @@ describe("unit: checkExfilUrl exact verdicts", () => {
 
 // ─── invariant: the `=` is not a hiding place ────────────────────────────────
 //
-// `?<payload>`, `?<payload>=` and `?d=<payload>` are one exfil channel: the
-// server reads the query string either way. Splitting on `=` and keeping only
-// the right-hand side gave the shortest spelling an empty value, and every
-// shape test reads the value — so dropping two characters bought silence.
+// `?<payload>`, `?<payload>=`, `?<payload>=x` and `?d=<payload>` are one exfil
+// channel: the server reads the query string either way, so a payload's
+// verdict must not depend on which side of the `=` it lands on or whether
+// there's an `=` at all — both the name and the value are shape-tested.
 
 describe("invariant: a parameter's exfil verdict ignores whether it carries an `=`", () => {
-  // Each payload as a named value, as a bare query token, and in the fragment,
-  // which carries the same `key=value` channel. The base64 payload's trailing
-  // `=` padding also covers the case where the split reads the padding as the
-  // separator and leaves an empty right-hand side.
+  // Each payload as a named value, as a bare query token, with a non-padding
+  // tail after it (payload lands in the NAME half of the pair, not the value),
+  // and in the fragment, which carries the same `key=value` channel.
   const spellings = (payload) => ({
     "named value": `?d=${payload}`,
     "bare token": `?${payload}`,
+    "with a trailing tail": `?${payload}=x`,
     "in the fragment": `#${payload}`,
   });
+  // [label, payload, expected verdict] — the verdict rides on the row so
+  // adding/reordering payloads can't silently re-point an assertion at a
+  // different one.
   const PAYLOADS = [
     [
       "a base64 blob with one padding char",
       "QUtJQVJPT1RTRUNSRVRLRVkxMjM0NTY3ODkwYWJjZGVmZ2hpams=",
+      "suspicious query parameter",
     ],
-    // Two padding characters (source length ≡ 1 mod 3): `indexOf("=")` finds
-    // the FIRST `=`, so the bare-token split left `"="` (the second pad char)
-    // as a non-empty right-hand side — the empty-value fallback below never
-    // fired, and the blob was dropped before reaching the shape regexes.
+    // Two padding characters (source length ≡ 1 mod 3): the bare-token split
+    // reads only the first `=` as the separator, so the whole trailing padding
+    // run — not just a single `=` — must route the token to the shape regexes.
     [
       "a base64 blob with two padding chars",
       "QUtJQUlPU0ZPRE5ON0VYQU1QTEVLRVlTRUNSRVRYWQ==",
+      "suspicious query parameter",
     ],
-    ["a hex blob", "a".repeat(16) + "b3c4d5e6f7081920"],
-    ["an ordinary word", "guide"],
+    [
+      "a hex blob",
+      "a".repeat(16) + "b3c4d5e6f7081920",
+      "suspicious query parameter",
+    ],
+    ["an ordinary word", "guide", null],
   ];
-  for (const [label, payload] of PAYLOADS) {
+  for (const [label, payload, expected] of PAYLOADS) {
     const forms = spellings(payload);
     it(`agrees across every spelling of ${label}`, () => {
       const verdicts = Object.fromEntries(
@@ -1187,30 +1195,12 @@ describe("invariant: a parameter's exfil verdict ignores whether it carries an `
           checkExfilUrl(`https://e.com/p${suffix}`),
         ]),
       );
-      const [first] = Object.values(verdicts);
       assert.deepEqual(
         verdicts,
-        Object.fromEntries(Object.keys(forms).map((form) => [form, first])),
+        Object.fromEntries(Object.keys(forms).map((form) => [form, expected])),
       );
     });
   }
-  // Non-vacuity: the payloads above must not ALL be null, or the agreement
-  // holds for a detector that never fires.
-  it("flags the blob spellings and clears the word (the corpus separates them)", () => {
-    assert.equal(
-      checkExfilUrl(`https://e.com/p?${PAYLOADS[0][1]}`),
-      "suspicious query parameter",
-    );
-    assert.equal(
-      checkExfilUrl(`https://e.com/p?${PAYLOADS[1][1]}`),
-      "suspicious query parameter",
-    );
-    assert.equal(
-      checkExfilUrl(`https://e.com/p?${PAYLOADS[2][1]}`),
-      "suspicious query parameter",
-    );
-    assert.equal(checkExfilUrl(`https://e.com/p?${PAYLOADS[3][1]}`), null);
-  });
   // Precision: the allowlist is keyed on the NAME, and a valueless param's
   // token is its name — so an allowlisted param stays silent, and a benign
   // valueless flag never becomes a finding.

--- a/test/html.test.mjs
+++ b/test/html.test.mjs
@@ -1163,7 +1163,18 @@ describe("invariant: a parameter's exfil verdict ignores whether it carries an `
     "in the fragment": `#${payload}`,
   });
   const PAYLOADS = [
-    ["a base64 blob", "QUtJQVJPT1RTRUNSRVRLRVkxMjM0NTY3ODkwYWJjZGVmZ2hpams="],
+    [
+      "a base64 blob with one padding char",
+      "QUtJQVJPT1RTRUNSRVRLRVkxMjM0NTY3ODkwYWJjZGVmZ2hpams=",
+    ],
+    // Two padding characters (source length ≡ 1 mod 3): `indexOf("=")` finds
+    // the FIRST `=`, so the bare-token split left `"="` (the second pad char)
+    // as a non-empty right-hand side — the empty-value fallback below never
+    // fired, and the blob was dropped before reaching the shape regexes.
+    [
+      "a base64 blob with two padding chars",
+      "QUtJQUlPU0ZPRE5ON0VYQU1QTEVLRVlTRUNSRVRYWQ==",
+    ],
     ["a hex blob", "a".repeat(16) + "b3c4d5e6f7081920"],
     ["an ordinary word", "guide"],
   ];
@@ -1194,7 +1205,11 @@ describe("invariant: a parameter's exfil verdict ignores whether it carries an `
       checkExfilUrl(`https://e.com/p?${PAYLOADS[1][1]}`),
       "suspicious query parameter",
     );
-    assert.equal(checkExfilUrl(`https://e.com/p?${PAYLOADS[2][1]}`), null);
+    assert.equal(
+      checkExfilUrl(`https://e.com/p?${PAYLOADS[2][1]}`),
+      "suspicious query parameter",
+    );
+    assert.equal(checkExfilUrl(`https://e.com/p?${PAYLOADS[3][1]}`), null);
   });
   // Precision: the allowlist is keyed on the NAME, and a valueless param's
   // token is its name — so an allowlisted param stays silent, and a benign


### PR DESCRIPTION
## Summary

`rawParams()` in `src/html.mjs` (Layer 3's exfil-URL detector) let a raw base64/hex/credential blob through an exfil URL's query string whenever it landed anywhere except the RIGHT-hand side of a `key=value` pair with no trailing junk. Two related gaps, both closed here:

1. A valueless query token whose base64 payload ends in two padding characters (`==`, the common case for a source length equal to 1 mod 3) was silently dropped, because `pair.indexOf("=")` found the first `=` and left the second as a non-empty "value" — the code's own empty-value fallback (meant to recover the whole token) never fired.
2. Fixing (1) with a padding-specific check still left the same channel open one step further: any blob with a non-padding tail after its `=` (`?PAYLOAD=x`) rides in the parameter NAME, which was never shape-tested at all — only the value was. A beacon URL like `https://evil.example/collect?PAYLOAD=x` (with a non-keyword name, under the coarse length threshold) bypassed detection entirely.

## Changes

- `src/html.mjs`: `rawParams` now returns both the value and the case-preserved parameter name; `paramExfilReason` shape-tests (blob-shape, credential-shape) BOTH halves of the `name=value` split as candidates, rather than only the value with a padding-specific special case. This subsumes the no-`=`, one-pad, two-pad and trailing-tail spellings uniformly, with less branching than the ternary it replaces.
- `test/html.test.mjs`: the "invariant: a parameter's exfil verdict ignores whether it carries an `=`" test block gets a "with a trailing tail" spelling (reproducing gap 2) alongside the existing named/bare-token/fragment spellings, and its `PAYLOADS` corpus now carries the expected verdict on each row instead of asserting it separately by positional index.
- Regenerated `plugin/dist/hooks/plugin-hooks.bundle.mjs` and `plugin/dist/hooks/hook-binaries.sha256` (the same logic is inlined into the committed hook bundle; both are build artifacts kept in sync by the project's pre-commit hook / `pnpm gen:hook-binaries`).

## Review focus

`paramExfilReason` in `src/html.mjs` — the loop over `[rawName, value]` candidates is the whole fix; everything else is plumbing the extra return value through. Worth checking: `rawName` is deliberately NOT lowercased before the shape test (only the allowlist-gate copy is), since `isBase64UrlBlob`'s uppercase+digit character-mix check needs the original case to tell a blob from a lowercase word-slug.

## How it was tested

- Both regression cases (two-padding-char blob, trailing-tail blob) confirmed red on the pre-fix code and green after, by reverting the relevant commit's `src/html.mjs` and re-running `node --test test/html.test.mjs`.
- `pnpm test` (full JS coverage suite, 100% on `src/`) and `pnpm lint` pass.
- `node plugin/scripts/build-plugin.mjs` is idempotent against the committed bundle (no diff on rebuild); `pnpm gen:hook-binaries` regenerates the manifest to match.

## Checklist

- [x] Commits follow Conventional Commits; each subject reads as a user-facing release note.
- [x] `pnpm test` and `pnpm lint` pass locally.
- [x] The changed detector has negative cases (ordinary word, allowlisted/benign params) alongside the positive ones, and pins the fix as an invariant (agreement across spellings) rather than a single repro.
- [x] No real secrets/tokens in the diff, tests, or description (test payloads are synthetic).
- [x] `CHANGELOG.md` and `package.json` version are untouched.