### PR TITLE
fix(hooks): split a slow hook's wait into CPU, redactor round trip, and neither

### DIFF
--- a/claude-hooks/lib/control-plane.mjs
+++ b/claude-hooks/lib/control-plane.mjs
@@ -198,6 +198,7 @@ export async function runJudgeCli(
           payloadBytes,
           tool,
           cpuMs: timer.cpuMs(),
+          daemonMs: timer.daemonMs(),
         }),
         event,
       ),
@@ -214,6 +215,7 @@ export async function runJudgeCli(
         payloadBytes,
         tool,
         cpuMs: timer.cpuMs(),
+        daemonMs: timer.daemonMs(),
       });
     onError(err, input);
   }

--- a/claude-hooks/lib/control-plane.mjs
+++ b/claude-hooks/lib/control-plane.mjs
@@ -198,7 +198,7 @@ export async function runJudgeCli(
           payloadBytes,
           tool,
           cpuMs: timer.cpuMs(),
-          daemonMs: timer.daemonMs(),
+          redactorMs: timer.redactorMs(),
         }),
         event,
       ),
@@ -215,7 +215,7 @@ export async function runJudgeCli(
         payloadBytes,
         tool,
         cpuMs: timer.cpuMs(),
-        daemonMs: timer.daemonMs(),
+        redactorMs: timer.redactorMs(),
       });
     onError(err, input);
   }

--- a/claude-hooks/lib/hook-timing.mjs
+++ b/claude-hooks/lib/hook-timing.mjs
@@ -9,12 +9,15 @@
  * before anyone traced it back here). A hook past the budget therefore says so
  * IN BAND, in the model's context, where it can be relayed to the operator.
  *
- * TWO numbers, because wall-clock alone cannot say whose cost it is: a hook on
+ * THREE numbers, because wall-clock alone cannot say whose cost it is: a hook on
  * a contended host waits far longer than it computes (a 1.1 KB payload and a
  * 235 KB one both reported 7.2s on a loaded 2-vCPU box, against 0.3s of work).
- * So the notice prints CPU beside the clock — the share every affected call
- * repeats — and never GATES on it: a hook wedged on a dead redactor socket
- * burns no CPU and is exactly the sanitizer's fault.
+ * So the notice prints, beside the clock, the CPU this process burned and the
+ * time it spent waiting on the redactor daemon — a separate, long-lived process
+ * whose CPU this one cannot see (see {@link processCpuMs}), so the daemon's cost
+ * is measured as the round trip that waits for it. The notice GATES on none of
+ * them: a hook wedged on a dead redactor socket burns no CPU and is exactly the
+ * sanitizer's fault.
  *
  * ONE-TIME PROVISIONING is excluded (see {@link excludeProvisioning}): charging
  * an install to the hook that merely waited it out would make the FIRST call of
@@ -90,13 +93,15 @@ export function formatBytes(bytes) {
  * that made this specific latency report take a manual multi-step
  * investigation to characterize (which tool call, how large a payload) before
  * anyone could act on it.
- * `cpuMs` is the run's own processor time (see {@link startHookTimer}); absent
- * when the caller has no way to measure it, which is what the shell port of
- * this module reports.
+ * `cpuMs` is the run's own processor time and `daemonMs` the wall-clock it spent
+ * waiting on the redactor daemon (both from {@link startHookTimer}); absent when
+ * the caller has no way to measure them, which is what the shell port of this
+ * module reports.
  * @typedef {{
  *   payloadBytes?: number | null,
  *   tool?: string | null,
  *   cpuMs?: number | null,
+ *   daemonMs?: number | null,
  * }} SlowHookContext
  */
 
@@ -138,6 +143,34 @@ function processCpuMs() {
 let provisioningMs = 0;
 let provisioningCpuMs = 0;
 
+// Process-wide total of wall-clock spent inside redactor-daemon round trips.
+// Wall-clock and not CPU because the daemon is a separate process: its work is
+// invisible to processCpuMs, so the only measurement this side can make is how
+// long it waited for an answer.
+let daemonWaitMs = 0;
+
+/**
+ * Run `work` — one redactor-daemon round trip — charging its duration to the
+ * daemon share, so a run's wait on the sanitizer's own daemon is told apart from
+ * a wait on a loaded host. Charged in a `finally`, since a round trip that
+ * THROWS (a stall that hit its deadline) is the one that spent the most.
+ *
+ * Unlike {@link excludeProvisioning} this only attributes; the time stays in the
+ * hook's wall-clock, because a slow daemon is a per-call cost the user waits for.
+ * @template T
+ * @param {() => Promise<T>} work
+ * @param {() => number} [now]  injectable clock, for tests
+ * @returns {Promise<T>}
+ */
+export async function chargeDaemonWait(work, now = Date.now) {
+  const started = now();
+  try {
+    return await work();
+  } finally {
+    daemonWaitMs += Math.max(0, now() - started);
+  }
+}
+
 /**
  * Run `work`, charging its whole duration to provisioning so no timer running
  * across it counts that time. Charged in a `finally`, so a provisioning step
@@ -177,24 +210,27 @@ export async function excludeProvisioning(
  * so far MINUS any provisioning charged in the meantime, and may be called more
  * than once.
  *
- * `wallMs` is what the user waited and `cpuMs` is what this process actually
- * computed. Both are needed to say whose cost a slow run is — see the module
- * header for the report that read a contended host as a sanitizer bug.
+ * `wallMs` is what the user waited, `cpuMs` is what this process actually
+ * computed, and `daemonMs` is what it spent waiting on the redactor daemon
+ * ({@link chargeDaemonWait}). All three are needed to say whose cost a slow run
+ * is — see the module header for the report that read a contended host as a
+ * sanitizer bug.
  *
- * Only provisioning charged since this timer started is subtracted, so an
- * earlier run's cold start cannot pay down a later run's real cost. A
- * provisioning window that straddles the timer's start would otherwise be able
- * to subtract more than the timer has measured, so both results are floored
- * at 0.
+ * Every reader counts only what was charged since this timer started, so an
+ * earlier run's cold start cannot pay down a later run's real cost, and an
+ * earlier run's daemon wait cannot be blamed on this one. A provisioning window
+ * that straddles the timer's start would otherwise be able to subtract more than
+ * the timer has measured, so the results are floored at 0.
  * @param {() => number} [now]  injectable clock, for tests
  * @param {() => number} [cpuNow]  injectable CPU clock, for tests
- * @returns {{ wallMs: () => number, cpuMs: () => number }}
+ * @returns {{ wallMs: () => number, cpuMs: () => number, daemonMs: () => number }}
  */
 export function startHookTimer(now = Date.now, cpuNow = processCpuMs) {
   const started = now();
   const cpuStarted = cpuNow();
   const provisionedBefore = provisioningMs;
   const provisionedCpuBefore = provisioningCpuMs;
+  const daemonBefore = daemonWaitMs;
   return {
     wallMs: () =>
       Math.max(0, now() - started - (provisioningMs - provisionedBefore)),
@@ -203,7 +239,39 @@ export function startHookTimer(now = Date.now, cpuNow = processCpuMs) {
         0,
         cpuNow() - cpuStarted - (provisioningCpuMs - provisionedCpuBefore),
       ),
+    daemonMs: () => Math.max(0, daemonWaitMs - daemonBefore),
   };
+}
+
+/**
+ * The attribution sentence for a run whose CPU and redactor-daemon shares are
+ * both known: the two numbers, then the one of the three shares that dominated.
+ *
+ * It NAMES the dominant share instead of listing candidates because the remedies
+ * are opposite — this hook's own computation and its daemon's are the sanitizer's
+ * to fix, a loaded host is not — and a notice that offers both sends the operator
+ * hunting the wrong one. The daemon share is wall-clock, not CPU: it is spent in
+ * another process that {@link processCpuMs} cannot see. The two shares can
+ * therefore overlap by the framing this side does mid-round-trip, which only
+ * strengthens the reading — a share that dominates despite the overlap is the
+ * one to act on.
+ * @param {number} elapsedMs
+ * @param {number} cpuMs
+ * @param {number} daemonMs
+ * @returns {string}
+ */
+function attributeWait(elapsedMs, cpuMs, daemonMs) {
+  const otherMs = Math.max(0, elapsedMs - cpuMs - daemonMs);
+  const verdict =
+    daemonMs >= cpuMs && daemonMs >= otherMs
+      ? "Most of it went to the redactor daemon, a separate sanitizer process — a per-call cost the sanitizer owns."
+      : cpuMs >= otherMs
+        ? "Most of it is this hook computing — a per-call cost the sanitizer owns, repeated by every affected call."
+        : "Most of it is neither: the hook was blocked on a loaded machine or on something outside the sanitizer that it called.";
+  return (
+    `, of which ${formatSeconds(cpuMs)}s was this hook's own CPU and ` +
+    `${formatSeconds(daemonMs)}s was waiting on the redactor daemon. ${verdict}`
+  );
 }
 
 /**
@@ -213,14 +281,16 @@ export function startHookTimer(now = Date.now, cpuNow = processCpuMs) {
  * is asked to relay the numbers, since the operator is the one who can file it.
  *
  * With `context.cpuMs` in hand the line says which share of the wait was the
- * sanitizer computing. Without it the line says that it cannot tell, rather
- * than asserting an attribution nothing measured: a wall-clock overrun on a
- * loaded host is the common case, and blaming it on the sanitizer sends the
- * operator hunting a per-call cost that does not exist.
+ * sanitizer computing, and with `context.daemonMs` too it names the share that
+ * dominated ({@link attributeWait}). Without them the line says that it cannot
+ * tell, rather than asserting an attribution nothing measured: a wall-clock
+ * overrun on a loaded host is the common case, and blaming it on the sanitizer
+ * sends the operator hunting a per-call cost that does not exist.
  *
- * The wait clause names candidates and picks none, for the same reason. A hook
- * that blocks on a dead socket inside a HOST extension spends no CPU and no
- * machine load, so naming either as the cause would be a second wrong guess.
+ * A CPU figure alone cannot pick a cause, so with only that the clause names
+ * candidates and commits to none. A hook that blocks on a dead socket inside a
+ * HOST extension spends no CPU and adds no machine load, so naming either as the
+ * cause would be a second wrong guess.
  * @param {string} hookName
  * @param {number} elapsedMs
  * @param {number} [thresholdMs]
@@ -237,16 +307,23 @@ export function slowHookNotice(
 ) {
   if (elapsedMs <= thresholdMs) return null;
   const cpuMs = context?.cpuMs;
-  const attribution =
-    typeof cpuMs === "number"
+  const daemonMs = context?.daemonMs;
+  const attributed = typeof cpuMs === "number" && typeof daemonMs === "number";
+  const attribution = attributed
+    ? attributeWait(elapsedMs, cpuMs, daemonMs)
+    : typeof cpuMs === "number"
       ? `, and used ${formatSeconds(cpuMs)}s of CPU. ` +
         "Only the CPU share is work every affected call repeats; the rest was spent waiting, on a busy machine or on something this hook called."
       : ". Wall-clock alone cannot separate the sanitizer's own work from a busy machine.";
+  const timings = attributed
+    ? "all three timings"
+    : typeof cpuMs === "number"
+      ? "both timings"
+      : "timing";
   return (
     `agent-sanitizer PERFORMANCE: the ${hookName} hook took ` +
     `${formatSeconds(elapsedMs)}s${formatContextSuffix(context)}, over its ${formatSeconds(thresholdMs)}s budget${attribution} ` +
-    `Tell the user, and suggest they report it at ${ISSUE_URL} with the hook name and ` +
-    `${typeof cpuMs === "number" ? "both timings" : "timing"}.`
+    `Tell the user, and suggest they report it at ${ISSUE_URL} with the hook name and ${timings}.`
   );
 }
 

--- a/claude-hooks/lib/hook-timing.mjs
+++ b/claude-hooks/lib/hook-timing.mjs
@@ -13,11 +13,11 @@
  * a contended host waits far longer than it computes (a 1.1 KB payload and a
  * 235 KB one both reported 7.2s on a loaded 2-vCPU box, against 0.3s of work).
  * So the notice prints, beside the clock, the CPU this process burned and the
- * time it spent waiting on the redactor daemon — a separate, long-lived process
- * whose CPU this one cannot see (see {@link processCpuMs}), so the daemon's cost
- * is measured as the round trip that waits for it. The notice GATES on none of
- * them: a hook wedged on a dead redactor socket burns no CPU and is exactly the
- * sanitizer's fault.
+ * time it spent inside redactor round trips — the daemon is a separate,
+ * long-lived process whose CPU this one cannot see (see {@link processCpuMs}),
+ * so the call that waits for it is the only measurable stand-in. The notice
+ * GATES on none of them: a hook wedged on a dead redactor socket burns no CPU
+ * and is exactly the sanitizer's fault.
  *
  * ONE-TIME PROVISIONING is excluded (see {@link excludeProvisioning}): charging
  * an install to the hook that merely waited it out would make the FIRST call of
@@ -93,15 +93,15 @@ export function formatBytes(bytes) {
  * that made this specific latency report take a manual multi-step
  * investigation to characterize (which tool call, how large a payload) before
  * anyone could act on it.
- * `cpuMs` is the run's own processor time and `daemonMs` the wall-clock it spent
- * waiting on the redactor daemon (both from {@link startHookTimer}); absent when
- * the caller has no way to measure them, which is what the shell port of this
- * module reports.
+ * `cpuMs` is the run's own processor time and `redactorMs` the wall-clock it
+ * spent inside redactor round trips (both from {@link startHookTimer}); absent
+ * when the caller has no way to measure them, which is what the shell port of
+ * this module reports.
  * @typedef {{
  *   payloadBytes?: number | null,
  *   tool?: string | null,
  *   cpuMs?: number | null,
- *   daemonMs?: number | null,
+ *   redactorMs?: number | null,
  * }} SlowHookContext
  */
 
@@ -143,31 +143,33 @@ function processCpuMs() {
 let provisioningMs = 0;
 let provisioningCpuMs = 0;
 
-// Process-wide total of wall-clock spent inside redactor-daemon round trips.
-// Wall-clock and not CPU because the daemon is a separate process: its work is
-// invisible to processCpuMs, so the only measurement this side can make is how
-// long it waited for an answer.
-let daemonWaitMs = 0;
+// Process-wide total of wall-clock spent inside redactor round trips. Wall-clock
+// and not CPU because the daemon is a separate process: its work is invisible to
+// processCpuMs, so how long this side waited for an answer is the only
+// measurement available.
+let redactorRoundTripMs = 0;
 
 /**
- * Run `work` — one redactor-daemon round trip — charging its duration to the
- * daemon share, so a run's wait on the sanitizer's own daemon is told apart from
- * a wait on a loaded host. Charged in a `finally`, since a round trip that
- * THROWS (a stall that hit its deadline) is the one that spent the most.
+ * Run `work` — one redactor round trip — charging its duration to the redactor
+ * share, so a run that spent its second inside a redaction call is told apart
+ * from one that spent it anywhere else. Charged in a `finally`, since a round
+ * trip that THROWS (a stall that hit its deadline) is the one that spent the
+ * most.
  *
  * Unlike {@link excludeProvisioning} this only attributes; the time stays in the
- * hook's wall-clock, because a slow daemon is a per-call cost the user waits for.
+ * hook's wall-clock, because a slow redaction is a per-call cost the user waits
+ * for.
  * @template T
  * @param {() => Promise<T>} work
  * @param {() => number} [now]  injectable clock, for tests
  * @returns {Promise<T>}
  */
-export async function chargeDaemonWait(work, now = Date.now) {
+export async function chargeRedactorRoundTrip(work, now = Date.now) {
   const started = now();
   try {
     return await work();
   } finally {
-    daemonWaitMs += Math.max(0, now() - started);
+    redactorRoundTripMs += Math.max(0, now() - started);
   }
 }
 
@@ -211,26 +213,26 @@ export async function excludeProvisioning(
  * than once.
  *
  * `wallMs` is what the user waited, `cpuMs` is what this process actually
- * computed, and `daemonMs` is what it spent waiting on the redactor daemon
- * ({@link chargeDaemonWait}). All three are needed to say whose cost a slow run
- * is — see the module header for the report that read a contended host as a
- * sanitizer bug.
+ * computed, and `redactorMs` is what it spent inside redactor round trips
+ * ({@link chargeRedactorRoundTrip}). All three are needed to say where a slow
+ * run's time went — see the module header for the report that read a contended
+ * host as a sanitizer bug.
  *
  * Every reader counts only what was charged since this timer started, so an
  * earlier run's cold start cannot pay down a later run's real cost, and an
- * earlier run's daemon wait cannot be blamed on this one. A provisioning window
+ * earlier run's round trip cannot be blamed on this one. A provisioning window
  * that straddles the timer's start would otherwise be able to subtract more than
  * the timer has measured, so the results are floored at 0.
  * @param {() => number} [now]  injectable clock, for tests
  * @param {() => number} [cpuNow]  injectable CPU clock, for tests
- * @returns {{ wallMs: () => number, cpuMs: () => number, daemonMs: () => number }}
+ * @returns {{ wallMs: () => number, cpuMs: () => number, redactorMs: () => number }}
  */
 export function startHookTimer(now = Date.now, cpuNow = processCpuMs) {
   const started = now();
   const cpuStarted = cpuNow();
   const provisionedBefore = provisioningMs;
   const provisionedCpuBefore = provisioningCpuMs;
-  const daemonBefore = daemonWaitMs;
+  const redactorBefore = redactorRoundTripMs;
   return {
     wallMs: () =>
       Math.max(0, now() - started - (provisioningMs - provisionedBefore)),
@@ -239,38 +241,44 @@ export function startHookTimer(now = Date.now, cpuNow = processCpuMs) {
         0,
         cpuNow() - cpuStarted - (provisioningCpuMs - provisionedCpuBefore),
       ),
-    daemonMs: () => Math.max(0, daemonWaitMs - daemonBefore),
+    redactorMs: () => Math.max(0, redactorRoundTripMs - redactorBefore),
   };
 }
 
 /**
- * The attribution sentence for a run whose CPU and redactor-daemon shares are
- * both known: the two numbers, then the one of the three shares that dominated.
+ * The attribution sentence for a run whose CPU and redactor-round-trip shares
+ * are both known: the two numbers, then which of the three WINDOWS the time went
+ * into — this hook computing, the redactor call, or neither.
  *
- * It NAMES the dominant share instead of listing candidates because the remedies
- * are opposite — this hook's own computation and its daemon's are the sanitizer's
- * to fix, a loaded host is not — and a notice that offers both sends the operator
- * hunting the wrong one. The daemon share is wall-clock, not CPU: it is spent in
- * another process that {@link processCpuMs} cannot see. The two shares can
- * therefore overlap by the framing this side does mid-round-trip, which only
- * strengthens the reading — a share that dominates despite the overlap is the
- * one to act on.
+ * A window, not a culprit. The round trip is wall-clock measured from this side,
+ * so it holds the daemon's scan AND whatever descheduling the host imposed on
+ * either end; claiming the daemon from it would re-commit, one bucket over, the
+ * overreach this whole split exists to retract. Separating those two needs
+ * telemetry from inside the daemon, and the wire protocol has no place to carry
+ * it — the response is `handle_request`'s object or a bare JSON `null`, which no
+ * sibling field can ride on. So the redactor verdict says WHERE and declines to
+ * say WHOSE, while the other two windows, which no host load can move time into,
+ * are named outright.
+ *
+ * The CPU and redactor shares overlap by the framing this side does
+ * mid-round-trip, so they do not sum to the elapsed time; a share that dominates
+ * despite the overlap is still the one to act on.
  * @param {number} elapsedMs
  * @param {number} cpuMs
- * @param {number} daemonMs
+ * @param {number} redactorMs
  * @returns {string}
  */
-function attributeWait(elapsedMs, cpuMs, daemonMs) {
-  const otherMs = Math.max(0, elapsedMs - cpuMs - daemonMs);
+function attributeWait(elapsedMs, cpuMs, redactorMs) {
+  const otherMs = Math.max(0, elapsedMs - cpuMs - redactorMs);
   const verdict =
-    daemonMs >= cpuMs && daemonMs >= otherMs
-      ? "Most of it went to the redactor daemon, a separate sanitizer process — a per-call cost the sanitizer owns."
+    redactorMs >= cpuMs && redactorMs >= otherMs
+      ? "Most of it was spent inside the redactor round trip — the daemon's scan, the host it shares, or both; this hook was not computing it."
       : cpuMs >= otherMs
         ? "Most of it is this hook computing — a per-call cost the sanitizer owns, repeated by every affected call."
-        : "Most of it is neither: the hook was blocked on a loaded machine or on something outside the sanitizer that it called.";
+        : "Most of it is neither the redactor nor this hook computing: it was blocked on a loaded machine or on something outside the sanitizer that it called.";
   return (
     `, of which ${formatSeconds(cpuMs)}s was this hook's own CPU and ` +
-    `${formatSeconds(daemonMs)}s was waiting on the redactor daemon. ${verdict}`
+    `${formatSeconds(redactorMs)}s was inside redactor round trips. ${verdict}`
   );
 }
 
@@ -281,8 +289,8 @@ function attributeWait(elapsedMs, cpuMs, daemonMs) {
  * is asked to relay the numbers, since the operator is the one who can file it.
  *
  * With `context.cpuMs` in hand the line says which share of the wait was the
- * sanitizer computing, and with `context.daemonMs` too it names the share that
- * dominated ({@link attributeWait}). Without them the line says that it cannot
+ * sanitizer computing, and with `context.redactorMs` too it names the window the
+ * time went into ({@link attributeWait}). Without them the line says that it cannot
  * tell, rather than asserting an attribution nothing measured: a wall-clock
  * overrun on a loaded host is the common case, and blaming it on the sanitizer
  * sends the operator hunting a per-call cost that does not exist.
@@ -307,10 +315,11 @@ export function slowHookNotice(
 ) {
   if (elapsedMs <= thresholdMs) return null;
   const cpuMs = context?.cpuMs;
-  const daemonMs = context?.daemonMs;
-  const attributed = typeof cpuMs === "number" && typeof daemonMs === "number";
+  const redactorMs = context?.redactorMs;
+  const attributed =
+    typeof cpuMs === "number" && typeof redactorMs === "number";
   const attribution = attributed
-    ? attributeWait(elapsedMs, cpuMs, daemonMs)
+    ? attributeWait(elapsedMs, cpuMs, redactorMs)
     : typeof cpuMs === "number"
       ? `, and used ${formatSeconds(cpuMs)}s of CPU. ` +
         "Only the CPU share is work every affected call repeats; the rest was spent waiting, on a busy machine or on something this hook called."

--- a/claude-hooks/lib/hook-timing.mjs
+++ b/claude-hooks/lib/hook-timing.mjs
@@ -272,10 +272,10 @@ function attributeWait(elapsedMs, cpuMs, redactorMs) {
   const otherMs = Math.max(0, elapsedMs - cpuMs - redactorMs);
   const verdict =
     redactorMs >= cpuMs && redactorMs >= otherMs
-      ? "Most of it was spent inside the redactor round trip — the daemon's scan, the host it shares, or both; this hook was not computing it."
+      ? "The largest share was spent inside the redactor round trip — the daemon's scan, the host it shares, or both; this hook was not computing it."
       : cpuMs >= otherMs
-        ? "Most of it is this hook computing — a per-call cost the sanitizer owns, repeated by every affected call."
-        : "Most of it is neither the redactor nor this hook computing: it was blocked on a loaded machine or on something outside the sanitizer that it called.";
+        ? "The largest share is this hook computing — a per-call cost the sanitizer owns, repeated by every affected call."
+        : "The largest share is neither the redactor nor this hook computing: it was blocked on a loaded machine or on something outside the sanitizer that it called.";
   return (
     `, of which ${formatSeconds(cpuMs)}s was this hook's own CPU and ` +
     `${formatSeconds(redactorMs)}s was inside redactor round trips. ${verdict}`

--- a/claude-hooks/lib/redactor-client.mjs
+++ b/claude-hooks/lib/redactor-client.mjs
@@ -18,7 +18,7 @@
  * daemon could not vet input.
  */
 import { spawn } from "node:child_process";
-import { excludeProvisioning } from "./hook-timing.mjs";
+import { chargeDaemonWait, excludeProvisioning } from "./hook-timing.mjs";
 import { existsSync, lstatSync } from "node:fs";
 import { createConnection } from "node:net";
 import { tmpdir, userInfo } from "node:os";
@@ -435,9 +435,9 @@ export async function redactViaDaemon(text, opts = {}) {
     connect = connectAndRequest,
     spawn: spawnFn = spawnDaemon,
     waitForSocket: waitFn = waitForSocket,
-    // The clock the provisioning charge is measured on; injectable alongside the
-    // waitForSocket seam it brackets, since a stubbed wait advances a test clock
-    // rather than real time.
+    // The clock the provisioning and daemon-wait charges are measured on;
+    // injectable alongside the seams they bracket, since a stubbed wait or
+    // connect advances a test clock rather than real time.
     now = Date.now,
   } = opts;
   // Remaining shared budget in ms, or undefined when no budget was threaded (the
@@ -487,9 +487,17 @@ export async function redactViaDaemon(text, opts = {}) {
       );
     return result;
   };
+  // Every dial is charged to the daemon share, so the slow-hook notice can say
+  // "the daemon was slow" instead of guessing: the daemon is a separate process,
+  // so its CPU appears in neither this process's getrusage(RUSAGE_SELF) nor —
+  // being long-lived and never reaped here — in RUSAGE_CHILDREN. The round trip
+  // this side waits out is the only measurement of it available.
+  /** @param {number | undefined} deadlineMs @returns {Promise<RedactResponse|null>} */
+  const dial = (deadlineMs) =>
+    chargeDaemonWait(() => connect(socketPath, request, deadlineMs), now);
   try {
     // undefined remaining → connectAndRequest's own default request deadline.
-    return validate(await connect(socketPath, request, remainingMs()));
+    return validate(await dial(remainingMs()));
   } catch (err) {
     if (!isRespawnable(err)) throw failClosed(err);
     // Socket absent or dead: (re)spawn the daemon, wait for it, retry exactly once
@@ -520,7 +528,7 @@ export async function redactViaDaemon(text, opts = {}) {
       );
     if (budgetSpent()) throw outOfBudget("after redactor respawn");
     try {
-      return validate(await connect(socketPath, request, remainingMs()));
+      return validate(await dial(remainingMs()));
     } catch (err2) {
       throw failClosed(err2);
     }

--- a/claude-hooks/lib/redactor-client.mjs
+++ b/claude-hooks/lib/redactor-client.mjs
@@ -18,7 +18,10 @@
  * daemon could not vet input.
  */
 import { spawn } from "node:child_process";
-import { chargeDaemonWait, excludeProvisioning } from "./hook-timing.mjs";
+import {
+  chargeRedactorRoundTrip,
+  excludeProvisioning,
+} from "./hook-timing.mjs";
 import { existsSync, lstatSync } from "node:fs";
 import { createConnection } from "node:net";
 import { tmpdir, userInfo } from "node:os";
@@ -435,7 +438,7 @@ export async function redactViaDaemon(text, opts = {}) {
     connect = connectAndRequest,
     spawn: spawnFn = spawnDaemon,
     waitForSocket: waitFn = waitForSocket,
-    // The clock the provisioning and daemon-wait charges are measured on;
+    // The clock the provisioning and round-trip charges are measured on;
     // injectable alongside the seams they bracket, since a stubbed wait or
     // connect advances a test clock rather than real time.
     now = Date.now,
@@ -487,14 +490,17 @@ export async function redactViaDaemon(text, opts = {}) {
       );
     return result;
   };
-  // Every dial is charged to the daemon share, so the slow-hook notice can say
-  // "the daemon was slow" instead of guessing: the daemon is a separate process,
-  // so its CPU appears in neither this process's getrusage(RUSAGE_SELF) nor —
-  // being long-lived and never reaped here — in RUSAGE_CHILDREN. The round trip
-  // this side waits out is the only measurement of it available.
+  // Every dial is charged to the redactor share, so the slow-hook notice can
+  // place the wait in this call rather than guess at it: the daemon is a
+  // separate process, so its cost appears in neither this process's
+  // getrusage(RUSAGE_SELF) nor — being long-lived and never reaped here — in
+  // RUSAGE_CHILDREN. The round trip is the only measurable stand-in.
   /** @param {number | undefined} deadlineMs @returns {Promise<RedactResponse|null>} */
   const dial = (deadlineMs) =>
-    chargeDaemonWait(() => connect(socketPath, request, deadlineMs), now);
+    chargeRedactorRoundTrip(
+      () => connect(socketPath, request, deadlineMs),
+      now,
+    );
   try {
     // undefined remaining → connectAndRequest's own default request deadline.
     return validate(await dial(remainingMs()));

--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=fedb4f82231e589814e5e5eac4a95698cbc5a49d13714d9d86492f7aba9dc24c
-60d747e89f06dc52a770c1a5702eba3f0366b659eb1839121157a0aeb6a847c0  agent-sanitizer-hooks-darwin-arm64
-d8bb90e150cf5e45a6b261e354656d928392b6540234a048145b8c447b0dbaf6  agent-sanitizer-hooks-darwin-x64
-d7c3f498679c5f09a8ae6855b27e25be61a55257856441e14500477de46a50c4  agent-sanitizer-hooks-linux-arm64
-656be0ce19fd4d139253b9c7524a7f4d340fef1410aefc5fb0e4239fffa6c874  agent-sanitizer-hooks-linux-x64
+# bundle=be11f2e8a3770e722d0ef16fea112ecc00667dced1ec08ceb6c7ee82449ede5a
+c0567d078892e5ad1e75b8d8595e4c51cbf3ea621c90afa14a29c75d3c2444ea  agent-sanitizer-hooks-darwin-arm64
+8973ff63cb975589372dfdb79ecaac830746c38b5e582542222cb05a54fc8624  agent-sanitizer-hooks-darwin-x64
+e24f9cf7bce7ea4a31cd3af0562d36a6751520afe8d089553c878e03b3698a7d  agent-sanitizer-hooks-linux-arm64
+48da0cc2a740c2a29102bf05686a754695bb07f0e21b70fd6978382e608d0d3d  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=be11f2e8a3770e722d0ef16fea112ecc00667dced1ec08ceb6c7ee82449ede5a
-c0567d078892e5ad1e75b8d8595e4c51cbf3ea621c90afa14a29c75d3c2444ea  agent-sanitizer-hooks-darwin-arm64
-8973ff63cb975589372dfdb79ecaac830746c38b5e582542222cb05a54fc8624  agent-sanitizer-hooks-darwin-x64
-e24f9cf7bce7ea4a31cd3af0562d36a6751520afe8d089553c878e03b3698a7d  agent-sanitizer-hooks-linux-arm64
-48da0cc2a740c2a29102bf05686a754695bb07f0e21b70fd6978382e608d0d3d  agent-sanitizer-hooks-linux-x64
+# bundle=4dcafe198956d25d35f9a0e6680dcb883e5487705efd72b8fa811496e2a60bb6
+d260ded2ac96a15d98196936e671e6522d76dc935f7820463116937d7f01c4ca  agent-sanitizer-hooks-darwin-arm64
+0afd67b67e8a0fb57261793c96e14596e109a40c7485db5e4f439a8e0ddf5e47  agent-sanitizer-hooks-darwin-x64
+778d907f1e0518a7244ae49c66a1860c3ab982d1f7d8b62e28a039679ee7daf9  agent-sanitizer-hooks-linux-arm64
+355b5c8473dcc4bf1f1ec68f19f94d5950132ae7063170044b4219cb6495e087  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=4dcafe198956d25d35f9a0e6680dcb883e5487705efd72b8fa811496e2a60bb6
-d260ded2ac96a15d98196936e671e6522d76dc935f7820463116937d7f01c4ca  agent-sanitizer-hooks-darwin-arm64
-0afd67b67e8a0fb57261793c96e14596e109a40c7485db5e4f439a8e0ddf5e47  agent-sanitizer-hooks-darwin-x64
-778d907f1e0518a7244ae49c66a1860c3ab982d1f7d8b62e28a039679ee7daf9  agent-sanitizer-hooks-linux-arm64
-355b5c8473dcc4bf1f1ec68f19f94d5950132ae7063170044b4219cb6495e087  agent-sanitizer-hooks-linux-x64
+# bundle=381220d637b1a8bfe7fa48ec0b0350d11de9db6ab8553119b00a35126e12b088
+6b097d767b97a819602ef765fa7a0050be083aaa9a7a9f6245ed3c9dbff408d2  agent-sanitizer-hooks-darwin-arm64
+443fbabe5ca7a1f2081d203dfe79943f303f7fc846ffdfcb68e97f70d1d4cd7a  agent-sanitizer-hooks-darwin-x64
+57eec48364785e2414d7ad1619629c6e26f540c6e3540ebc08560357835a3806  agent-sanitizer-hooks-linux-arm64
+5828ce81b85c9fec02794f9f0e9789e9f0432b38b2b94680998552c9917aa752  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -100,7 +100,7 @@ function startHookTimer(now = Date.now, cpuNow = processCpuMs) {
 }
 function attributeWait(elapsedMs, cpuMs, redactorMs) {
   const otherMs = Math.max(0, elapsedMs - cpuMs - redactorMs);
-  const verdict = redactorMs >= cpuMs && redactorMs >= otherMs ? "Most of it was spent inside the redactor round trip \u2014 the daemon's scan, the host it shares, or both; this hook was not computing it." : cpuMs >= otherMs ? "Most of it is this hook computing \u2014 a per-call cost the sanitizer owns, repeated by every affected call." : "Most of it is neither the redactor nor this hook computing: it was blocked on a loaded machine or on something outside the sanitizer that it called.";
+  const verdict = redactorMs >= cpuMs && redactorMs >= otherMs ? "The largest share was spent inside the redactor round trip \u2014 the daemon's scan, the host it shares, or both; this hook was not computing it." : cpuMs >= otherMs ? "The largest share is this hook computing \u2014 a per-call cost the sanitizer owns, repeated by every affected call." : "The largest share is neither the redactor nor this hook computing: it was blocked on a loaded machine or on something outside the sanitizer that it called.";
   return `, of which ${formatSeconds(cpuMs)}s was this hook's own CPU and ${formatSeconds(redactorMs)}s was inside redactor round trips. ${verdict}`;
 }
 function slowHookNotice(hookName, elapsedMs, thresholdMs = SLOW_HOOK_THRESHOLD_MS, context) {

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -65,12 +65,12 @@ function processCpuMs() {
   const { user, system } = process.cpuUsage();
   return (user + system) / 1e3;
 }
-async function chargeDaemonWait(work, now = Date.now) {
+async function chargeRedactorRoundTrip(work, now = Date.now) {
   const started = now();
   try {
     return await work();
   } finally {
-    daemonWaitMs += Math.max(0, now() - started);
+    redactorRoundTripMs += Math.max(0, now() - started);
   }
 }
 async function excludeProvisioning(work, now = Date.now, cpuNow = processCpuMs) {
@@ -88,27 +88,27 @@ function startHookTimer(now = Date.now, cpuNow = processCpuMs) {
   const cpuStarted = cpuNow();
   const provisionedBefore = provisioningMs;
   const provisionedCpuBefore = provisioningCpuMs;
-  const daemonBefore = daemonWaitMs;
+  const redactorBefore = redactorRoundTripMs;
   return {
     wallMs: () => Math.max(0, now() - started - (provisioningMs - provisionedBefore)),
     cpuMs: () => Math.max(
       0,
       cpuNow() - cpuStarted - (provisioningCpuMs - provisionedCpuBefore)
     ),
-    daemonMs: () => Math.max(0, daemonWaitMs - daemonBefore)
+    redactorMs: () => Math.max(0, redactorRoundTripMs - redactorBefore)
   };
 }
-function attributeWait(elapsedMs, cpuMs, daemonMs) {
-  const otherMs = Math.max(0, elapsedMs - cpuMs - daemonMs);
-  const verdict = daemonMs >= cpuMs && daemonMs >= otherMs ? "Most of it went to the redactor daemon, a separate sanitizer process \u2014 a per-call cost the sanitizer owns." : cpuMs >= otherMs ? "Most of it is this hook computing \u2014 a per-call cost the sanitizer owns, repeated by every affected call." : "Most of it is neither: the hook was blocked on a loaded machine or on something outside the sanitizer that it called.";
-  return `, of which ${formatSeconds(cpuMs)}s was this hook's own CPU and ${formatSeconds(daemonMs)}s was waiting on the redactor daemon. ${verdict}`;
+function attributeWait(elapsedMs, cpuMs, redactorMs) {
+  const otherMs = Math.max(0, elapsedMs - cpuMs - redactorMs);
+  const verdict = redactorMs >= cpuMs && redactorMs >= otherMs ? "Most of it was spent inside the redactor round trip \u2014 the daemon's scan, the host it shares, or both; this hook was not computing it." : cpuMs >= otherMs ? "Most of it is this hook computing \u2014 a per-call cost the sanitizer owns, repeated by every affected call." : "Most of it is neither the redactor nor this hook computing: it was blocked on a loaded machine or on something outside the sanitizer that it called.";
+  return `, of which ${formatSeconds(cpuMs)}s was this hook's own CPU and ${formatSeconds(redactorMs)}s was inside redactor round trips. ${verdict}`;
 }
 function slowHookNotice(hookName, elapsedMs, thresholdMs = SLOW_HOOK_THRESHOLD_MS, context) {
   if (elapsedMs <= thresholdMs) return null;
   const cpuMs = context?.cpuMs;
-  const daemonMs = context?.daemonMs;
-  const attributed = typeof cpuMs === "number" && typeof daemonMs === "number";
-  const attribution = attributed ? attributeWait(elapsedMs, cpuMs, daemonMs) : typeof cpuMs === "number" ? `, and used ${formatSeconds(cpuMs)}s of CPU. Only the CPU share is work every affected call repeats; the rest was spent waiting, on a busy machine or on something this hook called.` : ". Wall-clock alone cannot separate the sanitizer's own work from a busy machine.";
+  const redactorMs = context?.redactorMs;
+  const attributed = typeof cpuMs === "number" && typeof redactorMs === "number";
+  const attribution = attributed ? attributeWait(elapsedMs, cpuMs, redactorMs) : typeof cpuMs === "number" ? `, and used ${formatSeconds(cpuMs)}s of CPU. Only the CPU share is work every affected call repeats; the rest was spent waiting, on a busy machine or on something this hook called.` : ". Wall-clock alone cannot separate the sanitizer's own work from a busy machine.";
   const timings = attributed ? "all three timings" : typeof cpuMs === "number" ? "both timings" : "timing";
   return `agent-sanitizer PERFORMANCE: the ${hookName} hook took ${formatSeconds(elapsedMs)}s${formatContextSuffix(context)}, over its ${formatSeconds(thresholdMs)}s budget${attribution} Tell the user, and suggest they report it at ${ISSUE_URL} with the hook name and ${timings}.`;
 }
@@ -132,7 +132,7 @@ function reportSlowHook(hookName, elapsedMs, hookEventName, emit, writeErr = (ch
   emit(hookEventName, { additionalContext: notice });
   return true;
 }
-var SLOW_HOOK_THRESHOLD_MS, ISSUE_URL, provisioningMs, provisioningCpuMs, daemonWaitMs;
+var SLOW_HOOK_THRESHOLD_MS, ISSUE_URL, provisioningMs, provisioningCpuMs, redactorRoundTripMs;
 var init_hook_timing = __esm({
   "claude-hooks/lib/hook-timing.mjs"() {
     "use strict";
@@ -140,7 +140,7 @@ var init_hook_timing = __esm({
     ISSUE_URL = "https://github.com/AlexanderMattTurner/agent-sanitizer/issues/new";
     provisioningMs = 0;
     provisioningCpuMs = 0;
-    daemonWaitMs = 0;
+    redactorRoundTripMs = 0;
   }
 });
 
@@ -66198,7 +66198,7 @@ async function runJudgeCli(hookName, judge, {
           payloadBytes,
           tool,
           cpuMs: timer.cpuMs(),
-          daemonMs: timer.daemonMs()
+          redactorMs: timer.redactorMs()
         }),
         event
       )
@@ -66212,7 +66212,7 @@ async function runJudgeCli(hookName, judge, {
         payloadBytes,
         tool,
         cpuMs: timer.cpuMs(),
-        daemonMs: timer.daemonMs()
+        redactorMs: timer.redactorMs()
       });
     onError(err, input);
   }
@@ -67000,7 +67000,7 @@ async function redactViaDaemon(text5, opts = {}) {
     connect = connectAndRequest,
     spawn: spawnFn = spawnDaemon,
     waitForSocket: waitFn = waitForSocket,
-    // The clock the provisioning and daemon-wait charges are measured on;
+    // The clock the provisioning and round-trip charges are measured on;
     // injectable alongside the seams they bracket, since a stubbed wait or
     // connect advances a test clock rather than real time.
     now = Date.now
@@ -67033,7 +67033,10 @@ async function redactViaDaemon(text5, opts = {}) {
       );
     return result;
   };
-  const dial = (deadlineMs) => chargeDaemonWait(() => connect(socketPath, request, deadlineMs), now);
+  const dial = (deadlineMs) => chargeRedactorRoundTrip(
+    () => connect(socketPath, request, deadlineMs),
+    now
+  );
   try {
     return validate(await dial(remainingMs()));
   } catch (err) {

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -65,6 +65,14 @@ function processCpuMs() {
   const { user, system } = process.cpuUsage();
   return (user + system) / 1e3;
 }
+async function chargeDaemonWait(work, now = Date.now) {
+  const started = now();
+  try {
+    return await work();
+  } finally {
+    daemonWaitMs += Math.max(0, now() - started);
+  }
+}
 async function excludeProvisioning(work, now = Date.now, cpuNow = processCpuMs) {
   const started = now();
   const cpuStarted = cpuNow();
@@ -80,19 +88,29 @@ function startHookTimer(now = Date.now, cpuNow = processCpuMs) {
   const cpuStarted = cpuNow();
   const provisionedBefore = provisioningMs;
   const provisionedCpuBefore = provisioningCpuMs;
+  const daemonBefore = daemonWaitMs;
   return {
     wallMs: () => Math.max(0, now() - started - (provisioningMs - provisionedBefore)),
     cpuMs: () => Math.max(
       0,
       cpuNow() - cpuStarted - (provisioningCpuMs - provisionedCpuBefore)
-    )
+    ),
+    daemonMs: () => Math.max(0, daemonWaitMs - daemonBefore)
   };
+}
+function attributeWait(elapsedMs, cpuMs, daemonMs) {
+  const otherMs = Math.max(0, elapsedMs - cpuMs - daemonMs);
+  const verdict = daemonMs >= cpuMs && daemonMs >= otherMs ? "Most of it went to the redactor daemon, a separate sanitizer process \u2014 a per-call cost the sanitizer owns." : cpuMs >= otherMs ? "Most of it is this hook computing \u2014 a per-call cost the sanitizer owns, repeated by every affected call." : "Most of it is neither: the hook was blocked on a loaded machine or on something outside the sanitizer that it called.";
+  return `, of which ${formatSeconds(cpuMs)}s was this hook's own CPU and ${formatSeconds(daemonMs)}s was waiting on the redactor daemon. ${verdict}`;
 }
 function slowHookNotice(hookName, elapsedMs, thresholdMs = SLOW_HOOK_THRESHOLD_MS, context) {
   if (elapsedMs <= thresholdMs) return null;
   const cpuMs = context?.cpuMs;
-  const attribution = typeof cpuMs === "number" ? `, and used ${formatSeconds(cpuMs)}s of CPU. Only the CPU share is work every affected call repeats; the rest was spent waiting, on a busy machine or on something this hook called.` : ". Wall-clock alone cannot separate the sanitizer's own work from a busy machine.";
-  return `agent-sanitizer PERFORMANCE: the ${hookName} hook took ${formatSeconds(elapsedMs)}s${formatContextSuffix(context)}, over its ${formatSeconds(thresholdMs)}s budget${attribution} Tell the user, and suggest they report it at ${ISSUE_URL} with the hook name and ${typeof cpuMs === "number" ? "both timings" : "timing"}.`;
+  const daemonMs = context?.daemonMs;
+  const attributed = typeof cpuMs === "number" && typeof daemonMs === "number";
+  const attribution = attributed ? attributeWait(elapsedMs, cpuMs, daemonMs) : typeof cpuMs === "number" ? `, and used ${formatSeconds(cpuMs)}s of CPU. Only the CPU share is work every affected call repeats; the rest was spent waiting, on a busy machine or on something this hook called.` : ". Wall-clock alone cannot separate the sanitizer's own work from a busy machine.";
+  const timings = attributed ? "all three timings" : typeof cpuMs === "number" ? "both timings" : "timing";
+  return `agent-sanitizer PERFORMANCE: the ${hookName} hook took ${formatSeconds(elapsedMs)}s${formatContextSuffix(context)}, over its ${formatSeconds(thresholdMs)}s budget${attribution} Tell the user, and suggest they report it at ${ISSUE_URL} with the hook name and ${timings}.`;
 }
 function writeSlowHookNotice(hookName, elapsedMs, writeErr = (chunk) => process.stderr.write(chunk), context) {
   const notice = slowHookNotice(hookName, elapsedMs, void 0, context);
@@ -114,7 +132,7 @@ function reportSlowHook(hookName, elapsedMs, hookEventName, emit, writeErr = (ch
   emit(hookEventName, { additionalContext: notice });
   return true;
 }
-var SLOW_HOOK_THRESHOLD_MS, ISSUE_URL, provisioningMs, provisioningCpuMs;
+var SLOW_HOOK_THRESHOLD_MS, ISSUE_URL, provisioningMs, provisioningCpuMs, daemonWaitMs;
 var init_hook_timing = __esm({
   "claude-hooks/lib/hook-timing.mjs"() {
     "use strict";
@@ -122,6 +140,7 @@ var init_hook_timing = __esm({
     ISSUE_URL = "https://github.com/AlexanderMattTurner/agent-sanitizer/issues/new";
     provisioningMs = 0;
     provisioningCpuMs = 0;
+    daemonWaitMs = 0;
   }
 });
 
@@ -66178,7 +66197,8 @@ async function runJudgeCli(hookName, judge, {
         withSlowHookNotice(hookName, timer.wallMs(), judged, void 0, {
           payloadBytes,
           tool,
-          cpuMs: timer.cpuMs()
+          cpuMs: timer.cpuMs(),
+          daemonMs: timer.daemonMs()
         }),
         event
       )
@@ -66191,7 +66211,8 @@ async function runJudgeCli(hookName, judge, {
       writeSlowHookNotice(hookName, timer.wallMs(), void 0, {
         payloadBytes,
         tool,
-        cpuMs: timer.cpuMs()
+        cpuMs: timer.cpuMs(),
+        daemonMs: timer.daemonMs()
       });
     onError(err, input);
   }
@@ -66979,9 +67000,9 @@ async function redactViaDaemon(text5, opts = {}) {
     connect = connectAndRequest,
     spawn: spawnFn = spawnDaemon,
     waitForSocket: waitFn = waitForSocket,
-    // The clock the provisioning charge is measured on; injectable alongside the
-    // waitForSocket seam it brackets, since a stubbed wait advances a test clock
-    // rather than real time.
+    // The clock the provisioning and daemon-wait charges are measured on;
+    // injectable alongside the seams they bracket, since a stubbed wait or
+    // connect advances a test clock rather than real time.
     now = Date.now
   } = opts;
   const remainingMs = () => deadline ? deadline.remainingMs() : void 0;
@@ -67012,8 +67033,9 @@ async function redactViaDaemon(text5, opts = {}) {
       );
     return result;
   };
+  const dial = (deadlineMs) => chargeDaemonWait(() => connect(socketPath, request, deadlineMs), now);
   try {
-    return validate(await connect(socketPath, request, remainingMs()));
+    return validate(await dial(remainingMs()));
   } catch (err) {
     if (!isRespawnable(err)) throw failClosed(err);
     if (budgetSpent()) throw outOfBudget("before redactor respawn");
@@ -67030,7 +67052,7 @@ async function redactViaDaemon(text5, opts = {}) {
       );
     if (budgetSpent()) throw outOfBudget("after redactor respawn");
     try {
-      return validate(await connect(socketPath, request, remainingMs()));
+      return validate(await dial(remainingMs()));
     } catch (err2) {
       throw failClosed(err2);
     }

--- a/test/claude-hooks-timing.test.mjs
+++ b/test/claude-hooks-timing.test.mjs
@@ -193,21 +193,21 @@ describe("provisioning is not the hook's cost", () => {
       "the daemon cold start must not be charged",
     );
     assert.equal(
-      timer.daemonMs(),
+      timer.redactorMs(),
       0,
       "a cold start is provisioning, not a round trip",
     );
   });
 });
 
-describe("the redactor daemon's share of the wait", () => {
+describe("the redactor round trip's share of the wait", () => {
   // The daemon runs in its own long-lived process, so its cost lands in neither
   // this process's getrusage(RUSAGE_SELF) (what process.cpuUsage reads) nor
   // RUSAGE_CHILDREN (which needs a reaped child). Unmeasured, a hook whose
-  // second went entirely into the daemon reports near-zero CPU and reads as a
-  // busy machine — the one diagnosis with the opposite remedy.
+  // second went entirely into a redaction call reports near-zero CPU and reads
+  // as a busy machine that never touched the sanitizer.
 
-  it("charges a round trip to the daemon, and to the wall-clock the user waited", async () => {
+  it("charges a round trip to the redactor, and to the wall-clock the user waited", async () => {
     let t = 0;
     const clock = () => t;
     const timer = startHookTimer(clock, () => 0);
@@ -219,11 +219,11 @@ describe("the redactor daemon's share of the wait", () => {
       now: clock,
     });
     assert.deepEqual(result, { text: "some text", found: [] });
-    assert.equal(timer.daemonMs(), 2_500);
+    assert.equal(timer.redactorMs(), 2_500);
     assert.equal(
       timer.wallMs(),
       2_500,
-      "a slow daemon is a per-call cost the user waits for, so it stays in wall",
+      "a slow redaction is a per-call cost the user waits for, so it stays in wall",
     );
   });
 
@@ -243,7 +243,7 @@ describe("the redactor daemon's share of the wait", () => {
       }),
       /redactor response timeout/u,
     );
-    assert.equal(timer.daemonMs(), 20_000);
+    assert.equal(timer.redactorMs(), 20_000);
   });
 
   it("charges BOTH dials when a dead socket forces a respawn and retry", async () => {
@@ -265,10 +265,10 @@ describe("the redactor daemon's share of the wait", () => {
       },
       now: clock,
     });
-    assert.equal(timer.daemonMs(), 800, "both dials, and not the cold start");
+    assert.equal(timer.redactorMs(), 800, "both dials, and not the cold start");
   });
 
-  it("never lets one run's daemon wait land on a later run's timer", async () => {
+  it("never lets one run's round trip land on a later run's timer", async () => {
     let t = 0;
     const clock = () => t;
     await redactViaDaemon("some text", {
@@ -280,7 +280,7 @@ describe("the redactor daemon's share of the wait", () => {
     });
     const timer = startHookTimer(clock, () => 0);
     t += 40;
-    assert.equal(timer.daemonMs(), 0);
+    assert.equal(timer.redactorMs(), 0);
   });
 });
 
@@ -331,41 +331,55 @@ describe("slowHookNotice", () => {
     assert.doesNotMatch(notice, /the rest was waiting on a busy machine/);
   });
 
-  it("blames the daemon when the daemon is where the wait went", () => {
+  it("puts the wait in the redactor call when that is where it went", () => {
     // The report this wording exists for: 6.9s of wall against 0.05s of CPU,
-    // all of it inside a redactor round trip. Read as CPU-versus-the-rest that
-    // is indistinguishable from a loaded box, and the two have opposite
-    // remedies — one is the sanitizer's bug, the other is not its problem.
+    // all of it inside a redactor round trip. Read as CPU-versus-the-rest, that
+    // is indistinguishable from a loaded box that never called the sanitizer.
     const notice = slowHookNotice("sanitize-output", 6_900, undefined, {
       cpuMs: 50,
-      daemonMs: 6_800,
+      redactorMs: 6_800,
     });
     assert.match(notice, /0\.1s was this hook's own CPU/);
-    assert.match(notice, /6\.8s was waiting on the redactor daemon/);
-    assert.match(notice, /Most of it went to the redactor daemon/);
-    assert.doesNotMatch(notice, /busy machine/);
+    assert.match(notice, /6\.8s was inside redactor round trips/);
+    assert.match(notice, /Most of it was spent inside the redactor round trip/);
     assert.match(notice, /hook name and all three timings/);
+  });
+
+  it("names the round trip as a WINDOW, never as the culprit inside it", () => {
+    // The round trip is wall-clock from this side, so it holds the daemon's
+    // scan AND whatever descheduling a contended host imposed on either end.
+    // Naming the daemon from that number would re-commit, one bucket over, the
+    // overreach the CPU split exists to retract — so the verdict offers both
+    // and picks neither. Separating them needs telemetry from inside the
+    // daemon, which the wire protocol (whose response may be a bare null) has
+    // nowhere to carry.
+    const notice = slowHookNotice("sanitize-output", 6_900, undefined, {
+      cpuMs: 50,
+      redactorMs: 6_800,
+    });
+    assert.match(notice, /the daemon's scan, the host it shares, or both/);
+    assert.doesNotMatch(notice, /the sanitizer owns/);
   });
 
   it("blames this hook when the hook is what computed", () => {
     const notice = slowHookNotice("scan-invisible-chars", 4_000, undefined, {
       cpuMs: 3_800,
-      daemonMs: 100,
+      redactorMs: 100,
     });
     assert.match(notice, /Most of it is this hook computing/);
-    assert.doesNotMatch(notice, /Most of it went to the redactor daemon/);
+    assert.doesNotMatch(notice, /inside the redactor round trip/);
   });
 
   it("blames neither when the time went somewhere it can see neither of", () => {
-    // Same 7.2s-against-0.3s host contention as above, now with the daemon
-    // ruled OUT by measurement rather than left as an unfalsified candidate.
+    // Same 7.2s-against-0.3s host contention as above, now with the redactor
+    // call ruled OUT by measurement rather than left as an unfalsified
+    // candidate — the one thing this side CAN settle.
     const notice = slowHookNotice("sanitize-output", 7_200, undefined, {
       cpuMs: 300,
-      daemonMs: 120,
+      redactorMs: 120,
     });
-    assert.match(notice, /Most of it is neither/);
+    assert.match(notice, /Most of it is neither the redactor nor this hook/);
     assert.match(notice, /loaded machine/);
-    assert.doesNotMatch(notice, /Most of it went to the redactor daemon/);
   });
 
   it("admits it cannot attribute the wait when no CPU figure is given", () => {
@@ -633,19 +647,19 @@ describe("runJudgeCli times every judge hook", () => {
     // Compared, not pinned to 0.0s: the same window really does load the
     // control plane, and on a cold runner that is a tenth of a second of CPU.
     const timings = stdout.match(
-      /took (\d+\.\d)s .*?of which (\d+\.\d)s was this hook's own CPU and (\d+\.\d)s was waiting on the redactor daemon/u,
+      /took (\d+\.\d)s .*?of which (\d+\.\d)s was this hook's own CPU and (\d+\.\d)s was inside redactor round trips/u,
     );
     assert.ok(timings, stdout);
-    const [, wall, cpu, daemon] = timings;
+    const [, wall, cpu, redactor] = timings;
     assert.ok(
       Number(cpu) < Number(wall),
       `a sleeping judge must report CPU (${cpu}s) below wall (${wall}s)`,
     );
     // A judge that never dialled the daemon is the case the third number
-    // exonerates it in: the notice can only name the sanitizer's own daemon as
-    // the cause when a round trip actually happened.
-    assert.equal(daemon, "0.0", stdout);
-    assert.match(stdout, /Most of it is neither/);
+    // exonerates the redactor in: the notice can only place a wait in that call
+    // when a round trip actually happened.
+    assert.equal(redactor, "0.0", stdout);
+    assert.match(stdout, /Most of it is neither the redactor nor this hook/);
     assert.ok(
       errs.some((line) => line.includes("PERFORMANCE")),
       "the timing must also reach stderr",

--- a/test/claude-hooks-timing.test.mjs
+++ b/test/claude-hooks-timing.test.mjs
@@ -341,7 +341,10 @@ describe("slowHookNotice", () => {
     });
     assert.match(notice, /0\.1s was this hook's own CPU/);
     assert.match(notice, /6\.8s was inside redactor round trips/);
-    assert.match(notice, /Most of it was spent inside the redactor round trip/);
+    assert.match(
+      notice,
+      /The largest share was spent inside the redactor round trip/,
+    );
     assert.match(notice, /hook name and all three timings/);
   });
 
@@ -366,7 +369,7 @@ describe("slowHookNotice", () => {
       cpuMs: 3_800,
       redactorMs: 100,
     });
-    assert.match(notice, /Most of it is this hook computing/);
+    assert.match(notice, /The largest share is this hook computing/);
     assert.doesNotMatch(notice, /inside the redactor round trip/);
   });
 
@@ -378,7 +381,10 @@ describe("slowHookNotice", () => {
       cpuMs: 300,
       redactorMs: 120,
     });
-    assert.match(notice, /Most of it is neither the redactor nor this hook/);
+    assert.match(
+      notice,
+      /The largest share is neither the redactor nor this hook/,
+    );
     assert.match(notice, /loaded machine/);
   });
 
@@ -659,7 +665,10 @@ describe("runJudgeCli times every judge hook", () => {
     // exonerates the redactor in: the notice can only place a wait in that call
     // when a round trip actually happened.
     assert.equal(redactor, "0.0", stdout);
-    assert.match(stdout, /Most of it is neither the redactor nor this hook/);
+    assert.match(
+      stdout,
+      /The largest share is neither the redactor nor this hook/,
+    );
     assert.ok(
       errs.some((line) => line.includes("PERFORMANCE")),
       "the timing must also reach stderr",
@@ -702,6 +711,13 @@ describe("runJudgeCli times every judge hook", () => {
     assert.match(stderr, /sanitize-output hook error: judge exploded/);
     assert.match(stderr, /PERFORMANCE/);
     assert.match(stderr, /sanitize-output hook took/);
+    // The error path carries all three timings too: a judge that threw after
+    // stalling inside a redaction call is the run whose redactor share is the
+    // finding, and this stderr line is its only report.
+    assert.match(
+      stderr,
+      /of which \d+\.\ds was this hook's own CPU and 0\.0s was inside redactor round trips/u,
+    );
     // The posture still runs: the timing is an addition to the fault report,
     // never a replacement for it.
     assert.ok(onErrorCalled, "onError must still take the failure posture");

--- a/test/claude-hooks-timing.test.mjs
+++ b/test/claude-hooks-timing.test.mjs
@@ -192,6 +192,95 @@ describe("provisioning is not the hook's cost", () => {
       0,
       "the daemon cold start must not be charged",
     );
+    assert.equal(
+      timer.daemonMs(),
+      0,
+      "a cold start is provisioning, not a round trip",
+    );
+  });
+});
+
+describe("the redactor daemon's share of the wait", () => {
+  // The daemon runs in its own long-lived process, so its cost lands in neither
+  // this process's getrusage(RUSAGE_SELF) (what process.cpuUsage reads) nor
+  // RUSAGE_CHILDREN (which needs a reaped child). Unmeasured, a hook whose
+  // second went entirely into the daemon reports near-zero CPU and reads as a
+  // busy machine — the one diagnosis with the opposite remedy.
+
+  it("charges a round trip to the daemon, and to the wall-clock the user waited", async () => {
+    let t = 0;
+    const clock = () => t;
+    const timer = startHookTimer(clock, () => 0);
+    const result = await redactViaDaemon("some text", {
+      connect: async () => {
+        t += 2_500;
+        return { text: "some text", found: [] };
+      },
+      now: clock,
+    });
+    assert.deepEqual(result, { text: "some text", found: [] });
+    assert.equal(timer.daemonMs(), 2_500);
+    assert.equal(
+      timer.wallMs(),
+      2_500,
+      "a slow daemon is a per-call cost the user waits for, so it stays in wall",
+    );
+  });
+
+  it("charges a round trip that FAILED", async () => {
+    // A dial that stalled to its deadline is the most expensive one there is;
+    // dropping it would hand the whole wait to the busy-machine reading.
+    let t = 0;
+    const clock = () => t;
+    const timer = startHookTimer(clock, () => 0);
+    await assert.rejects(
+      redactViaDaemon("some text", {
+        connect: async () => {
+          t += 20_000;
+          throw new Error("redactor response timeout");
+        },
+        now: clock,
+      }),
+      /redactor response timeout/u,
+    );
+    assert.equal(timer.daemonMs(), 20_000);
+  });
+
+  it("charges BOTH dials when a dead socket forces a respawn and retry", async () => {
+    let t = 0;
+    const clock = () => t;
+    const timer = startHookTimer(clock, () => 0);
+    const dead = Object.assign(new Error("no socket"), { code: "ENOENT" });
+    let dialled = 0;
+    await redactViaDaemon("some text", {
+      connect: async () => {
+        t += 400;
+        if (++dialled === 1) throw dead;
+        return { text: "some text", found: [] };
+      },
+      spawn: () => {},
+      waitForSocket: async () => {
+        t += 3_000; // provisioning: the cold detect-secrets import
+        return true;
+      },
+      now: clock,
+    });
+    assert.equal(timer.daemonMs(), 800, "both dials, and not the cold start");
+  });
+
+  it("never lets one run's daemon wait land on a later run's timer", async () => {
+    let t = 0;
+    const clock = () => t;
+    await redactViaDaemon("some text", {
+      connect: async () => {
+        t += 5_000;
+        return { text: "some text", found: [] };
+      },
+      now: clock,
+    });
+    const timer = startHookTimer(clock, () => 0);
+    t += 40;
+    assert.equal(timer.daemonMs(), 0);
   });
 });
 
@@ -240,6 +329,43 @@ describe("slowHookNotice", () => {
     });
     assert.match(notice, /on a busy machine or on something this hook called/);
     assert.doesNotMatch(notice, /the rest was waiting on a busy machine/);
+  });
+
+  it("blames the daemon when the daemon is where the wait went", () => {
+    // The report this wording exists for: 6.9s of wall against 0.05s of CPU,
+    // all of it inside a redactor round trip. Read as CPU-versus-the-rest that
+    // is indistinguishable from a loaded box, and the two have opposite
+    // remedies — one is the sanitizer's bug, the other is not its problem.
+    const notice = slowHookNotice("sanitize-output", 6_900, undefined, {
+      cpuMs: 50,
+      daemonMs: 6_800,
+    });
+    assert.match(notice, /0\.1s was this hook's own CPU/);
+    assert.match(notice, /6\.8s was waiting on the redactor daemon/);
+    assert.match(notice, /Most of it went to the redactor daemon/);
+    assert.doesNotMatch(notice, /busy machine/);
+    assert.match(notice, /hook name and all three timings/);
+  });
+
+  it("blames this hook when the hook is what computed", () => {
+    const notice = slowHookNotice("scan-invisible-chars", 4_000, undefined, {
+      cpuMs: 3_800,
+      daemonMs: 100,
+    });
+    assert.match(notice, /Most of it is this hook computing/);
+    assert.doesNotMatch(notice, /Most of it went to the redactor daemon/);
+  });
+
+  it("blames neither when the time went somewhere it can see neither of", () => {
+    // Same 7.2s-against-0.3s host contention as above, now with the daemon
+    // ruled OUT by measurement rather than left as an unfalsified candidate.
+    const notice = slowHookNotice("sanitize-output", 7_200, undefined, {
+      cpuMs: 300,
+      daemonMs: 120,
+    });
+    assert.match(notice, /Most of it is neither/);
+    assert.match(notice, /loaded machine/);
+    assert.doesNotMatch(notice, /Most of it went to the redactor daemon/);
   });
 
   it("admits it cannot attribute the wait when no CPU figure is given", () => {
@@ -506,13 +632,20 @@ describe("runJudgeCli times every judge hook", () => {
     // notice has to say so rather than call the whole second sanitizer work.
     // Compared, not pinned to 0.0s: the same window really does load the
     // control plane, and on a cold runner that is a tenth of a second of CPU.
-    const timings = stdout.match(/took (\d+\.\d)s .*?used (\d+\.\d)s of CPU/u);
+    const timings = stdout.match(
+      /took (\d+\.\d)s .*?of which (\d+\.\d)s was this hook's own CPU and (\d+\.\d)s was waiting on the redactor daemon/u,
+    );
     assert.ok(timings, stdout);
-    const [, wall, cpu] = timings;
+    const [, wall, cpu, daemon] = timings;
     assert.ok(
       Number(cpu) < Number(wall),
       `a sleeping judge must report CPU (${cpu}s) below wall (${wall}s)`,
     );
+    // A judge that never dialled the daemon is the case the third number
+    // exonerates it in: the notice can only name the sanitizer's own daemon as
+    // the cause when a round trip actually happened.
+    assert.equal(daemon, "0.0", stdout);
+    assert.match(stdout, /Most of it is neither/);
     assert.ok(
       errs.some((line) => line.includes("PERFORMANCE")),
       "the timing must also reach stderr",


### PR DESCRIPTION
Claims `claude-hooks/lib/hook-timing.mjs` + `lib/redactor-client.mjs` (slow-hook timing attribution).

## Summary

Measure the time a hook spends inside redactor round trips and report it as a third number, so the slow-hook notice can say which of three windows the time went into — this hook computing, the redactor call, or neither — instead of offering one bucket of candidates.

`slowHookNotice` split an overrun into this process's CPU and "the rest", offered as "a busy machine or on something this hook called". `process.cpuUsage()` is `getrusage(RUSAGE_SELF)`: it counts this process only. `redactor-client.mjs:20` spawns the daemon detached and talks to it over a per-session unix socket, and that daemon is long-lived and never reaped during a hook, so its cost lands in neither `RUSAGE_SELF` nor `RUSAGE_CHILDREN`. A hook whose seconds went into a redaction call therefore reported near-zero CPU against multi-second wall-clock — indistinguishable from a loaded box that never touched the sanitizer at all.

The round trip is measured from this side, so it holds the daemon's scan *and* any descheduling the host imposed on either end. It is reported as a **window, not a culprit**: the verdict for that bucket names the daemon and the host and picks neither. The other two windows, which no host load can move time into, are named outright.

Before:

> took 6.9s (a 1.1 KB payload, tool Bash), over its 1.0s budget, and used 0.1s of CPU. Only the CPU share is work every affected call repeats; the rest was spent waiting, on a busy machine or on something this hook called.

After:

> took 6.9s (a 1.1 KB payload, tool Bash), over its 1.0s budget, of which 0.1s was this hook's own CPU and 6.8s was inside redactor round trips. Most of it was spent inside the redactor round trip — the daemon's scan, the host it shares, or both; this hook was not computing it.

## Review focus

Read `claude-hooks/lib/hook-timing.mjs` first — `chargeRedactorRoundTrip` and `attributeWait` carry the change, and `attributeWait`'s header is where the deliberate limit on what the number can claim is stated.

The cross-file invariant the diff can't show on one screen: in `redactViaDaemon`, the cold-start `waitForSocket` stays inside `excludeProvisioning` (charged to nobody) while both dials sit inside `chargeRedactorRoundTrip` (charged to the redactor share and left in wall-clock). The two windows must stay disjoint or a cold start would be double-counted; the respawn test pins that (800ms of dials, 3s of cold start, `redactorMs === 800`).

Least certain: whether the redactor verdict's wording earns its keep given that it deliberately declines to name a culprit. It still rules the redactor call in or out, which is what no prior number could do.

## Changes

- `lib/hook-timing.mjs`: `chargeRedactorRoundTrip()` plus a process-wide round-trip accumulator; `startHookTimer()` gains a `redactorMs()` reader scoped to that timer's window; `SlowHookContext` gains `redactorMs`; `attributeWait()` prints both numbers and names the dominant window.
- `lib/redactor-client.mjs`: both dials in `redactViaDaemon` (first attempt, post-respawn retry) run inside `chargeRedactorRoundTrip`.
- `lib/control-plane.mjs`: passes `redactorMs` on the verdict and the error path.
- `test/claude-hooks-timing.test.mjs`: round-trip accounting (successful dial, failed dial, both dials across a respawn, cross-run isolation, cold start excluded); the three verdicts; a case pinning that the redactor verdict never names a culprit inside the window; the `runJudgeCli` e2e pins that a judge which never dialled reports `0.0s` and gets the "neither" verdict.
- `plugin/dist/hooks/plugin-hooks.bundle.mjs`, `hook-binaries.sha256`: regenerated (`build-plugin.mjs`, `pnpm gen:hook-binaries`).

The no-CPU wording the shell port emits is untouched, so `hook-timing-shell-parity` still pins byte-identical output.

## Tests / verification

- `pnpm test` (full coverage suite), `pnpm lint`, `pnpm check` — all pass locally at this head.
- Non-vacuity: with the `chargeRedactorRoundTrip` wrapping removed from `redactor-client.mjs`, three of the new cases go red (the round-trip share reads 0 where the dial spent seconds).

## Decisions made

- **The round-trip share is reported as a window, not attributed to the daemon.** Client-side wall-clock cannot separate the daemon's scan from host contention, and claiming it could would repeat the overreach this split exists to retract.
- **No daemon-side telemetry.** That is the only definitive separation, but the response frame is `handle_request`'s object or a bare JSON `null`, so no sibling timing field can ride on it; widening the envelope would require a client and a long-lived daemon from an earlier session to upgrade in lockstep — an unacceptable failure mode for a fail-closed layer, in service of a performance notice.
- **The round trip stays inside `wallMs`** rather than being excluded like provisioning: a slow redaction is a per-call cost the user really waits for. Excluding it would silence the notice on exactly the runs it should fire for.
- **`scan-invisible-chars` / `scan-loaded-instructions` keep the CPU-only wording.** Neither can reach `redactViaDaemon`, so a `0.0s` redactor clause there names a subsystem they never call.
- **`cpuMs` and `redactorMs` overlap** by the JSON framing this side does mid-round-trip, so the shares do not sum to the elapsed time; documented at `attributeWait`.

<details>
<summary>Author checklist</summary>

- [x] Commits follow Conventional Commits; each subject reads as a user-facing release note.
- [x] `pnpm test`, `pnpm lint`, `pnpm check` pass locally.
- [x] No detector changes (timing attribution only).
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version left untouched.

</details>