### PR TITLE
fix(claude-hooks): forward the permission mode to PreToolUse host gates

### DIFF
--- a/claude-hooks/pretooluse-sanitize.mjs
+++ b/claude-hooks/pretooluse-sanitize.mjs
@@ -81,7 +81,8 @@ const HOOK_NAME = "pretooluse-sanitize";
  * must be blocked, or null to let the pipeline continue. Hosts use these for
  * policy the package has no view of (a required workflow step, a project-local
  * rule); the package ships none.
- * @typedef {(input: { tool_name: string | null, tool_input: any, session_id?: string })
+ * @typedef {(input: { tool_name: string | null, tool_input: any, session_id?: string,
+ *   permission_mode?: string })
  *   => string | null | undefined} HostGate
  */
 
@@ -595,13 +596,16 @@ export async function judgePreToolUseSanitize(event, rehydrate, opts = {}) {
   // a pass is the one incentive a gate must never create.
   if (event.event === EventKind.UNKNOWN)
     return { decision: Decision.DENY, reason: messages.unknownEvent };
-  // The session identity travels in `meta`, not alongside the tool input; a host
-  // gate keyed on the session (a once-per-session checkpoint) cannot tell two
-  // sessions apart without it.
+  // The session identity and the permission mode travel in `meta`, not alongside
+  // the tool input. A gate keyed on the session (a once-per-session checkpoint)
+  // cannot tell two sessions apart without the first, and a gate keyed on the
+  // mode reads `undefined` without the second — so it fires in EVERY mode, which
+  // is the safe direction but not the intended one.
   const input = {
     tool_name: event.tool,
     tool_input: event.input,
     session_id: event.meta?.session_id,
+    permission_mode: event.meta?.permission_mode,
   };
   // Host gates run BEFORE any rewriting layer, because they decide whether the
   // call may happen at all rather than what its input contains — and returning

--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=04b9787beaa121351499f9b999f62b689a182ff158ec0eeaf7a36e7ed23ed687
-8ceb7689cb5076700bd14039715639eaf98512bee876b17470ef606ef21d0b9c  agent-sanitizer-hooks-darwin-arm64
-30b761349596566ba7ac066d218f90fd41c552e9f624371580f7cbd9ee2a0cce  agent-sanitizer-hooks-darwin-x64
-11b47c77b2fcbe7d1f154398154e0492b7a6072f87f0528efc11a1a4b6a82b17  agent-sanitizer-hooks-linux-arm64
-801ad6523ee65963af6fc45d3de491fa86ee04538c2416eee9857a3317e1f19d  agent-sanitizer-hooks-linux-x64
+# bundle=a116c9c3f2577cdf16c20af7a4754cc7431a03a13f5f6cfef15e4d9c7da60f96
+e237a9ba5eb3f11ce7472b49717b482b731662ac4ea6cc7943d7230404d0e047  agent-sanitizer-hooks-darwin-arm64
+928a9eb5ac76825228a28a657f66b2450f9fd7cc609faa849acb6c169040ea18  agent-sanitizer-hooks-darwin-x64
+da2cc3bdf0ffc9fd5961cd8d5ca04bb3a5de7297456e76a3e12e1cf5e1e1a717  agent-sanitizer-hooks-linux-arm64
+4f346ca5991e8c3ea08eb3159d92750722473ecf8195c09b514d6d3fd2eba102  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -67718,7 +67718,8 @@ async function judgePreToolUseSanitize(event, rehydrate, opts = {}) {
   const input = {
     tool_name: event.tool,
     tool_input: event.input,
-    session_id: event.meta?.session_id
+    session_id: event.meta?.session_id,
+    permission_mode: event.meta?.permission_mode
   };
   for (const gate of gates) {
     const denyReason = gate(input);

--- a/test/claude-hooks-host-seams.test.mjs
+++ b/test/claude-hooks-host-seams.test.mjs
@@ -577,6 +577,59 @@ describe("PreToolUse host gates", () => {
     assert.equal(got.tool_name, "Bash");
   });
 
+  it("hands the gate the permission mode, which also rides in meta", async () => {
+    const modeSeenFor = async (permissionMode) => {
+      let got;
+      const event = parse({
+        hook_event_name: "PreToolUse",
+        tool_name: "Write",
+        tool_input: { file_path: "/tmp/plan.md", content: "step one" },
+        session_id: SESSION,
+        ...(permissionMode === undefined
+          ? {}
+          : { permission_mode: permissionMode }),
+      });
+      await judgePreToolUseSanitize(event, undefined, {
+        gates: [
+          (input) => {
+            got = input;
+            return null;
+          },
+        ],
+      });
+      return got.permission_mode;
+    };
+    // A gate that fires only in plan mode reads undefined without this, so it
+    // fires in every mode instead of the one it names.
+    assert.equal(await modeSeenFor("plan"), "plan");
+    assert.equal(await modeSeenFor("acceptEdits"), "acceptEdits");
+    // Absent stays absent: the gate still decides what an unknown mode means.
+    assert.equal(await modeSeenFor(undefined), undefined);
+  });
+
+  it("lets a mode-keyed gate deny in plan mode alone", async () => {
+    // The property the forwarding buys, driven through the real judge rather
+    // than asserted of the input bag: one gate, two modes, opposite verdicts.
+    const planOnlyGate = (input) =>
+      input.permission_mode === "plan"
+        ? "denied: plan mode needs the skill"
+        : null;
+    const verdictIn = async (permissionMode) =>
+      await judgePreToolUseSanitize(
+        parse({
+          hook_event_name: "PreToolUse",
+          tool_name: "Write",
+          tool_input: { file_path: "/tmp/plan.md", content: "step one" },
+          session_id: SESSION,
+          permission_mode: permissionMode,
+        }),
+        undefined,
+        { gates: [planOnlyGate] },
+      );
+    assert.equal((await verdictIn("plan")).decision, Decision.DENY);
+    assert.equal((await verdictIn("acceptEdits")).decision, Decision.ALLOW);
+  });
+
   it("fills the unset fields of a PARTIAL reason table", async () => {
     // Every other seam case spreads the whole default table, which is exactly the
     // shape that cannot expose a wholesale substitution. A bare one-field object


### PR DESCRIPTION
## Summary

`judgePreToolUseSanitize` built each host gate's input from `tool_name`, `tool_input` and `session_id`. The permission mode travels on `event.meta` alongside the session id, so a gate keyed on the mode read `undefined` and fired in **every** mode instead of the one it names. This passes the mode through beside the session id — the same seam, one more field.

A downstream gate already documents the gap at its own definition: "`agent-sanitizer`'s host-gate input carries `tool_name`, `tool_input` and `session_id` alone, so the mode is absent in production until the package forwards it." A host cannot patch it from outside: `cliMain` parses the event itself, and the package exports no `claude-hooks/lib/control-plane` subpath, so there is no seam to inject through.

Absent stays absent — a gate still decides what an unknown or missing mode means, and the fail-closed direction is unchanged for any gate that treats absence as "fire".

## Changes

- `claude-hooks/pretooluse-sanitize.mjs` — add `permission_mode: event.meta?.permission_mode` to the gate input; widen the `HostGate` typedef.
- `test/claude-hooks-host-seams.test.mjs` — two cases (below).
- `plugin/dist/hooks/{plugin-hooks.bundle.mjs,hook-binaries.sha256}` — regenerated by the pre-commit hook, which then reported the manifest pinned a stale bundle; `pnpm gen:hook-binaries` settled it, and the amended commit reports `plugin artifacts already current`.

## Tests / verification

- `node --test test/claude-hooks-host-seams.test.mjs` — 62 pass, 0 fail.
- `env -C . node --test test/gates-mutation-kill.test.mjs test/downstream-parity.test.mjs test/claude-hooks-extensions.test.mjs test/claude-hooks-host-seams.test.mjs` — 110 pass, 0 fail.
- `env -C . node --test test/shipped-gates.test.mjs` — 14 pass, 0 fail.
- `pnpm typecheck` clean; `eslint` clean on both changed files; `prettier --check` clean.

**Non-vacuity, observed.** With `permission_mode:` deleted from the input and nothing else changed, the same file reports 60 pass / 2 fail, and the two failures are the new cases with the right signatures: `expected: 'plan'` (got `undefined`) and `expected: 'deny', actual: 'allow'`. Restored, 62/62.

The two cases test different things on purpose. The first asserts the field reaches the gate for `plan` and `acceptEdits`, and stays `undefined` when the payload carries no mode. The second drives the property the forwarding actually buys through the real judge: one mode-keyed gate, two modes, opposite verdicts — which a bag-shape assertion cannot show.

<details>
<summary>What I did not run</summary>

Not run: the full `pnpm test` (`scripts/coverage.mjs`) — I ran the four suites covering the host-gate seam and its neighbours instead. CI is the first whole-suite run.

`test/shipped-gates.test.mjs` resolves paths from `process.cwd()`, so it fails with `ENOENT ... scandir` when invoked from another directory. That is an artifact of how it is launched, not of this diff; run from the repo root it is 14/14.

</details>

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/); each subject reads as a user-facing release note.
- [ ] `pnpm test`, `pnpm lint`, and `pnpm check` pass locally. — `check` and `lint` yes; `pnpm test` not run (see above).
- [x] New or changed detectors have negative tests (zero findings on legitimate input) and pin their invariants with property/fuzz tests. — the absent-mode case and the `acceptEdits` allow are the negative directions.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version are left untouched.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRt5TtBH1nA2Cp2pwY2sJk

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRt5TtBH1nA2Cp2pwY2sJk)_