### PR TITLE
docs(readme): say what the library does before comparing it to classifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
 # `agent-sanitizer`
 
-Most prompt-injection tools run a classifier _over_ the text and hope it
-generalizes. This library targets a narrower, verifiable claim: the
-specific byte-level channels—invisible Unicode, ANSI escapes, human-hidden
-HTML, confusable glyphs and look-alike hosts, exfil-shaped URLs—that let an
-attacker smuggle a payload the operator can't see but the model still reads.
-Every layer is a
-deterministic transform you can unit-test with equality assertions.
+**Strips hidden instructions out of untrusted text before your agent reads it.** An attacker hides a payload where a person cannot see it but the model still reads it: invisible Unicode, ANSI escapes, human-hidden HTML, confusable glyphs and look-alike hosts, and exfil-shaped URLs.
+
+This library closes those channels one at a time. Every layer is a deterministic transform, so you can unit-test it with equality assertions. There is no classifier and no model call, so nothing depends on whether a prediction generalized.
 
 **As a library:**
 
@@ -28,9 +24,7 @@ Enter one at a time:
 
 Finally, navigate: `/plugin` → Marketplaces → `agent-sanitizer` → Enable auto-update.
 
-[What installing entails](#what-installing-entails) covers the footprint of each
-path and how a failure looks; [Using it with Claude
-Code](#using-it-with-claude-code) covers each hook and hand-wiring.
+[What installing entails](#what-installing-entails) covers the footprint of each path and how a failure looks; [Using it with Claude Code](#using-it-with-claude-code) covers each hook and hand-wiring.
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # `agent-sanitizer`
 
-**Strips hidden instructions out of untrusted text before your agent reads it.** An attacker hides a payload where a person cannot see it but the model still reads it: invisible Unicode, ANSI escapes, human-hidden HTML, confusable glyphs and look-alike hosts, and exfil-shaped URLs.
+**Cleans untrusted text before your agent reads it.** An attacker hides a payload where a person cannot see it but the model still reads it: invisible Unicode, ANSI escapes, human-hidden HTML, confusable glyphs, look-alike hosts, and exfil-shaped URLs.
 
-This library closes those channels one at a time. Every layer is a deterministic transform, so you can unit-test it with equality assertions. There is no classifier and no model call, so nothing depends on whether a prediction generalized.
+This library handles each channel on its own terms. It strips invisible characters and ANSI escapes by default, splices out hidden HTML when you opt in, and _reports_ exfil-shaped URLs and look-alike hosts rather than rewriting them — mangling a legitimate link is the worse failure. Every layer is a deterministic transform, so you can unit-test it with equality assertions. There is no classifier and no model call, so nothing rests on whether a prediction generalized.
 
 **As a library:**
 


### PR DESCRIPTION
Rewrites the README's opening so it says what the library does first, and says it accurately. The install blocks, the pointers to "What installing entails" and "Using it with Claude Code", and everything below are unchanged.

The old first sentence described what *other* tools do ("most prompt-injection tools run a classifier and hope it generalizes"), so a reader met the competitive framing before the product. The new lead states the job, then says what each channel actually gets: invisible characters and ANSI escapes stripped by default, hidden HTML spliced out when you opt into `{ html: true }`, and exfil-shaped URLs and look-alike hosts *reported* rather than rewritten. Report-only is a deliberate precision-over-recall choice, so the lead states the reason — mangling a legitimate link is the worse failure — instead of glossing it.

Review caught a real overclaim in my first draft: it listed exfil-shaped URLs and look-alike hosts among channels the library "closes", which contradicts the entry-points table ("Reports only — never rewrites") and the found-codes table ("reported, not removed"). Verified both against the tables before rewriting.

This README also renders on the open-source page of turntrout.com, which embeds the preamble plus the first section, so the lead is what most readers see.

Merging on explicit instruction from the repository owner, 2026-08-25: "merge all of them yourself".