### PR TITLE
fix(ci): sparse-checkout config/ in the reviewer-hold sweeper

### DIFF
--- a/.github/workflows/claude-reviewer-hold-clear.yaml
+++ b/.github/workflows/claude-reviewer-hold-clear.yaml
@@ -67,7 +67,13 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-          sparse-checkout: .github/scripts
+          # review-findings-gate.sh reads config/review-severities.json (the
+          # gating-severity SSOT); omitting it here makes the gate fail closed
+          # with "missing ... review-severities.json" on every PR whose hold
+          # actually clears, since rederive_review_gates() calls that script.
+          sparse-checkout: |
+            .github/scripts
+            config
           sparse-checkout-cone-mode: false
       - name: Sweep open PRs and clear any cleared reviewer hold
         run: bash .github/scripts/sweep-reviewer-holds.sh

--- a/tests/_source_closure.py
+++ b/tests/_source_closure.py
@@ -165,27 +165,62 @@ def _resolve_tail(tail: str, sourcing_file: str, tracked: set[str]) -> str | Non
     return None
 
 
+#: Command names whose first argument is read like a `source`: the script
+#: named there has to be on the same checkout list as `rel` itself. `bash` is
+#: lenient rather than strict like `source`/`.` below — a repo-wide grep turns
+#: up `bash -c`, `bash <(...)`, and third-party scripts nothing here tracks,
+#: and demanding every one of those resolve would raise on code this check was
+#: never meant to cover. It only ever ADDS an edge, on a target it can resolve.
+_LENIENT_INVOCATIONS = ("bash",)
+_STRICT_INVOCATIONS = ("source", ".")
+
+#: A tracked file with one of these suffixes is walked further for its own
+#: `source`s; anything else (`config/review-severities.json`) is a leaf the
+#: closure still has to list.
+_SHELL_SUFFIXES = (".sh", ".bash")
+
+
 def _source_targets(rel: str, tracked: set[str]):
-    """(argument as written, tracked file or None) for each `source` in `rel`.
+    """(argument as written, tracked file or None) for each checkout-relevant
+    reference in `rel`: a `source`/`.`/`bash` target, or an assignment whose
+    literal tail names a tracked non-shell file.
 
     None means the target is a real path that is simply not tracked here — an
-    absolute system path, say. A target the grammar cannot READ raises instead:
-    telling those two apart is the whole point, because a silently dropped edge
-    is a checkout requirement this module failed to state.
+    absolute system path, say. A `source`/`.` target the grammar cannot READ
+    raises instead: telling those two apart is the whole point, because a
+    silently dropped edge is a checkout requirement this module failed to
+    state. `bash` and the assignment scan below never raise on an unresolved
+    target — they only add edges, on the class of reference proven to exist
+    (`review-findings-gate.sh` reads `config/review-severities.json` through a
+    plain assignment, never a `source`).
     """
     tree = _BASH_PARSER.parse((REPO_ROOT / rel).read_bytes())
     assigned = _assigned_tails(tree)
+
+    # A config/data path is routinely tested (`[[ -f "$VAR" ]]`) or read
+    # (`jq ... "$VAR"`) without ever being `source`d, so the assignment itself
+    # is the only place that reference shows up.
+    for tails in assigned.values():
+        for tail in tails:
+            resolved = _resolve_tail(tail, rel, tracked)
+            if resolved is not None and not resolved.endswith(_SHELL_SUFFIXES):
+                yield tail, resolved
+
     for command in (
         QueryCursor(_BASH_COMMANDS).captures(tree.root_node).get("command", [])
     ):
         name = command.child_by_field_name("name")
-        if name is None or name.text.decode() not in ("source", "."):
+        name_text = None if name is None else name.text.decode()
+        strict = name_text in _STRICT_INVOCATIONS
+        if not strict and name_text not in _LENIENT_INVOCATIONS:
             continue
         arguments = [c for c in command.children[1:] if c.type in _ARGUMENT_TYPES]
         written = arguments[0].text.decode() if arguments else ""
         tail = _literal_tail(arguments[0]) if arguments else None
         if tail is not None:
-            yield written, _resolve_tail(tail, rel, tracked)
+            resolved = _resolve_tail(tail, rel, tracked)
+            if strict or resolved is not None:
+                yield written, resolved
             continue
         # No literal in the argument itself: the name usually comes from an
         # assignment in the same file, so ask that before giving up.
@@ -200,6 +235,8 @@ def _source_targets(rel: str, tracked: set[str]):
             )
         if resolved:
             yield written, resolved.pop()
+            continue
+        if not strict:
             continue
         reason = _RUNTIME_NAMED_TARGETS.get((rel, written))
         if reason is None:

--- a/tests/test_review_findings_gate.py
+++ b/tests/test_review_findings_gate.py
@@ -339,8 +339,13 @@ def _copy_gate_tree(
     # The file set is DERIVED from what the gate script sources, not listed here:
     # a hand-written list is a second spelling of the script's own `source` lines,
     # and the copy that goes stale produces a "No such file" the assertions below
-    # read as the failure they were checking for.
+    # read as the failure they were checking for. The closure also names
+    # config/review-severities.json (an assignment, not a `source`), but this
+    # fixture is the thing that varies that exact file via `with_config`, so the
+    # script closure here is scripts only.
     for rel in source_closure({GATE_REL}):
+        if not rel.endswith((".sh", ".bash")):
+            continue
         copied = dest / rel
         copied.parent.mkdir(parents=True, exist_ok=True)
         copied.write_bytes((REPO_ROOT / rel).read_bytes())


### PR DESCRIPTION
## Summary

`claude-reviewer-hold-clear.yaml`'s sweep job failed every time it actually cleared a hold (runs #398-414 today, [`ci-health` alerts](https://github.com/AlexanderMattTurner/agent-sanitizer/actions/workflows/claude-reviewer-hold-clear.yaml)). The checkout step sparse-checked-out only `.github/scripts`, but `review-findings-gate.sh` reads `config/review-severities.json`. `sweep-reviewer-holds.sh` reaches that script through `rederive_review_gates()` whenever a PR's approval hits the routine "GitHub Actions cannot approve" path, so the file was missing on the exact runs that needed it, and the script fails closed with exit 1.

## Changes

- Add `config` to the sparse-checkout paths in `claude-reviewer-hold-clear.yaml`.
- Extend `tests/_source_closure.py`'s walk past `source`/`.` edges: a lenient `bash <tracked .sh>` edge, and an edge for any assignment whose resolved tail names a tracked non-shell file — the review found neither edge on this path was a `source`, so the guard built for this exact defect class couldn't see it.

## Decisions made

- `reconcile-review-gate.sh` (the second step) never hit this, since it only calls `review-gate.sh`, not `review-findings-gate.sh` — so it kept masking the failure as a single red step rather than a fully broken sweep.
- The `bash` edge is lenient (never raises on an unresolved target): a repo-wide grep turns up `bash -c`/third-party scripts this check was never meant to cover, and this guard's failure mode must stay "fetches too much" rather than "raises on unrelated code."

## Tests / verification

`uv run --extra dev pytest tests/test_source_closure.py tests/test_sparse_checkout_source_closure.py -q` — 40 passed, including the new case this PR's own bug would have caught.

## Checklist

- [x] Commits follow Conventional Commits.
- [x] Tests pass locally (see above); `pnpm lint`/`check` not run — no JS/TS changed.
- [x] No secrets in the diff.
- [x] `CHANGELOG.md`/`package.json` untouched.
