### PR TITLE
fix(ci): grant the review-gate the permission its label removal needs

### DIFF
--- a/.github/workflows/review-findings-gate.yaml
+++ b/.github/workflows/review-findings-gate.yaml
@@ -87,8 +87,13 @@ jobs:
     permissions:
       contents: read # sparse-checkout the trusted gate script
       checks: write # post the "Review findings resolved" check run on the head
-      pull-requests: read # read the PR's reviews and threads
-      issues: write # remove the recheck-review-gate command label
+      # Write, not read: a label on a PULL REQUEST is checked against the
+      # pull-requests permission, even though the endpoint sits under /issues/.
+      # With `issues: write` alone the DELETE below answered 403 "Resource not
+      # accessible by integration", so the label stayed on the PR — and while it
+      # sits there re-adding it fires no `labeled` event, which makes the recheck
+      # hatch one-shot for the whole life of the PR.
+      pull-requests: write # read the PR's threads, remove the command label
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_REPO: ${{ github.repository }}

--- a/.github/workflows/review-findings-gate.yaml
+++ b/.github/workflows/review-findings-gate.yaml
@@ -87,12 +87,11 @@ jobs:
     permissions:
       contents: read # sparse-checkout the trusted gate script
       checks: write # post the "Review findings resolved" check run on the head
-      # Write, not read: a label on a PULL REQUEST is checked against the
-      # pull-requests permission, even though the endpoint sits under /issues/.
-      # With `issues: write` alone the DELETE below answered 403 "Resource not
-      # accessible by integration", so the label stayed on the PR — and while it
-      # sits there re-adding it fires no `labeled` event, which makes the recheck
-      # hatch one-shot for the whole life of the PR.
+      # A label on a PULL REQUEST is checked against the pull-requests
+      # permission, not issues. Under `issues: write` alone the DELETE below
+      # 403s and the label stays; while it sits there re-adding it fires no
+      # `labeled` event, which makes the recheck hatch one-shot for the whole
+      # life of the PR.
       pull-requests: write # read the PR's threads, remove the command label
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/review-findings-gate.yaml
+++ b/.github/workflows/review-findings-gate.yaml
@@ -26,7 +26,7 @@ name: Review-findings gate
 # enforcement point: no PR-authored code is ever checked out or executed here —
 # the job reads review/thread state via the API and posts a check run. Least
 # privilege: contents:read (checkout the scripts) + checks:write (post the
-# verdict) + pull-requests:read + issues:write (remove the command label).
+# verdict) + pull-requests:write (read the threads, remove the command label).
 
 on: # zizmor: ignore[dangerous-triggers] — no PR code executes: API-only scripts off a default-branch checkout; see the SECURITY header
   # A new head sha needs a fresh verdict (synchronize), and a PR becomes gateable

--- a/tests/test_review_findings_gate.py
+++ b/tests/test_review_findings_gate.py
@@ -577,6 +577,12 @@ def test_the_label_removal_step_is_first_and_unconditional() -> None:
     removal = steps[0]
     assert removal["name"] == "Remove the recheck-review-gate command label"
     assert "if" not in removal
+    # A label on a PR is checked against pull-requests, not issues: under
+    # `issues: write` alone the DELETE 403s and the label stays stuck, which is
+    # the dead hatch above, reached at runtime instead of by displacement. Only
+    # a static assertion catches a narrowing back — the 403 is invisible until
+    # someone uses the hatch on a live PR and reads the warning annotation.
+    assert _evaluate_job()["permissions"].get("pull-requests") == "write"
 
 
 def test_the_evaluate_job_actually_posts_a_verdict_on_the_head() -> None:


### PR DESCRIPTION
The `recheck-review-gate` hatch removes its own label as the evaluate job's first step. That DELETE answered `403 Resource not accessible by integration` on #345 ([run 32104267792](https://github.com/AlexanderMattTurner/agent-sanitizer/actions/runs/32104267792)), because a label on a **pull request** is checked against the `pull-requests` permission even though the endpoint sits under `/issues/` — `issues: write` does not cover it. The label then stays on the PR, and while it sits there re-adding it fires no `labeled` event, so the hatch works once per PR and never again.

`pr-review-advisory-comment.yaml:51` already labels PRs under `pull-requests: write`; this matches it. The job also needed `pull-requests: read` for the PR's threads, so the write grant replaces both lines rather than adding a third. `test_the_label_removal_step_is_first_and_unconditional` now asserts the grant, so a narrowing back to `read` reds the suite instead of waiting for the next live 403.

## Decisions made

- **Widened the existing job rather than splitting the removal into its own job.** A separate job would need its own concurrency handling, and the step's comment explains why removal must be the evaluate job's first step: a `labeled` run displaced while queued runs zero steps, so only its displacer can free the label. The job checks out the default branch and runs a trusted script, so the wider grant reaches no PR-authored code.
- **The user approved this token widening explicitly**, after the permission classifier held the commit.

<details>
<summary>Verification</summary>

`uv run pytest tests/test_review_findings_gate.py -q` — 29 passed. Non-vacuity for the new assertion: narrowing the workflow back to `pull-requests: read` fails `test_the_label_removal_step_is_first_and_unconditional` at line 585 (28 passed, 1 failed). The pre-commit paired-guard battery ran the other four guards for this file (`script-reachability`, `workflow-step-refs`, `failure-notify-roster`, `test-runner-partition`) — 21 passed.

Observed, not inferred: the 403 is quoted from the job log of the `Post the review-findings verdict on the PR head` step at 05:47:49Z. Inferred: that `pull-requests: write` makes the DELETE succeed — no test can drive a real GitHub token grant, so the check is the next use of the hatch on a PR built after this lands. `pull_request_target` reads the workflow from the default branch, so the fix is inert until merge.

</details>

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/); each subject reads as a user-facing release note.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version are left untouched.