### PR TITLE
test(secrets): count the gap scans the attribution guard now spends

### DIFF
--- a/tests/secrets/test_literal_probe.py
+++ b/tests/secrets/test_literal_probe.py
@@ -271,34 +271,43 @@ def test_a_weak_pattern_match_claims_every_line_it_touches():
 
 
 class _CountingText(str):
-    """A text that counts the newline searches run over it."""
+    """A text that counts every newline scan run over it — both the searches and
+    the gap counts, since the walk spends one of each per line it advances."""
 
     def __new__(cls, body: str) -> "_CountingText":
         text = super().__new__(cls, body)
         text.finds = 0
+        text.counts = 0
         return text
 
     def find(self, *args) -> int:  # type: ignore[override]
         self.finds += 1
         return super().find(*args)
 
+    def count(self, *args) -> int:  # type: ignore[override]
+        self.counts += 1
+        return super().count(*args)
 
-def test_line_attribution_searches_the_newlines_once_not_once_per_hit():
-    """A hit that does not advance the line must not re-search the text for a
-    newline: one long line with a hit per credential noun is attacker-shaped
-    input against a shared daemon, and re-searching per hit is quadratic in it.
 
-    Bounded on search COUNT, not wall clock, so the guard cannot go quiet on a
-    faster runner — and the count must still EXCEED the newline count, or the
-    walk stopped happening at all.
+def test_line_attribution_scans_the_newlines_once_not_once_per_hit():
+    """A hit that does not advance the line must not scan the text for a newline:
+    one long line with a hit per credential noun is attacker-shaped input against
+    a shared daemon, and re-scanning per hit is quadratic in it.
+
+    Bounded on SCAN COUNT, not wall clock, so the guard cannot go quiet on a
+    faster runner — and both operations the walk spends are counted, since a
+    bound on only one of them would be blind to the other becoming per-hit.
     """
     line = "key " * 4000
     text = _CountingText("\n".join([line] * 3))
     hits = [(m.start(), m.end(), ()) for m in re.finditer("key", text)]
     assert len(hits) == 12000
     P._patterns_by_line(text, hits)
-    # 2 newlines to walk, plus the terminal search that reports none is left.
+    # 2 newlines to walk, plus the opening search that finds the first one.
     assert text.finds == 3
+    # One gap count per line that HAS a hit, never one per hit — and none for the
+    # first line, whose index the opening search already settled.
+    assert text.counts == 2
 
 
 def _attribute_naively(text, hits):


### PR DESCRIPTION
Claimed area: `tests/secrets/test_literal_probe.py` — the quadratic-attribution guard. Follow-up to #355, which merged before this could land on its branch.

## Summary

The guard on `_patterns_by_line`'s worst case (one very long line with a hit on every credential noun) bounded `str.find` calls alone. #355 changed the per-line advance from a `find` loop to one `str.count` over the gap since the previous hit, so `count` is now the dominant operation — and the guard could not see it.

Today the bound still holds, but only by coupling: `count` and `find` sit in the same `if`, so a `count` that went per-hit would drag a per-hit `find` with it and trip the existing assert. That coupling is an implementation detail, not what the test asserts, and the guard's own docstring promised a bound on scan count that no longer covered the dominant operation.

`_CountingText` now instruments both, and the test asserts `counts == 2` — one gap count per line that *has* a hit, never one per hit.

## Changes

- `_CountingText` gains a `count` override and a `counts` counter beside the existing `find`/`finds`.
- `test_line_attribution_searches_the_newlines_once_not_once_per_hit` → `..._scans_the_newlines_once_...`, asserting both counters. Its docstring now says why both are counted rather than promising a bound on one.

## Tests / verification

- `uv run --extra dev pytest tests/secrets/test_literal_probe.py -q` — 179 passed.
- **Non-vacuity, verified rather than assumed.** Hoisting the `count` out of the `if` in `_patterns_by_line` so it runs per hit — while leaving `find` gated, i.e. exactly the regression the old guard was blind to — fails the new assertion:

  ```
  >       assert text.counts == 2
  ```

  The old guard passed that same mutant.

## Review focus

One file, one test. The load-bearing question is whether `counts == 2` is the right number: the payload is three lines with 12,000 hits, and the opening `text.find("\n")` already settles the first line's index, so only the two *subsequent* lines pay a gap count. If that reasoning is wrong the assertion is an accidental fit rather than a bound — the mutant above is what argues it is not.
