### PR TITLE
fix(ci): report the review-findings gate as a commit status, not a check run

### DIFF
--- a/.github/scripts/review-findings-gate.sh
+++ b/.github/scripts/review-findings-gate.sh
@@ -14,14 +14,22 @@
 # post-pr-review.mjs stamps from, so the writer and this reader cannot drift.
 #
 # Two modes, one predicate:
-#   * REPORT_SHA set — post the verdict as a GitHub CHECK RUN named
-#     "$CHECK_NAME" on that sha (the PR head), so the ruleset's required check
-#     is satisfied or red there. Exit 0 once the check run is posted, whatever
-#     the verdict; a failure to POST the check run is a hard red (a gate that
-#     cannot report is a gate that hangs the PR at "Expected").
+#   * REPORT_SHA set — post the verdict as a COMMIT STATUS under the context
+#     "$GATE_CONTEXT" on that sha (the PR head), so the ruleset's required check
+#     is satisfied or red there. Exit 0 once the status is posted, whatever the
+#     verdict; a failure to POST it is a hard red (a gate that cannot report is
+#     a gate that hangs the PR at "Expected").
 #   * REPORT_SHA unset — exit 0 when the gate is green, 1 when red. This is the
 #     merge_group mode: the calling job is itself the check on the queue sha,
 #     so its exit status is the report.
+#
+# A STATUS, not a check run, and that distinction is load-bearing: a check run
+# POSTed for a bare sha lands in a check suite of the app's own making, whose
+# `pull_requests` array is empty, and the PR-scoped merge box counts only the
+# suites tied to the pull request. Such a run shows green on the commit and in
+# the Checks tab while the required context sits at "Expected — Waiting for
+# status to be reported" forever. A status carries no suite and is read on the
+# sha itself, which is how the sibling gate (review-gate.sh) reports too.
 #
 # GATE_UNREPORTED set skips the predicate entirely and posts a RED verdict on
 # REPORT_SHA — the caller's `always()` arm for a run that died before it could
@@ -31,7 +39,8 @@
 # propagates as a non-zero exit (set -e), because a gate that fails open lets a
 # PR merge past findings nobody read.
 #
-# Env: GH_TOKEN, GH_REPO (owner/name), PR; REPORT_SHA and GATE_UNREPORTED optional.
+# Env: GH_TOKEN, GH_REPO (owner/name), PR; REPORT_SHA, RUN_URL and
+# GATE_UNREPORTED optional.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -46,12 +55,27 @@ source "$SCRIPT_DIR/lib/pr-reviews.bash"
 
 # MUST stay byte-identical to the `name:` of the merge_gate job in
 # review-findings-merge-gate.yaml: the ruleset's required-check context is
-# derived from that job name (sync-required-checks), and the check run posted
-# here has to land under the same context or the PR head never satisfies the gate.
-CHECK_NAME="Review findings resolved"
+# derived from that job name (sync-required-checks), and the status posted
+# here has to carry the same context or the PR head never satisfies the gate.
+GATE_CONTEXT="Review findings resolved"
+
+# GitHub caps a status description at 140 characters, so the reason a reader
+# acts on lives in this run's log and behind target_url; the merge box gets as
+# much of its head as fits.
+post_verdict() {
+  local state="$1" description="$2"
+  if ((${#description} > 140)); then
+    description="${description:0:137}..."
+  fi
+  retry gh api --method POST "repos/${GH_REPO}/statuses/${REPORT_SHA}" \
+    -f "state=${state}" \
+    -f "context=${GATE_CONTEXT}" \
+    -f "description=${description}" \
+    -f "target_url=${RUN_URL:-}" >/dev/null
+}
 
 # GATE_UNREPORTED mode: the evaluation below never reached its POST, so report
-# red here instead of leaving the head with no check run at all. An unposted
+# red here instead of leaving the head with no verdict at all. An unposted
 # REQUIRED context reads as "Expected — Waiting for status to be reported", which
 # blocks the merge on a check that never arrives: thread resolution fires no
 # workflow event, so nothing re-derives this gate until the next push or a
@@ -59,14 +83,9 @@ CHECK_NAME="Review findings resolved"
 # meanwhile. Red is the same state said out loud, and it keeps the retry path.
 if [[ -n "${GATE_UNREPORTED:-}" ]]; then
   : "${REPORT_SHA:?REPORT_SHA required to report an unevaluated gate}"
-  retry gh api --method POST "repos/${GH_REPO}/check-runs" \
-    -f "name=${CHECK_NAME}" \
-    -f "head_sha=${REPORT_SHA}" \
-    -f "status=completed" \
-    -f "conclusion=failure" \
-    -f "output[title]=red: review-findings gate did not complete" \
-    -f "output[summary]=the gate evaluation failed or was cancelled before deriving a verdict, so it reports red rather than leaving the required check unreported — re-run it by removing and re-adding the recheck-review-gate label" >/dev/null
-  echo "posted failure check run '${CHECK_NAME}' on ${REPORT_SHA}: evaluation did not complete" >&2
+  post_verdict failure \
+    "the gate evaluation did not complete — re-run it by removing and re-adding the recheck-review-gate label"
+  echo "posted failure status '${GATE_CONTEXT}' on ${REPORT_SHA}: evaluation did not complete" >&2
   exit 0
 fi
 
@@ -138,15 +157,9 @@ if [[ -z "${REPORT_SHA:-}" ]]; then
   exit 0
 fi
 
-conclusion=success
-[[ "$verdict" == "green" ]] || conclusion=failure
+state=success
+[[ "$verdict" == "green" ]] || state=failure
 # No `|| true`: a verdict that cannot be reported leaves the required check
 # hanging at "Expected", so a failed POST must red this run loudly.
-retry gh api --method POST "repos/${GH_REPO}/check-runs" \
-  -f "name=${CHECK_NAME}" \
-  -f "head_sha=${REPORT_SHA}" \
-  -f "status=completed" \
-  -f "conclusion=${conclusion}" \
-  -f "output[title]=${verdict}: review-findings gate" \
-  -f "output[summary]=${reason}" >/dev/null
-echo "posted ${conclusion} check run '${CHECK_NAME}' on ${REPORT_SHA}" >&2
+post_verdict "$state" "$reason"
+echo "posted ${state} status '${GATE_CONTEXT}' on ${REPORT_SHA}" >&2

--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -158,8 +158,7 @@ jobs:
     permissions:
       contents: read # checkout the trusted base branch
       pull-requests: write # post the review
-      checks: write # re-post the "Review findings resolved" verdict on the head
-      statuses: write # re-post the "Automated review posted" status on the head
+      statuses: write # re-post both gate verdicts on the head
     steps:
       - name: Checkout base (trusted) branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -338,8 +337,8 @@ jobs:
   # bot-authored PRs like Dependabot), and clear the review-findings gate for
   # them. A skipped PR gets no reviewer review at all, so the gate's
   # reviewed-at-all leg is red on it and would block the class forever — the
-  # deliberate skip decision is what licenses the merge, and the check run posted
-  # below is that decision made legible on the PR. Its body points a human at the
+  # deliberate skip decision is what licenses the merge, and the status posted
+  # below is that decision made legible on the PR. It points a human at the
   # `needs-auto-review` label to force a real Opus read when one is wanted. Draft
   # PRs are excluded — they can't merge anyway and get reviewed on
   # `ready_for_review`.
@@ -347,15 +346,15 @@ jobs:
   # The job runs on `synchronize` TOO, but its two steps have different reasons to
   # fire, so each carries its own condition. The approval is a first-look act and
   # persists across pushes (the ruleset does not dismiss on push), so it stays on
-  # opened/ready_for_review. The gate check run is per-SHA and does NOT carry
-  # over: every new head starts with no clearing check, and review-findings-gate
+  # opened/ready_for_review. The gate status is per-SHA and does NOT carry
+  # over: every new head starts with no clearing status, and review-findings-gate
   # posts a RED verdict there (nothing reviewed this PR), so without a push-time
   # re-clear a skipped PR would merge on its first head and be blocked forever
   # after its second.
   #
   # THE TRUST GATE BELOW IS WHAT STOPS A PR FROM APPROVING ITSELF. The three
   # steps here clear three merge levers — an approving review, the "Review
-  # findings resolved" check run, and the "Automated review posted" status — and
+  # findings resolved" status, and the "Automated review posted" status — and
   # the skip set they key on is the PR TITLE, which the PR author writes. The
   # author (`user.type`) does come from the event payload and cannot be spoofed;
   # the title carries no such guarantee, so without this gate any fork PR named
@@ -367,8 +366,8 @@ jobs:
   # construction: an untrusted PR is never skipped there, so it gets the real
   # review instead of the approval it cannot earn here.
   #
-  # This posts a review and a check run, runs no PR code, and holds
-  # pull-requests:write + checks:write and nothing else.
+  # This posts a review and two commit statuses, runs no PR code, and holds
+  # pull-requests:write + statuses:write and nothing else.
   auto-approve-skipped:
     name: Auto-approve low-risk and bot PRs the reviewer skips
     if: >-
@@ -393,8 +392,7 @@ jobs:
     permissions:
       contents: read # sparse-checkout the trusted approval script
       pull-requests: write # submit an approving review
-      checks: write # clear the review-findings gate for the skipped class
-      statuses: write # re-post the "Automated review posted" status on the head
+      statuses: write # clear the review-findings gate, re-post the review status
     steps:
       - name: Checkout base (trusted) approval script
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -424,18 +422,18 @@ jobs:
 
       # Posted directly, NOT through review-findings-gate.sh: the gate's predicate
       # would (correctly) say red here, because nothing reviewed this PR. This
-      # class merges on the strength of the skip decision instead, and the check
-      # run's summary says exactly that — so the PR's own check list records why
-      # it was allowed through rather than hiding it in a workflow condition.
+      # class merges on the strength of the skip decision instead, and the
+      # status's description says exactly that — so the PR's own check list
+      # records why it was allowed through rather than hiding it in a condition.
       #
-      # The name must stay byte-identical to the CHECK_NAME in
+      # The context must stay byte-identical to the GATE_CONTEXT in
       # review-findings-gate.sh and the merge_gate job's `name:`: one required
       # context, and a rename here would leave this class blocked again.
       #
-      # `always()` — every head of a skipped PR needs its own clearing check run,
+      # `always()` — every head of a skipped PR needs its own clearing status,
       # INCLUDING when the approve step above failed. Approval and gate-clearing
       # are independent: the approval satisfies a review-required ruleset, the
-      # check run satisfies the required context. A bare step (no `if:`) reads as
+      # status satisfies the required context. A bare step (no `if:`) reads as
       # unconditional but is not — a failed predecessor skips it — so with
       # "Allow GitHub Actions to create and approve pull requests" disabled, the
       # approve step's `GitHub Actions is not permitted to approve pull requests`
@@ -448,14 +446,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          gh api --method POST "repos/${GH_REPO}/check-runs" \
-            -f "name=Review findings resolved" \
-            -f "head_sha=${HEAD_SHA}" \
-            -f "status=completed" \
-            -f "conclusion=success" \
-            -f "output[title]=green: review deliberately skipped" \
-            -f "output[summary]=This PR is in the class the reviewer skips (bot-authored, or a chore/style/release title), so no automated review was run and there are no findings to resolve. Add the needs-auto-review label to force a full review." >/dev/null
+          gh api --method POST "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
+            -f "state=success" \
+            -f "context=Review findings resolved" \
+            -f "description=Review deliberately skipped: bot-authored, or a chore/style/release title. Add needs-auto-review to force a full review." \
+            -f "target_url=${RUN_URL}" >/dev/null
 
       # The approval above is a REVIEW posted with GITHUB_TOKEN, so it fires no
       # pull_request_review event, and review-gate.yaml's other leg already ran

--- a/.github/workflows/claude-reviewer-hold-clear.yaml
+++ b/.github/workflows/claude-reviewer-hold-clear.yaml
@@ -27,10 +27,10 @@ name: Claude reviewer-hold sweeper
 # SECURITY — schedule + workflow_dispatch run from the DEFAULT branch (trusted repo
 # content) with the base repo's GITHUB_TOKEN; the job checks out ONLY the trusted
 # approval scripts and executes no PR code — it reads thread/review state via the
-# API and can only post an approval, a commit status or a check run. Least
+# API and can only post an approval or a commit status. Least
 # privilege: contents:read (checkout the scripts) + pull-requests:write (post the
-# approval) + statuses:write (the `Automated review posted` verdict) +
-# checks:write (the `Review findings resolved` verdict), nothing else, so even an
+# approval) + statuses:write (both gate verdicts — `Automated review posted` and
+# `Review findings resolved` are commit statuses), nothing else, so even an
 # unexpected PR can only be approved or have its gate verdicts corrected, never
 # pushed to, merged, or otherwise reached.
 
@@ -50,8 +50,7 @@ jobs:
     permissions:
       contents: read # sparse-checkout the trusted approval scripts
       pull-requests: write # submit the approving review
-      statuses: write # re-derive the "Automated review posted" gate
-      checks: write # re-post the "Review findings resolved" check run; no other scope
+      statuses: write # re-derive both gate verdicts; no other scope
     env:
       # The sweep's own PR listing runs on the Actions token.
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/review-findings-gate.yaml
+++ b/.github/workflows/review-findings-gate.yaml
@@ -9,9 +9,12 @@ name: Review-findings gate
 # the last gating thread is the whole clearing ceremony — no approval to mint,
 # no sticky verdict to supersede, no scheduled sweep to unstick either.
 #
-# One job, posting the predicate (review-findings-gate.sh) as a check run named
-# "Review findings resolved" on the PR HEAD sha, so the ruleset's required check
-# is satisfied (or red) there. Thread RESOLUTION fires no workflow event of its
+# One job, posting the predicate (review-findings-gate.sh) as a commit status
+# under the context "Review findings resolved" on the PR HEAD sha, so the
+# ruleset's required check is satisfied (or red) there. A status rather than a
+# check run because a check run POSTed for a bare sha lands in a suite GitHub
+# does not tie to the pull request, and the PR-scoped merge box never counts it
+# — see the script's header. Thread RESOLUTION fires no workflow event of its
 # own, so whoever resolves a thread adds the `recheck-review-gate` label to re-run
 # this evaluation (the labeled trigger below); claude-reviewer-hold-clear.yaml's
 # cron bounds a forgotten one to a half-hour of staleness. The merge queue's leg of the same predicate lives in
@@ -24,8 +27,8 @@ name: Review-findings gate
 # SECURITY — pull_request_target and the review events run in the BASE repo's
 # context. The explicit default-branch `ref:` on the checkout below is the
 # enforcement point: no PR-authored code is ever checked out or executed here —
-# the job reads review/thread state via the API and posts a check run. Least
-# privilege: contents:read (checkout the scripts) + checks:write (post the
+# the job reads review/thread state via the API and posts a commit status. Least
+# privilege: contents:read (checkout the scripts) + statuses:write (post the
 # verdict) + pull-requests:write (read the threads, remove the command label).
 
 on: # zizmor: ignore[dangerous-triggers] — no PR code executes: API-only scripts off a default-branch checkout; see the SECURITY header
@@ -73,7 +76,7 @@ jobs:
     # among runs that would post to the SAME sha. NEVER cancelling the running
     # evaluation: cancel-in-progress stays false because GitHub cancels
     # mid-step, so a true here can kill a run between reading the PR state
-    # and POSTing the check run — the verdict is lost and the head keeps a
+    # and POSTing the verdict — that verdict is lost and the head keeps a
     # stale one. With false, only the QUEUED run is ever cancelled, and only
     # by a newer same-head run that itself executes unconditionally (no job
     # `if:`) and posts a fresher verdict — every cancellation is a strict
@@ -86,7 +89,7 @@ jobs:
       cancel-in-progress: false
     permissions:
       contents: read # sparse-checkout the trusted gate script
-      checks: write # post the "Review findings resolved" check run on the head
+      statuses: write # post the "Review findings resolved" verdict on the head
       # A label on a PULL REQUEST is checked against the pull-requests
       # permission, not issues. Under `issues: write` alone the DELETE below
       # 403s and the label stays; while it sits there re-adding it fires no
@@ -139,15 +142,18 @@ jobs:
         # label and posts nothing, so the required "Review findings resolved"
         # context is never reported on a new head and the PR blocks forever on
         # a check that will never arrive. REPORT_SHA is what routes the verdict
-        # to the head's check context; without it the script only exits 0/1.
+        # to the head's status context; without it the script only exits 0/1.
         env:
           REPORT_SHA: ${{ github.event.pull_request.head.sha }}
+          # A status description is capped at 140 characters, so this is where a
+          # reader gets the finding list a red verdict names.
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: bash .github/scripts/review-findings-gate.sh
       - name: Report red when the evaluation posted no verdict
         # The step above posts the required check only if it reaches its POST, so
         # an evaluation that dies first — an exhausted API retry ladder, a jq
         # failure on the severity config, a lost runner — leaves the head with NO
-        # check run under a REQUIRED context. GitHub renders that as
+        # status under a REQUIRED context. GitHub renders that as
         # "Expected — Waiting for status to be reported" and blocks the merge on
         # a check nothing will ever send: thread resolution fires no workflow
         # event, so the gate is not re-derived until the next push or a
@@ -159,4 +165,7 @@ jobs:
         env:
           REPORT_SHA: ${{ github.event.pull_request.head.sha }}
           GATE_UNREPORTED: "1"
+          # Points at the run that failed, which is where the reason this arm
+          # fired at all is legible.
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: bash .github/scripts/review-findings-gate.sh

--- a/.github/workflows/review-findings-merge-gate.yaml
+++ b/.github/workflows/review-findings-merge-gate.yaml
@@ -15,10 +15,10 @@ name: Review-findings merge gate
 #
 # This job is also where the required-check CONTEXT NAME lives: sync-required-checks
 # reads the `# required-check: true` marker below and registers this job's `name:`
-# in the ruleset, and review-findings-gate.sh posts its PR-head check runs under
-# that same name. This repository has no merge queue enabled, so the job itself
-# does not fire today and the PR-head post is the only reporting surface; the leg
-# is correct the moment a queue is turned on.
+# in the ruleset, and review-findings-gate.sh posts its PR-head commit statuses
+# under that same context. This repository has no merge queue enabled, so the job
+# itself does not fire today and the PR-head post is the only reporting surface;
+# the leg is correct the moment a queue is turned on.
 
 on:
   merge_group:
@@ -29,7 +29,7 @@ jobs:
   merge_gate:
     name: Review findings resolved # required-check: true
     # The job name is the required-check context sync-required-checks registers,
-    # and review-findings-gate.sh posts its PR-head check runs under the SAME
+    # and review-findings-gate.sh posts its PR-head statuses under the SAME
     # name — one context, two reporting surfaces (queue sha here, PR head sha
     # from review-findings-gate.yaml's evaluate job and the resolver step).
     runs-on: ubuntu-latest

--- a/tests/test_pr_review_fork_guard.py
+++ b/tests/test_pr_review_fork_guard.py
@@ -3,7 +3,7 @@
 A PR title is written by the PR author. Two jobs key on it: `decide` skips the
 model review for a `chore:`/`style:`/`release:` title, and `auto-approve-skipped`
 answers that same skip with an approving review, a green "Review findings
-resolved" check run, and a re-derived "Automated review posted" status. Three
+resolved" status, and a re-derived "Automated review posted" status. Three
 merge levers, chosen by a string the author controls — so an untrusted PR named
 `chore: bump` merged without ever being read.
 
@@ -199,7 +199,7 @@ def test_no_title_routes_a_cross_repository_pr_into_auto_approve(
     title: str, trust: dict, user_type: str
 ) -> None:
     # The finding: `auto-approve-skipped` submits an approving review, greens
-    # the review-findings check run and re-derives the review status. A fork PR
+    # the review-findings status and re-derives the review status. A fork PR
     # must reach none of that by naming itself.
     github = _github(title, user_type=user_type, **trust)
     assert not _evaluate(AUTO_APPROVE_IF, github)

--- a/tests/test_review_findings_gate.py
+++ b/tests/test_review_findings_gate.py
@@ -6,10 +6,10 @@ the thread's ROOT comment, with the leading emoji as a fallback for threads
 posted before the marker existed); GREEN otherwise.
 
 Two modes, one predicate:
-  * REPORT_SHA set — the verdict is POSTed as a check run named "Review
-    findings resolved" on that sha; the run exits 0 whatever the verdict, and a
-    failed POST is a hard red (a gate that cannot report leaves the required
-    check hanging at "Expected").
+  * REPORT_SHA set — the verdict is POSTed as a COMMIT STATUS under the context
+    "Review findings resolved" on that sha; the run exits 0 whatever the verdict,
+    and a failed POST is a hard red (a gate that cannot report leaves the
+    required check hanging at "Expected").
   * REPORT_SHA unset — the exit status IS the report (merge_group mode; the
     workflow parses the PR number out of the merge-group ref, tested below).
 
@@ -17,7 +17,7 @@ Drives the REAL script (sourcing the real lib/pr-reviews.bash and
 lib/review-threads.bash) with a fake `gh` on PATH that serves the two GraphQL
 reads from canned node arrays by running the script's OWN --jq programs through
 REAL jq — so the reviewer filter, the severity selection, and the emoji
-fallback are exercised, never re-implemented — and records the check-run POST's
+fallback are exercised, never re-implemented — and records the status POST's
 fields for assertion. gh is stubbed because there is no live GitHub to ask; the
 node shapes mirror the GraphQL documents in the two lib files (in particular:
 GraphQL returns an app bot's login WITHOUT the REST `[bot]` suffix).
@@ -25,6 +25,7 @@ GraphQL returns an app bot's login WITHOUT the REST `[bot]` suffix).
 
 import json
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -40,12 +41,12 @@ SCRIPT = REPO_ROOT / GATE_REL
 # can ever report the required context as a passing `skipped` instance.
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "review-findings-merge-gate.yaml"
 
-# The check-run name the gate posts must be byte-identical to the merge_gate
-# job's `name:` (one required-check context, two reporting surfaces), so the
-# expected name is READ from the workflow rather than restated here.
-CHECK_NAME = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]["merge_gate"][
-    "name"
-]
+# The status context the gate posts under must be byte-identical to the
+# merge_gate job's `name:` (one required-check context, two reporting surfaces),
+# so the expected context is READ from the workflow rather than restated here.
+GATE_CONTEXT = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"][
+    "merge_gate"
+]["name"]
 
 # The severity SSOT the gate builds its predicate from at runtime — the tests
 # iterate its gating list member-by-member so a severity added to the config
@@ -68,7 +69,7 @@ WARNING = _marker("warning")
 _FAKE_GH = r"""#!/usr/bin/env python3
 # gh stub for the gate: serves the two GraphQL reads from canned node files,
 # running the CALLER'S --jq through real jq (those filters are the logic under
-# test), and records the check-run POST's fields. Anything else is unhandled
+# test), and records the status POST's fields. Anything else is unhandled
 # (exit 2), so a stray API call — a review post, a mutation — reds the run.
 import json, os, shutil, subprocess, sys
 
@@ -134,11 +135,14 @@ if path == "graphql":
             nodes = json.load(f)
         emit({"data": {"repository": {"pullRequest": {"reviews": {"nodes": nodes}}}}})
 
-if path and path.endswith("/check-runs") and method == "POST":
-    if os.environ.get("FAIL_CHECK_POST") == "1":
-        sys.stderr.write("fake gh: HTTP 502 posting the check run\n")
+if path and "/statuses/" in path and method == "POST":
+    if os.environ.get("FAIL_STATUS_POST") == "1":
+        sys.stderr.write("fake gh: HTTP 502 posting the status\n")
         sys.exit(1)
-    with open(os.environ["CHECK_RUN_LOG"], "a", encoding="utf-8") as f:
+    # The sha rides in the path, so it is recorded beside the fields the caller
+    # passed — an assertion on WHICH head got the verdict has nothing else to read.
+    fields["sha"] = path.rsplit("/", 1)[-1]
+    with open(os.environ["STATUS_LOG"], "a", encoding="utf-8") as f:
         f.write(json.dumps(fields) + "\n")
     sys.exit(0)
 
@@ -187,7 +191,7 @@ def _run(
     gate_unreported: bool = False,
 ) -> tuple[subprocess.CompletedProcess, list[dict]]:
     """Run the real gate script against canned review/thread nodes; return the
-    process and the check runs the fake gh recorded."""
+    process and the statuses the fake gh recorded."""
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(exist_ok=True)
     gh = bin_dir / "gh"
@@ -195,7 +199,7 @@ def _run(
     gh.chmod(0o755)
     (tmp_path / "reviews.json").write_text(json.dumps(reviews))
     (tmp_path / "threads.json").write_text(json.dumps(threads))
-    log = tmp_path / "check_runs"
+    log = tmp_path / "statuses"
     log.write_text("")
     env = {
         "PATH": f"{bin_dir}:{os.environ['PATH']}",
@@ -205,12 +209,12 @@ def _run(
         "RETRY_BASE_DELAY": "0",  # a failing API call must not sleep out the backoff
         "GH_REVIEWS": str(tmp_path / "reviews.json"),
         "GH_THREADS": str(tmp_path / "threads.json"),
-        "CHECK_RUN_LOG": str(log),
+        "STATUS_LOG": str(log),
     }
     if report_sha is not None:
         env["REPORT_SHA"] = report_sha
     if fail_post:
-        env["FAIL_CHECK_POST"] = "1"
+        env["FAIL_STATUS_POST"] = "1"
     if fail_reads:
         env["FAIL_READS"] = "1"
     if gate_unreported:
@@ -317,9 +321,9 @@ def test_an_empty_body_review_does_not_count_as_reviewed(tmp_path: Path) -> None
     assert posted == []
 
 
-def test_a_failed_api_read_fails_closed_with_no_check_run(tmp_path: Path) -> None:
+def test_a_failed_api_read_fails_closed_with_no_status(tmp_path: Path) -> None:
     # Can't-verify is RED, never green: a read that exhausts the retry ladder
-    # must exit non-zero WITHOUT posting any check run — a gate that reported a
+    # must exit non-zero WITHOUT posting any status — a gate that reported a
     # verdict it could not compute would let a PR merge past findings nobody
     # read (success), or hide the outage behind a plausible red (failure).
     proc, posted = _run(
@@ -420,30 +424,29 @@ def test_green_once_every_gating_thread_is_resolved(tmp_path: Path) -> None:
     assert proc.returncode == 0, proc.stderr
 
 
-# ── REPORT_SHA mode: the verdict is a check run ─────────────────────────────
+# ── REPORT_SHA mode: the verdict is a commit status ─────────────────────────
 
 
-def test_report_mode_posts_a_success_check_run(tmp_path: Path) -> None:
+def test_report_mode_posts_a_success_status(tmp_path: Path) -> None:
     proc, posted = _run(
         tmp_path, reviews=[_review()], threads=[], report_sha="cafe1234"
     )
     assert proc.returncode == 0, proc.stderr
     assert len(posted) == 1
-    run = posted[0]
-    # The name must match the merge_gate job's `name:` — one required-check
+    status = posted[0]
+    # The context must match the merge_gate job's `name:` — one required-check
     # context, two reporting surfaces — so it is read from the workflow, and a
     # rename that desyncs the two surfaces reds here.
-    assert run["name"] == CHECK_NAME
-    assert run["head_sha"] == "cafe1234"
-    assert run["status"] == "completed"
-    assert run["conclusion"] == "success"
+    assert status["context"] == GATE_CONTEXT
+    assert status["sha"] == "cafe1234"
+    assert status["state"] == "success"
 
 
-def test_report_mode_posts_a_failure_check_run_and_still_exits_zero(
+def test_report_mode_posts_a_failure_status_and_still_exits_zero(
     tmp_path: Path,
 ) -> None:
-    # The check run IS the report: a red verdict lands as conclusion=failure on
-    # the sha while the posting run itself stays green.
+    # The status IS the report: a red verdict lands as state=failure on the sha
+    # while the posting run itself stays green.
     proc, posted = _run(
         tmp_path,
         reviews=[_review()],
@@ -451,8 +454,8 @@ def test_report_mode_posts_a_failure_check_run_and_still_exits_zero(
         report_sha="cafe1234",
     )
     assert proc.returncode == 0, proc.stderr
-    assert [(r["name"], r["head_sha"], r["conclusion"]) for r in posted] == [
-        (CHECK_NAME, "cafe1234", "failure")
+    assert [(r["context"], r["sha"], r["state"]) for r in posted] == [
+        (GATE_CONTEXT, "cafe1234", "failure")
     ]
 
 
@@ -460,7 +463,7 @@ def test_an_unevaluated_gate_reports_red_rather_than_going_unreported(
     tmp_path: Path,
 ) -> None:
     # The caller's always() arm. An evaluation that dies before its POST leaves
-    # the head with NO check run under a REQUIRED context, which renders as
+    # the head with NO status under a REQUIRED context, which renders as
     # "Expected — Waiting for status to be reported" and blocks the merge on a
     # check nothing will ever send: resolving a thread fires no workflow event,
     # so nothing re-derives the gate until the next push or a recheck label.
@@ -477,13 +480,13 @@ def test_an_unevaluated_gate_reports_red_rather_than_going_unreported(
         gate_unreported=True,
     )
     assert proc.returncode == 0, proc.stderr
-    assert [
-        (r["name"], r["head_sha"], r["status"], r["conclusion"]) for r in posted
-    ] == [(CHECK_NAME, "cafe1234", "completed", "failure")]
+    assert [(r["context"], r["sha"], r["state"]) for r in posted] == [
+        (GATE_CONTEXT, "cafe1234", "failure")
+    ]
 
 
 def test_an_unevaluated_gate_refuses_to_report_against_no_sha(tmp_path: Path) -> None:
-    # Fail loud rather than POST an empty head_sha: a check run on "" satisfies
+    # Fail loud rather than POST against an empty sha: a status on "" satisfies
     # nothing and would strand the head exactly as the silence it replaced does.
     proc, posted = _run(tmp_path, reviews=[_review()], threads=[], gate_unreported=True)
     assert proc.returncode != 0
@@ -491,7 +494,7 @@ def test_an_unevaluated_gate_refuses_to_report_against_no_sha(tmp_path: Path) ->
     assert posted == []
 
 
-def test_a_failed_check_run_post_fails_the_run_loudly(tmp_path: Path) -> None:
+def test_a_failed_status_post_fails_the_run_loudly(tmp_path: Path) -> None:
     # A verdict that cannot be reported leaves the required check hanging at
     # "Expected" — the POST failure must red this run, never be swallowed.
     proc, posted = _run(
@@ -582,7 +585,7 @@ def _evaluate_job() -> dict:
 
 def test_the_evaluate_job_never_cancels_a_running_verdict_post() -> None:
     # GitHub cancels mid-step, so cancel-in-progress: true can kill the run
-    # between reading the PR state and POSTing the check run — the verdict is
+    # between reading the PR state and POSTing the verdict — that verdict is
     # lost and the head keeps a stale one. With false, a running evaluation
     # always finishes its POST; only the queued run is ever displaced.
     concurrency = _evaluate_job()["concurrency"]
@@ -633,10 +636,10 @@ def test_the_evaluate_job_actually_posts_a_verdict_on_the_head() -> None:
     # and label assertions above imply: a job that removes the label and posts
     # nothing leaves the required context unreported on every new head, so the
     # PR blocks forever on a check that never arrives. REPORT_SHA is what routes
-    # the verdict to the head's check context.
+    # the verdict to the head's status context.
     steps = _evaluate_job()["steps"]
     gate_steps = [s for s in steps if "review-findings-gate.sh" in (s.get("run") or "")]
-    # Two arms, and both must route to the HEAD's check context: the evaluation
+    # Two arms, and both must route to the HEAD's status context: the evaluation
     # itself, and the always() arm that reports red when the evaluation posted
     # nothing. Without the second, a run that dies before its POST strands the
     # required context at "Expected — Waiting for status to be reported", which
@@ -659,7 +662,7 @@ def test_the_evaluate_job_actually_posts_a_verdict_on_the_head() -> None:
     assert "steps.evaluate.outcome" in unreported.get("if", "")
     # The script is read from the DEFAULT branch, never the event's sha: this
     # job runs in the base repo's context under pull_request_target, so a
-    # head-ref checkout would execute PR-authored code with checks:write.
+    # head-ref checkout would execute PR-authored code with statuses:write.
     checkouts = [s for s in steps if "actions/checkout" in (s.get("uses") or "")]
     assert len(checkouts) == 1
     assert (
@@ -700,11 +703,11 @@ def test_every_predicate_changing_job_reposts_the_gate_on_the_head(
     # The re-post must come AFTER the write it reports on, or it reads the
     # pre-write state and posts a stale verdict.
     assert gate_steps[0] is not steps[0]
-    # Posting a check run needs checks:write, or the re-post 403s at runtime.
-    assert jobs[job]["permissions"].get("checks") == "write"
+    # Posting the verdict needs statuses:write, or the re-post 403s at runtime.
+    assert jobs[job]["permissions"].get("statuses") == "write"
 
 
-def test_the_skipped_class_is_cleared_under_the_same_check_name() -> None:
+def test_the_skipped_class_is_cleared_under_the_same_context() -> None:
     # A PR the reviewer deliberately skips gets no review, so the gate's
     # reviewed-at-all leg is red on it and the class would be blocked forever.
     # The auto-approve job clears it by posting the SAME required context — a
@@ -715,13 +718,21 @@ def test_the_skipped_class_is_cleared_under_the_same_check_name() -> None:
         )
     )["jobs"]
     job = jobs["auto-approve-skipped"]
-    clearing = [s for s in job["steps"] if "check-runs" in (s.get("run") or "")]
+    clearing = [s for s in job["steps"] if "/statuses/" in (s.get("run") or "")]
     assert len(clearing) == 1
-    assert f"name={CHECK_NAME}" in clearing[0]["run"]
-    assert "conclusion=success" in clearing[0]["run"]
-    assert job["permissions"].get("checks") == "write"
+    assert f"context={GATE_CONTEXT}" in clearing[0]["run"]
+    assert "state=success" in clearing[0]["run"]
+    assert job["permissions"].get("statuses") == "write"
 
-    # A check run is per-SHA and does not carry over to a new head, while the
+    # GitHub truncates a status description past 140 characters, and this one is
+    # the whole explanation the class gets — the gate script's own descriptions
+    # are truncated deliberately (post_verdict), but this literal has no such
+    # guard, so the cap is asserted where it can actually be exceeded.
+    described = re.search(r'description=(?P<text>.*?)"', clearing[0]["run"], re.S)
+    assert described is not None
+    assert len(described["text"]) <= 140
+
+    # A status is per-SHA and does not carry over to a new head, while the
     # gate posts RED on every head of a skipped PR (nothing reviewed it). So the
     # clearing step must fire on EVERY event the job sees, including
     # `synchronize` — gate it to the first-look events and a skipped PR merges on
@@ -748,16 +759,16 @@ def test_the_skipped_class_is_cleared_under_the_same_check_name() -> None:
     assert "opened" not in (job["if"] or "")
 
 
-def test_drift_guard_the_check_name_is_duplicated_in_the_gate_script() -> None:
+def test_drift_guard_the_gate_context_is_duplicated_in_the_gate_script() -> None:
     """DRIFT GUARD — this asserts two copies of one string agree, which means the
-    check name is duplicated rather than sourced once. Naming it honestly instead
-    of "…agree on the check name", which launders exactly the smell a drift guard
+    context is duplicated rather than sourced once. Naming it honestly instead
+    of "…agree on the context", which launders exactly the smell a drift guard
     should expose.
 
     Why a true SSOT is infeasible here: the required-check context is a GitHub job
     `name:`, and a job name cannot be computed — it must be a static literal in the
     workflow YAML. The gate script needs the same string at runtime to POST its
-    check runs under that context. Nothing can generate both, and having the script
+    statuses under that context. Nothing can generate both, and having the script
     grep the name out of the workflow at runtime trades this guard for hand-rolled
     YAML parsing in bash, which is worse.
 
@@ -765,4 +776,4 @@ def test_drift_guard_the_check_name_is_duplicated_in_the_gate_script() -> None:
     requires, and the required context is never reported at all — so PRs hang at
     "Expected" forever. That is why the duplication is guarded rather than left bare.
     """
-    assert f'CHECK_NAME="{CHECK_NAME}"' in SCRIPT.read_text(encoding="utf-8")
+    assert f'GATE_CONTEXT="{GATE_CONTEXT}"' in SCRIPT.read_text(encoding="utf-8")


### PR DESCRIPTION
Claims: the `Review findings resolved` required check and everything that posts under that context.

## What & why

The required check `Review findings resolved` never activates. Every PR sits at **"Expected — Waiting for status to be reported"** under it, forever, and merges only via the bypass button (that is how #362 landed).

Cause: the gate posts its verdict as a **check run** on a bare head sha. A check run POSTed to `POST /repos/{r}/check-runs` for a sha with no PR context lands in a check suite of the app's own making, and that suite's `pull_requests` array is empty. The commit-scoped API and the Checks tab read suites by sha, so the run looks green there; the **PR merge box counts only suites tied to the pull request**, so it counts nothing. The required context is therefore never satisfied by anything the gate does.

Fix: post the verdict as a **commit status** under the same context. Statuses carry no check suite and are read on the sha itself. This is exactly how the sibling gate `Automated review posted` has always reported — same triggers, same token, same permissions — and that one has never had this problem.

Unchanged: the context name, the ruleset entry, the posting app (`github-actions`, id 15368), `REPORT_SHA` routing, the `GATE_UNREPORTED` always()-arm, the merge-queue leg, and the sweeper's push-free re-derivation.

Forensics on the head of #362 (`eddea8f`), for the record:

- the gate ran and posted — 11 successful check runs, 21:21:32 → 02:00:44;
- the ruleset is in sync — `sync-required-checks` with `check-only=true` reported "already in sync (12 contexts)";
- context and app match the ruleset entry `{"context":"Review findings resolved","integration_id":15368}`;
- no duplicate requirement — legacy branch protection 404s ("Branch not protected");
- all 11 runs share check suite `88507901538`, whose dump is `"prs": []`. That empty array is the bug.

## Review focus

`.github/scripts/review-findings-gate.sh` first — the two POST sites collapse into one `post_verdict` helper, and the only behavioral question is whether every caller still reports. The cross-file invariant: the status `context` must stay byte-identical to the `merge_gate` job `name:` in `review-findings-merge-gate.yaml`, because `sync-required-checks` derives the ruleset entry from that job name. `tests/test_review_findings_gate.py` now reads the constant out of that workflow rather than hardcoding it, and a drift guard asserts the script's literal matches.

Least sure of: the 140-character truncation. GitHub caps a status `description`, and a red verdict's reason (a list of `path:line`) can exceed it, so `post_verdict` truncates to 137 + `...` and the full reason stays in the job log and behind `target_url`. A truncated middle of a finding list is less useful than the run log, which is why `RUN_URL` is now passed on both arms.

Permissions drop from `checks: write` to `statuses: write` in every workflow that posts this context — `review-findings-gate.yaml`, `claude-reviewer-hold-clear.yaml`, and both jobs in `claude-pr-review.yaml` (including the step that clears the context for the deliberately-skipped review class).

**This PR cannot test its own fix, and will still need a bypass merge.** `review-findings-gate.yaml` runs on `pull_request_target` and checks out `ref: default_branch`, so the gate evaluating this PR is `main`'s script — the check-run version. Confirmed on this head: `Review findings resolved` here is check run `97586493301`, not a status. The fix is exercised on the first PR opened after this one merges; that PR's merge box either shows the context reporting or it does not, and that is the test.

## How it was tested

- `pytest tests/ -q` → 3610 passed, 5 skipped
- `pytest tests/test_review_findings_gate.py -q` → 31 passed (the behavioral suite drives the real script against a fake `gh` and asserts on the recorded POSTs; its stub now records `/statuses/`, including which sha got the verdict)
- `node --test test/review-gate-compensation.test.mjs` → 3/3
- pre-commit over the diff → clean (shellcheck, shfmt, ruff, zizmor, ci-truth-serum aggregates)

## Decisions made

- **Status vs. renaming the `evaluate` job to carry the context.** Renaming the job would also fix suite association, since the job's own check run is tied to the PR. It would delete push-free re-derivation: only a workflow run can update a job's check run, so a thread resolved with no push would need `recheck-review-gate` label ping-pong on every open PR on every sweep. The status keeps the sweeper working. Under the alternative, `claude-reviewer-hold-clear.yaml`'s reconciler for this gate would have to be dropped or rewritten as a dispatch loop.
- **Truncate the description rather than shorten the reason.** The reason string is also the job-log line and the merge-queue leg's output, where the full finding list is the point.
- **`fix(ci):`, not `fix(ci)!:`.** The context name and ruleset are unchanged, so no consumer wiring changes; a `!` would cut a major release of the published package for a CI-only change.
- **Left the two gates separate.** `Automated review posted`'s whole predicate is a near-copy of clause (a) of this gate — same GraphQL document, same `lib/reviewer-identity.bash`. They differ only in that the sibling excludes `DISMISSED` reviews and clause (a) does not. Making clause (a) dismissal-aware would make the sibling context strictly redundant and retire a required check, a job, and `reconcile-review-gate.sh`. That changes which merges are allowed, so it is not folded into a reporting fix.

## Lessons Learned

**What:** in `.github/scripts/review-findings-gate.sh` (and any gate script that reports a required context on a PR head), POST to `repos/{repo}/statuses/{sha}`, never `repos/{repo}/check-runs`.

**Where:** the gate scripts under `.github/scripts/` and the `permissions:` blocks of every workflow that runs them — `statuses: write`, not `checks: write`.

**Why:** a check run created for a bare head sha lands in a check suite whose `pull_requests` array is empty, and the PR merge box counts only suites tied to the pull request. The failure is silent and looks like success: the run is green on the commit and in the Checks tab while the required context reads "Expected — Waiting for status to be reported" and the PR can only merge by bypass. Downstream repos inherit these workflows and the ruleset sync, so they inherit the stuck gate.
