### PR TITLE
perf(html): import css-tree by subpath, dropping mdn-data from shipped bundles

### DIFF
--- a/.github/scripts/prepare-pr-review-input.sh
+++ b/.github/scripts/prepare-pr-review-input.sh
@@ -5,10 +5,16 @@
 # diff — so an injection payload hidden in it (zero-width control text, ANSI
 # escapes, exfil beacons) cannot reach the agent intact.
 #
+# Generated-file filter: every path config/auto-resolve-regen-rules.json declares
+# as GENERATED is stripped from the diff before it is counted or sanitized. CI
+# rebuilds those artifacts and fails on any difference, so reviewing them adds no
+# signal, and this repo commits a ~29k-line hook bundle that pushed ordinary
+# source edits over the size guard below.
+#
 # Oversized-diff guard: the base-only checkout means diff.txt is the ONLY source
 # of the PR's changes — the agent cannot reconstruct them from the trusted base
-# tree, so an enormous diff (a mega-merge, a vendored/generated dump) would be
-# ingested whole into an Opus read that is slow, costly, and low-signal. Above
+# tree, so an enormous diff (a mega-merge, a vendored dump) would be ingested
+# whole into an Opus read that is slow, costly, and low-signal. Above
 # MAX_DIFF_LINES lines this skips the review, emitting oversized=true so the
 # caller posts a "please review manually" notice instead of spending the read.
 #
@@ -46,7 +52,9 @@ emit_output() {
 # grants the agent read over PR_INPUT_DIR via --add-dir), so only the SANITIZED
 # diff.txt ever reaches the reviewer.
 raw_diff="$(mktemp)"
-trap 'rm -f "$raw_diff"' EXIT
+review_diff="$(mktemp)"
+owned_list="$(mktemp)"
+trap 'rm -f "$raw_diff" "$review_diff" "$owned_list"' EXIT
 # curl for the diff media type, not `gh api`/`gh pr diff`: gh's own
 # client-side safety guard (pkg/iostreams content sanitization) refuses to
 # print ANY response holding a raw terminal escape sequence unless
@@ -66,7 +74,17 @@ raw_diff_content="$(retry_stdout curl -fsS \
   "${api_url}/repos/${GH_REPO}/pulls/${PR}")"
 printf '%s\n' "$raw_diff_content" >"$raw_diff"
 
-diff_lines="$(wc -l <"$raw_diff" | tr -d '[:space:]')"
+# Drop the generated files before counting or reviewing. CI rebuilds each one
+# and fails on any difference, so its diff cannot disagree with the sources — and
+# this repo commits a ~29k-line hook bundle, so leaving them in pushed an
+# ordinary source edit past MAX_DIFF_LINES and skipped the review of the very
+# lines a human wrote. resolve-generated.mjs is the same ownership oracle the
+# auto-resolver partitions on; nothing classifies a path here.
+node .github/scripts/resolve-generated.mjs --owned >"$owned_list"
+node .github/scripts/strip-generated-diff.mjs "$owned_list" \
+  <"$raw_diff" >"$review_diff"
+
+diff_lines="$(wc -l <"$review_diff" | tr -d '[:space:]')"
 if ((diff_lines > MAX_DIFF_LINES)); then
   emit_output "oversized=true"
   emit_output "diff_lines=$diff_lines"
@@ -80,7 +98,7 @@ emit_output "oversized=false"
 
 sanitize() { node .github/scripts/sanitize-pr-input.mjs; }
 
-sanitize <"$raw_diff" >"${PR_INPUT_DIR}/diff.txt" 2>"${PR_INPUT_DIR}/diff.report.txt"
+sanitize <"$review_diff" >"${PR_INPUT_DIR}/diff.txt" 2>"${PR_INPUT_DIR}/diff.report.txt"
 # Capture the metadata JSON with retry_stdout, THEN pipe the clean result into
 # the sanitizer — retrying gh directly inside the `| sanitize` pipe is unsafe (a
 # failing attempt would stream partial JSON into the sanitizer, and a SIGPIPE if

--- a/.github/scripts/strip-generated-diff.mjs
+++ b/.github/scripts/strip-generated-diff.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// Drop GENERATED files' sections from a unified diff, so the automated reviewer
+// reads the hand-written change instead of a rebuilt artifact.
+//
+// PROBLEM CLASS — a review budget spent on bytes nobody wrote. This repo commits
+// its build outputs (plugin/dist/hooks/plugin-hooks.bundle.mjs and friends), so a
+// 25-line source edit arrives as a ~30k-line diff. That is over
+// prepare-pr-review-input.sh's MAX_DIFF_LINES, so the review is skipped
+// entirely and the source edit gets no automated read at all — the opposite of
+// what the size guard is for. The artifacts need no review anyway: CI rebuilds
+// each one and fails on any difference, so the diff cannot disagree with its
+// sources.
+//
+// Ownership comes from `resolve-generated.mjs --owned`, the same oracle the
+// auto-resolver partitions on, passed in on argv. A path is never classified
+// here.
+//
+// Reads the diff on stdin, writes the filtered diff on stdout, and reports what
+// it dropped on stderr. Fails OPEN: a section whose header this cannot parse
+// unambiguously is KEPT, because the cost of keeping a generated file is some
+// wasted review budget and the cost of dropping a hand-written one is an unread
+// change.
+//
+// Usage: node .github/scripts/strip-generated-diff.mjs <owned-list-file> <diff
+// where <owned-list-file> holds one owned path per line.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// A section header git wrote for a path with no whitespace, which every owned
+// path in this repo is. A quoted or space-bearing path does not match, and its
+// section is kept — see the fail-open note above.
+const HEADER = /^diff --git a\/(\S+) b\/(\S+)$/u;
+
+/** True when `path` is generated: an exact `owns` entry, or under an
+ * `ownsPrefix` (which the oracle prints with its trailing slash). */
+function isOwned(path, owned) {
+  return owned.some((entry) =>
+    entry.endsWith("/") ? path.startsWith(entry) : path === entry,
+  );
+}
+
+/** Split a unified diff into sections, each starting at a `diff --git` line.
+ * A leading chunk before the first header (git emits none, but a caller may
+ * prepend text) becomes its own always-kept section. */
+function splitSections(diff) {
+  const lines = diff.split("\n");
+  /** @type {string[][]} */
+  const sections = [];
+  for (const line of lines) {
+    if (HEADER.test(line) || sections.length === 0) sections.push([]);
+    sections[sections.length - 1].push(line);
+  }
+  return sections.map((s) => s.join("\n"));
+}
+
+/** The filtered diff and the paths dropped from it.
+ * @param {string} diff a unified diff
+ * @param {string[]} owned paths and path prefixes that are generated
+ * @returns {{ kept: string, dropped: {path: string, lines: number}[] }} */
+export function stripGenerated(diff, owned) {
+  /** @type {{path: string, lines: number}[]} */
+  const dropped = [];
+  const kept = [];
+  for (const section of splitSections(diff)) {
+    const header = HEADER.exec(section.split("\n", 1)[0]);
+    // Both sides must be generated, so a rename that moves a hand-written file
+    // onto a generated path (or the reverse) stays in the review.
+    if (header && isOwned(header[1], owned) && isOwned(header[2], owned)) {
+      dropped.push({ path: header[2], lines: section.split("\n").length });
+      continue;
+    }
+    kept.push(section);
+  }
+  return { kept: kept.join("\n"), dropped };
+}
+
+/** The note prepended to a filtered diff, so the reviewer knows the artifacts
+ * changed and why it is not being shown them. Empty when nothing was dropped —
+ * an unfiltered diff must pass through byte for byte. */
+export function omissionNote(dropped) {
+  if (dropped.length === 0) return "";
+  const rows = dropped.map(
+    (d) => `#   ${d.path} (${d.lines} diff lines, omitted)`,
+  );
+  return [
+    `# NOTE: ${dropped.length} generated file(s) are omitted from the diff below.`,
+    "# They are build outputs listed in config/auto-resolve-regen-rules.json.",
+    "# CI rebuilds each one and fails on any difference, so they cannot disagree",
+    "# with the sources shown here. Review the sources.",
+    ...rows,
+    "",
+    "",
+  ].join("\n");
+}
+
+function main(ownedListFile) {
+  const owned = readFileSync(ownedListFile, "utf8").split("\n").filter(Boolean);
+  const diff = readFileSync(0, "utf8");
+  const { kept, dropped } = stripGenerated(diff, owned);
+  process.stdout.write(
+    dropped.length === 0 ? diff : omissionNote(dropped) + kept,
+  );
+  for (const d of dropped)
+    process.stderr.write(
+      `strip-generated-diff: omitted ${d.path} (${d.lines} lines)\n`,
+    );
+}
+
+// Only when RUN, not when the test suite imports the pure functions above.
+if (
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === resolve(process.argv[1])
+)
+  main(process.argv[2]);

--- a/.github/scripts/strip-generated-diff.test.mjs
+++ b/.github/scripts/strip-generated-diff.test.mjs
@@ -1,0 +1,103 @@
+// strip-generated-diff decides what the automated reviewer never sees, so the
+// asymmetry is the whole test: dropping a hand-written file is an unread change,
+// while keeping a generated one costs only review budget. Every case below is a
+// header shape that could be misread in one of those two directions.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { omissionNote, stripGenerated } from "./strip-generated-diff.mjs";
+
+/** A minimal but real two-file diff: one generated, one hand-written. */
+const DIFF = [
+  "diff --git a/plugin/dist/hooks/plugin-hooks.bundle.mjs b/plugin/dist/hooks/plugin-hooks.bundle.mjs",
+  "index 1111111..2222222 100644",
+  "--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs",
+  "+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs",
+  "@@ -1 +1 @@",
+  "-var a = 1;",
+  "+var a = 2;",
+  "diff --git a/src/html.mjs b/src/html.mjs",
+  "index 3333333..4444444 100644",
+  "--- a/src/html.mjs",
+  "+++ b/src/html.mjs",
+  "@@ -1 +1 @@",
+  '-import * as csstree from "css-tree";',
+  '+import cssParse from "css-tree/parser";',
+  "",
+].join("\n");
+
+const OWNED = ["plugin/dist/hooks/plugin-hooks.bundle.mjs", "types/"];
+
+test("drops a generated file's section and keeps the hand-written one", () => {
+  const { kept, dropped } = stripGenerated(DIFF, OWNED);
+  assert.deepEqual(
+    dropped.map((d) => d.path),
+    ["plugin/dist/hooks/plugin-hooks.bundle.mjs"],
+  );
+  assert.ok(kept.includes("diff --git a/src/html.mjs b/src/html.mjs"));
+  assert.ok(!kept.includes("plugin-hooks.bundle.mjs"));
+  // The kept section must survive intact, not merely be present: a splitter that
+  // ate the first or last line of a section would still pass a substring check.
+  assert.ok(kept.includes('+import cssParse from "css-tree/parser";'));
+});
+
+test("a diff with nothing generated passes through byte for byte", () => {
+  const { kept, dropped } = stripGenerated(DIFF, ["types/"]);
+  assert.deepEqual(dropped, []);
+  assert.equal(kept, DIFF);
+});
+
+test("an ownsPrefix entry covers its whole subtree", () => {
+  const diff = [
+    "diff --git a/types/index.d.ts b/types/index.d.ts",
+    "@@ -1 +1 @@",
+    "-declare const a: 1;",
+    "+declare const a: 2;",
+    "",
+  ].join("\n");
+  assert.deepEqual(
+    stripGenerated(diff, OWNED).dropped.map((d) => d.path),
+    ["types/index.d.ts"],
+  );
+  // The prefix must not match a sibling that merely starts with the same letters.
+  assert.deepEqual(
+    stripGenerated(diff.replaceAll("types/", "types-doc/"), OWNED).dropped,
+    [],
+  );
+});
+
+test("a rename with only one generated side is kept", () => {
+  const diff = [
+    "diff --git a/src/html.mjs b/plugin/dist/hooks/plugin-hooks.bundle.mjs",
+    "similarity index 100%",
+    "",
+  ].join("\n");
+  assert.deepEqual(stripGenerated(diff, OWNED).dropped, []);
+});
+
+test("an unparsable header is kept, never dropped", () => {
+  // git leaves a space-bearing path unquoted, so the header is ambiguous. Keeping
+  // it costs review budget; dropping it would hide a change nobody reviewed.
+  const diff = [
+    'diff --git "a/plugin/dist/hooks/plugin-hooks.bundle.mjs" "b/plugin/dist/hooks/plugin-hooks.bundle.mjs"',
+    "@@ -1 +1 @@",
+    "-a",
+    "+b",
+    "",
+  ].join("\n");
+  assert.deepEqual(stripGenerated(diff, OWNED).dropped, []);
+});
+
+test("an empty owned list drops nothing", () => {
+  assert.deepEqual(stripGenerated(DIFF, []).dropped, []);
+});
+
+test("the note names every omitted path and is empty when none were", () => {
+  assert.equal(omissionNote([]), "");
+  const note = omissionNote([{ path: "a/b.json", lines: 42 }]);
+  assert.match(note, /1 generated file\(s\)/u);
+  assert.match(note, /a\/b\.json \(42 diff lines, omitted\)/u);
+  // Every line must be a comment, so the note cannot be read as diff content.
+  for (const line of note.split("\n").filter(Boolean))
+    assert.match(line, /^#/u);
+});

--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=0b43597e575e8682486d88d276094099f0910bdf4d283b574aa6dc96d73c9e96
-706a7ac4250ccc8da38859b77fd0063f977a5527eda87bf3d8be7971fb21b9af  agent-sanitizer-hooks-darwin-arm64
-fae914396cdeca3cf8f3b458d2ad70c19ad64c88f1b88f8592af3dbacd0afabc  agent-sanitizer-hooks-darwin-x64
-6175675caf1a83fb272393a3846e9842885ccb1303c40fc2a75ded66f2bce2a1  agent-sanitizer-hooks-linux-arm64
-de8760101094cad7c6e5f63af854f5d4a5f70adf51c55755a79ae90cc86e4a4c  agent-sanitizer-hooks-linux-x64
+# bundle=f7ebe392829fe369fa720e37d3611d1d95e151e76bd02acfd708dc8d4f29494a
+a1b8a59991e305a0d52c73f620a31d25b2790d7763a4a7e53adef02776047c16  agent-sanitizer-hooks-darwin-arm64
+14a72b060c15ed9950c3d4af24f60b2c56aa43faea805aa3fd2cb6fb0e6dd8ee  agent-sanitizer-hooks-darwin-x64
+110535ee2d6e099acfc94056cfc12a01263097bf3a1414c0d7e0dde776b86804  agent-sanitizer-hooks-linux-arm64
+d0b8fffb00e714571f3dc55bdcd2e9a578b42bd285e3658866f5717a6d394648  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -4377,6 +4377,425 @@ var init_view_map = __esm({
   }
 });
 
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/utils/List.js
+var releasedCursors, List;
+var init_List = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/utils/List.js"() {
+    releasedCursors = null;
+    List = class _List {
+      static createItem(data) {
+        return {
+          prev: null,
+          next: null,
+          data
+        };
+      }
+      constructor() {
+        this.head = null;
+        this.tail = null;
+        this.cursor = null;
+      }
+      createItem(data) {
+        return _List.createItem(data);
+      }
+      // cursor helpers
+      allocateCursor(prev, next2) {
+        let cursor;
+        if (releasedCursors !== null) {
+          cursor = releasedCursors;
+          releasedCursors = releasedCursors.cursor;
+          cursor.prev = prev;
+          cursor.next = next2;
+          cursor.cursor = this.cursor;
+        } else {
+          cursor = {
+            prev,
+            next: next2,
+            cursor: this.cursor
+          };
+        }
+        this.cursor = cursor;
+        return cursor;
+      }
+      releaseCursor() {
+        const { cursor } = this;
+        this.cursor = cursor.cursor;
+        cursor.prev = null;
+        cursor.next = null;
+        cursor.cursor = releasedCursors;
+        releasedCursors = cursor;
+      }
+      updateCursors(prevOld, prevNew, nextOld, nextNew) {
+        let { cursor } = this;
+        while (cursor !== null) {
+          if (cursor.prev === prevOld) {
+            cursor.prev = prevNew;
+          }
+          if (cursor.next === nextOld) {
+            cursor.next = nextNew;
+          }
+          cursor = cursor.cursor;
+        }
+      }
+      *[Symbol.iterator]() {
+        for (let cursor = this.head; cursor !== null; cursor = cursor.next) {
+          yield cursor.data;
+        }
+      }
+      // getters
+      get size() {
+        let size = 0;
+        for (let cursor = this.head; cursor !== null; cursor = cursor.next) {
+          size++;
+        }
+        return size;
+      }
+      get isEmpty() {
+        return this.head === null;
+      }
+      get first() {
+        return this.head && this.head.data;
+      }
+      get last() {
+        return this.tail && this.tail.data;
+      }
+      // convertors
+      fromArray(array) {
+        let cursor = null;
+        this.head = null;
+        for (let data of array) {
+          const item = _List.createItem(data);
+          if (cursor !== null) {
+            cursor.next = item;
+          } else {
+            this.head = item;
+          }
+          item.prev = cursor;
+          cursor = item;
+        }
+        this.tail = cursor;
+        return this;
+      }
+      toArray() {
+        return [...this];
+      }
+      toJSON() {
+        return [...this];
+      }
+      // array-like methods
+      forEach(fn, thisArg = this) {
+        const cursor = this.allocateCursor(null, this.head);
+        while (cursor.next !== null) {
+          const item = cursor.next;
+          cursor.next = item.next;
+          fn.call(thisArg, item.data, item, this);
+        }
+        this.releaseCursor();
+      }
+      forEachRight(fn, thisArg = this) {
+        const cursor = this.allocateCursor(this.tail, null);
+        while (cursor.prev !== null) {
+          const item = cursor.prev;
+          cursor.prev = item.prev;
+          fn.call(thisArg, item.data, item, this);
+        }
+        this.releaseCursor();
+      }
+      reduce(fn, initialValue, thisArg = this) {
+        let cursor = this.allocateCursor(null, this.head);
+        let acc = initialValue;
+        let item;
+        while (cursor.next !== null) {
+          item = cursor.next;
+          cursor.next = item.next;
+          acc = fn.call(thisArg, acc, item.data, item, this);
+        }
+        this.releaseCursor();
+        return acc;
+      }
+      reduceRight(fn, initialValue, thisArg = this) {
+        let cursor = this.allocateCursor(this.tail, null);
+        let acc = initialValue;
+        let item;
+        while (cursor.prev !== null) {
+          item = cursor.prev;
+          cursor.prev = item.prev;
+          acc = fn.call(thisArg, acc, item.data, item, this);
+        }
+        this.releaseCursor();
+        return acc;
+      }
+      some(fn, thisArg = this) {
+        for (let cursor = this.head; cursor !== null; cursor = cursor.next) {
+          if (fn.call(thisArg, cursor.data, cursor, this)) {
+            return true;
+          }
+        }
+        return false;
+      }
+      map(fn, thisArg = this) {
+        const result = new _List();
+        for (let cursor = this.head; cursor !== null; cursor = cursor.next) {
+          result.appendData(fn.call(thisArg, cursor.data, cursor, this));
+        }
+        return result;
+      }
+      filter(fn, thisArg = this) {
+        const result = new _List();
+        for (let cursor = this.head; cursor !== null; cursor = cursor.next) {
+          if (fn.call(thisArg, cursor.data, cursor, this)) {
+            result.appendData(cursor.data);
+          }
+        }
+        return result;
+      }
+      nextUntil(start, fn, thisArg = this) {
+        if (start === null) {
+          return;
+        }
+        const cursor = this.allocateCursor(null, start);
+        while (cursor.next !== null) {
+          const item = cursor.next;
+          cursor.next = item.next;
+          if (fn.call(thisArg, item.data, item, this)) {
+            break;
+          }
+        }
+        this.releaseCursor();
+      }
+      prevUntil(start, fn, thisArg = this) {
+        if (start === null) {
+          return;
+        }
+        const cursor = this.allocateCursor(start, null);
+        while (cursor.prev !== null) {
+          const item = cursor.prev;
+          cursor.prev = item.prev;
+          if (fn.call(thisArg, item.data, item, this)) {
+            break;
+          }
+        }
+        this.releaseCursor();
+      }
+      // mutation
+      clear() {
+        this.head = null;
+        this.tail = null;
+      }
+      copy() {
+        const result = new _List();
+        for (let data of this) {
+          result.appendData(data);
+        }
+        return result;
+      }
+      prepend(item) {
+        this.updateCursors(null, item, this.head, item);
+        if (this.head !== null) {
+          this.head.prev = item;
+          item.next = this.head;
+        } else {
+          this.tail = item;
+        }
+        this.head = item;
+        return this;
+      }
+      prependData(data) {
+        return this.prepend(_List.createItem(data));
+      }
+      append(item) {
+        return this.insert(item);
+      }
+      appendData(data) {
+        return this.insert(_List.createItem(data));
+      }
+      insert(item, before = null) {
+        if (before !== null) {
+          this.updateCursors(before.prev, item, before, item);
+          if (before.prev === null) {
+            if (this.head !== before) {
+              throw new Error("before doesn't belong to list");
+            }
+            this.head = item;
+            before.prev = item;
+            item.next = before;
+            this.updateCursors(null, item);
+          } else {
+            before.prev.next = item;
+            item.prev = before.prev;
+            before.prev = item;
+            item.next = before;
+          }
+        } else {
+          this.updateCursors(this.tail, item, null, item);
+          if (this.tail !== null) {
+            this.tail.next = item;
+            item.prev = this.tail;
+          } else {
+            this.head = item;
+          }
+          this.tail = item;
+        }
+        return this;
+      }
+      insertData(data, before) {
+        return this.insert(_List.createItem(data), before);
+      }
+      remove(item) {
+        this.updateCursors(item, item.prev, item, item.next);
+        if (item.prev !== null) {
+          item.prev.next = item.next;
+        } else {
+          if (this.head !== item) {
+            throw new Error("item doesn't belong to list");
+          }
+          this.head = item.next;
+        }
+        if (item.next !== null) {
+          item.next.prev = item.prev;
+        } else {
+          if (this.tail !== item) {
+            throw new Error("item doesn't belong to list");
+          }
+          this.tail = item.prev;
+        }
+        item.prev = null;
+        item.next = null;
+        return item;
+      }
+      push(data) {
+        this.insert(_List.createItem(data));
+      }
+      pop() {
+        return this.tail !== null ? this.remove(this.tail) : null;
+      }
+      unshift(data) {
+        this.prepend(_List.createItem(data));
+      }
+      shift() {
+        return this.head !== null ? this.remove(this.head) : null;
+      }
+      prependList(list3) {
+        return this.insertList(list3, this.head);
+      }
+      appendList(list3) {
+        return this.insertList(list3);
+      }
+      insertList(list3, before) {
+        if (list3.head === null) {
+          return this;
+        }
+        if (before !== void 0 && before !== null) {
+          this.updateCursors(before.prev, list3.tail, before, list3.head);
+          if (before.prev !== null) {
+            before.prev.next = list3.head;
+            list3.head.prev = before.prev;
+          } else {
+            this.head = list3.head;
+          }
+          before.prev = list3.tail;
+          list3.tail.next = before;
+        } else {
+          this.updateCursors(this.tail, list3.tail, null, list3.head);
+          if (this.tail !== null) {
+            this.tail.next = list3.head;
+            list3.head.prev = this.tail;
+          } else {
+            this.head = list3.head;
+          }
+          this.tail = list3.tail;
+        }
+        list3.head = null;
+        list3.tail = null;
+        return this;
+      }
+      replace(oldItem, newItemOrList) {
+        if ("head" in newItemOrList) {
+          this.insertList(newItemOrList, oldItem);
+        } else {
+          this.insert(newItemOrList, oldItem);
+        }
+        this.remove(oldItem);
+      }
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/utils/create-custom-error.js
+function createCustomError(name50, message) {
+  const error = Object.create(SyntaxError.prototype);
+  const errorStack = new Error();
+  return Object.assign(error, {
+    name: name50,
+    message,
+    get stack() {
+      return (errorStack.stack || "").replace(/^(.+\n){1,3}/, `${name50}: ${message}
+`);
+    }
+  });
+}
+var init_create_custom_error = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/utils/create-custom-error.js"() {
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/parser/SyntaxError.js
+function sourceFragment({ source, line, column, baseLine, baseColumn }, extraLines) {
+  function processLines(start, end) {
+    return lines.slice(start, end).map(
+      (line2, idx) => String(start + idx + 1).padStart(maxNumLength) + " |" + line2
+    ).join("\n");
+  }
+  const prelines = "\n".repeat(Math.max(baseLine - 1, 0));
+  const precolumns = " ".repeat(Math.max(baseColumn - 1, 0));
+  const lines = (prelines + precolumns + source).split(/\r\n?|\n|\f/);
+  const startLine = Math.max(1, line - extraLines) - 1;
+  const endLine = Math.min(line + extraLines, lines.length + 1);
+  const maxNumLength = Math.max(4, String(endLine).length) + 1;
+  let cutLeft = 0;
+  column += (TAB_REPLACEMENT.length - 1) * (lines[line - 1].substr(0, column - 1).match(/\t/g) || []).length;
+  if (column > MAX_LINE_LENGTH) {
+    cutLeft = column - OFFSET_CORRECTION + 3;
+    column = OFFSET_CORRECTION - 2;
+  }
+  for (let i = startLine; i <= endLine; i++) {
+    if (i >= 0 && i < lines.length) {
+      lines[i] = lines[i].replace(/\t/g, TAB_REPLACEMENT);
+      lines[i] = (cutLeft > 0 && lines[i].length > cutLeft ? "\u2026" : "") + lines[i].substr(cutLeft, MAX_LINE_LENGTH - 2) + (lines[i].length > cutLeft + MAX_LINE_LENGTH - 1 ? "\u2026" : "");
+    }
+  }
+  return [
+    processLines(startLine, line),
+    new Array(column + maxNumLength + 2).join("-") + "^",
+    processLines(line, endLine)
+  ].filter(Boolean).join("\n").replace(/^(\s+\d+\s+\|\n)+/, "").replace(/\n(\s+\d+\s+\|)+$/, "");
+}
+function SyntaxError2(message, source, offset, line, column, baseLine = 1, baseColumn = 1) {
+  const error = Object.assign(createCustomError("SyntaxError", message), {
+    source,
+    offset,
+    line,
+    column,
+    sourceFragment(extraLines) {
+      return sourceFragment({ source, line, column, baseLine, baseColumn }, isNaN(extraLines) ? 0 : extraLines);
+    },
+    get formattedMessage() {
+      return `Parse error: ${message}
+` + sourceFragment({ source, line, column, baseLine, baseColumn }, 2);
+    }
+  });
+  return error;
+}
+var MAX_LINE_LENGTH, OFFSET_CORRECTION, TAB_REPLACEMENT;
+var init_SyntaxError = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/parser/SyntaxError.js"() {
+    init_create_custom_error();
+    MAX_LINE_LENGTH = 100;
+    OFFSET_CORRECTION = 60;
+    TAB_REPLACEMENT = "    ";
+  }
+});
+
 // node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/tokenizer/types.js
 var EOF, Ident, Function, AtKeyword, Hash, String2, BadString, Url, BadUrl, Delim, Number2, Percentage, Dimension, WhiteSpace, CDO, CDC, Colon, Semicolon, Comma, LeftSquareBracket, RightSquareBracket, LeftParenthesis, RightParenthesis, LeftCurlyBracket, RightCurlyBracket, Comment;
 var init_types = __esm({
@@ -4822,8 +5241,8 @@ var init_TokenStream = __esm({
     blockTokens[RightSquareBracket] = BLOCK_CLOSE_TOKEN;
     blockTokens[RightCurlyBracket] = BLOCK_CLOSE_TOKEN;
     TokenStream = class {
-      constructor(source, tokenize3) {
-        this.setSource(source, tokenize3);
+      constructor(source, tokenize2) {
+        this.setSource(source, tokenize2);
       }
       reset() {
         this.eof = false;
@@ -4832,7 +5251,7 @@ var init_TokenStream = __esm({
         this.tokenStart = this.firstCharOffset;
         this.tokenEnd = this.firstCharOffset;
       }
-      setSource(source = "", tokenize3 = () => {
+      setSource(source = "", tokenize2 = () => {
       }) {
         source = String(source || "");
         const sourceLength = source.length;
@@ -4845,7 +5264,7 @@ var init_TokenStream = __esm({
         this.offsetAndType = null;
         this.balance = null;
         balance.fill(0);
-        tokenize3(source, (type, start, end) => {
+        tokenize2(source, (type, start, end) => {
           const index2 = tokenCount++;
           offsetAndType[index2] = type << TYPE_SHIFT | end;
           if (firstCharOffset === -1) {
@@ -4892,10 +5311,10 @@ var init_TokenStream = __esm({
       }
       lookupTypeNonSC(idx) {
         for (let offset = this.tokenIndex; offset < this.tokenCount; offset++) {
-          const tokenType2 = this.offsetAndType[offset] >> TYPE_SHIFT;
-          if (tokenType2 !== WhiteSpace && tokenType2 !== Comment) {
+          const tokenType = this.offsetAndType[offset] >> TYPE_SHIFT;
+          if (tokenType !== WhiteSpace && tokenType !== Comment) {
             if (idx-- === 0) {
-              return tokenType2;
+              return tokenType;
             }
           }
         }
@@ -4910,8 +5329,8 @@ var init_TokenStream = __esm({
       }
       lookupOffsetNonSC(idx) {
         for (let offset = this.tokenIndex; offset < this.tokenCount; offset++) {
-          const tokenType2 = this.offsetAndType[offset] >> TYPE_SHIFT;
-          if (tokenType2 !== WhiteSpace && tokenType2 !== Comment) {
+          const tokenType = this.offsetAndType[offset] >> TYPE_SHIFT;
+          if (tokenType !== WhiteSpace && tokenType !== Comment) {
             if (idx-- === 0) {
               return offset - this.tokenIndex;
             }
@@ -4955,11 +5374,11 @@ var init_TokenStream = __esm({
       substrToCursor(start) {
         return this.source.substring(start, this.tokenStart);
       }
-      isBlockOpenerTokenType(tokenType2) {
-        return blockTokens[tokenType2] === BLOCK_OPEN_TOKEN;
+      isBlockOpenerTokenType(tokenType) {
+        return blockTokens[tokenType] === BLOCK_OPEN_TOKEN;
       }
-      isBlockCloserTokenType(tokenType2) {
-        return blockTokens[tokenType2] === BLOCK_CLOSE_TOKEN;
+      isBlockCloserTokenType(tokenType) {
+        return blockTokens[tokenType] === BLOCK_CLOSE_TOKEN;
       }
       getBlockTokenPairIndex(tokenIndex) {
         const type = this.getTokenType(tokenIndex);
@@ -5381,425 +5800,6 @@ var init_tokenizer = __esm({
   }
 });
 
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/utils/List.js
-var releasedCursors, List;
-var init_List = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/utils/List.js"() {
-    releasedCursors = null;
-    List = class _List {
-      static createItem(data) {
-        return {
-          prev: null,
-          next: null,
-          data
-        };
-      }
-      constructor() {
-        this.head = null;
-        this.tail = null;
-        this.cursor = null;
-      }
-      createItem(data) {
-        return _List.createItem(data);
-      }
-      // cursor helpers
-      allocateCursor(prev, next2) {
-        let cursor;
-        if (releasedCursors !== null) {
-          cursor = releasedCursors;
-          releasedCursors = releasedCursors.cursor;
-          cursor.prev = prev;
-          cursor.next = next2;
-          cursor.cursor = this.cursor;
-        } else {
-          cursor = {
-            prev,
-            next: next2,
-            cursor: this.cursor
-          };
-        }
-        this.cursor = cursor;
-        return cursor;
-      }
-      releaseCursor() {
-        const { cursor } = this;
-        this.cursor = cursor.cursor;
-        cursor.prev = null;
-        cursor.next = null;
-        cursor.cursor = releasedCursors;
-        releasedCursors = cursor;
-      }
-      updateCursors(prevOld, prevNew, nextOld, nextNew) {
-        let { cursor } = this;
-        while (cursor !== null) {
-          if (cursor.prev === prevOld) {
-            cursor.prev = prevNew;
-          }
-          if (cursor.next === nextOld) {
-            cursor.next = nextNew;
-          }
-          cursor = cursor.cursor;
-        }
-      }
-      *[Symbol.iterator]() {
-        for (let cursor = this.head; cursor !== null; cursor = cursor.next) {
-          yield cursor.data;
-        }
-      }
-      // getters
-      get size() {
-        let size = 0;
-        for (let cursor = this.head; cursor !== null; cursor = cursor.next) {
-          size++;
-        }
-        return size;
-      }
-      get isEmpty() {
-        return this.head === null;
-      }
-      get first() {
-        return this.head && this.head.data;
-      }
-      get last() {
-        return this.tail && this.tail.data;
-      }
-      // convertors
-      fromArray(array) {
-        let cursor = null;
-        this.head = null;
-        for (let data of array) {
-          const item = _List.createItem(data);
-          if (cursor !== null) {
-            cursor.next = item;
-          } else {
-            this.head = item;
-          }
-          item.prev = cursor;
-          cursor = item;
-        }
-        this.tail = cursor;
-        return this;
-      }
-      toArray() {
-        return [...this];
-      }
-      toJSON() {
-        return [...this];
-      }
-      // array-like methods
-      forEach(fn, thisArg = this) {
-        const cursor = this.allocateCursor(null, this.head);
-        while (cursor.next !== null) {
-          const item = cursor.next;
-          cursor.next = item.next;
-          fn.call(thisArg, item.data, item, this);
-        }
-        this.releaseCursor();
-      }
-      forEachRight(fn, thisArg = this) {
-        const cursor = this.allocateCursor(this.tail, null);
-        while (cursor.prev !== null) {
-          const item = cursor.prev;
-          cursor.prev = item.prev;
-          fn.call(thisArg, item.data, item, this);
-        }
-        this.releaseCursor();
-      }
-      reduce(fn, initialValue, thisArg = this) {
-        let cursor = this.allocateCursor(null, this.head);
-        let acc = initialValue;
-        let item;
-        while (cursor.next !== null) {
-          item = cursor.next;
-          cursor.next = item.next;
-          acc = fn.call(thisArg, acc, item.data, item, this);
-        }
-        this.releaseCursor();
-        return acc;
-      }
-      reduceRight(fn, initialValue, thisArg = this) {
-        let cursor = this.allocateCursor(this.tail, null);
-        let acc = initialValue;
-        let item;
-        while (cursor.prev !== null) {
-          item = cursor.prev;
-          cursor.prev = item.prev;
-          acc = fn.call(thisArg, acc, item.data, item, this);
-        }
-        this.releaseCursor();
-        return acc;
-      }
-      some(fn, thisArg = this) {
-        for (let cursor = this.head; cursor !== null; cursor = cursor.next) {
-          if (fn.call(thisArg, cursor.data, cursor, this)) {
-            return true;
-          }
-        }
-        return false;
-      }
-      map(fn, thisArg = this) {
-        const result = new _List();
-        for (let cursor = this.head; cursor !== null; cursor = cursor.next) {
-          result.appendData(fn.call(thisArg, cursor.data, cursor, this));
-        }
-        return result;
-      }
-      filter(fn, thisArg = this) {
-        const result = new _List();
-        for (let cursor = this.head; cursor !== null; cursor = cursor.next) {
-          if (fn.call(thisArg, cursor.data, cursor, this)) {
-            result.appendData(cursor.data);
-          }
-        }
-        return result;
-      }
-      nextUntil(start, fn, thisArg = this) {
-        if (start === null) {
-          return;
-        }
-        const cursor = this.allocateCursor(null, start);
-        while (cursor.next !== null) {
-          const item = cursor.next;
-          cursor.next = item.next;
-          if (fn.call(thisArg, item.data, item, this)) {
-            break;
-          }
-        }
-        this.releaseCursor();
-      }
-      prevUntil(start, fn, thisArg = this) {
-        if (start === null) {
-          return;
-        }
-        const cursor = this.allocateCursor(start, null);
-        while (cursor.prev !== null) {
-          const item = cursor.prev;
-          cursor.prev = item.prev;
-          if (fn.call(thisArg, item.data, item, this)) {
-            break;
-          }
-        }
-        this.releaseCursor();
-      }
-      // mutation
-      clear() {
-        this.head = null;
-        this.tail = null;
-      }
-      copy() {
-        const result = new _List();
-        for (let data of this) {
-          result.appendData(data);
-        }
-        return result;
-      }
-      prepend(item) {
-        this.updateCursors(null, item, this.head, item);
-        if (this.head !== null) {
-          this.head.prev = item;
-          item.next = this.head;
-        } else {
-          this.tail = item;
-        }
-        this.head = item;
-        return this;
-      }
-      prependData(data) {
-        return this.prepend(_List.createItem(data));
-      }
-      append(item) {
-        return this.insert(item);
-      }
-      appendData(data) {
-        return this.insert(_List.createItem(data));
-      }
-      insert(item, before = null) {
-        if (before !== null) {
-          this.updateCursors(before.prev, item, before, item);
-          if (before.prev === null) {
-            if (this.head !== before) {
-              throw new Error("before doesn't belong to list");
-            }
-            this.head = item;
-            before.prev = item;
-            item.next = before;
-            this.updateCursors(null, item);
-          } else {
-            before.prev.next = item;
-            item.prev = before.prev;
-            before.prev = item;
-            item.next = before;
-          }
-        } else {
-          this.updateCursors(this.tail, item, null, item);
-          if (this.tail !== null) {
-            this.tail.next = item;
-            item.prev = this.tail;
-          } else {
-            this.head = item;
-          }
-          this.tail = item;
-        }
-        return this;
-      }
-      insertData(data, before) {
-        return this.insert(_List.createItem(data), before);
-      }
-      remove(item) {
-        this.updateCursors(item, item.prev, item, item.next);
-        if (item.prev !== null) {
-          item.prev.next = item.next;
-        } else {
-          if (this.head !== item) {
-            throw new Error("item doesn't belong to list");
-          }
-          this.head = item.next;
-        }
-        if (item.next !== null) {
-          item.next.prev = item.prev;
-        } else {
-          if (this.tail !== item) {
-            throw new Error("item doesn't belong to list");
-          }
-          this.tail = item.prev;
-        }
-        item.prev = null;
-        item.next = null;
-        return item;
-      }
-      push(data) {
-        this.insert(_List.createItem(data));
-      }
-      pop() {
-        return this.tail !== null ? this.remove(this.tail) : null;
-      }
-      unshift(data) {
-        this.prepend(_List.createItem(data));
-      }
-      shift() {
-        return this.head !== null ? this.remove(this.head) : null;
-      }
-      prependList(list3) {
-        return this.insertList(list3, this.head);
-      }
-      appendList(list3) {
-        return this.insertList(list3);
-      }
-      insertList(list3, before) {
-        if (list3.head === null) {
-          return this;
-        }
-        if (before !== void 0 && before !== null) {
-          this.updateCursors(before.prev, list3.tail, before, list3.head);
-          if (before.prev !== null) {
-            before.prev.next = list3.head;
-            list3.head.prev = before.prev;
-          } else {
-            this.head = list3.head;
-          }
-          before.prev = list3.tail;
-          list3.tail.next = before;
-        } else {
-          this.updateCursors(this.tail, list3.tail, null, list3.head);
-          if (this.tail !== null) {
-            this.tail.next = list3.head;
-            list3.head.prev = this.tail;
-          } else {
-            this.head = list3.head;
-          }
-          this.tail = list3.tail;
-        }
-        list3.head = null;
-        list3.tail = null;
-        return this;
-      }
-      replace(oldItem, newItemOrList) {
-        if ("head" in newItemOrList) {
-          this.insertList(newItemOrList, oldItem);
-        } else {
-          this.insert(newItemOrList, oldItem);
-        }
-        this.remove(oldItem);
-      }
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/utils/create-custom-error.js
-function createCustomError(name50, message) {
-  const error = Object.create(SyntaxError.prototype);
-  const errorStack = new Error();
-  return Object.assign(error, {
-    name: name50,
-    message,
-    get stack() {
-      return (errorStack.stack || "").replace(/^(.+\n){1,3}/, `${name50}: ${message}
-`);
-    }
-  });
-}
-var init_create_custom_error = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/utils/create-custom-error.js"() {
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/parser/SyntaxError.js
-function sourceFragment({ source, line, column, baseLine, baseColumn }, extraLines) {
-  function processLines(start, end) {
-    return lines.slice(start, end).map(
-      (line2, idx) => String(start + idx + 1).padStart(maxNumLength) + " |" + line2
-    ).join("\n");
-  }
-  const prelines = "\n".repeat(Math.max(baseLine - 1, 0));
-  const precolumns = " ".repeat(Math.max(baseColumn - 1, 0));
-  const lines = (prelines + precolumns + source).split(/\r\n?|\n|\f/);
-  const startLine = Math.max(1, line - extraLines) - 1;
-  const endLine = Math.min(line + extraLines, lines.length + 1);
-  const maxNumLength = Math.max(4, String(endLine).length) + 1;
-  let cutLeft = 0;
-  column += (TAB_REPLACEMENT.length - 1) * (lines[line - 1].substr(0, column - 1).match(/\t/g) || []).length;
-  if (column > MAX_LINE_LENGTH) {
-    cutLeft = column - OFFSET_CORRECTION + 3;
-    column = OFFSET_CORRECTION - 2;
-  }
-  for (let i = startLine; i <= endLine; i++) {
-    if (i >= 0 && i < lines.length) {
-      lines[i] = lines[i].replace(/\t/g, TAB_REPLACEMENT);
-      lines[i] = (cutLeft > 0 && lines[i].length > cutLeft ? "\u2026" : "") + lines[i].substr(cutLeft, MAX_LINE_LENGTH - 2) + (lines[i].length > cutLeft + MAX_LINE_LENGTH - 1 ? "\u2026" : "");
-    }
-  }
-  return [
-    processLines(startLine, line),
-    new Array(column + maxNumLength + 2).join("-") + "^",
-    processLines(line, endLine)
-  ].filter(Boolean).join("\n").replace(/^(\s+\d+\s+\|\n)+/, "").replace(/\n(\s+\d+\s+\|)+$/, "");
-}
-function SyntaxError2(message, source, offset, line, column, baseLine = 1, baseColumn = 1) {
-  const error = Object.assign(createCustomError("SyntaxError", message), {
-    source,
-    offset,
-    line,
-    column,
-    sourceFragment(extraLines) {
-      return sourceFragment({ source, line, column, baseLine, baseColumn }, isNaN(extraLines) ? 0 : extraLines);
-    },
-    get formattedMessage() {
-      return `Parse error: ${message}
-` + sourceFragment({ source, line, column, baseLine, baseColumn }, 2);
-    }
-  });
-  return error;
-}
-var MAX_LINE_LENGTH, OFFSET_CORRECTION, TAB_REPLACEMENT;
-var init_SyntaxError = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/parser/SyntaxError.js"() {
-    init_create_custom_error();
-    MAX_LINE_LENGTH = 100;
-    OFFSET_CORRECTION = 60;
-    TAB_REPLACEMENT = "    ";
-  }
-});
-
 // node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/parser/sequence.js
 function readSequence(recognizer) {
   const children = this.createList();
@@ -5953,9 +5953,9 @@ function createParser(config) {
     cmpStr(offsetStart, offsetEnd, str) {
       return cmpStr(source, offsetStart, offsetEnd, str);
     },
-    consume(tokenType2) {
+    consume(tokenType) {
       const start = this.tokenStart;
-      this.eat(tokenType2);
+      this.eat(tokenType);
       return this.substrToCursor(start);
     },
     consumeFunctionName() {
@@ -5964,16 +5964,16 @@ function createParser(config) {
       return name50;
     },
     consumeNumber(type) {
-      const number3 = source.substring(this.tokenStart, consumeNumber(source, this.tokenStart));
+      const number2 = source.substring(this.tokenStart, consumeNumber(source, this.tokenStart));
       this.eat(type);
-      return number3;
+      return number2;
     },
-    eat(tokenType2) {
-      if (this.tokenType !== tokenType2) {
-        const tokenName = names_default[tokenType2].slice(0, -6).replace(/-/g, " ").replace(/^./, (m) => m.toUpperCase());
+    eat(tokenType) {
+      if (this.tokenType !== tokenType) {
+        const tokenName = names_default[tokenType].slice(0, -6).replace(/-/g, " ").replace(/^./, (m) => m.toUpperCase());
         let message = `${/[[\](){}]/.test(tokenName) ? `"${tokenName}"` : tokenName} is expected`;
         let offset = this.tokenStart;
-        switch (tokenType2) {
+        switch (tokenType) {
           case Ident:
             if (this.tokenType === Function || this.tokenType === Url) {
               offset = this.tokenEnd - 1;
@@ -6064,7 +6064,7 @@ function createParser(config) {
     getLocation: (offset) => locationMap.getLocation(offset, filename),
     getRangeLocation: (start, end) => locationMap.getLocationRange(start, end, filename)
   });
-  const parse57 = function(source_, options) {
+  const parse55 = function(source_, options) {
     source = source_;
     options = options || {};
     parser.setSource(source, tokenize);
@@ -6109,7 +6109,7 @@ function createParser(config) {
     }
     return ast;
   };
-  return Object.assign(parse57, {
+  return Object.assign(parse55, {
     SyntaxError: SyntaxError2,
     config: parser.config
   });
@@ -6159,22 +6159,4142 @@ var init_create = __esm({
   }
 });
 
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/scope/default.js
+function defaultRecognizer(context) {
+  switch (this.tokenType) {
+    case Hash:
+      return this.Hash();
+    case Comma:
+      return this.Operator();
+    case LeftParenthesis:
+      return this.Parentheses(this.readSequence, context.recognizer);
+    case LeftSquareBracket:
+      return this.Brackets(this.readSequence, context.recognizer);
+    case String2:
+      return this.String();
+    case Dimension:
+      return this.Dimension();
+    case Percentage:
+      return this.Percentage();
+    case Number2:
+      return this.Number();
+    case Function:
+      return this.cmpStr(this.tokenStart, this.tokenEnd, "url(") ? this.Url() : this.Function(this.readSequence, context.recognizer);
+    case Url:
+      return this.Url();
+    case Ident:
+      if (this.cmpChar(this.tokenStart, U) && this.cmpChar(this.tokenStart + 1, PLUSSIGN)) {
+        return this.UnicodeRange();
+      } else {
+        return this.Identifier();
+      }
+    case Delim: {
+      const code4 = this.charCodeAt(this.tokenStart);
+      if (code4 === SOLIDUS || code4 === ASTERISK || code4 === PLUSSIGN || code4 === HYPHENMINUS) {
+        return this.Operator();
+      }
+      if (code4 === NUMBERSIGN2) {
+        this.error("Hex or identifier is expected", this.tokenStart + 1);
+      }
+      break;
+    }
+  }
+}
+var NUMBERSIGN2, ASTERISK, PLUSSIGN, HYPHENMINUS, SOLIDUS, U;
+var init_default = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/scope/default.js"() {
+    init_tokenizer();
+    NUMBERSIGN2 = 35;
+    ASTERISK = 42;
+    PLUSSIGN = 43;
+    HYPHENMINUS = 45;
+    SOLIDUS = 47;
+    U = 117;
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/scope/atrulePrelude.js
+var atrulePrelude_default;
+var init_atrulePrelude = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/scope/atrulePrelude.js"() {
+    init_default();
+    atrulePrelude_default = {
+      getNode: defaultRecognizer
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/scope/selector.js
+function onWhiteSpace(next2, children) {
+  if (children.last !== null && children.last.type !== "Combinator" && next2 !== null && next2.type !== "Combinator") {
+    children.push({
+      // FIXME: this.Combinator() should be used instead
+      type: "Combinator",
+      loc: null,
+      name: " "
+    });
+  }
+}
+function getNode() {
+  switch (this.tokenType) {
+    case LeftSquareBracket:
+      return this.AttributeSelector();
+    case Hash:
+      return this.IdSelector();
+    case Colon:
+      if (this.lookupType(1) === Colon) {
+        return this.PseudoElementSelector();
+      } else {
+        return this.PseudoClassSelector();
+      }
+    case Ident:
+      return this.TypeSelector();
+    case Number2:
+    case Percentage:
+      return this.Percentage();
+    case Dimension:
+      if (this.charCodeAt(this.tokenStart) === FULLSTOP) {
+        this.error("Identifier is expected", this.tokenStart + 1);
+      }
+      break;
+    case Delim: {
+      const code4 = this.charCodeAt(this.tokenStart);
+      switch (code4) {
+        case PLUSSIGN2:
+        case GREATERTHANSIGN:
+        case TILDE:
+        case SOLIDUS2:
+          return this.Combinator();
+        case FULLSTOP:
+          return this.ClassSelector();
+        case ASTERISK2:
+        case VERTICALLINE:
+          return this.TypeSelector();
+        case NUMBERSIGN3:
+          return this.IdSelector();
+        case AMPERSAND:
+          return this.NestingSelector();
+      }
+      break;
+    }
+  }
+}
+var NUMBERSIGN3, AMPERSAND, ASTERISK2, PLUSSIGN2, SOLIDUS2, FULLSTOP, GREATERTHANSIGN, VERTICALLINE, TILDE, selector_default;
+var init_selector = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/scope/selector.js"() {
+    init_tokenizer();
+    NUMBERSIGN3 = 35;
+    AMPERSAND = 38;
+    ASTERISK2 = 42;
+    PLUSSIGN2 = 43;
+    SOLIDUS2 = 47;
+    FULLSTOP = 46;
+    GREATERTHANSIGN = 62;
+    VERTICALLINE = 124;
+    TILDE = 126;
+    selector_default = {
+      onWhiteSpace,
+      getNode
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/function/expression.js
+function expression_default() {
+  return this.createSingleNodeList(
+    this.Raw(null, false)
+  );
+}
+var init_expression = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/function/expression.js"() {
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/function/var.js
+function var_default() {
+  const children = this.createList();
+  this.skipSC();
+  children.push(this.Identifier());
+  this.skipSC();
+  if (this.tokenType === Comma) {
+    children.push(this.Operator());
+    const startIndex = this.tokenIndex;
+    const value = this.parseCustomProperty ? this.Value(null) : this.Raw(this.consumeUntilExclamationMarkOrSemicolon, false);
+    if (value.type === "Value" && value.children.isEmpty) {
+      for (let offset = startIndex - this.tokenIndex; offset <= 0; offset++) {
+        if (this.lookupType(offset) === WhiteSpace) {
+          value.children.appendData({
+            type: "WhiteSpace",
+            loc: null,
+            value: " "
+          });
+          break;
+        }
+      }
+    }
+    children.push(value);
+  }
+  return children;
+}
+var init_var = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/function/var.js"() {
+    init_tokenizer();
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/scope/value.js
+function isPlusMinusOperator(node2) {
+  return node2 !== null && node2.type === "Operator" && (node2.value[node2.value.length - 1] === "-" || node2.value[node2.value.length - 1] === "+");
+}
+var value_default;
+var init_value = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/scope/value.js"() {
+    init_default();
+    init_expression();
+    init_var();
+    value_default = {
+      getNode: defaultRecognizer,
+      onWhiteSpace(next2, children) {
+        if (isPlusMinusOperator(next2)) {
+          next2.value = " " + next2.value;
+        }
+        if (isPlusMinusOperator(children.last)) {
+          children.last.value += " ";
+        }
+      },
+      "expression": expression_default,
+      "var": var_default
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/scope/index.js
+var scope_exports = {};
+__export(scope_exports, {
+  AtrulePrelude: () => atrulePrelude_default,
+  Selector: () => selector_default,
+  Value: () => value_default
+});
+var init_scope = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/scope/index.js"() {
+    init_atrulePrelude();
+    init_selector();
+    init_value();
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/container.js
+var nonContainerNameKeywords, container_default;
+var init_container = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/container.js"() {
+    init_tokenizer();
+    nonContainerNameKeywords = /* @__PURE__ */ new Set(["none", "and", "not", "or"]);
+    container_default = {
+      parse: {
+        prelude() {
+          const children = this.createList();
+          if (this.tokenType === Ident) {
+            const name50 = this.substring(this.tokenStart, this.tokenEnd);
+            if (!nonContainerNameKeywords.has(name50.toLowerCase())) {
+              children.push(this.Identifier());
+            }
+          }
+          children.push(this.Condition("container"));
+          return children;
+        },
+        block(nested = false) {
+          return this.Block(nested);
+        }
+      }
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/font-face.js
+var font_face_default;
+var init_font_face = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/font-face.js"() {
+    font_face_default = {
+      parse: {
+        prelude: null,
+        block() {
+          return this.Block(true);
+        }
+      }
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/import.js
+function parseWithFallback(parse55, fallback) {
+  return this.parseWithFallback(
+    () => {
+      try {
+        return parse55.call(this);
+      } finally {
+        this.skipSC();
+        if (this.lookupNonWSType(0) !== RightParenthesis) {
+          this.error();
+        }
+      }
+    },
+    fallback || (() => this.Raw(null, true))
+  );
+}
+var parseFunctions, import_default3;
+var init_import = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/import.js"() {
+    init_tokenizer();
+    parseFunctions = {
+      layer() {
+        this.skipSC();
+        const children = this.createList();
+        const node2 = parseWithFallback.call(this, this.Layer);
+        if (node2.type !== "Raw" || node2.value !== "") {
+          children.push(node2);
+        }
+        return children;
+      },
+      supports() {
+        this.skipSC();
+        const children = this.createList();
+        const node2 = parseWithFallback.call(
+          this,
+          this.Declaration,
+          () => parseWithFallback.call(this, () => this.Condition("supports"))
+        );
+        if (node2.type !== "Raw" || node2.value !== "") {
+          children.push(node2);
+        }
+        return children;
+      }
+    };
+    import_default3 = {
+      parse: {
+        prelude() {
+          const children = this.createList();
+          switch (this.tokenType) {
+            case String2:
+              children.push(this.String());
+              break;
+            case Url:
+            case Function:
+              children.push(this.Url());
+              break;
+            default:
+              this.error("String or url() is expected");
+          }
+          this.skipSC();
+          if (this.tokenType === Ident && this.cmpStr(this.tokenStart, this.tokenEnd, "layer")) {
+            children.push(this.Identifier());
+          } else if (this.tokenType === Function && this.cmpStr(this.tokenStart, this.tokenEnd, "layer(")) {
+            children.push(this.Function(null, parseFunctions));
+          }
+          this.skipSC();
+          if (this.tokenType === Function && this.cmpStr(this.tokenStart, this.tokenEnd, "supports(")) {
+            children.push(this.Function(null, parseFunctions));
+          }
+          if (this.lookupNonWSType(0) === Ident || this.lookupNonWSType(0) === LeftParenthesis) {
+            children.push(this.MediaQueryList());
+          }
+          return children;
+        },
+        block: null
+      }
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/layer.js
+var layer_default;
+var init_layer = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/layer.js"() {
+    layer_default = {
+      parse: {
+        prelude() {
+          return this.createSingleNodeList(
+            this.LayerList()
+          );
+        },
+        block() {
+          return this.Block(false);
+        }
+      }
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/media.js
+var media_default;
+var init_media = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/media.js"() {
+    media_default = {
+      parse: {
+        prelude() {
+          return this.createSingleNodeList(
+            this.MediaQueryList()
+          );
+        },
+        block(nested = false) {
+          return this.Block(nested);
+        }
+      }
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/nest.js
+var nest_default;
+var init_nest = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/nest.js"() {
+    nest_default = {
+      parse: {
+        prelude() {
+          return this.createSingleNodeList(
+            this.SelectorList()
+          );
+        },
+        block() {
+          return this.Block(true);
+        }
+      }
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/page.js
+var page_default;
+var init_page = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/page.js"() {
+    page_default = {
+      parse: {
+        prelude() {
+          return this.createSingleNodeList(
+            this.SelectorList()
+          );
+        },
+        block() {
+          return this.Block(true);
+        }
+      }
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/scope.js
+var scope_default;
+var init_scope2 = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/scope.js"() {
+    scope_default = {
+      parse: {
+        prelude() {
+          return this.createSingleNodeList(
+            this.Scope()
+          );
+        },
+        block(nested = false) {
+          return this.Block(nested);
+        }
+      }
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/starting-style.js
+var starting_style_default;
+var init_starting_style = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/starting-style.js"() {
+    starting_style_default = {
+      parse: {
+        prelude: null,
+        block(nested = false) {
+          return this.Block(nested);
+        }
+      }
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/supports.js
+var supports_default;
+var init_supports = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/supports.js"() {
+    supports_default = {
+      parse: {
+        prelude() {
+          return this.createSingleNodeList(
+            this.Condition("supports")
+          );
+        },
+        block(nested = false) {
+          return this.Block(nested);
+        }
+      }
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/index.js
+var atrule_default;
+var init_atrule = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/index.js"() {
+    init_container();
+    init_font_face();
+    init_import();
+    init_layer();
+    init_media();
+    init_nest();
+    init_page();
+    init_scope2();
+    init_starting_style();
+    init_supports();
+    atrule_default = {
+      container: container_default,
+      "font-face": font_face_default,
+      import: import_default3,
+      layer: layer_default,
+      media: media_default,
+      nest: nest_default,
+      page: page_default,
+      scope: scope_default,
+      "starting-style": starting_style_default,
+      supports: supports_default
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/pseudo/lang.js
+function parseLanguageRangeList() {
+  const children = this.createList();
+  this.skipSC();
+  loop: while (!this.eof) {
+    switch (this.tokenType) {
+      case Ident:
+        children.push(this.Identifier());
+        break;
+      case String2:
+        children.push(this.String());
+        break;
+      case Comma:
+        children.push(this.Operator());
+        break;
+      case RightParenthesis:
+        break loop;
+      default:
+        this.error("Identifier, string or comma is expected");
+    }
+    this.skipSC();
+  }
+  return children;
+}
+var init_lang = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/pseudo/lang.js"() {
+    init_tokenizer();
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/pseudo/index.js
+var selectorList, selector, identList, langList, nth, pseudo_default;
+var init_pseudo = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/pseudo/index.js"() {
+    init_lang();
+    selectorList = {
+      parse() {
+        return this.createSingleNodeList(
+          this.SelectorList()
+        );
+      }
+    };
+    selector = {
+      parse() {
+        return this.createSingleNodeList(
+          this.Selector()
+        );
+      }
+    };
+    identList = {
+      parse() {
+        return this.createSingleNodeList(
+          this.Identifier()
+        );
+      }
+    };
+    langList = {
+      parse: parseLanguageRangeList
+    };
+    nth = {
+      parse() {
+        return this.createSingleNodeList(
+          this.Nth()
+        );
+      }
+    };
+    pseudo_default = {
+      "dir": identList,
+      "has": selectorList,
+      "lang": langList,
+      "matches": selectorList,
+      "is": selectorList,
+      "-moz-any": selectorList,
+      "-webkit-any": selectorList,
+      "where": selectorList,
+      "not": selectorList,
+      "nth-child": nth,
+      "nth-last-child": nth,
+      "nth-last-of-type": nth,
+      "nth-of-type": nth,
+      "slotted": selector,
+      "host": selector,
+      "host-context": selector
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/AnPlusB.js
+var AnPlusB_exports = {};
+__export(AnPlusB_exports, {
+  generate: () => generate,
+  name: () => name,
+  parse: () => parse2,
+  structure: () => structure
+});
+function checkInteger(offset, disallowSign) {
+  let pos = this.tokenStart + offset;
+  const code4 = this.charCodeAt(pos);
+  if (code4 === PLUSSIGN3 || code4 === HYPHENMINUS2) {
+    if (disallowSign) {
+      this.error("Number sign is not allowed");
+    }
+    pos++;
+  }
+  for (; pos < this.tokenEnd; pos++) {
+    if (!isDigit(this.charCodeAt(pos))) {
+      this.error("Integer is expected", pos);
+    }
+  }
+}
+function checkTokenIsInteger(disallowSign) {
+  return checkInteger.call(this, 0, disallowSign);
+}
+function expectCharCode(offset, code4) {
+  if (!this.cmpChar(this.tokenStart + offset, code4)) {
+    let msg = "";
+    switch (code4) {
+      case N2:
+        msg = "N is expected";
+        break;
+      case HYPHENMINUS2:
+        msg = "HyphenMinus is expected";
+        break;
+    }
+    this.error(msg, this.tokenStart + offset);
+  }
+}
+function consumeB() {
+  let offset = 0;
+  let sign = 0;
+  let type = this.tokenType;
+  while (type === WhiteSpace || type === Comment) {
+    type = this.lookupType(++offset);
+  }
+  if (type !== Number2) {
+    if (this.isDelim(PLUSSIGN3, offset) || this.isDelim(HYPHENMINUS2, offset)) {
+      sign = this.isDelim(PLUSSIGN3, offset) ? PLUSSIGN3 : HYPHENMINUS2;
+      do {
+        type = this.lookupType(++offset);
+      } while (type === WhiteSpace || type === Comment);
+      if (type !== Number2) {
+        this.skip(offset);
+        checkTokenIsInteger.call(this, DISALLOW_SIGN);
+      }
+    } else {
+      return null;
+    }
+  }
+  if (offset > 0) {
+    this.skip(offset);
+  }
+  if (sign === 0) {
+    type = this.charCodeAt(this.tokenStart);
+    if (type !== PLUSSIGN3 && type !== HYPHENMINUS2) {
+      this.error("Number sign is expected");
+    }
+  }
+  checkTokenIsInteger.call(this, sign !== 0);
+  return sign === HYPHENMINUS2 ? "-" + this.consume(Number2) : this.consume(Number2);
+}
+function parse2() {
+  const start = this.tokenStart;
+  let a = null;
+  let b = null;
+  if (this.tokenType === Number2) {
+    checkTokenIsInteger.call(this, ALLOW_SIGN);
+    b = this.consume(Number2);
+  } else if (this.tokenType === Ident && this.cmpChar(this.tokenStart, HYPHENMINUS2)) {
+    a = "-1";
+    expectCharCode.call(this, 1, N2);
+    switch (this.tokenEnd - this.tokenStart) {
+      // -n
+      // -n <signed-integer>
+      // -n ['+' | '-'] <signless-integer>
+      case 2:
+        this.next();
+        b = consumeB.call(this);
+        break;
+      // -n- <signless-integer>
+      case 3:
+        expectCharCode.call(this, 2, HYPHENMINUS2);
+        this.next();
+        this.skipSC();
+        checkTokenIsInteger.call(this, DISALLOW_SIGN);
+        b = "-" + this.consume(Number2);
+        break;
+      // <dashndashdigit-ident>
+      default:
+        expectCharCode.call(this, 2, HYPHENMINUS2);
+        checkInteger.call(this, 3, DISALLOW_SIGN);
+        this.next();
+        b = this.substrToCursor(start + 2);
+    }
+  } else if (this.tokenType === Ident || this.isDelim(PLUSSIGN3) && this.lookupType(1) === Ident) {
+    let sign = 0;
+    a = "1";
+    if (this.isDelim(PLUSSIGN3)) {
+      sign = 1;
+      this.next();
+    }
+    expectCharCode.call(this, 0, N2);
+    switch (this.tokenEnd - this.tokenStart) {
+      // '+'? n
+      // '+'? n <signed-integer>
+      // '+'? n ['+' | '-'] <signless-integer>
+      case 1:
+        this.next();
+        b = consumeB.call(this);
+        break;
+      // '+'? n- <signless-integer>
+      case 2:
+        expectCharCode.call(this, 1, HYPHENMINUS2);
+        this.next();
+        this.skipSC();
+        checkTokenIsInteger.call(this, DISALLOW_SIGN);
+        b = "-" + this.consume(Number2);
+        break;
+      // '+'? <ndashdigit-ident>
+      default:
+        expectCharCode.call(this, 1, HYPHENMINUS2);
+        checkInteger.call(this, 2, DISALLOW_SIGN);
+        this.next();
+        b = this.substrToCursor(start + sign + 1);
+    }
+  } else if (this.tokenType === Dimension) {
+    const code4 = this.charCodeAt(this.tokenStart);
+    const sign = code4 === PLUSSIGN3 || code4 === HYPHENMINUS2;
+    let i = this.tokenStart + sign;
+    for (; i < this.tokenEnd; i++) {
+      if (!isDigit(this.charCodeAt(i))) {
+        break;
+      }
+    }
+    if (i === this.tokenStart + sign) {
+      this.error("Integer is expected", this.tokenStart + sign);
+    }
+    expectCharCode.call(this, i - this.tokenStart, N2);
+    a = this.substring(start, i);
+    if (i + 1 === this.tokenEnd) {
+      this.next();
+      b = consumeB.call(this);
+    } else {
+      expectCharCode.call(this, i - this.tokenStart + 1, HYPHENMINUS2);
+      if (i + 2 === this.tokenEnd) {
+        this.next();
+        this.skipSC();
+        checkTokenIsInteger.call(this, DISALLOW_SIGN);
+        b = "-" + this.consume(Number2);
+      } else {
+        checkInteger.call(this, i - this.tokenStart + 2, DISALLOW_SIGN);
+        this.next();
+        b = this.substrToCursor(i + 1);
+      }
+    }
+  } else {
+    this.error();
+  }
+  if (a !== null && a.charCodeAt(0) === PLUSSIGN3) {
+    a = a.substr(1);
+  }
+  if (b !== null && b.charCodeAt(0) === PLUSSIGN3) {
+    b = b.substr(1);
+  }
+  return {
+    type: "AnPlusB",
+    loc: this.getLocation(start, this.tokenStart),
+    a,
+    b
+  };
+}
+function generate(node2) {
+  if (node2.a) {
+    const a = node2.a === "+1" && "n" || node2.a === "1" && "n" || node2.a === "-1" && "-n" || node2.a + "n";
+    if (node2.b) {
+      const b = node2.b[0] === "-" || node2.b[0] === "+" ? node2.b : "+" + node2.b;
+      this.tokenize(a + b);
+    } else {
+      this.tokenize(a);
+    }
+  } else {
+    this.tokenize(node2.b);
+  }
+}
+var PLUSSIGN3, HYPHENMINUS2, N2, DISALLOW_SIGN, ALLOW_SIGN, name, structure;
+var init_AnPlusB = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/AnPlusB.js"() {
+    init_tokenizer();
+    PLUSSIGN3 = 43;
+    HYPHENMINUS2 = 45;
+    N2 = 110;
+    DISALLOW_SIGN = true;
+    ALLOW_SIGN = false;
+    name = "AnPlusB";
+    structure = {
+      a: [String, null],
+      b: [String, null]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Atrule.js
+var Atrule_exports = {};
+__export(Atrule_exports, {
+  generate: () => generate2,
+  name: () => name2,
+  parse: () => parse3,
+  structure: () => structure2,
+  walkContext: () => walkContext
+});
+function consumeRaw() {
+  return this.Raw(this.consumeUntilLeftCurlyBracketOrSemicolon, true);
+}
+function isDeclarationBlockAtrule() {
+  for (let offset = 1, type; type = this.lookupType(offset); offset++) {
+    if (type === RightCurlyBracket) {
+      return true;
+    }
+    if (type === LeftCurlyBracket || type === AtKeyword) {
+      return false;
+    }
+  }
+  return false;
+}
+function parse3(isDeclaration = false) {
+  const start = this.tokenStart;
+  let name50;
+  let nameLowerCase;
+  let prelude = null;
+  let block = null;
+  this.eat(AtKeyword);
+  name50 = this.substrToCursor(start + 1);
+  nameLowerCase = name50.toLowerCase();
+  this.skipSC();
+  if (this.eof === false && this.tokenType !== LeftCurlyBracket && this.tokenType !== Semicolon) {
+    if (this.parseAtrulePrelude) {
+      prelude = this.parseWithFallback(this.AtrulePrelude.bind(this, name50, isDeclaration), consumeRaw);
+    } else {
+      prelude = consumeRaw.call(this, this.tokenIndex);
+    }
+    this.skipSC();
+  }
+  switch (this.tokenType) {
+    case Semicolon:
+      this.next();
+      break;
+    case LeftCurlyBracket:
+      if (hasOwnProperty.call(this.atrule, nameLowerCase) && typeof this.atrule[nameLowerCase].block === "function") {
+        block = this.atrule[nameLowerCase].block.call(this, isDeclaration);
+      } else {
+        block = this.Block(isDeclarationBlockAtrule.call(this));
+      }
+      break;
+  }
+  return {
+    type: "Atrule",
+    loc: this.getLocation(start, this.tokenStart),
+    name: name50,
+    prelude,
+    block
+  };
+}
+function generate2(node2) {
+  this.token(AtKeyword, "@" + node2.name);
+  if (node2.prelude !== null) {
+    this.node(node2.prelude);
+  }
+  if (node2.block) {
+    this.node(node2.block);
+  } else {
+    this.token(Semicolon, ";");
+  }
+}
+var name2, walkContext, structure2;
+var init_Atrule = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Atrule.js"() {
+    init_tokenizer();
+    name2 = "Atrule";
+    walkContext = "atrule";
+    structure2 = {
+      name: String,
+      prelude: ["AtrulePrelude", "Raw", null],
+      block: ["Block", null]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/AtrulePrelude.js
+var AtrulePrelude_exports = {};
+__export(AtrulePrelude_exports, {
+  generate: () => generate3,
+  name: () => name3,
+  parse: () => parse4,
+  structure: () => structure3,
+  walkContext: () => walkContext2
+});
+function parse4(name50) {
+  let children = null;
+  if (name50 !== null) {
+    name50 = name50.toLowerCase();
+  }
+  this.skipSC();
+  if (hasOwnProperty.call(this.atrule, name50) && typeof this.atrule[name50].prelude === "function") {
+    children = this.atrule[name50].prelude.call(this);
+  } else {
+    children = this.readSequence(this.scope.AtrulePrelude);
+  }
+  this.skipSC();
+  if (this.eof !== true && this.tokenType !== LeftCurlyBracket && this.tokenType !== Semicolon) {
+    this.error("Semicolon or block is expected");
+  }
+  return {
+    type: "AtrulePrelude",
+    loc: this.getLocationFromList(children),
+    children
+  };
+}
+function generate3(node2) {
+  this.children(node2);
+}
+var name3, walkContext2, structure3;
+var init_AtrulePrelude = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/AtrulePrelude.js"() {
+    init_tokenizer();
+    name3 = "AtrulePrelude";
+    walkContext2 = "atrulePrelude";
+    structure3 = {
+      children: [[]]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/AttributeSelector.js
+var AttributeSelector_exports = {};
+__export(AttributeSelector_exports, {
+  generate: () => generate4,
+  name: () => name4,
+  parse: () => parse5,
+  structure: () => structure4
+});
+function getAttributeName() {
+  if (this.eof) {
+    this.error("Unexpected end of input");
+  }
+  const start = this.tokenStart;
+  let expectIdent = false;
+  if (this.isDelim(ASTERISK3)) {
+    expectIdent = true;
+    this.next();
+  } else if (!this.isDelim(VERTICALLINE2)) {
+    this.eat(Ident);
+  }
+  if (this.isDelim(VERTICALLINE2)) {
+    if (this.charCodeAt(this.tokenStart + 1) !== EQUALSSIGN) {
+      this.next();
+      this.eat(Ident);
+    } else if (expectIdent) {
+      this.error("Identifier is expected", this.tokenEnd);
+    }
+  } else if (expectIdent) {
+    this.error("Vertical line is expected");
+  }
+  return {
+    type: "Identifier",
+    loc: this.getLocation(start, this.tokenStart),
+    name: this.substrToCursor(start)
+  };
+}
+function getOperator() {
+  const start = this.tokenStart;
+  const code4 = this.charCodeAt(start);
+  if (code4 !== EQUALSSIGN && // =
+  code4 !== TILDE2 && // ~=
+  code4 !== CIRCUMFLEXACCENT && // ^=
+  code4 !== DOLLARSIGN && // $=
+  code4 !== ASTERISK3 && // *=
+  code4 !== VERTICALLINE2) {
+    this.error("Attribute selector (=, ~=, ^=, $=, *=, |=) is expected");
+  }
+  this.next();
+  if (code4 !== EQUALSSIGN) {
+    if (!this.isDelim(EQUALSSIGN)) {
+      this.error("Equal sign is expected");
+    }
+    this.next();
+  }
+  return this.substrToCursor(start);
+}
+function parse5() {
+  const start = this.tokenStart;
+  let name50;
+  let matcher = null;
+  let value = null;
+  let flags = null;
+  this.eat(LeftSquareBracket);
+  this.skipSC();
+  name50 = getAttributeName.call(this);
+  this.skipSC();
+  if (this.tokenType !== RightSquareBracket) {
+    if (this.tokenType !== Ident) {
+      matcher = getOperator.call(this);
+      this.skipSC();
+      value = this.tokenType === String2 ? this.String() : this.Identifier();
+      this.skipSC();
+    }
+    if (this.tokenType === Ident) {
+      flags = this.consume(Ident);
+      this.skipSC();
+    }
+  }
+  this.eat(RightSquareBracket);
+  return {
+    type: "AttributeSelector",
+    loc: this.getLocation(start, this.tokenStart),
+    name: name50,
+    matcher,
+    value,
+    flags
+  };
+}
+function generate4(node2) {
+  this.token(Delim, "[");
+  this.node(node2.name);
+  if (node2.matcher !== null) {
+    this.tokenize(node2.matcher);
+    this.node(node2.value);
+  }
+  if (node2.flags !== null) {
+    this.token(Ident, node2.flags);
+  }
+  this.token(Delim, "]");
+}
+var DOLLARSIGN, ASTERISK3, EQUALSSIGN, CIRCUMFLEXACCENT, VERTICALLINE2, TILDE2, name4, structure4;
+var init_AttributeSelector = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/AttributeSelector.js"() {
+    init_tokenizer();
+    DOLLARSIGN = 36;
+    ASTERISK3 = 42;
+    EQUALSSIGN = 61;
+    CIRCUMFLEXACCENT = 94;
+    VERTICALLINE2 = 124;
+    TILDE2 = 126;
+    name4 = "AttributeSelector";
+    structure4 = {
+      name: "Identifier",
+      matcher: [String, null],
+      value: ["String", "Identifier", null],
+      flags: [String, null]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Block.js
+var Block_exports = {};
+__export(Block_exports, {
+  generate: () => generate5,
+  name: () => name5,
+  parse: () => parse6,
+  structure: () => structure5,
+  walkContext: () => walkContext3
+});
+function consumeRaw2() {
+  return this.Raw(null, true);
+}
+function consumeRule() {
+  return this.parseWithFallback(this.Rule, consumeRaw2);
+}
+function consumeRawDeclaration() {
+  return this.Raw(this.consumeUntilSemicolonIncluded, true);
+}
+function consumeDeclaration() {
+  if (this.tokenType === Semicolon) {
+    return consumeRawDeclaration.call(this, this.tokenIndex);
+  }
+  const node2 = this.parseWithFallback(this.Declaration, consumeRawDeclaration);
+  if (this.tokenType === Semicolon) {
+    this.next();
+  }
+  return node2;
+}
+function parse6(isStyleBlock) {
+  const consumer = isStyleBlock ? consumeDeclaration : consumeRule;
+  const start = this.tokenStart;
+  let children = this.createList();
+  this.eat(LeftCurlyBracket);
+  scan:
+    while (!this.eof) {
+      switch (this.tokenType) {
+        case RightCurlyBracket:
+          break scan;
+        case WhiteSpace:
+        case Comment:
+          this.next();
+          break;
+        case AtKeyword:
+          children.push(this.parseWithFallback(this.Atrule.bind(this, isStyleBlock), consumeRaw2));
+          break;
+        default:
+          if (isStyleBlock && this.isDelim(AMPERSAND2)) {
+            children.push(consumeRule.call(this));
+          } else {
+            children.push(consumer.call(this));
+          }
+      }
+    }
+  if (!this.eof) {
+    this.eat(RightCurlyBracket);
+  }
+  return {
+    type: "Block",
+    loc: this.getLocation(start, this.tokenStart),
+    children
+  };
+}
+function generate5(node2) {
+  this.token(LeftCurlyBracket, "{");
+  this.children(node2, (prev) => {
+    if (prev.type === "Declaration") {
+      this.token(Semicolon, ";");
+    }
+  });
+  this.token(RightCurlyBracket, "}");
+}
+var AMPERSAND2, name5, walkContext3, structure5;
+var init_Block = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Block.js"() {
+    init_tokenizer();
+    AMPERSAND2 = 38;
+    name5 = "Block";
+    walkContext3 = "block";
+    structure5 = {
+      children: [[
+        "Atrule",
+        "Rule",
+        "Declaration"
+      ]]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Brackets.js
+var Brackets_exports = {};
+__export(Brackets_exports, {
+  generate: () => generate6,
+  name: () => name6,
+  parse: () => parse7,
+  structure: () => structure6
+});
+function parse7(readSequence2, recognizer) {
+  const start = this.tokenStart;
+  let children = null;
+  this.eat(LeftSquareBracket);
+  children = readSequence2.call(this, recognizer);
+  if (!this.eof) {
+    this.eat(RightSquareBracket);
+  }
+  return {
+    type: "Brackets",
+    loc: this.getLocation(start, this.tokenStart),
+    children
+  };
+}
+function generate6(node2) {
+  this.token(Delim, "[");
+  this.children(node2);
+  this.token(Delim, "]");
+}
+var name6, structure6;
+var init_Brackets = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Brackets.js"() {
+    init_tokenizer();
+    name6 = "Brackets";
+    structure6 = {
+      children: [[]]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/CDC.js
+var CDC_exports = {};
+__export(CDC_exports, {
+  generate: () => generate7,
+  name: () => name7,
+  parse: () => parse8,
+  structure: () => structure7
+});
+function parse8() {
+  const start = this.tokenStart;
+  this.eat(CDC);
+  return {
+    type: "CDC",
+    loc: this.getLocation(start, this.tokenStart)
+  };
+}
+function generate7() {
+  this.token(CDC, "-->");
+}
+var name7, structure7;
+var init_CDC = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/CDC.js"() {
+    init_tokenizer();
+    name7 = "CDC";
+    structure7 = [];
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/CDO.js
+var CDO_exports = {};
+__export(CDO_exports, {
+  generate: () => generate8,
+  name: () => name8,
+  parse: () => parse9,
+  structure: () => structure8
+});
+function parse9() {
+  const start = this.tokenStart;
+  this.eat(CDO);
+  return {
+    type: "CDO",
+    loc: this.getLocation(start, this.tokenStart)
+  };
+}
+function generate8() {
+  this.token(CDO, "<!--");
+}
+var name8, structure8;
+var init_CDO = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/CDO.js"() {
+    init_tokenizer();
+    name8 = "CDO";
+    structure8 = [];
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/ClassSelector.js
+var ClassSelector_exports = {};
+__export(ClassSelector_exports, {
+  generate: () => generate9,
+  name: () => name9,
+  parse: () => parse10,
+  structure: () => structure9
+});
+function parse10() {
+  this.eatDelim(FULLSTOP2);
+  return {
+    type: "ClassSelector",
+    loc: this.getLocation(this.tokenStart - 1, this.tokenEnd),
+    name: this.consume(Ident)
+  };
+}
+function generate9(node2) {
+  this.token(Delim, ".");
+  this.token(Ident, node2.name);
+}
+var FULLSTOP2, name9, structure9;
+var init_ClassSelector = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/ClassSelector.js"() {
+    init_tokenizer();
+    FULLSTOP2 = 46;
+    name9 = "ClassSelector";
+    structure9 = {
+      name: String
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Combinator.js
+var Combinator_exports = {};
+__export(Combinator_exports, {
+  generate: () => generate10,
+  name: () => name10,
+  parse: () => parse11,
+  structure: () => structure10
+});
+function parse11() {
+  const start = this.tokenStart;
+  let name50;
+  switch (this.tokenType) {
+    case WhiteSpace:
+      name50 = " ";
+      break;
+    case Delim:
+      switch (this.charCodeAt(this.tokenStart)) {
+        case GREATERTHANSIGN2:
+        case PLUSSIGN4:
+        case TILDE3:
+          this.next();
+          break;
+        case SOLIDUS3:
+          this.next();
+          this.eatIdent("deep");
+          this.eatDelim(SOLIDUS3);
+          break;
+        default:
+          this.error("Combinator is expected");
+      }
+      name50 = this.substrToCursor(start);
+      break;
+  }
+  return {
+    type: "Combinator",
+    loc: this.getLocation(start, this.tokenStart),
+    name: name50
+  };
+}
+function generate10(node2) {
+  this.tokenize(node2.name);
+}
+var PLUSSIGN4, SOLIDUS3, GREATERTHANSIGN2, TILDE3, name10, structure10;
+var init_Combinator = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Combinator.js"() {
+    init_tokenizer();
+    PLUSSIGN4 = 43;
+    SOLIDUS3 = 47;
+    GREATERTHANSIGN2 = 62;
+    TILDE3 = 126;
+    name10 = "Combinator";
+    structure10 = {
+      name: String
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Comment.js
+var Comment_exports = {};
+__export(Comment_exports, {
+  generate: () => generate11,
+  name: () => name11,
+  parse: () => parse12,
+  structure: () => structure11
+});
+function parse12() {
+  const start = this.tokenStart;
+  let end = this.tokenEnd;
+  this.eat(Comment);
+  if (end - start + 2 >= 2 && this.charCodeAt(end - 2) === ASTERISK4 && this.charCodeAt(end - 1) === SOLIDUS4) {
+    end -= 2;
+  }
+  return {
+    type: "Comment",
+    loc: this.getLocation(start, this.tokenStart),
+    value: this.substring(start + 2, end)
+  };
+}
+function generate11(node2) {
+  this.token(Comment, "/*" + node2.value + "*/");
+}
+var ASTERISK4, SOLIDUS4, name11, structure11;
+var init_Comment = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Comment.js"() {
+    init_tokenizer();
+    ASTERISK4 = 42;
+    SOLIDUS4 = 47;
+    name11 = "Comment";
+    structure11 = {
+      value: String
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Condition.js
+var Condition_exports = {};
+__export(Condition_exports, {
+  generate: () => generate12,
+  name: () => name12,
+  parse: () => parse13,
+  structure: () => structure12
+});
+function featureOrRange(kind2) {
+  if (this.lookupTypeNonSC(1) === Ident && likelyFeatureToken.has(this.lookupTypeNonSC(2))) {
+    return this.Feature(kind2);
+  }
+  return this.FeatureRange(kind2);
+}
+function parse13(kind2 = "media") {
+  const children = this.createList();
+  scan: while (!this.eof) {
+    switch (this.tokenType) {
+      case Comment:
+      case WhiteSpace:
+        this.next();
+        continue;
+      case Ident:
+        children.push(this.Identifier());
+        break;
+      case LeftParenthesis: {
+        let term = this.parseWithFallback(
+          () => parentheses[kind2].call(this, kind2),
+          () => null
+        );
+        if (!term) {
+          term = this.parseWithFallback(
+            () => {
+              this.eat(LeftParenthesis);
+              const res = this.Condition(kind2);
+              this.eat(RightParenthesis);
+              return res;
+            },
+            () => {
+              return this.GeneralEnclosed(kind2);
+            }
+          );
+        }
+        children.push(term);
+        break;
+      }
+      case Function: {
+        let term = this.parseWithFallback(
+          () => this.FeatureFunction(kind2),
+          () => null
+        );
+        if (!term) {
+          term = this.GeneralEnclosed(kind2);
+        }
+        children.push(term);
+        break;
+      }
+      default:
+        break scan;
+    }
+  }
+  if (children.isEmpty) {
+    this.error("Condition is expected");
+  }
+  return {
+    type: "Condition",
+    loc: this.getLocationFromList(children),
+    kind: kind2,
+    children
+  };
+}
+function generate12(node2) {
+  node2.children.forEach((child) => {
+    if (child.type === "Condition") {
+      this.token(LeftParenthesis, "(");
+      this.node(child);
+      this.token(RightParenthesis, ")");
+    } else {
+      this.node(child);
+    }
+  });
+}
+var likelyFeatureToken, name12, structure12, parentheses;
+var init_Condition = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Condition.js"() {
+    init_tokenizer();
+    likelyFeatureToken = /* @__PURE__ */ new Set([Colon, RightParenthesis, EOF]);
+    name12 = "Condition";
+    structure12 = {
+      kind: String,
+      children: [[
+        "Identifier",
+        "Feature",
+        "FeatureFunction",
+        "FeatureRange",
+        "SupportsDeclaration"
+      ]]
+    };
+    parentheses = {
+      media: featureOrRange,
+      container: featureOrRange,
+      supports() {
+        return this.SupportsDeclaration();
+      }
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/utils/names.js
+function isCustomProperty(str, offset) {
+  offset = offset || 0;
+  return str.length - offset >= 2 && str.charCodeAt(offset) === HYPHENMINUS3 && str.charCodeAt(offset + 1) === HYPHENMINUS3;
+}
+var HYPHENMINUS3;
+var init_names2 = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/utils/names.js"() {
+    HYPHENMINUS3 = 45;
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Declaration.js
+var Declaration_exports = {};
+__export(Declaration_exports, {
+  generate: () => generate13,
+  name: () => name13,
+  parse: () => parse14,
+  structure: () => structure13,
+  walkContext: () => walkContext4
+});
+function consumeValueRaw() {
+  return this.Raw(this.consumeUntilExclamationMarkOrSemicolon, true);
+}
+function consumeCustomPropertyRaw() {
+  return this.Raw(this.consumeUntilExclamationMarkOrSemicolon, false);
+}
+function consumeValue() {
+  const startValueToken = this.tokenIndex;
+  const value = this.Value();
+  if (value.type !== "Raw" && this.eof === false && this.tokenType !== Semicolon && this.isDelim(EXCLAMATIONMARK2) === false && this.isBalanceEdge(startValueToken) === false) {
+    this.error();
+  }
+  return value;
+}
+function parse14() {
+  const start = this.tokenStart;
+  const startToken = this.tokenIndex;
+  const property = readProperty.call(this);
+  const customProperty = isCustomProperty(property);
+  const parseValue = customProperty ? this.parseCustomProperty : this.parseValue;
+  const consumeRaw6 = customProperty ? consumeCustomPropertyRaw : consumeValueRaw;
+  let important = false;
+  let value;
+  this.skipSC();
+  this.eat(Colon);
+  const valueStart = this.tokenIndex;
+  if (!customProperty) {
+    this.skipSC();
+  }
+  if (parseValue) {
+    value = this.parseWithFallback(consumeValue, consumeRaw6);
+  } else {
+    value = consumeRaw6.call(this, this.tokenIndex);
+  }
+  if (customProperty && value.type === "Value" && value.children.isEmpty) {
+    for (let offset = valueStart - this.tokenIndex; offset <= 0; offset++) {
+      if (this.lookupType(offset) === WhiteSpace) {
+        value.children.appendData({
+          type: "WhiteSpace",
+          loc: null,
+          value: " "
+        });
+        break;
+      }
+    }
+  }
+  if (this.isDelim(EXCLAMATIONMARK2)) {
+    important = getImportant.call(this);
+    this.skipSC();
+  }
+  if (this.eof === false && this.tokenType !== Semicolon && this.isBalanceEdge(startToken) === false) {
+    this.error();
+  }
+  return {
+    type: "Declaration",
+    loc: this.getLocation(start, this.tokenStart),
+    important,
+    property,
+    value
+  };
+}
+function generate13(node2) {
+  this.token(Ident, node2.property);
+  this.token(Colon, ":");
+  this.node(node2.value);
+  if (node2.important) {
+    this.token(Delim, "!");
+    this.token(Ident, node2.important === true ? "important" : node2.important);
+  }
+}
+function readProperty() {
+  const start = this.tokenStart;
+  if (this.tokenType === Delim) {
+    switch (this.charCodeAt(this.tokenStart)) {
+      case ASTERISK5:
+      case DOLLARSIGN2:
+      case PLUSSIGN5:
+      case NUMBERSIGN4:
+      case AMPERSAND3:
+        this.next();
+        break;
+      // TODO: not sure we should support this hack
+      case SOLIDUS5:
+        this.next();
+        if (this.isDelim(SOLIDUS5)) {
+          this.next();
+        }
+        break;
+    }
+  }
+  if (this.tokenType === Hash) {
+    this.eat(Hash);
+  } else {
+    this.eat(Ident);
+  }
+  return this.substrToCursor(start);
+}
+function getImportant() {
+  this.eat(Delim);
+  this.skipSC();
+  const important = this.consume(Ident);
+  return important === "important" ? true : important;
+}
+var EXCLAMATIONMARK2, NUMBERSIGN4, DOLLARSIGN2, AMPERSAND3, ASTERISK5, PLUSSIGN5, SOLIDUS5, name13, walkContext4, structure13;
+var init_Declaration = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Declaration.js"() {
+    init_names2();
+    init_tokenizer();
+    EXCLAMATIONMARK2 = 33;
+    NUMBERSIGN4 = 35;
+    DOLLARSIGN2 = 36;
+    AMPERSAND3 = 38;
+    ASTERISK5 = 42;
+    PLUSSIGN5 = 43;
+    SOLIDUS5 = 47;
+    name13 = "Declaration";
+    walkContext4 = "declaration";
+    structure13 = {
+      important: [Boolean, String],
+      property: String,
+      value: ["Value", "Raw"]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/DeclarationList.js
+var DeclarationList_exports = {};
+__export(DeclarationList_exports, {
+  generate: () => generate14,
+  name: () => name14,
+  parse: () => parse15,
+  structure: () => structure14
+});
+function consumeRaw3() {
+  return this.Raw(this.consumeUntilSemicolonIncluded, true);
+}
+function parse15() {
+  const children = this.createList();
+  scan:
+    while (!this.eof) {
+      switch (this.tokenType) {
+        case WhiteSpace:
+        case Comment:
+        case Semicolon:
+          this.next();
+          break;
+        case AtKeyword:
+          children.push(this.parseWithFallback(this.Atrule.bind(this, true), consumeRaw3));
+          break;
+        default:
+          if (this.isDelim(AMPERSAND4)) {
+            children.push(this.parseWithFallback(this.Rule, consumeRaw3));
+          } else {
+            children.push(this.parseWithFallback(this.Declaration, consumeRaw3));
+          }
+      }
+    }
+  return {
+    type: "DeclarationList",
+    loc: this.getLocationFromList(children),
+    children
+  };
+}
+function generate14(node2) {
+  this.children(node2, (prev) => {
+    if (prev.type === "Declaration") {
+      this.token(Semicolon, ";");
+    }
+  });
+}
+var AMPERSAND4, name14, structure14;
+var init_DeclarationList = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/DeclarationList.js"() {
+    init_tokenizer();
+    AMPERSAND4 = 38;
+    name14 = "DeclarationList";
+    structure14 = {
+      children: [[
+        "Declaration",
+        "Atrule",
+        "Rule"
+      ]]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Dimension.js
+var Dimension_exports = {};
+__export(Dimension_exports, {
+  generate: () => generate15,
+  name: () => name15,
+  parse: () => parse16,
+  structure: () => structure15
+});
+function parse16() {
+  const start = this.tokenStart;
+  const value = this.consumeNumber(Dimension);
+  return {
+    type: "Dimension",
+    loc: this.getLocation(start, this.tokenStart),
+    value,
+    unit: this.substring(start + value.length, this.tokenStart)
+  };
+}
+function generate15(node2) {
+  this.token(Dimension, node2.value + node2.unit);
+}
+var name15, structure15;
+var init_Dimension = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Dimension.js"() {
+    init_tokenizer();
+    name15 = "Dimension";
+    structure15 = {
+      value: String,
+      unit: String
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Feature.js
+var Feature_exports = {};
+__export(Feature_exports, {
+  generate: () => generate16,
+  name: () => name16,
+  parse: () => parse17,
+  structure: () => structure16
+});
+function parse17(kind2) {
+  const start = this.tokenStart;
+  let name50;
+  let value = null;
+  this.eat(LeftParenthesis);
+  this.skipSC();
+  name50 = this.consume(Ident);
+  this.skipSC();
+  if (this.tokenType !== RightParenthesis) {
+    this.eat(Colon);
+    this.skipSC();
+    switch (this.tokenType) {
+      case Number2:
+        if (this.lookupNonWSType(1) === Delim) {
+          value = this.Ratio();
+        } else {
+          value = this.Number();
+        }
+        break;
+      case Dimension:
+        value = this.Dimension();
+        break;
+      case Ident:
+        value = this.Identifier();
+        break;
+      case Function:
+        value = this.parseWithFallback(
+          () => {
+            const res = this.Function(this.readSequence, this.scope.Value);
+            this.skipSC();
+            if (this.isDelim(SOLIDUS6)) {
+              this.error();
+            }
+            return res;
+          },
+          () => {
+            return this.Ratio();
+          }
+        );
+        break;
+      default:
+        this.error("Number, dimension, ratio or identifier is expected");
+    }
+    this.skipSC();
+  }
+  if (!this.eof) {
+    this.eat(RightParenthesis);
+  }
+  return {
+    type: "Feature",
+    loc: this.getLocation(start, this.tokenStart),
+    kind: kind2,
+    name: name50,
+    value
+  };
+}
+function generate16(node2) {
+  this.token(LeftParenthesis, "(");
+  this.token(Ident, node2.name);
+  if (node2.value !== null) {
+    this.token(Colon, ":");
+    this.node(node2.value);
+  }
+  this.token(RightParenthesis, ")");
+}
+var SOLIDUS6, name16, structure16;
+var init_Feature = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Feature.js"() {
+    init_tokenizer();
+    SOLIDUS6 = 47;
+    name16 = "Feature";
+    structure16 = {
+      kind: String,
+      name: String,
+      value: ["Identifier", "Number", "Dimension", "Ratio", "Function", null]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/FeatureFunction.js
+var FeatureFunction_exports = {};
+__export(FeatureFunction_exports, {
+  generate: () => generate17,
+  name: () => name17,
+  parse: () => parse18,
+  structure: () => structure17
+});
+function getFeatureParser(kind2, name50) {
+  const featuresOfKind = this.features[kind2] || {};
+  const parser = featuresOfKind[name50];
+  if (typeof parser !== "function") {
+    this.error(`Unknown feature ${name50}()`);
+  }
+  return parser;
+}
+function parse18(kind2 = "unknown") {
+  const start = this.tokenStart;
+  const functionName = this.consumeFunctionName();
+  const valueParser = getFeatureParser.call(this, kind2, functionName.toLowerCase());
+  this.skipSC();
+  const value = this.parseWithFallback(
+    () => {
+      const startValueToken = this.tokenIndex;
+      const value2 = valueParser.call(this);
+      if (this.eof === false && this.isBalanceEdge(startValueToken) === false) {
+        this.error();
+      }
+      return value2;
+    },
+    () => this.Raw(null, false)
+  );
+  if (!this.eof) {
+    this.eat(RightParenthesis);
+  }
+  return {
+    type: "FeatureFunction",
+    loc: this.getLocation(start, this.tokenStart),
+    kind: kind2,
+    feature: functionName,
+    value
+  };
+}
+function generate17(node2) {
+  this.token(Function, node2.feature + "(");
+  this.node(node2.value);
+  this.token(RightParenthesis, ")");
+}
+var name17, structure17;
+var init_FeatureFunction = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/FeatureFunction.js"() {
+    init_tokenizer();
+    name17 = "FeatureFunction";
+    structure17 = {
+      kind: String,
+      feature: String,
+      value: ["Declaration", "Selector"]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/FeatureRange.js
+var FeatureRange_exports = {};
+__export(FeatureRange_exports, {
+  generate: () => generate18,
+  name: () => name18,
+  parse: () => parse19,
+  structure: () => structure18
+});
+function readTerm() {
+  this.skipSC();
+  switch (this.tokenType) {
+    case Number2:
+      if (this.isDelim(SOLIDUS7, this.lookupOffsetNonSC(1))) {
+        return this.Ratio();
+      } else {
+        return this.Number();
+      }
+    case Dimension:
+      return this.Dimension();
+    case Ident:
+      return this.Identifier();
+    case Function:
+      return this.parseWithFallback(
+        () => {
+          const res = this.Function(this.readSequence, this.scope.Value);
+          this.skipSC();
+          if (this.isDelim(SOLIDUS7)) {
+            this.error();
+          }
+          return res;
+        },
+        () => {
+          return this.Ratio();
+        }
+      );
+    default:
+      this.error("Number, dimension, ratio or identifier is expected");
+  }
+}
+function readComparison(expectColon) {
+  this.skipSC();
+  if (this.isDelim(LESSTHANSIGN) || this.isDelim(GREATERTHANSIGN3)) {
+    const value = this.source[this.tokenStart];
+    this.next();
+    if (this.isDelim(EQUALSSIGN2)) {
+      this.next();
+      return value + "=";
+    }
+    return value;
+  }
+  if (this.isDelim(EQUALSSIGN2)) {
+    return "=";
+  }
+  this.error(`Expected ${expectColon ? '":", ' : ""}"<", ">", "=" or ")"`);
+}
+function parse19(kind2 = "unknown") {
+  const start = this.tokenStart;
+  this.skipSC();
+  this.eat(LeftParenthesis);
+  const left = readTerm.call(this);
+  const leftComparison = readComparison.call(this, left.type === "Identifier");
+  const middle = readTerm.call(this);
+  let rightComparison = null;
+  let right = null;
+  if (this.lookupNonWSType(0) !== RightParenthesis) {
+    rightComparison = readComparison.call(this);
+    right = readTerm.call(this);
+  }
+  this.skipSC();
+  this.eat(RightParenthesis);
+  return {
+    type: "FeatureRange",
+    loc: this.getLocation(start, this.tokenStart),
+    kind: kind2,
+    left,
+    leftComparison,
+    middle,
+    rightComparison,
+    right
+  };
+}
+function generate18(node2) {
+  this.token(LeftParenthesis, "(");
+  this.node(node2.left);
+  this.tokenize(node2.leftComparison);
+  this.node(node2.middle);
+  if (node2.right) {
+    this.tokenize(node2.rightComparison);
+    this.node(node2.right);
+  }
+  this.token(RightParenthesis, ")");
+}
+var SOLIDUS7, LESSTHANSIGN, EQUALSSIGN2, GREATERTHANSIGN3, name18, structure18;
+var init_FeatureRange = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/FeatureRange.js"() {
+    init_tokenizer();
+    SOLIDUS7 = 47;
+    LESSTHANSIGN = 60;
+    EQUALSSIGN2 = 61;
+    GREATERTHANSIGN3 = 62;
+    name18 = "FeatureRange";
+    structure18 = {
+      kind: String,
+      left: ["Identifier", "Number", "Dimension", "Ratio", "Function"],
+      leftComparison: String,
+      middle: ["Identifier", "Number", "Dimension", "Ratio", "Function"],
+      rightComparison: [String, null],
+      right: ["Identifier", "Number", "Dimension", "Ratio", "Function", null]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Function.js
+var Function_exports = {};
+__export(Function_exports, {
+  generate: () => generate19,
+  name: () => name19,
+  parse: () => parse20,
+  structure: () => structure19,
+  walkContext: () => walkContext5
+});
+function parse20(readSequence2, recognizer) {
+  const start = this.tokenStart;
+  const name50 = this.consumeFunctionName();
+  const nameLowerCase = name50.toLowerCase();
+  let children;
+  children = recognizer.hasOwnProperty(nameLowerCase) ? recognizer[nameLowerCase].call(this, recognizer) : readSequence2.call(this, recognizer);
+  if (!this.eof) {
+    this.eat(RightParenthesis);
+  }
+  return {
+    type: "Function",
+    loc: this.getLocation(start, this.tokenStart),
+    name: name50,
+    children
+  };
+}
+function generate19(node2) {
+  this.token(Function, node2.name + "(");
+  this.children(node2);
+  this.token(RightParenthesis, ")");
+}
+var name19, walkContext5, structure19;
+var init_Function = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Function.js"() {
+    init_tokenizer();
+    name19 = "Function";
+    walkContext5 = "function";
+    structure19 = {
+      name: String,
+      children: [[]]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/GeneralEnclosed.js
+var GeneralEnclosed_exports = {};
+__export(GeneralEnclosed_exports, {
+  generate: () => generate20,
+  name: () => name20,
+  parse: () => parse21,
+  structure: () => structure20
+});
+function parse21(kind2) {
+  const start = this.tokenStart;
+  let functionName = null;
+  if (this.tokenType === Function) {
+    functionName = this.consumeFunctionName();
+  } else {
+    this.eat(LeftParenthesis);
+  }
+  const children = this.parseWithFallback(
+    () => {
+      const startValueToken = this.tokenIndex;
+      const children2 = this.readSequence(this.scope.Value);
+      if (this.eof === false && this.isBalanceEdge(startValueToken) === false) {
+        this.error();
+      }
+      return children2;
+    },
+    () => this.createSingleNodeList(
+      this.Raw(null, false)
+    )
+  );
+  if (!this.eof) {
+    this.eat(RightParenthesis);
+  }
+  return {
+    type: "GeneralEnclosed",
+    loc: this.getLocation(start, this.tokenStart),
+    kind: kind2,
+    function: functionName,
+    children
+  };
+}
+function generate20(node2) {
+  if (node2.function) {
+    this.token(Function, node2.function + "(");
+  } else {
+    this.token(LeftParenthesis, "(");
+  }
+  this.children(node2);
+  this.token(RightParenthesis, ")");
+}
+var name20, structure20;
+var init_GeneralEnclosed = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/GeneralEnclosed.js"() {
+    init_tokenizer();
+    name20 = "GeneralEnclosed";
+    structure20 = {
+      kind: String,
+      function: [String, null],
+      children: [[]]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Hash.js
+var Hash_exports = {};
+__export(Hash_exports, {
+  generate: () => generate21,
+  name: () => name21,
+  parse: () => parse22,
+  structure: () => structure21,
+  xxx: () => xxx
+});
+function parse22() {
+  const start = this.tokenStart;
+  this.eat(Hash);
+  return {
+    type: "Hash",
+    loc: this.getLocation(start, this.tokenStart),
+    value: this.substrToCursor(start + 1)
+  };
+}
+function generate21(node2) {
+  this.token(Hash, "#" + node2.value);
+}
+var xxx, name21, structure21;
+var init_Hash = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Hash.js"() {
+    init_tokenizer();
+    xxx = "XXX";
+    name21 = "Hash";
+    structure21 = {
+      value: String
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Identifier.js
+var Identifier_exports = {};
+__export(Identifier_exports, {
+  generate: () => generate22,
+  name: () => name22,
+  parse: () => parse23,
+  structure: () => structure22
+});
+function parse23() {
+  return {
+    type: "Identifier",
+    loc: this.getLocation(this.tokenStart, this.tokenEnd),
+    name: this.consume(Ident)
+  };
+}
+function generate22(node2) {
+  this.token(Ident, node2.name);
+}
+var name22, structure22;
+var init_Identifier = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Identifier.js"() {
+    init_tokenizer();
+    name22 = "Identifier";
+    structure22 = {
+      name: String
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/IdSelector.js
+var IdSelector_exports = {};
+__export(IdSelector_exports, {
+  generate: () => generate23,
+  name: () => name23,
+  parse: () => parse24,
+  structure: () => structure23
+});
+function parse24() {
+  const start = this.tokenStart;
+  this.eat(Hash);
+  return {
+    type: "IdSelector",
+    loc: this.getLocation(start, this.tokenStart),
+    name: this.substrToCursor(start + 1)
+  };
+}
+function generate23(node2) {
+  this.token(Delim, "#" + node2.name);
+}
+var name23, structure23;
+var init_IdSelector = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/IdSelector.js"() {
+    init_tokenizer();
+    name23 = "IdSelector";
+    structure23 = {
+      name: String
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Layer.js
+var Layer_exports = {};
+__export(Layer_exports, {
+  generate: () => generate24,
+  name: () => name24,
+  parse: () => parse25,
+  structure: () => structure24
+});
+function parse25() {
+  let tokenStart = this.tokenStart;
+  let name50 = this.consume(Ident);
+  while (this.isDelim(FULLSTOP3)) {
+    this.eat(Delim);
+    name50 += "." + this.consume(Ident);
+  }
+  return {
+    type: "Layer",
+    loc: this.getLocation(tokenStart, this.tokenStart),
+    name: name50
+  };
+}
+function generate24(node2) {
+  this.tokenize(node2.name);
+}
+var FULLSTOP3, name24, structure24;
+var init_Layer = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Layer.js"() {
+    init_tokenizer();
+    FULLSTOP3 = 46;
+    name24 = "Layer";
+    structure24 = {
+      name: String
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/LayerList.js
+var LayerList_exports = {};
+__export(LayerList_exports, {
+  generate: () => generate25,
+  name: () => name25,
+  parse: () => parse26,
+  structure: () => structure25
+});
+function parse26() {
+  const children = this.createList();
+  this.skipSC();
+  while (!this.eof) {
+    children.push(this.Layer());
+    if (this.lookupTypeNonSC(0) !== Comma) {
+      break;
+    }
+    this.skipSC();
+    this.next();
+    this.skipSC();
+  }
+  return {
+    type: "LayerList",
+    loc: this.getLocationFromList(children),
+    children
+  };
+}
+function generate25(node2) {
+  this.children(node2, () => this.token(Comma, ","));
+}
+var name25, structure25;
+var init_LayerList = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/LayerList.js"() {
+    init_tokenizer();
+    name25 = "LayerList";
+    structure25 = {
+      children: [[
+        "Layer"
+      ]]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/MediaQuery.js
+var MediaQuery_exports = {};
+__export(MediaQuery_exports, {
+  generate: () => generate26,
+  name: () => name26,
+  parse: () => parse27,
+  structure: () => structure26
+});
+function parse27() {
+  const start = this.tokenStart;
+  let modifier = null;
+  let mediaType = null;
+  let condition = null;
+  this.skipSC();
+  if (this.tokenType === Ident && this.lookupTypeNonSC(1) !== LeftParenthesis) {
+    const ident = this.consume(Ident);
+    const identLowerCase = ident.toLowerCase();
+    if (identLowerCase === "not" || identLowerCase === "only") {
+      this.skipSC();
+      modifier = identLowerCase;
+      mediaType = this.consume(Ident);
+    } else {
+      mediaType = ident;
+    }
+    switch (this.lookupTypeNonSC(0)) {
+      case Ident: {
+        this.skipSC();
+        this.eatIdent("and");
+        condition = this.Condition("media");
+        break;
+      }
+      case LeftCurlyBracket:
+      case Semicolon:
+      case Comma:
+      case EOF:
+        break;
+      default:
+        this.error("Identifier or parenthesis is expected");
+    }
+  } else {
+    switch (this.tokenType) {
+      case Ident:
+      case LeftParenthesis:
+      case Function: {
+        condition = this.Condition("media");
+        break;
+      }
+      case LeftCurlyBracket:
+      case Semicolon:
+      case EOF:
+        break;
+      default:
+        this.error("Identifier or parenthesis is expected");
+    }
+  }
+  return {
+    type: "MediaQuery",
+    loc: this.getLocation(start, this.tokenStart),
+    modifier,
+    mediaType,
+    condition
+  };
+}
+function generate26(node2) {
+  if (node2.mediaType) {
+    if (node2.modifier) {
+      this.token(Ident, node2.modifier);
+    }
+    this.token(Ident, node2.mediaType);
+    if (node2.condition) {
+      this.token(Ident, "and");
+      this.node(node2.condition);
+    }
+  } else if (node2.condition) {
+    this.node(node2.condition);
+  }
+}
+var name26, structure26;
+var init_MediaQuery = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/MediaQuery.js"() {
+    init_tokenizer();
+    name26 = "MediaQuery";
+    structure26 = {
+      modifier: [String, null],
+      mediaType: [String, null],
+      condition: ["Condition", null]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/MediaQueryList.js
+var MediaQueryList_exports = {};
+__export(MediaQueryList_exports, {
+  generate: () => generate27,
+  name: () => name27,
+  parse: () => parse28,
+  structure: () => structure27
+});
+function parse28() {
+  const children = this.createList();
+  this.skipSC();
+  while (!this.eof) {
+    children.push(this.MediaQuery());
+    if (this.tokenType !== Comma) {
+      break;
+    }
+    this.next();
+  }
+  return {
+    type: "MediaQueryList",
+    loc: this.getLocationFromList(children),
+    children
+  };
+}
+function generate27(node2) {
+  this.children(node2, () => this.token(Comma, ","));
+}
+var name27, structure27;
+var init_MediaQueryList = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/MediaQueryList.js"() {
+    init_tokenizer();
+    name27 = "MediaQueryList";
+    structure27 = {
+      children: [[
+        "MediaQuery"
+      ]]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/NestingSelector.js
+var NestingSelector_exports = {};
+__export(NestingSelector_exports, {
+  generate: () => generate28,
+  name: () => name28,
+  parse: () => parse29,
+  structure: () => structure28
+});
+function parse29() {
+  const start = this.tokenStart;
+  this.eatDelim(AMPERSAND5);
+  return {
+    type: "NestingSelector",
+    loc: this.getLocation(start, this.tokenStart)
+  };
+}
+function generate28() {
+  this.token(Delim, "&");
+}
+var AMPERSAND5, name28, structure28;
+var init_NestingSelector = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/NestingSelector.js"() {
+    init_tokenizer();
+    AMPERSAND5 = 38;
+    name28 = "NestingSelector";
+    structure28 = {};
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Nth.js
+var Nth_exports = {};
+__export(Nth_exports, {
+  generate: () => generate29,
+  name: () => name29,
+  parse: () => parse30,
+  structure: () => structure29
+});
+function parse30() {
+  this.skipSC();
+  const start = this.tokenStart;
+  let end = start;
+  let selector2 = null;
+  let nth2;
+  if (this.lookupValue(0, "odd") || this.lookupValue(0, "even")) {
+    nth2 = this.Identifier();
+  } else {
+    nth2 = this.AnPlusB();
+  }
+  end = this.tokenStart;
+  this.skipSC();
+  if (this.lookupValue(0, "of")) {
+    this.next();
+    selector2 = this.SelectorList();
+    end = this.tokenStart;
+  }
+  return {
+    type: "Nth",
+    loc: this.getLocation(start, end),
+    nth: nth2,
+    selector: selector2
+  };
+}
+function generate29(node2) {
+  this.node(node2.nth);
+  if (node2.selector !== null) {
+    this.token(Ident, "of");
+    this.node(node2.selector);
+  }
+}
+var name29, structure29;
+var init_Nth = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Nth.js"() {
+    init_tokenizer();
+    name29 = "Nth";
+    structure29 = {
+      nth: ["AnPlusB", "Identifier"],
+      selector: ["SelectorList", null]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Number.js
+var Number_exports = {};
+__export(Number_exports, {
+  generate: () => generate30,
+  name: () => name30,
+  parse: () => parse31,
+  structure: () => structure30
+});
+function parse31() {
+  return {
+    type: "Number",
+    loc: this.getLocation(this.tokenStart, this.tokenEnd),
+    value: this.consume(Number2)
+  };
+}
+function generate30(node2) {
+  this.token(Number2, node2.value);
+}
+var name30, structure30;
+var init_Number = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Number.js"() {
+    init_tokenizer();
+    name30 = "Number";
+    structure30 = {
+      value: String
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Operator.js
+var Operator_exports = {};
+__export(Operator_exports, {
+  generate: () => generate31,
+  name: () => name31,
+  parse: () => parse32,
+  structure: () => structure31
+});
+function parse32() {
+  const start = this.tokenStart;
+  this.next();
+  return {
+    type: "Operator",
+    loc: this.getLocation(start, this.tokenStart),
+    value: this.substrToCursor(start)
+  };
+}
+function generate31(node2) {
+  this.tokenize(node2.value);
+}
+var name31, structure31;
+var init_Operator = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Operator.js"() {
+    name31 = "Operator";
+    structure31 = {
+      value: String
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Parentheses.js
+var Parentheses_exports = {};
+__export(Parentheses_exports, {
+  generate: () => generate32,
+  name: () => name32,
+  parse: () => parse33,
+  structure: () => structure32
+});
+function parse33(readSequence2, recognizer) {
+  const start = this.tokenStart;
+  let children = null;
+  this.eat(LeftParenthesis);
+  children = readSequence2.call(this, recognizer);
+  if (!this.eof) {
+    this.eat(RightParenthesis);
+  }
+  return {
+    type: "Parentheses",
+    loc: this.getLocation(start, this.tokenStart),
+    children
+  };
+}
+function generate32(node2) {
+  this.token(LeftParenthesis, "(");
+  this.children(node2);
+  this.token(RightParenthesis, ")");
+}
+var name32, structure32;
+var init_Parentheses = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Parentheses.js"() {
+    init_tokenizer();
+    name32 = "Parentheses";
+    structure32 = {
+      children: [[]]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Percentage.js
+var Percentage_exports = {};
+__export(Percentage_exports, {
+  generate: () => generate33,
+  name: () => name33,
+  parse: () => parse34,
+  structure: () => structure33
+});
+function parse34() {
+  return {
+    type: "Percentage",
+    loc: this.getLocation(this.tokenStart, this.tokenEnd),
+    value: this.consumeNumber(Percentage)
+  };
+}
+function generate33(node2) {
+  this.token(Percentage, node2.value + "%");
+}
+var name33, structure33;
+var init_Percentage = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Percentage.js"() {
+    init_tokenizer();
+    name33 = "Percentage";
+    structure33 = {
+      value: String
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/PseudoClassSelector.js
+var PseudoClassSelector_exports = {};
+__export(PseudoClassSelector_exports, {
+  generate: () => generate34,
+  name: () => name34,
+  parse: () => parse35,
+  structure: () => structure34,
+  walkContext: () => walkContext6
+});
+function parse35() {
+  const start = this.tokenStart;
+  let children = null;
+  let name50;
+  let nameLowerCase;
+  this.eat(Colon);
+  if (this.tokenType === Function) {
+    name50 = this.consumeFunctionName();
+    nameLowerCase = name50.toLowerCase();
+    if (this.lookupNonWSType(0) == RightParenthesis) {
+      children = this.createList();
+    } else if (hasOwnProperty.call(this.pseudo, nameLowerCase)) {
+      this.skipSC();
+      children = this.pseudo[nameLowerCase].call(this);
+      this.skipSC();
+    } else {
+      children = this.createList();
+      children.push(
+        this.Raw(null, false)
+      );
+    }
+    this.eat(RightParenthesis);
+  } else {
+    name50 = this.consume(Ident);
+  }
+  return {
+    type: "PseudoClassSelector",
+    loc: this.getLocation(start, this.tokenStart),
+    name: name50,
+    children
+  };
+}
+function generate34(node2) {
+  this.token(Colon, ":");
+  if (node2.children === null) {
+    this.token(Ident, node2.name);
+  } else {
+    this.token(Function, node2.name + "(");
+    this.children(node2);
+    this.token(RightParenthesis, ")");
+  }
+}
+var name34, walkContext6, structure34;
+var init_PseudoClassSelector = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/PseudoClassSelector.js"() {
+    init_tokenizer();
+    name34 = "PseudoClassSelector";
+    walkContext6 = "function";
+    structure34 = {
+      name: String,
+      children: [["Raw"], null]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/PseudoElementSelector.js
+var PseudoElementSelector_exports = {};
+__export(PseudoElementSelector_exports, {
+  generate: () => generate35,
+  name: () => name35,
+  parse: () => parse36,
+  structure: () => structure35,
+  walkContext: () => walkContext7
+});
+function parse36() {
+  const start = this.tokenStart;
+  let children = null;
+  let name50;
+  let nameLowerCase;
+  this.eat(Colon);
+  this.eat(Colon);
+  if (this.tokenType === Function) {
+    name50 = this.consumeFunctionName();
+    nameLowerCase = name50.toLowerCase();
+    if (this.lookupNonWSType(0) == RightParenthesis) {
+      children = this.createList();
+    } else if (hasOwnProperty.call(this.pseudo, nameLowerCase)) {
+      this.skipSC();
+      children = this.pseudo[nameLowerCase].call(this);
+      this.skipSC();
+    } else {
+      children = this.createList();
+      children.push(
+        this.Raw(null, false)
+      );
+    }
+    this.eat(RightParenthesis);
+  } else {
+    name50 = this.consume(Ident);
+  }
+  return {
+    type: "PseudoElementSelector",
+    loc: this.getLocation(start, this.tokenStart),
+    name: name50,
+    children
+  };
+}
+function generate35(node2) {
+  this.token(Colon, ":");
+  this.token(Colon, ":");
+  if (node2.children === null) {
+    this.token(Ident, node2.name);
+  } else {
+    this.token(Function, node2.name + "(");
+    this.children(node2);
+    this.token(RightParenthesis, ")");
+  }
+}
+var name35, walkContext7, structure35;
+var init_PseudoElementSelector = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/PseudoElementSelector.js"() {
+    init_tokenizer();
+    name35 = "PseudoElementSelector";
+    walkContext7 = "function";
+    structure35 = {
+      name: String,
+      children: [["Raw"], null]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Ratio.js
+var Ratio_exports = {};
+__export(Ratio_exports, {
+  generate: () => generate36,
+  name: () => name36,
+  parse: () => parse37,
+  structure: () => structure36
+});
+function consumeTerm() {
+  this.skipSC();
+  switch (this.tokenType) {
+    case Number2:
+      return this.Number();
+    case Function:
+      return this.Function(this.readSequence, this.scope.Value);
+    default:
+      this.error("Number of function is expected");
+  }
+}
+function parse37() {
+  const start = this.tokenStart;
+  const left = consumeTerm.call(this);
+  let right = null;
+  this.skipSC();
+  if (this.isDelim(SOLIDUS8)) {
+    this.eatDelim(SOLIDUS8);
+    right = consumeTerm.call(this);
+  }
+  return {
+    type: "Ratio",
+    loc: this.getLocation(start, this.tokenStart),
+    left,
+    right
+  };
+}
+function generate36(node2) {
+  this.node(node2.left);
+  this.token(Delim, "/");
+  if (node2.right) {
+    this.node(node2.right);
+  } else {
+    this.node(Number2, 1);
+  }
+}
+var SOLIDUS8, name36, structure36;
+var init_Ratio = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Ratio.js"() {
+    init_tokenizer();
+    SOLIDUS8 = 47;
+    name36 = "Ratio";
+    structure36 = {
+      left: ["Number", "Function"],
+      right: ["Number", "Function", null]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Raw.js
+var Raw_exports = {};
+__export(Raw_exports, {
+  generate: () => generate37,
+  name: () => name37,
+  parse: () => parse38,
+  structure: () => structure37
+});
+function getOffsetExcludeWS() {
+  if (this.tokenIndex > 0) {
+    if (this.lookupType(-1) === WhiteSpace) {
+      return this.tokenIndex > 1 ? this.getTokenStart(this.tokenIndex - 1) : this.firstCharOffset;
+    }
+  }
+  return this.tokenStart;
+}
+function parse38(consumeUntil, excludeWhiteSpace) {
+  const startOffset = this.getTokenStart(this.tokenIndex);
+  let endOffset;
+  this.skipUntilBalanced(this.tokenIndex, consumeUntil || this.consumeUntilBalanceEnd);
+  if (excludeWhiteSpace && this.tokenStart > startOffset) {
+    endOffset = getOffsetExcludeWS.call(this);
+  } else {
+    endOffset = this.tokenStart;
+  }
+  return {
+    type: "Raw",
+    loc: this.getLocation(startOffset, endOffset),
+    value: this.substring(startOffset, endOffset)
+  };
+}
+function generate37(node2) {
+  this.tokenize(node2.value);
+}
+var name37, structure37;
+var init_Raw = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Raw.js"() {
+    init_tokenizer();
+    name37 = "Raw";
+    structure37 = {
+      value: String
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Rule.js
+var Rule_exports = {};
+__export(Rule_exports, {
+  generate: () => generate38,
+  name: () => name38,
+  parse: () => parse39,
+  structure: () => structure38,
+  walkContext: () => walkContext8
+});
+function consumeRaw4() {
+  return this.Raw(this.consumeUntilLeftCurlyBracket, true);
+}
+function consumePrelude() {
+  const prelude = this.SelectorList();
+  if (prelude.type !== "Raw" && this.eof === false && this.tokenType !== LeftCurlyBracket) {
+    this.error();
+  }
+  return prelude;
+}
+function parse39() {
+  const startToken = this.tokenIndex;
+  const startOffset = this.tokenStart;
+  let prelude;
+  let block;
+  if (this.parseRulePrelude) {
+    prelude = this.parseWithFallback(consumePrelude, consumeRaw4);
+  } else {
+    prelude = consumeRaw4.call(this, startToken);
+  }
+  block = this.Block(true);
+  return {
+    type: "Rule",
+    loc: this.getLocation(startOffset, this.tokenStart),
+    prelude,
+    block
+  };
+}
+function generate38(node2) {
+  this.node(node2.prelude);
+  this.node(node2.block);
+}
+var name38, walkContext8, structure38;
+var init_Rule = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Rule.js"() {
+    init_tokenizer();
+    name38 = "Rule";
+    walkContext8 = "rule";
+    structure38 = {
+      prelude: ["SelectorList", "Raw"],
+      block: ["Block"]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Scope.js
+var Scope_exports = {};
+__export(Scope_exports, {
+  generate: () => generate39,
+  name: () => name39,
+  parse: () => parse40,
+  structure: () => structure39
+});
+function parse40() {
+  let root2 = null;
+  let limit = null;
+  this.skipSC();
+  const startOffset = this.tokenStart;
+  if (this.tokenType === LeftParenthesis) {
+    this.next();
+    this.skipSC();
+    root2 = this.parseWithFallback(
+      this.SelectorList,
+      () => this.Raw(false, true)
+    );
+    this.skipSC();
+    this.eat(RightParenthesis);
+  }
+  if (this.lookupNonWSType(0) === Ident) {
+    this.skipSC();
+    this.eatIdent("to");
+    this.skipSC();
+    this.eat(LeftParenthesis);
+    this.skipSC();
+    limit = this.parseWithFallback(
+      this.SelectorList,
+      () => this.Raw(false, true)
+    );
+    this.skipSC();
+    this.eat(RightParenthesis);
+  }
+  return {
+    type: "Scope",
+    loc: this.getLocation(startOffset, this.tokenStart),
+    root: root2,
+    limit
+  };
+}
+function generate39(node2) {
+  if (node2.root) {
+    this.token(LeftParenthesis, "(");
+    this.node(node2.root);
+    this.token(RightParenthesis, ")");
+  }
+  if (node2.limit) {
+    this.token(Ident, "to");
+    this.token(LeftParenthesis, "(");
+    this.node(node2.limit);
+    this.token(RightParenthesis, ")");
+  }
+}
+var name39, structure39;
+var init_Scope = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Scope.js"() {
+    init_tokenizer();
+    name39 = "Scope";
+    structure39 = {
+      root: ["SelectorList", "Raw", null],
+      limit: ["SelectorList", "Raw", null]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Selector.js
+var Selector_exports = {};
+__export(Selector_exports, {
+  generate: () => generate40,
+  name: () => name40,
+  parse: () => parse41,
+  structure: () => structure40
+});
+function parse41() {
+  const children = this.readSequence(this.scope.Selector);
+  if (this.getFirstListNode(children) === null) {
+    this.error("Selector is expected");
+  }
+  return {
+    type: "Selector",
+    loc: this.getLocationFromList(children),
+    children
+  };
+}
+function generate40(node2) {
+  this.children(node2);
+}
+var name40, structure40;
+var init_Selector = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Selector.js"() {
+    name40 = "Selector";
+    structure40 = {
+      children: [[
+        "TypeSelector",
+        "IdSelector",
+        "ClassSelector",
+        "AttributeSelector",
+        "PseudoClassSelector",
+        "PseudoElementSelector",
+        "Combinator"
+      ]]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/SelectorList.js
+var SelectorList_exports = {};
+__export(SelectorList_exports, {
+  generate: () => generate41,
+  name: () => name41,
+  parse: () => parse42,
+  structure: () => structure41,
+  walkContext: () => walkContext9
+});
+function parse42() {
+  const children = this.createList();
+  while (!this.eof) {
+    children.push(this.Selector());
+    if (this.tokenType === Comma) {
+      this.next();
+      continue;
+    }
+    break;
+  }
+  return {
+    type: "SelectorList",
+    loc: this.getLocationFromList(children),
+    children
+  };
+}
+function generate41(node2) {
+  this.children(node2, () => this.token(Comma, ","));
+}
+var name41, walkContext9, structure41;
+var init_SelectorList = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/SelectorList.js"() {
+    init_tokenizer();
+    name41 = "SelectorList";
+    walkContext9 = "selector";
+    structure41 = {
+      children: [[
+        "Selector",
+        "Raw"
+      ]]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/utils/string.js
+function decode(str) {
+  const len = str.length;
+  const firstChar = str.charCodeAt(0);
+  const start = firstChar === QUOTATION_MARK || firstChar === APOSTROPHE ? 1 : 0;
+  const end = start === 1 && len > 1 && str.charCodeAt(len - 1) === firstChar ? len - 2 : len - 1;
+  let decoded = "";
+  for (let i = start; i <= end; i++) {
+    let code4 = str.charCodeAt(i);
+    if (code4 === REVERSE_SOLIDUS) {
+      if (i === end) {
+        if (i !== len - 1) {
+          decoded = str.substr(i + 1);
+        }
+        break;
+      }
+      code4 = str.charCodeAt(++i);
+      if (isValidEscape(REVERSE_SOLIDUS, code4)) {
+        const escapeStart = i - 1;
+        const escapeEnd = consumeEscaped(str, escapeStart);
+        i = escapeEnd - 1;
+        decoded += decodeEscaped(str.substring(escapeStart + 1, escapeEnd));
+      } else {
+        if (code4 === 13 && str.charCodeAt(i + 1) === 10) {
+          i++;
+        }
+      }
+    } else {
+      decoded += str[i];
+    }
+  }
+  return decoded;
+}
+function encode(str, apostrophe) {
+  const quote = apostrophe ? "'" : '"';
+  const quoteCode = apostrophe ? APOSTROPHE : QUOTATION_MARK;
+  let encoded = "";
+  let wsBeforeHexIsNeeded = false;
+  for (let i = 0; i < str.length; i++) {
+    const code4 = str.charCodeAt(i);
+    if (code4 === 0) {
+      encoded += "\uFFFD";
+      continue;
+    }
+    if (code4 <= 31 || code4 === 127) {
+      encoded += "\\" + code4.toString(16);
+      wsBeforeHexIsNeeded = true;
+      continue;
+    }
+    if (code4 === quoteCode || code4 === REVERSE_SOLIDUS) {
+      encoded += "\\" + str.charAt(i);
+      wsBeforeHexIsNeeded = false;
+    } else {
+      if (wsBeforeHexIsNeeded && (isHexDigit(code4) || isWhiteSpace(code4))) {
+        encoded += " ";
+      }
+      encoded += str.charAt(i);
+      wsBeforeHexIsNeeded = false;
+    }
+  }
+  return quote + encoded + quote;
+}
+var REVERSE_SOLIDUS, QUOTATION_MARK, APOSTROPHE;
+var init_string = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/utils/string.js"() {
+    init_tokenizer();
+    REVERSE_SOLIDUS = 92;
+    QUOTATION_MARK = 34;
+    APOSTROPHE = 39;
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/String.js
+var String_exports = {};
+__export(String_exports, {
+  generate: () => generate42,
+  name: () => name42,
+  parse: () => parse43,
+  structure: () => structure42
+});
+function parse43() {
+  return {
+    type: "String",
+    loc: this.getLocation(this.tokenStart, this.tokenEnd),
+    value: decode(this.consume(String2))
+  };
+}
+function generate42(node2) {
+  this.token(String2, encode(node2.value));
+}
+var name42, structure42;
+var init_String = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/String.js"() {
+    init_tokenizer();
+    init_string();
+    name42 = "String";
+    structure42 = {
+      value: String
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/StyleSheet.js
+var StyleSheet_exports = {};
+__export(StyleSheet_exports, {
+  generate: () => generate43,
+  name: () => name43,
+  parse: () => parse44,
+  structure: () => structure43,
+  walkContext: () => walkContext10
+});
+function consumeRaw5() {
+  return this.Raw(null, false);
+}
+function parse44() {
+  const start = this.tokenStart;
+  const children = this.createList();
+  let child;
+  scan:
+    while (!this.eof) {
+      switch (this.tokenType) {
+        case WhiteSpace:
+          this.next();
+          continue;
+        case Comment:
+          if (this.charCodeAt(this.tokenStart + 2) !== EXCLAMATIONMARK3) {
+            this.next();
+            continue;
+          }
+          child = this.Comment();
+          break;
+        case CDO:
+          child = this.CDO();
+          break;
+        case CDC:
+          child = this.CDC();
+          break;
+        // CSS Syntax Module Level 3
+        // §2.2 Error handling
+        // At the "top level" of a stylesheet, an <at-keyword-token> starts an at-rule.
+        case AtKeyword:
+          child = this.parseWithFallback(this.Atrule, consumeRaw5);
+          break;
+        // Anything else starts a qualified rule ...
+        default:
+          child = this.parseWithFallback(this.Rule, consumeRaw5);
+      }
+      children.push(child);
+    }
+  return {
+    type: "StyleSheet",
+    loc: this.getLocation(start, this.tokenStart),
+    children
+  };
+}
+function generate43(node2) {
+  this.children(node2);
+}
+var EXCLAMATIONMARK3, name43, walkContext10, structure43;
+var init_StyleSheet = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/StyleSheet.js"() {
+    init_tokenizer();
+    EXCLAMATIONMARK3 = 33;
+    name43 = "StyleSheet";
+    walkContext10 = "stylesheet";
+    structure43 = {
+      children: [[
+        "Comment",
+        "CDO",
+        "CDC",
+        "Atrule",
+        "Rule",
+        "Raw"
+      ]]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/SupportsDeclaration.js
+var SupportsDeclaration_exports = {};
+__export(SupportsDeclaration_exports, {
+  generate: () => generate44,
+  name: () => name44,
+  parse: () => parse45,
+  structure: () => structure44
+});
+function parse45() {
+  const start = this.tokenStart;
+  this.eat(LeftParenthesis);
+  this.skipSC();
+  const declaration = this.Declaration();
+  if (!this.eof) {
+    this.eat(RightParenthesis);
+  }
+  return {
+    type: "SupportsDeclaration",
+    loc: this.getLocation(start, this.tokenStart),
+    declaration
+  };
+}
+function generate44(node2) {
+  this.token(LeftParenthesis, "(");
+  this.node(node2.declaration);
+  this.token(RightParenthesis, ")");
+}
+var name44, structure44;
+var init_SupportsDeclaration = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/SupportsDeclaration.js"() {
+    init_tokenizer();
+    name44 = "SupportsDeclaration";
+    structure44 = {
+      declaration: "Declaration"
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/TypeSelector.js
+var TypeSelector_exports = {};
+__export(TypeSelector_exports, {
+  generate: () => generate45,
+  name: () => name45,
+  parse: () => parse46,
+  structure: () => structure45
+});
+function eatIdentifierOrAsterisk() {
+  if (this.tokenType !== Ident && this.isDelim(ASTERISK6) === false) {
+    this.error("Identifier or asterisk is expected");
+  }
+  this.next();
+}
+function parse46() {
+  const start = this.tokenStart;
+  if (this.isDelim(VERTICALLINE3)) {
+    this.next();
+    eatIdentifierOrAsterisk.call(this);
+  } else {
+    eatIdentifierOrAsterisk.call(this);
+    if (this.isDelim(VERTICALLINE3)) {
+      this.next();
+      eatIdentifierOrAsterisk.call(this);
+    }
+  }
+  return {
+    type: "TypeSelector",
+    loc: this.getLocation(start, this.tokenStart),
+    name: this.substrToCursor(start)
+  };
+}
+function generate45(node2) {
+  this.tokenize(node2.name);
+}
+var ASTERISK6, VERTICALLINE3, name45, structure45;
+var init_TypeSelector = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/TypeSelector.js"() {
+    init_tokenizer();
+    ASTERISK6 = 42;
+    VERTICALLINE3 = 124;
+    name45 = "TypeSelector";
+    structure45 = {
+      name: String
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/UnicodeRange.js
+var UnicodeRange_exports = {};
+__export(UnicodeRange_exports, {
+  generate: () => generate46,
+  name: () => name46,
+  parse: () => parse47,
+  structure: () => structure46
+});
+function eatHexSequence(offset, allowDash) {
+  let len = 0;
+  for (let pos = this.tokenStart + offset; pos < this.tokenEnd; pos++) {
+    const code4 = this.charCodeAt(pos);
+    if (code4 === HYPHENMINUS4 && allowDash && len !== 0) {
+      eatHexSequence.call(this, offset + len + 1, false);
+      return -1;
+    }
+    if (!isHexDigit(code4)) {
+      this.error(
+        allowDash && len !== 0 ? "Hyphen minus" + (len < 6 ? " or hex digit" : "") + " is expected" : len < 6 ? "Hex digit is expected" : "Unexpected input",
+        pos
+      );
+    }
+    if (++len > 6) {
+      this.error("Too many hex digits", pos);
+    }
+    ;
+  }
+  this.next();
+  return len;
+}
+function eatQuestionMarkSequence(max) {
+  let count = 0;
+  while (this.isDelim(QUESTIONMARK)) {
+    if (++count > max) {
+      this.error("Too many question marks");
+    }
+    this.next();
+  }
+}
+function startsWith(code4) {
+  if (this.charCodeAt(this.tokenStart) !== code4) {
+    this.error((code4 === PLUSSIGN6 ? "Plus sign" : "Hyphen minus") + " is expected");
+  }
+}
+function scanUnicodeRange() {
+  let hexLength = 0;
+  switch (this.tokenType) {
+    case Number2:
+      hexLength = eatHexSequence.call(this, 1, true);
+      if (this.isDelim(QUESTIONMARK)) {
+        eatQuestionMarkSequence.call(this, 6 - hexLength);
+        break;
+      }
+      if (this.tokenType === Dimension || this.tokenType === Number2) {
+        startsWith.call(this, HYPHENMINUS4);
+        eatHexSequence.call(this, 1, false);
+        break;
+      }
+      break;
+    case Dimension:
+      hexLength = eatHexSequence.call(this, 1, true);
+      if (hexLength > 0) {
+        eatQuestionMarkSequence.call(this, 6 - hexLength);
+      }
+      break;
+    default:
+      this.eatDelim(PLUSSIGN6);
+      if (this.tokenType === Ident) {
+        hexLength = eatHexSequence.call(this, 0, true);
+        if (hexLength > 0) {
+          eatQuestionMarkSequence.call(this, 6 - hexLength);
+        }
+        break;
+      }
+      if (this.isDelim(QUESTIONMARK)) {
+        this.next();
+        eatQuestionMarkSequence.call(this, 5);
+        break;
+      }
+      this.error("Hex digit or question mark is expected");
+  }
+}
+function parse47() {
+  const start = this.tokenStart;
+  this.eatIdent("u");
+  scanUnicodeRange.call(this);
+  return {
+    type: "UnicodeRange",
+    loc: this.getLocation(start, this.tokenStart),
+    value: this.substrToCursor(start)
+  };
+}
+function generate46(node2) {
+  this.tokenize(node2.value);
+}
+var PLUSSIGN6, HYPHENMINUS4, QUESTIONMARK, name46, structure46;
+var init_UnicodeRange = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/UnicodeRange.js"() {
+    init_tokenizer();
+    PLUSSIGN6 = 43;
+    HYPHENMINUS4 = 45;
+    QUESTIONMARK = 63;
+    name46 = "UnicodeRange";
+    structure46 = {
+      value: String
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/utils/url.js
+function decode2(str) {
+  const len = str.length;
+  let start = 4;
+  let end = str.charCodeAt(len - 1) === RIGHTPARENTHESIS ? len - 2 : len - 1;
+  let decoded = "";
+  while (start < end && isWhiteSpace(str.charCodeAt(start))) {
+    start++;
+  }
+  while (start < end && isWhiteSpace(str.charCodeAt(end))) {
+    end--;
+  }
+  for (let i = start; i <= end; i++) {
+    let code4 = str.charCodeAt(i);
+    if (code4 === REVERSE_SOLIDUS2) {
+      if (i === end) {
+        if (i !== len - 1) {
+          decoded = str.substr(i + 1);
+        }
+        break;
+      }
+      code4 = str.charCodeAt(++i);
+      if (isValidEscape(REVERSE_SOLIDUS2, code4)) {
+        const escapeStart = i - 1;
+        const escapeEnd = consumeEscaped(str, escapeStart);
+        i = escapeEnd - 1;
+        decoded += decodeEscaped(str.substring(escapeStart + 1, escapeEnd));
+      } else {
+        if (code4 === 13 && str.charCodeAt(i + 1) === 10) {
+          i++;
+        }
+      }
+    } else {
+      decoded += str[i];
+    }
+  }
+  return decoded;
+}
+function encode2(str) {
+  let encoded = "";
+  let wsBeforeHexIsNeeded = false;
+  for (let i = 0; i < str.length; i++) {
+    const code4 = str.charCodeAt(i);
+    if (code4 === 0) {
+      encoded += "\uFFFD";
+      continue;
+    }
+    if (code4 <= 31 || code4 === 127) {
+      encoded += "\\" + code4.toString(16);
+      wsBeforeHexIsNeeded = true;
+      continue;
+    }
+    if (code4 === SPACE || code4 === REVERSE_SOLIDUS2 || code4 === QUOTATION_MARK2 || code4 === APOSTROPHE2 || code4 === LEFTPARENTHESIS || code4 === RIGHTPARENTHESIS) {
+      encoded += "\\" + str.charAt(i);
+      wsBeforeHexIsNeeded = false;
+    } else {
+      if (wsBeforeHexIsNeeded && isHexDigit(code4)) {
+        encoded += " ";
+      }
+      encoded += str.charAt(i);
+      wsBeforeHexIsNeeded = false;
+    }
+  }
+  return "url(" + encoded + ")";
+}
+var SPACE, REVERSE_SOLIDUS2, QUOTATION_MARK2, APOSTROPHE2, LEFTPARENTHESIS, RIGHTPARENTHESIS;
+var init_url = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/utils/url.js"() {
+    init_tokenizer();
+    SPACE = 32;
+    REVERSE_SOLIDUS2 = 92;
+    QUOTATION_MARK2 = 34;
+    APOSTROPHE2 = 39;
+    LEFTPARENTHESIS = 40;
+    RIGHTPARENTHESIS = 41;
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Url.js
+var Url_exports = {};
+__export(Url_exports, {
+  generate: () => generate47,
+  name: () => name47,
+  parse: () => parse48,
+  structure: () => structure47
+});
+function parse48() {
+  const start = this.tokenStart;
+  let value;
+  switch (this.tokenType) {
+    case Url:
+      value = decode2(this.consume(Url));
+      break;
+    case Function:
+      if (!this.cmpStr(this.tokenStart, this.tokenEnd, "url(")) {
+        this.error("Function name must be `url`");
+      }
+      this.eat(Function);
+      this.skipSC();
+      value = decode(this.consume(String2));
+      this.skipSC();
+      if (!this.eof) {
+        this.eat(RightParenthesis);
+      }
+      break;
+    default:
+      this.error("Url or Function is expected");
+  }
+  return {
+    type: "Url",
+    loc: this.getLocation(start, this.tokenStart),
+    value
+  };
+}
+function generate47(node2) {
+  this.token(Url, encode2(node2.value));
+}
+var name47, structure47;
+var init_Url = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Url.js"() {
+    init_url();
+    init_string();
+    init_tokenizer();
+    name47 = "Url";
+    structure47 = {
+      value: String
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Value.js
+var Value_exports = {};
+__export(Value_exports, {
+  generate: () => generate48,
+  name: () => name48,
+  parse: () => parse49,
+  structure: () => structure48
+});
+function parse49() {
+  const start = this.tokenStart;
+  const children = this.readSequence(this.scope.Value);
+  return {
+    type: "Value",
+    loc: this.getLocation(start, this.tokenStart),
+    children
+  };
+}
+function generate48(node2) {
+  this.children(node2);
+}
+var name48, structure48;
+var init_Value = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Value.js"() {
+    name48 = "Value";
+    structure48 = {
+      children: [[]]
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/WhiteSpace.js
+var WhiteSpace_exports = {};
+__export(WhiteSpace_exports, {
+  generate: () => generate49,
+  name: () => name49,
+  parse: () => parse50,
+  structure: () => structure49
+});
+function parse50() {
+  this.eat(WhiteSpace);
+  return SPACE2;
+}
+function generate49(node2) {
+  this.token(WhiteSpace, node2.value);
+}
+var SPACE2, name49, structure49;
+var init_WhiteSpace = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/WhiteSpace.js"() {
+    init_tokenizer();
+    SPACE2 = Object.freeze({
+      type: "WhiteSpace",
+      loc: null,
+      value: " "
+    });
+    name49 = "WhiteSpace";
+    structure49 = {
+      value: String
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/index-parse.js
+var index_parse_exports = {};
+__export(index_parse_exports, {
+  AnPlusB: () => parse2,
+  Atrule: () => parse3,
+  AtrulePrelude: () => parse4,
+  AttributeSelector: () => parse5,
+  Block: () => parse6,
+  Brackets: () => parse7,
+  CDC: () => parse8,
+  CDO: () => parse9,
+  ClassSelector: () => parse10,
+  Combinator: () => parse11,
+  Comment: () => parse12,
+  Condition: () => parse13,
+  Declaration: () => parse14,
+  DeclarationList: () => parse15,
+  Dimension: () => parse16,
+  Feature: () => parse17,
+  FeatureFunction: () => parse18,
+  FeatureRange: () => parse19,
+  Function: () => parse20,
+  GeneralEnclosed: () => parse21,
+  Hash: () => parse22,
+  IdSelector: () => parse24,
+  Identifier: () => parse23,
+  Layer: () => parse25,
+  LayerList: () => parse26,
+  MediaQuery: () => parse27,
+  MediaQueryList: () => parse28,
+  NestingSelector: () => parse29,
+  Nth: () => parse30,
+  Number: () => parse31,
+  Operator: () => parse32,
+  Parentheses: () => parse33,
+  Percentage: () => parse34,
+  PseudoClassSelector: () => parse35,
+  PseudoElementSelector: () => parse36,
+  Ratio: () => parse37,
+  Raw: () => parse38,
+  Rule: () => parse39,
+  Scope: () => parse40,
+  Selector: () => parse41,
+  SelectorList: () => parse42,
+  String: () => parse43,
+  StyleSheet: () => parse44,
+  SupportsDeclaration: () => parse45,
+  TypeSelector: () => parse46,
+  UnicodeRange: () => parse47,
+  Url: () => parse48,
+  Value: () => parse49,
+  WhiteSpace: () => parse50
+});
+var init_index_parse = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/index-parse.js"() {
+    init_AnPlusB();
+    init_Atrule();
+    init_AtrulePrelude();
+    init_AttributeSelector();
+    init_Block();
+    init_Brackets();
+    init_CDC();
+    init_CDO();
+    init_ClassSelector();
+    init_Combinator();
+    init_Comment();
+    init_Condition();
+    init_Declaration();
+    init_DeclarationList();
+    init_Dimension();
+    init_Feature();
+    init_FeatureFunction();
+    init_FeatureRange();
+    init_Function();
+    init_GeneralEnclosed();
+    init_Hash();
+    init_Identifier();
+    init_IdSelector();
+    init_Layer();
+    init_LayerList();
+    init_MediaQuery();
+    init_MediaQueryList();
+    init_NestingSelector();
+    init_Nth();
+    init_Number();
+    init_Operator();
+    init_Parentheses();
+    init_Percentage();
+    init_PseudoClassSelector();
+    init_PseudoElementSelector();
+    init_Ratio();
+    init_Raw();
+    init_Rule();
+    init_Scope();
+    init_Selector();
+    init_SelectorList();
+    init_String();
+    init_StyleSheet();
+    init_SupportsDeclaration();
+    init_TypeSelector();
+    init_UnicodeRange();
+    init_Url();
+    init_Value();
+    init_WhiteSpace();
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/config/parser.js
+var parser_default;
+var init_parser = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/config/parser.js"() {
+    init_scope();
+    init_atrule();
+    init_pseudo();
+    init_index_parse();
+    parser_default = {
+      parseContext: {
+        default: "StyleSheet",
+        stylesheet: "StyleSheet",
+        atrule: "Atrule",
+        atrulePrelude(options) {
+          return this.AtrulePrelude(options.atrule ? String(options.atrule) : null);
+        },
+        mediaQueryList: "MediaQueryList",
+        mediaQuery: "MediaQuery",
+        condition(options) {
+          return this.Condition(options.kind);
+        },
+        rule: "Rule",
+        selectorList: "SelectorList",
+        selector: "Selector",
+        block() {
+          return this.Block(true);
+        },
+        declarationList: "DeclarationList",
+        declaration: "Declaration",
+        value: "Value"
+      },
+      features: {
+        supports: {
+          selector() {
+            return this.Selector();
+          }
+        },
+        container: {
+          style() {
+            return this.Declaration();
+          }
+        }
+      },
+      scope: scope_exports,
+      atrule: atrule_default,
+      pseudo: pseudo_default,
+      node: index_parse_exports
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/parser/index.js
+var parser_default2;
+var init_parser2 = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/parser/index.js"() {
+    init_create();
+    init_parser();
+    parser_default2 = createParser(parser_default);
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/walker/create.js
+function ensureFunction(value) {
+  return typeof value === "function" ? value : noop;
+}
+function invokeForType(fn, type) {
+  return function(node2, item, list3) {
+    if (node2.type === type) {
+      fn.call(this, node2, item, list3);
+    }
+  };
+}
+function getWalkersFromStructure(name50, nodeType) {
+  const structure50 = nodeType.structure;
+  const walkers = [];
+  for (const key in structure50) {
+    if (hasOwnProperty2.call(structure50, key) === false) {
+      continue;
+    }
+    let fieldTypes = structure50[key];
+    const walker = {
+      name: key,
+      type: false,
+      nullable: false
+    };
+    if (!Array.isArray(fieldTypes)) {
+      fieldTypes = [fieldTypes];
+    }
+    for (const fieldType of fieldTypes) {
+      if (fieldType === null) {
+        walker.nullable = true;
+      } else if (typeof fieldType === "string") {
+        walker.type = "node";
+      } else if (Array.isArray(fieldType)) {
+        walker.type = "list";
+      }
+    }
+    if (walker.type) {
+      walkers.push(walker);
+    }
+  }
+  if (walkers.length) {
+    return {
+      context: nodeType.walkContext,
+      fields: walkers
+    };
+  }
+  return null;
+}
+function getTypesFromConfig(config) {
+  const types = {};
+  for (const name50 in config.node) {
+    if (hasOwnProperty2.call(config.node, name50)) {
+      const nodeType = config.node[name50];
+      if (!nodeType.structure) {
+        throw new Error("Missed `structure` field in `" + name50 + "` node type definition");
+      }
+      types[name50] = getWalkersFromStructure(name50, nodeType);
+    }
+  }
+  return types;
+}
+function createTypeIterator(config, reverse) {
+  const fields = config.fields.slice();
+  const contextName = config.context;
+  const useContext = typeof contextName === "string";
+  if (reverse) {
+    fields.reverse();
+  }
+  return function(node2, context, walk2, walkReducer) {
+    let prevContextValue;
+    if (useContext) {
+      prevContextValue = context[contextName];
+      context[contextName] = node2;
+    }
+    for (const field of fields) {
+      const ref = node2[field.name];
+      if (!field.nullable || ref) {
+        if (field.type === "list") {
+          const breakWalk = reverse ? ref.reduceRight(walkReducer, false) : ref.reduce(walkReducer, false);
+          if (breakWalk) {
+            return true;
+          }
+        } else if (walk2(ref)) {
+          return true;
+        }
+      }
+    }
+    if (useContext) {
+      context[contextName] = prevContextValue;
+    }
+  };
+}
+function createFastTraveralMap({
+  StyleSheet,
+  Atrule,
+  Rule,
+  Block,
+  DeclarationList
+}) {
+  return {
+    Atrule: {
+      StyleSheet,
+      Atrule,
+      Rule,
+      Block
+    },
+    Rule: {
+      StyleSheet,
+      Atrule,
+      Rule,
+      Block
+    },
+    Declaration: {
+      StyleSheet,
+      Atrule,
+      Rule,
+      Block,
+      DeclarationList
+    }
+  };
+}
+function createWalker(config) {
+  const types = getTypesFromConfig(config);
+  const iteratorsNatural = {};
+  const iteratorsReverse = {};
+  const breakWalk = /* @__PURE__ */ Symbol("break-walk");
+  const skipNode = /* @__PURE__ */ Symbol("skip-node");
+  for (const name50 in types) {
+    if (hasOwnProperty2.call(types, name50) && types[name50] !== null) {
+      iteratorsNatural[name50] = createTypeIterator(types[name50], false);
+      iteratorsReverse[name50] = createTypeIterator(types[name50], true);
+    }
+  }
+  const fastTraversalIteratorsNatural = createFastTraveralMap(iteratorsNatural);
+  const fastTraversalIteratorsReverse = createFastTraveralMap(iteratorsReverse);
+  const walk2 = function(root2, options) {
+    function walkNode(node2, item, list3) {
+      const enterRet = enter.call(context, node2, item, list3);
+      if (enterRet === breakWalk) {
+        return true;
+      }
+      if (enterRet === skipNode) {
+        return false;
+      }
+      if (iterators.hasOwnProperty(node2.type)) {
+        if (iterators[node2.type](node2, context, walkNode, walkReducer)) {
+          return true;
+        }
+      }
+      if (leave.call(context, node2, item, list3) === breakWalk) {
+        return true;
+      }
+      return false;
+    }
+    let enter = noop;
+    let leave = noop;
+    let iterators = iteratorsNatural;
+    let walkReducer = (ret, data, item, list3) => ret || walkNode(data, item, list3);
+    const context = {
+      break: breakWalk,
+      skip: skipNode,
+      root: root2,
+      stylesheet: null,
+      atrule: null,
+      atrulePrelude: null,
+      rule: null,
+      selector: null,
+      block: null,
+      declaration: null,
+      function: null
+    };
+    if (typeof options === "function") {
+      enter = options;
+    } else if (options) {
+      enter = ensureFunction(options.enter);
+      leave = ensureFunction(options.leave);
+      if (options.reverse) {
+        iterators = iteratorsReverse;
+      }
+      if (options.visit) {
+        if (fastTraversalIteratorsNatural.hasOwnProperty(options.visit)) {
+          iterators = options.reverse ? fastTraversalIteratorsReverse[options.visit] : fastTraversalIteratorsNatural[options.visit];
+        } else if (!types.hasOwnProperty(options.visit)) {
+          throw new Error("Bad value `" + options.visit + "` for `visit` option (should be: " + Object.keys(types).sort().join(", ") + ")");
+        }
+        enter = invokeForType(enter, options.visit);
+        leave = invokeForType(leave, options.visit);
+      }
+    }
+    if (enter === noop && leave === noop) {
+      throw new Error("Neither `enter` nor `leave` walker handler is set or both aren't a function");
+    }
+    walkNode(root2);
+  };
+  walk2.break = breakWalk;
+  walk2.skip = skipNode;
+  walk2.find = function(ast, fn) {
+    let found = null;
+    walk2(ast, function(node2, item, list3) {
+      if (fn.call(this, node2, item, list3)) {
+        found = node2;
+        return breakWalk;
+      }
+    });
+    return found;
+  };
+  walk2.findLast = function(ast, fn) {
+    let found = null;
+    walk2(ast, {
+      reverse: true,
+      enter(node2, item, list3) {
+        if (fn.call(this, node2, item, list3)) {
+          found = node2;
+          return breakWalk;
+        }
+      }
+    });
+    return found;
+  };
+  walk2.findAll = function(ast, fn) {
+    const found = [];
+    walk2(ast, function(node2, item, list3) {
+      if (fn.call(this, node2, item, list3)) {
+        found.push(node2);
+      }
+    });
+    return found;
+  };
+  return walk2;
+}
+var hasOwnProperty2, noop;
+var init_create2 = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/walker/create.js"() {
+    ({ hasOwnProperty: hasOwnProperty2 } = Object.prototype);
+    noop = function() {
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/index.js
+var node_exports = {};
+__export(node_exports, {
+  AnPlusB: () => AnPlusB_exports,
+  Atrule: () => Atrule_exports,
+  AtrulePrelude: () => AtrulePrelude_exports,
+  AttributeSelector: () => AttributeSelector_exports,
+  Block: () => Block_exports,
+  Brackets: () => Brackets_exports,
+  CDC: () => CDC_exports,
+  CDO: () => CDO_exports,
+  ClassSelector: () => ClassSelector_exports,
+  Combinator: () => Combinator_exports,
+  Comment: () => Comment_exports,
+  Condition: () => Condition_exports,
+  Declaration: () => Declaration_exports,
+  DeclarationList: () => DeclarationList_exports,
+  Dimension: () => Dimension_exports,
+  Feature: () => Feature_exports,
+  FeatureFunction: () => FeatureFunction_exports,
+  FeatureRange: () => FeatureRange_exports,
+  Function: () => Function_exports,
+  GeneralEnclosed: () => GeneralEnclosed_exports,
+  Hash: () => Hash_exports,
+  IdSelector: () => IdSelector_exports,
+  Identifier: () => Identifier_exports,
+  Layer: () => Layer_exports,
+  LayerList: () => LayerList_exports,
+  MediaQuery: () => MediaQuery_exports,
+  MediaQueryList: () => MediaQueryList_exports,
+  NestingSelector: () => NestingSelector_exports,
+  Nth: () => Nth_exports,
+  Number: () => Number_exports,
+  Operator: () => Operator_exports,
+  Parentheses: () => Parentheses_exports,
+  Percentage: () => Percentage_exports,
+  PseudoClassSelector: () => PseudoClassSelector_exports,
+  PseudoElementSelector: () => PseudoElementSelector_exports,
+  Ratio: () => Ratio_exports,
+  Raw: () => Raw_exports,
+  Rule: () => Rule_exports,
+  Scope: () => Scope_exports,
+  Selector: () => Selector_exports,
+  SelectorList: () => SelectorList_exports,
+  String: () => String_exports,
+  StyleSheet: () => StyleSheet_exports,
+  SupportsDeclaration: () => SupportsDeclaration_exports,
+  TypeSelector: () => TypeSelector_exports,
+  UnicodeRange: () => UnicodeRange_exports,
+  Url: () => Url_exports,
+  Value: () => Value_exports,
+  WhiteSpace: () => WhiteSpace_exports
+});
+var init_node = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/index.js"() {
+    init_AnPlusB();
+    init_Atrule();
+    init_AtrulePrelude();
+    init_AttributeSelector();
+    init_Block();
+    init_Brackets();
+    init_CDC();
+    init_CDO();
+    init_ClassSelector();
+    init_Combinator();
+    init_Comment();
+    init_Condition();
+    init_Declaration();
+    init_DeclarationList();
+    init_Dimension();
+    init_Feature();
+    init_FeatureFunction();
+    init_FeatureRange();
+    init_Function();
+    init_GeneralEnclosed();
+    init_Hash();
+    init_Identifier();
+    init_IdSelector();
+    init_Layer();
+    init_LayerList();
+    init_MediaQuery();
+    init_MediaQueryList();
+    init_NestingSelector();
+    init_Nth();
+    init_Number();
+    init_Operator();
+    init_Parentheses();
+    init_Percentage();
+    init_PseudoClassSelector();
+    init_PseudoElementSelector();
+    init_Ratio();
+    init_Raw();
+    init_Rule();
+    init_Scope();
+    init_Selector();
+    init_SelectorList();
+    init_String();
+    init_StyleSheet();
+    init_SupportsDeclaration();
+    init_TypeSelector();
+    init_UnicodeRange();
+    init_Url();
+    init_Value();
+    init_WhiteSpace();
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/config/walker.js
+var walker_default;
+var init_walker = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/config/walker.js"() {
+    init_node();
+    walker_default = {
+      node: node_exports
+    };
+  }
+});
+
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/walker/index.js
+var walker_default2;
+var init_walker2 = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/walker/index.js"() {
+    init_create2();
+    init_walker();
+    walker_default2 = createWalker(walker_default);
+  }
+});
+
 // node_modules/.pnpm/source-map-js@1.2.1/node_modules/source-map-js/lib/base64.js
 var require_base64 = __commonJS({
   "node_modules/.pnpm/source-map-js@1.2.1/node_modules/source-map-js/lib/base64.js"(exports) {
     var intToCharMap = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split("");
-    exports.encode = function(number3) {
-      if (0 <= number3 && number3 < intToCharMap.length) {
-        return intToCharMap[number3];
+    exports.encode = function(number2) {
+      if (0 <= number2 && number2 < intToCharMap.length) {
+        return intToCharMap[number2];
       }
-      throw new TypeError("Must be between 0 and 63: " + number3);
+      throw new TypeError("Must be between 0 and 63: " + number2);
     };
     exports.decode = function(charCode) {
       var bigA = 65;
       var bigZ = 90;
       var littleA = 97;
       var littleZ = 122;
-      var zero2 = 48;
+      var zero = 48;
       var nine = 57;
       var plus = 43;
       var slash = 47;
@@ -6186,8 +10306,8 @@ var require_base64 = __commonJS({
       if (littleA <= charCode && charCode <= littleZ) {
         return charCode - littleA + littleOffset;
       }
-      if (zero2 <= charCode && charCode <= nine) {
-        return charCode - zero2 + numberOffset;
+      if (zero <= charCode && charCode <= nine) {
+        return charCode - zero + numberOffset;
       }
       if (charCode == plus) {
         return 62;
@@ -6461,14 +10581,14 @@ var require_util = __commonJS({
       if (!s2) {
         return false;
       }
-      var length2 = s2.length;
-      if (length2 < 9) {
+      var length = s2.length;
+      if (length < 9) {
         return false;
       }
-      if (s2.charCodeAt(length2 - 1) !== 95 || s2.charCodeAt(length2 - 2) !== 95 || s2.charCodeAt(length2 - 3) !== 111 || s2.charCodeAt(length2 - 4) !== 116 || s2.charCodeAt(length2 - 5) !== 111 || s2.charCodeAt(length2 - 6) !== 114 || s2.charCodeAt(length2 - 7) !== 112 || s2.charCodeAt(length2 - 8) !== 95 || s2.charCodeAt(length2 - 9) !== 95) {
+      if (s2.charCodeAt(length - 1) !== 95 || s2.charCodeAt(length - 2) !== 95 || s2.charCodeAt(length - 3) !== 111 || s2.charCodeAt(length - 4) !== 116 || s2.charCodeAt(length - 5) !== 111 || s2.charCodeAt(length - 6) !== 114 || s2.charCodeAt(length - 7) !== 112 || s2.charCodeAt(length - 8) !== 95 || s2.charCodeAt(length - 9) !== 95) {
         return false;
       }
-      for (var i = length2 - 10; i >= 0; i--) {
+      for (var i = length - 10; i >= 0; i--) {
         if (s2.charCodeAt(i) !== 36) {
           return false;
         }
@@ -7133,16 +11253,16 @@ function createMap(pairs) {
   return function(prevCode, type, value) {
     const nextCode = code(type, value);
     const nextCharCode = value.charCodeAt(0);
-    const emitWs = nextCharCode === HYPHENMINUS && type !== Ident && type !== Function && type !== CDC || nextCharCode === PLUSSIGN ? isWhiteSpaceRequired.has((prevCode & 65534) << 16 | nextCharCode << 7) : isWhiteSpaceRequired.has((prevCode & 65534) << 16 | nextCode);
+    const emitWs = nextCharCode === HYPHENMINUS5 && type !== Ident && type !== Function && type !== CDC || nextCharCode === PLUSSIGN7 ? isWhiteSpaceRequired.has((prevCode & 65534) << 16 | nextCharCode << 7) : isWhiteSpaceRequired.has((prevCode & 65534) << 16 | nextCode);
     return nextCode | emitWs;
   };
 }
-var PLUSSIGN, HYPHENMINUS, code, specPairs, safePairs, spec, safe;
+var PLUSSIGN7, HYPHENMINUS5, code, specPairs, safePairs, spec, safe;
 var init_token_before = __esm({
   "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/generator/token-before.js"() {
     init_tokenizer();
-    PLUSSIGN = 43;
-    HYPHENMINUS = 45;
+    PLUSSIGN7 = 43;
+    HYPHENMINUS5 = 45;
     code = (type, value) => {
       if (type === Delim) {
         type = value;
@@ -7339,7 +11459,7 @@ function createGenerator(config) {
   };
 }
 var REVERSESOLIDUS;
-var init_create2 = __esm({
+var init_create3 = __esm({
   "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/generator/create.js"() {
     init_tokenizer();
     init_sourceMap();
@@ -7348,22276 +11468,137 @@ var init_create2 = __esm({
   }
 });
 
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/convertor/create.js
-function createConvertor(walk4) {
-  return {
-    fromPlainObject(ast) {
-      walk4(ast, {
-        enter(node2) {
-          if (node2.children && node2.children instanceof List === false) {
-            node2.children = new List().fromArray(node2.children);
-          }
-        }
-      });
-      return ast;
-    },
-    toPlainObject(ast) {
-      walk4(ast, {
-        leave(node2) {
-          if (node2.children && node2.children instanceof List) {
-            node2.children = node2.children.toArray();
-          }
-        }
-      });
-      return ast;
-    }
-  };
-}
-var init_create3 = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/convertor/create.js"() {
-    init_List();
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/index-generate.js
+var index_generate_exports = {};
+__export(index_generate_exports, {
+  AnPlusB: () => generate,
+  Atrule: () => generate2,
+  AtrulePrelude: () => generate3,
+  AttributeSelector: () => generate4,
+  Block: () => generate5,
+  Brackets: () => generate6,
+  CDC: () => generate7,
+  CDO: () => generate8,
+  ClassSelector: () => generate9,
+  Combinator: () => generate10,
+  Comment: () => generate11,
+  Condition: () => generate12,
+  Declaration: () => generate13,
+  DeclarationList: () => generate14,
+  Dimension: () => generate15,
+  Feature: () => generate16,
+  FeatureFunction: () => generate17,
+  FeatureRange: () => generate18,
+  Function: () => generate19,
+  GeneralEnclosed: () => generate20,
+  Hash: () => generate21,
+  IdSelector: () => generate23,
+  Identifier: () => generate22,
+  Layer: () => generate24,
+  LayerList: () => generate25,
+  MediaQuery: () => generate26,
+  MediaQueryList: () => generate27,
+  NestingSelector: () => generate28,
+  Nth: () => generate29,
+  Number: () => generate30,
+  Operator: () => generate31,
+  Parentheses: () => generate32,
+  Percentage: () => generate33,
+  PseudoClassSelector: () => generate34,
+  PseudoElementSelector: () => generate35,
+  Ratio: () => generate36,
+  Raw: () => generate37,
+  Rule: () => generate38,
+  Scope: () => generate39,
+  Selector: () => generate40,
+  SelectorList: () => generate41,
+  String: () => generate42,
+  StyleSheet: () => generate43,
+  SupportsDeclaration: () => generate44,
+  TypeSelector: () => generate45,
+  UnicodeRange: () => generate46,
+  Url: () => generate47,
+  Value: () => generate48,
+  WhiteSpace: () => generate49
+});
+var init_index_generate = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/index-generate.js"() {
+    init_AnPlusB();
+    init_Atrule();
+    init_AtrulePrelude();
+    init_AttributeSelector();
+    init_Block();
+    init_Brackets();
+    init_CDC();
+    init_CDO();
+    init_ClassSelector();
+    init_Combinator();
+    init_Comment();
+    init_Condition();
+    init_Declaration();
+    init_DeclarationList();
+    init_Dimension();
+    init_Feature();
+    init_FeatureFunction();
+    init_FeatureRange();
+    init_Function();
+    init_GeneralEnclosed();
+    init_Hash();
+    init_Identifier();
+    init_IdSelector();
+    init_Layer();
+    init_LayerList();
+    init_MediaQuery();
+    init_MediaQueryList();
+    init_NestingSelector();
+    init_Nth();
+    init_Number();
+    init_Operator();
+    init_Parentheses();
+    init_Percentage();
+    init_PseudoClassSelector();
+    init_PseudoElementSelector();
+    init_Ratio();
+    init_Raw();
+    init_Rule();
+    init_Scope();
+    init_Selector();
+    init_SelectorList();
+    init_String();
+    init_StyleSheet();
+    init_SupportsDeclaration();
+    init_TypeSelector();
+    init_UnicodeRange();
+    init_Url();
+    init_Value();
+    init_WhiteSpace();
   }
 });
 
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/walker/create.js
-function ensureFunction(value) {
-  return typeof value === "function" ? value : noop;
-}
-function invokeForType(fn, type) {
-  return function(node2, item, list3) {
-    if (node2.type === type) {
-      fn.call(this, node2, item, list3);
-    }
-  };
-}
-function getWalkersFromStructure(name50, nodeType) {
-  const structure50 = nodeType.structure;
-  const walkers = [];
-  for (const key in structure50) {
-    if (hasOwnProperty2.call(structure50, key) === false) {
-      continue;
-    }
-    let fieldTypes = structure50[key];
-    const walker = {
-      name: key,
-      type: false,
-      nullable: false
-    };
-    if (!Array.isArray(fieldTypes)) {
-      fieldTypes = [fieldTypes];
-    }
-    for (const fieldType of fieldTypes) {
-      if (fieldType === null) {
-        walker.nullable = true;
-      } else if (typeof fieldType === "string") {
-        walker.type = "node";
-      } else if (Array.isArray(fieldType)) {
-        walker.type = "list";
-      }
-    }
-    if (walker.type) {
-      walkers.push(walker);
-    }
-  }
-  if (walkers.length) {
-    return {
-      context: nodeType.walkContext,
-      fields: walkers
-    };
-  }
-  return null;
-}
-function getTypesFromConfig(config) {
-  const types = {};
-  for (const name50 in config.node) {
-    if (hasOwnProperty2.call(config.node, name50)) {
-      const nodeType = config.node[name50];
-      if (!nodeType.structure) {
-        throw new Error("Missed `structure` field in `" + name50 + "` node type definition");
-      }
-      types[name50] = getWalkersFromStructure(name50, nodeType);
-    }
-  }
-  return types;
-}
-function createTypeIterator(config, reverse) {
-  const fields = config.fields.slice();
-  const contextName = config.context;
-  const useContext = typeof contextName === "string";
-  if (reverse) {
-    fields.reverse();
-  }
-  return function(node2, context, walk4, walkReducer) {
-    let prevContextValue;
-    if (useContext) {
-      prevContextValue = context[contextName];
-      context[contextName] = node2;
-    }
-    for (const field of fields) {
-      const ref = node2[field.name];
-      if (!field.nullable || ref) {
-        if (field.type === "list") {
-          const breakWalk = reverse ? ref.reduceRight(walkReducer, false) : ref.reduce(walkReducer, false);
-          if (breakWalk) {
-            return true;
-          }
-        } else if (walk4(ref)) {
-          return true;
-        }
-      }
-    }
-    if (useContext) {
-      context[contextName] = prevContextValue;
-    }
-  };
-}
-function createFastTraveralMap({
-  StyleSheet,
-  Atrule,
-  Rule,
-  Block,
-  DeclarationList
-}) {
-  return {
-    Atrule: {
-      StyleSheet,
-      Atrule,
-      Rule,
-      Block
-    },
-    Rule: {
-      StyleSheet,
-      Atrule,
-      Rule,
-      Block
-    },
-    Declaration: {
-      StyleSheet,
-      Atrule,
-      Rule,
-      Block,
-      DeclarationList
-    }
-  };
-}
-function createWalker(config) {
-  const types = getTypesFromConfig(config);
-  const iteratorsNatural = {};
-  const iteratorsReverse = {};
-  const breakWalk = /* @__PURE__ */ Symbol("break-walk");
-  const skipNode = /* @__PURE__ */ Symbol("skip-node");
-  for (const name50 in types) {
-    if (hasOwnProperty2.call(types, name50) && types[name50] !== null) {
-      iteratorsNatural[name50] = createTypeIterator(types[name50], false);
-      iteratorsReverse[name50] = createTypeIterator(types[name50], true);
-    }
-  }
-  const fastTraversalIteratorsNatural = createFastTraveralMap(iteratorsNatural);
-  const fastTraversalIteratorsReverse = createFastTraveralMap(iteratorsReverse);
-  const walk4 = function(root2, options) {
-    function walkNode(node2, item, list3) {
-      const enterRet = enter.call(context, node2, item, list3);
-      if (enterRet === breakWalk) {
-        return true;
-      }
-      if (enterRet === skipNode) {
-        return false;
-      }
-      if (iterators.hasOwnProperty(node2.type)) {
-        if (iterators[node2.type](node2, context, walkNode, walkReducer)) {
-          return true;
-        }
-      }
-      if (leave.call(context, node2, item, list3) === breakWalk) {
-        return true;
-      }
-      return false;
-    }
-    let enter = noop;
-    let leave = noop;
-    let iterators = iteratorsNatural;
-    let walkReducer = (ret, data, item, list3) => ret || walkNode(data, item, list3);
-    const context = {
-      break: breakWalk,
-      skip: skipNode,
-      root: root2,
-      stylesheet: null,
-      atrule: null,
-      atrulePrelude: null,
-      rule: null,
-      selector: null,
-      block: null,
-      declaration: null,
-      function: null
-    };
-    if (typeof options === "function") {
-      enter = options;
-    } else if (options) {
-      enter = ensureFunction(options.enter);
-      leave = ensureFunction(options.leave);
-      if (options.reverse) {
-        iterators = iteratorsReverse;
-      }
-      if (options.visit) {
-        if (fastTraversalIteratorsNatural.hasOwnProperty(options.visit)) {
-          iterators = options.reverse ? fastTraversalIteratorsReverse[options.visit] : fastTraversalIteratorsNatural[options.visit];
-        } else if (!types.hasOwnProperty(options.visit)) {
-          throw new Error("Bad value `" + options.visit + "` for `visit` option (should be: " + Object.keys(types).sort().join(", ") + ")");
-        }
-        enter = invokeForType(enter, options.visit);
-        leave = invokeForType(leave, options.visit);
-      }
-    }
-    if (enter === noop && leave === noop) {
-      throw new Error("Neither `enter` nor `leave` walker handler is set or both aren't a function");
-    }
-    walkNode(root2);
-  };
-  walk4.break = breakWalk;
-  walk4.skip = skipNode;
-  walk4.find = function(ast, fn) {
-    let found = null;
-    walk4(ast, function(node2, item, list3) {
-      if (fn.call(this, node2, item, list3)) {
-        found = node2;
-        return breakWalk;
-      }
-    });
-    return found;
-  };
-  walk4.findLast = function(ast, fn) {
-    let found = null;
-    walk4(ast, {
-      reverse: true,
-      enter(node2, item, list3) {
-        if (fn.call(this, node2, item, list3)) {
-          found = node2;
-          return breakWalk;
-        }
-      }
-    });
-    return found;
-  };
-  walk4.findAll = function(ast, fn) {
-    const found = [];
-    walk4(ast, function(node2, item, list3) {
-      if (fn.call(this, node2, item, list3)) {
-        found.push(node2);
-      }
-    });
-    return found;
-  };
-  return walk4;
-}
-var hasOwnProperty2, noop;
-var init_create4 = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/walker/create.js"() {
-    ({ hasOwnProperty: hasOwnProperty2 } = Object.prototype);
-    noop = function() {
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/config/generator.js
+var generator_default;
+var init_generator = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/config/generator.js"() {
+    init_index_generate();
+    generator_default = {
+      node: index_generate_exports
     };
   }
 });
 
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/definition-syntax/generate.js
-function noop2(value) {
-  return value;
-}
-function generateMultiplier(multiplier) {
-  const { min, max, comma } = multiplier;
-  if (min === 0 && max === 0) {
-    return comma ? "#?" : "*";
-  }
-  if (min === 0 && max === 1) {
-    return "?";
-  }
-  if (min === 1 && max === 0) {
-    return comma ? "#" : "+";
-  }
-  if (min === 1 && max === 1) {
-    return "";
-  }
-  return (comma ? "#" : "") + (min === max ? "{" + min + "}" : "{" + min + "," + (max !== 0 ? max : "") + "}");
-}
-function generateTypeOpts(node2) {
-  switch (node2.type) {
-    case "Range":
-      return " [" + (node2.min === null ? "-\u221E" : node2.min) + "," + (node2.max === null ? "\u221E" : node2.max) + "]";
-    default:
-      throw new Error("Unknown node type `" + node2.type + "`");
-  }
-}
-function generateSequence(node2, decorate, forceBraces, compact) {
-  const combinator = node2.combinator === " " || compact ? node2.combinator : " " + node2.combinator + " ";
-  const result = node2.terms.map((term) => internalGenerate(term, decorate, forceBraces, compact)).join(combinator);
-  if (node2.explicit || forceBraces) {
-    return (compact || result[0] === "," ? "[" : "[ ") + result + (compact ? "]" : " ]");
-  }
-  return result;
-}
-function internalGenerate(node2, decorate, forceBraces, compact) {
-  let result;
-  switch (node2.type) {
-    case "Group":
-      result = generateSequence(node2, decorate, forceBraces, compact) + (node2.disallowEmpty ? "!" : "");
-      break;
-    case "Multiplier":
-      return internalGenerate(node2.term, decorate, forceBraces, compact) + decorate(generateMultiplier(node2), node2);
-    case "Boolean":
-      result = "<boolean-expr[" + internalGenerate(node2.term, decorate, forceBraces, compact) + "]>";
-      break;
-    case "Type":
-      result = "<" + node2.name + (node2.opts ? decorate(generateTypeOpts(node2.opts), node2.opts) : "") + ">";
-      break;
-    case "Property":
-      result = "<'" + node2.name + "'>";
-      break;
-    case "Keyword":
-      result = node2.name;
-      break;
-    case "AtKeyword":
-      result = "@" + node2.name;
-      break;
-    case "Function":
-      result = node2.name + "(";
-      break;
-    case "String":
-    case "Token":
-      result = node2.value;
-      break;
-    case "Comma":
-      result = ",";
-      break;
-    default:
-      throw new Error("Unknown node type `" + node2.type + "`");
-  }
-  return decorate(result, node2);
-}
-function generate(node2, options) {
-  let decorate = noop2;
-  let forceBraces = false;
-  let compact = false;
-  if (typeof options === "function") {
-    decorate = options;
-  } else if (options) {
-    forceBraces = Boolean(options.forceBraces);
-    compact = Boolean(options.compact);
-    if (typeof options.decorate === "function") {
-      decorate = options.decorate;
-    }
-  }
-  return internalGenerate(node2, decorate, forceBraces, compact);
-}
-var init_generate = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/definition-syntax/generate.js"() {
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/error.js
-function locateMismatch(matchResult, node2) {
-  const tokens = matchResult.tokens;
-  const longestMatch = matchResult.longestMatch;
-  const mismatchNode = longestMatch < tokens.length ? tokens[longestMatch].node || null : null;
-  const badNode = mismatchNode !== node2 ? mismatchNode : null;
-  let mismatchOffset = 0;
-  let mismatchLength = 0;
-  let entries = 0;
-  let css = "";
-  let start;
-  let end;
-  for (let i = 0; i < tokens.length; i++) {
-    const token = tokens[i].value;
-    if (i === longestMatch) {
-      mismatchLength = token.length;
-      mismatchOffset = css.length;
-    }
-    if (badNode !== null && tokens[i].node === badNode) {
-      if (i <= longestMatch) {
-        entries++;
-      } else {
-        entries = 0;
-      }
-    }
-    css += token;
-  }
-  if (longestMatch === tokens.length || entries > 1) {
-    start = fromLoc(badNode || node2, "end") || buildLoc(defaultLoc, css);
-    end = buildLoc(start);
-  } else {
-    start = fromLoc(badNode, "start") || buildLoc(fromLoc(node2, "start") || defaultLoc, css.slice(0, mismatchOffset));
-    end = fromLoc(badNode, "end") || buildLoc(start, css.substr(mismatchOffset, mismatchLength));
-  }
-  return {
-    css,
-    mismatchOffset,
-    mismatchLength,
-    start,
-    end
-  };
-}
-function fromLoc(node2, point4) {
-  const value = node2 && node2.loc && node2.loc[point4];
-  if (value) {
-    return "line" in value ? buildLoc(value) : value;
-  }
-  return null;
-}
-function buildLoc({ offset, line, column }, extra) {
-  const loc = {
-    offset,
-    line,
-    column
-  };
-  if (extra) {
-    const lines = extra.split(/\n|\r\n?|\f/);
-    loc.offset += extra.length;
-    loc.line += lines.length - 1;
-    loc.column = lines.length === 1 ? loc.column + extra.length : lines.pop().length + 1;
-  }
-  return loc;
-}
-var defaultLoc, SyntaxReferenceError, SyntaxMatchError;
-var init_error = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/error.js"() {
-    init_create_custom_error();
-    init_generate();
-    defaultLoc = { offset: 0, line: 1, column: 1 };
-    SyntaxReferenceError = function(type, referenceName) {
-      const error = createCustomError(
-        "SyntaxReferenceError",
-        type + (referenceName ? " `" + referenceName + "`" : "")
-      );
-      error.reference = referenceName;
-      return error;
-    };
-    SyntaxMatchError = function(message, syntax, node2, matchResult) {
-      const error = createCustomError("SyntaxMatchError", message);
-      const {
-        css,
-        mismatchOffset,
-        mismatchLength,
-        start,
-        end
-      } = locateMismatch(matchResult, node2);
-      error.rawMessage = message;
-      error.syntax = syntax ? generate(syntax) : "<generic>";
-      error.css = css;
-      error.mismatchOffset = mismatchOffset;
-      error.mismatchLength = mismatchLength;
-      error.message = message + "\n  syntax: " + error.syntax + "\n   value: " + (css || "<empty string>") + "\n  --------" + new Array(error.mismatchOffset + 1).join("-") + "^";
-      Object.assign(error, start);
-      error.loc = {
-        source: node2 && node2.loc && node2.loc.source || "<unknown>",
-        start,
-        end
-      };
-      return error;
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/utils/names.js
-function isCustomProperty(str, offset) {
-  offset = offset || 0;
-  return str.length - offset >= 2 && str.charCodeAt(offset) === HYPHENMINUS2 && str.charCodeAt(offset + 1) === HYPHENMINUS2;
-}
-function getVendorPrefix(str, offset) {
-  offset = offset || 0;
-  if (str.length - offset >= 3) {
-    if (str.charCodeAt(offset) === HYPHENMINUS2 && str.charCodeAt(offset + 1) !== HYPHENMINUS2) {
-      const secondDashIndex = str.indexOf("-", offset + 2);
-      if (secondDashIndex !== -1) {
-        return str.substring(offset, secondDashIndex + 1);
-      }
-    }
-  }
-  return "";
-}
-function getKeywordDescriptor(keyword2) {
-  if (keywords.has(keyword2)) {
-    return keywords.get(keyword2);
-  }
-  const name50 = keyword2.toLowerCase();
-  let descriptor = keywords.get(name50);
-  if (descriptor === void 0) {
-    const custom = isCustomProperty(name50, 0);
-    const vendor = !custom ? getVendorPrefix(name50, 0) : "";
-    descriptor = Object.freeze({
-      basename: name50.substr(vendor.length),
-      name: name50,
-      prefix: vendor,
-      vendor,
-      custom
-    });
-  }
-  keywords.set(keyword2, descriptor);
-  return descriptor;
-}
-function getPropertyDescriptor(property2) {
-  if (properties.has(property2)) {
-    return properties.get(property2);
-  }
-  let name50 = property2;
-  let hack = property2[0];
-  if (hack === "/") {
-    hack = property2[1] === "/" ? "//" : "/";
-  } else if (hack !== "_" && hack !== "*" && hack !== "$" && hack !== "#" && hack !== "+" && hack !== "&") {
-    hack = "";
-  }
-  const custom = isCustomProperty(name50, hack.length);
-  if (!custom) {
-    name50 = name50.toLowerCase();
-    if (properties.has(name50)) {
-      const descriptor2 = properties.get(name50);
-      properties.set(property2, descriptor2);
-      return descriptor2;
-    }
-  }
-  const vendor = !custom ? getVendorPrefix(name50, hack.length) : "";
-  const prefix = name50.substr(0, hack.length + vendor.length);
-  const descriptor = Object.freeze({
-    basename: name50.substr(prefix.length),
-    name: name50.substr(hack.length),
-    hack,
-    vendor,
-    prefix,
-    custom
-  });
-  properties.set(property2, descriptor);
-  return descriptor;
-}
-var keywords, properties, HYPHENMINUS2, keyword, property;
-var init_names2 = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/utils/names.js"() {
-    keywords = /* @__PURE__ */ new Map();
-    properties = /* @__PURE__ */ new Map();
-    HYPHENMINUS2 = 45;
-    keyword = getKeywordDescriptor;
-    property = getPropertyDescriptor;
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/generic-const.js
-var cssWideKeywords;
-var init_generic_const = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/generic-const.js"() {
-    cssWideKeywords = [
-      "initial",
-      "inherit",
-      "unset",
-      "revert",
-      "revert-layer"
-    ];
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/generic-an-plus-b.js
-function isDelim(token, code4) {
-  return token !== null && token.type === Delim && token.value.charCodeAt(0) === code4;
-}
-function skipSC(token, offset, getNextToken) {
-  while (token !== null && (token.type === WhiteSpace || token.type === Comment)) {
-    token = getNextToken(++offset);
-  }
-  return offset;
-}
-function checkInteger(token, valueOffset, disallowSign, offset) {
-  if (!token) {
-    return 0;
-  }
-  const code4 = token.value.charCodeAt(valueOffset);
-  if (code4 === PLUSSIGN2 || code4 === HYPHENMINUS3) {
-    if (disallowSign) {
-      return 0;
-    }
-    valueOffset++;
-  }
-  for (; valueOffset < token.value.length; valueOffset++) {
-    if (!isDigit(token.value.charCodeAt(valueOffset))) {
-      return 0;
-    }
-  }
-  return offset + 1;
-}
-function consumeB(token, offset_, getNextToken) {
-  let sign = false;
-  let offset = skipSC(token, offset_, getNextToken);
-  token = getNextToken(offset);
-  if (token === null) {
-    return offset_;
-  }
-  if (token.type !== Number2) {
-    if (isDelim(token, PLUSSIGN2) || isDelim(token, HYPHENMINUS3)) {
-      sign = true;
-      offset = skipSC(getNextToken(++offset), offset, getNextToken);
-      token = getNextToken(offset);
-      if (token === null || token.type !== Number2) {
-        return 0;
-      }
-    } else {
-      return offset_;
-    }
-  }
-  if (!sign) {
-    const code4 = token.value.charCodeAt(0);
-    if (code4 !== PLUSSIGN2 && code4 !== HYPHENMINUS3) {
-      return 0;
-    }
-  }
-  return checkInteger(token, sign ? 0 : 1, sign, offset);
-}
-function anPlusB(token, getNextToken) {
-  let offset = 0;
-  if (!token) {
-    return 0;
-  }
-  if (token.type === Number2) {
-    return checkInteger(token, 0, ALLOW_SIGN, offset);
-  } else if (token.type === Ident && token.value.charCodeAt(0) === HYPHENMINUS3) {
-    if (!cmpChar(token.value, 1, N2)) {
-      return 0;
-    }
-    switch (token.value.length) {
-      // -n
-      // -n <signed-integer>
-      // -n ['+' | '-'] <signless-integer>
-      case 2:
-        return consumeB(getNextToken(++offset), offset, getNextToken);
-      // -n- <signless-integer>
-      case 3:
-        if (token.value.charCodeAt(2) !== HYPHENMINUS3) {
-          return 0;
-        }
-        offset = skipSC(getNextToken(++offset), offset, getNextToken);
-        token = getNextToken(offset);
-        return checkInteger(token, 0, DISALLOW_SIGN, offset);
-      // <dashndashdigit-ident>
-      default:
-        if (token.value.charCodeAt(2) !== HYPHENMINUS3) {
-          return 0;
-        }
-        return checkInteger(token, 3, DISALLOW_SIGN, offset);
-    }
-  } else if (token.type === Ident || isDelim(token, PLUSSIGN2) && getNextToken(offset + 1).type === Ident) {
-    if (token.type !== Ident) {
-      token = getNextToken(++offset);
-    }
-    if (token === null || !cmpChar(token.value, 0, N2)) {
-      return 0;
-    }
-    switch (token.value.length) {
-      // '+'? n
-      // '+'? n <signed-integer>
-      // '+'? n ['+' | '-'] <signless-integer>
-      case 1:
-        return consumeB(getNextToken(++offset), offset, getNextToken);
-      // '+'? n- <signless-integer>
-      case 2:
-        if (token.value.charCodeAt(1) !== HYPHENMINUS3) {
-          return 0;
-        }
-        offset = skipSC(getNextToken(++offset), offset, getNextToken);
-        token = getNextToken(offset);
-        return checkInteger(token, 0, DISALLOW_SIGN, offset);
-      // '+'? <ndashdigit-ident>
-      default:
-        if (token.value.charCodeAt(1) !== HYPHENMINUS3) {
-          return 0;
-        }
-        return checkInteger(token, 2, DISALLOW_SIGN, offset);
-    }
-  } else if (token.type === Dimension) {
-    let code4 = token.value.charCodeAt(0);
-    let sign = code4 === PLUSSIGN2 || code4 === HYPHENMINUS3 ? 1 : 0;
-    let i = sign;
-    for (; i < token.value.length; i++) {
-      if (!isDigit(token.value.charCodeAt(i))) {
-        break;
-      }
-    }
-    if (i === sign) {
-      return 0;
-    }
-    if (!cmpChar(token.value, i, N2)) {
-      return 0;
-    }
-    if (i + 1 === token.value.length) {
-      return consumeB(getNextToken(++offset), offset, getNextToken);
-    } else {
-      if (token.value.charCodeAt(i + 1) !== HYPHENMINUS3) {
-        return 0;
-      }
-      if (i + 2 === token.value.length) {
-        offset = skipSC(getNextToken(++offset), offset, getNextToken);
-        token = getNextToken(offset);
-        return checkInteger(token, 0, DISALLOW_SIGN, offset);
-      } else {
-        return checkInteger(token, i + 2, DISALLOW_SIGN, offset);
-      }
-    }
-  }
-  return 0;
-}
-var PLUSSIGN2, HYPHENMINUS3, N2, DISALLOW_SIGN, ALLOW_SIGN;
-var init_generic_an_plus_b = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/generic-an-plus-b.js"() {
-    init_tokenizer();
-    PLUSSIGN2 = 43;
-    HYPHENMINUS3 = 45;
-    N2 = 110;
-    DISALLOW_SIGN = true;
-    ALLOW_SIGN = false;
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/generic-urange.js
-function isDelim2(token, code4) {
-  return token !== null && token.type === Delim && token.value.charCodeAt(0) === code4;
-}
-function startsWith(token, code4) {
-  return token.value.charCodeAt(0) === code4;
-}
-function hexSequence(token, offset, allowDash) {
-  let hexlen = 0;
-  for (let pos = offset; pos < token.value.length; pos++) {
-    const code4 = token.value.charCodeAt(pos);
-    if (code4 === HYPHENMINUS4 && allowDash && hexlen !== 0) {
-      hexSequence(token, offset + hexlen + 1, false);
-      return 6;
-    }
-    if (!isHexDigit(code4)) {
-      return 0;
-    }
-    if (++hexlen > 6) {
-      return 0;
-    }
-    ;
-  }
-  return hexlen;
-}
-function withQuestionMarkSequence(consumed, length2, getNextToken) {
-  if (!consumed) {
-    return 0;
-  }
-  while (isDelim2(getNextToken(length2), QUESTIONMARK)) {
-    if (++consumed > 6) {
-      return 0;
-    }
-    length2++;
-  }
-  return length2;
-}
-function urange(token, getNextToken) {
-  let length2 = 0;
-  if (token === null || token.type !== Ident || !cmpChar(token.value, 0, U)) {
-    return 0;
-  }
-  token = getNextToken(++length2);
-  if (token === null) {
-    return 0;
-  }
-  if (isDelim2(token, PLUSSIGN3)) {
-    token = getNextToken(++length2);
-    if (token === null) {
-      return 0;
-    }
-    if (token.type === Ident) {
-      return withQuestionMarkSequence(hexSequence(token, 0, true), ++length2, getNextToken);
-    }
-    if (isDelim2(token, QUESTIONMARK)) {
-      return withQuestionMarkSequence(1, ++length2, getNextToken);
-    }
-    return 0;
-  }
-  if (token.type === Number2) {
-    const consumedHexLength = hexSequence(token, 1, true);
-    if (consumedHexLength === 0) {
-      return 0;
-    }
-    token = getNextToken(++length2);
-    if (token === null) {
-      return length2;
-    }
-    if (token.type === Dimension || token.type === Number2) {
-      if (!startsWith(token, HYPHENMINUS4) || !hexSequence(token, 1, false)) {
-        return 0;
-      }
-      return length2 + 1;
-    }
-    return withQuestionMarkSequence(consumedHexLength, length2, getNextToken);
-  }
-  if (token.type === Dimension) {
-    return withQuestionMarkSequence(hexSequence(token, 1, true), ++length2, getNextToken);
-  }
-  return 0;
-}
-var PLUSSIGN3, HYPHENMINUS4, QUESTIONMARK, U;
-var init_generic_urange = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/generic-urange.js"() {
-    init_tokenizer();
-    PLUSSIGN3 = 43;
-    HYPHENMINUS4 = 45;
-    QUESTIONMARK = 63;
-    U = 117;
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/generic.js
-function charCodeAt(str, index2) {
-  return index2 < str.length ? str.charCodeAt(index2) : 0;
-}
-function eqStr(actual, expected) {
-  return cmpStr(actual, 0, actual.length, expected);
-}
-function eqStrAny(actual, expected) {
-  for (let i = 0; i < expected.length; i++) {
-    if (eqStr(actual, expected[i])) {
-      return true;
-    }
-  }
-  return false;
-}
-function isPostfixIeHack(str, offset) {
-  if (offset !== str.length - 2) {
-    return false;
-  }
-  return charCodeAt(str, offset) === 92 && // U+005C REVERSE SOLIDUS (\)
-  isDigit(charCodeAt(str, offset + 1));
-}
-function outOfRange(opts, value, numEnd) {
-  if (opts && opts.type === "Range") {
-    const num = Number(
-      numEnd !== void 0 && numEnd !== value.length ? value.substr(0, numEnd) : value
-    );
-    if (isNaN(num)) {
-      return true;
-    }
-    if (opts.min !== null && num < opts.min && typeof opts.min !== "string") {
-      return true;
-    }
-    if (opts.max !== null && num > opts.max && typeof opts.max !== "string") {
-      return true;
-    }
-  }
-  return false;
-}
-function consumeFunction(token, getNextToken) {
-  let balanceCloseType = 0;
-  let balanceStash = [];
-  let length2 = 0;
-  scan:
-    do {
-      switch (token.type) {
-        case RightCurlyBracket:
-        case RightParenthesis:
-        case RightSquareBracket:
-          if (token.type !== balanceCloseType) {
-            break scan;
-          }
-          balanceCloseType = balanceStash.pop();
-          if (balanceStash.length === 0) {
-            length2++;
-            break scan;
-          }
-          break;
-        case Function:
-        case LeftParenthesis:
-        case LeftSquareBracket:
-        case LeftCurlyBracket:
-          balanceStash.push(balanceCloseType);
-          balanceCloseType = balancePair2.get(token.type);
-          break;
-      }
-      length2++;
-    } while (token = getNextToken(length2));
-  return length2;
-}
-function math(next2, functionNames) {
-  return function(token, getNextToken, opts) {
-    if (token === null) {
-      return 0;
-    }
-    if (token.type === Function && eqStrAny(token.value, functionNames)) {
-      return consumeFunction(token, getNextToken);
-    }
-    return next2(token, getNextToken, opts);
-  };
-}
-function tokenType(expectedTokenType) {
-  return function(token) {
-    if (token === null || token.type !== expectedTokenType) {
-      return 0;
-    }
-    return 1;
-  };
-}
-function customIdent(token) {
-  if (token === null || token.type !== Ident) {
-    return 0;
-  }
-  const name50 = token.value.toLowerCase();
-  if (eqStrAny(name50, cssWideKeywords)) {
-    return 0;
-  }
-  if (eqStr(name50, "default")) {
-    return 0;
-  }
-  return 1;
-}
-function dashedIdent(token) {
-  if (token === null || token.type !== Ident) {
-    return 0;
-  }
-  if (charCodeAt(token.value, 0) !== 45 || charCodeAt(token.value, 1) !== 45) {
-    return 0;
-  }
-  return 1;
-}
-function customPropertyName(token) {
-  if (!dashedIdent(token)) {
-    return 0;
-  }
-  if (token.value === "--") {
-    return 0;
-  }
-  return 1;
-}
-function hexColor(token) {
-  if (token === null || token.type !== Hash) {
-    return 0;
-  }
-  const length2 = token.value.length;
-  if (length2 !== 4 && length2 !== 5 && length2 !== 7 && length2 !== 9) {
-    return 0;
-  }
-  for (let i = 1; i < length2; i++) {
-    if (!isHexDigit(charCodeAt(token.value, i))) {
-      return 0;
-    }
-  }
-  return 1;
-}
-function idSelector(token) {
-  if (token === null || token.type !== Hash) {
-    return 0;
-  }
-  if (!isIdentifierStart(charCodeAt(token.value, 1), charCodeAt(token.value, 2), charCodeAt(token.value, 3))) {
-    return 0;
-  }
-  return 1;
-}
-function declarationValue(token, getNextToken) {
-  if (!token) {
-    return 0;
-  }
-  let balanceCloseType = 0;
-  let balanceStash = [];
-  let length2 = 0;
-  scan:
-    do {
-      switch (token.type) {
-        // ... <bad-string-token>, <bad-url-token>,
-        case BadString:
-        case BadUrl:
-          break scan;
-        // ... unmatched <)-token>, <]-token>, or <}-token>,
-        case RightCurlyBracket:
-        case RightParenthesis:
-        case RightSquareBracket:
-          if (token.type !== balanceCloseType) {
-            break scan;
-          }
-          balanceCloseType = balanceStash.pop();
-          break;
-        // ... or top-level <semicolon-token> tokens
-        case Semicolon:
-          if (balanceCloseType === 0) {
-            break scan;
-          }
-          break;
-        // ... or <delim-token> tokens with a value of "!"
-        case Delim:
-          if (balanceCloseType === 0 && token.value === "!") {
-            break scan;
-          }
-          break;
-        case Function:
-        case LeftParenthesis:
-        case LeftSquareBracket:
-        case LeftCurlyBracket:
-          balanceStash.push(balanceCloseType);
-          balanceCloseType = balancePair2.get(token.type);
-          break;
-      }
-      length2++;
-    } while (token = getNextToken(length2));
-  return length2;
-}
-function anyValue(token, getNextToken) {
-  if (!token) {
-    return 0;
-  }
-  let balanceCloseType = 0;
-  let balanceStash = [];
-  let length2 = 0;
-  scan:
-    do {
-      switch (token.type) {
-        // ... does not contain <bad-string-token>, <bad-url-token>,
-        case BadString:
-        case BadUrl:
-          break scan;
-        // ... unmatched <)-token>, <]-token>, or <}-token>,
-        case RightCurlyBracket:
-        case RightParenthesis:
-        case RightSquareBracket:
-          if (token.type !== balanceCloseType) {
-            break scan;
-          }
-          balanceCloseType = balanceStash.pop();
-          break;
-        case Function:
-        case LeftParenthesis:
-        case LeftSquareBracket:
-        case LeftCurlyBracket:
-          balanceStash.push(balanceCloseType);
-          balanceCloseType = balancePair2.get(token.type);
-          break;
-      }
-      length2++;
-    } while (token = getNextToken(length2));
-  return length2;
-}
-function dimension(type) {
-  if (type) {
-    type = new Set(type);
-  }
-  return function(token, getNextToken, opts) {
-    if (token === null || token.type !== Dimension) {
-      return 0;
-    }
-    const numberEnd = consumeNumber(token.value, 0);
-    if (type !== null) {
-      const reverseSolidusOffset = token.value.indexOf("\\", numberEnd);
-      const unit = reverseSolidusOffset === -1 || !isPostfixIeHack(token.value, reverseSolidusOffset) ? token.value.substr(numberEnd) : token.value.substring(numberEnd, reverseSolidusOffset);
-      if (type.has(unit.toLowerCase()) === false) {
-        return 0;
-      }
-    }
-    if (outOfRange(opts, token.value, numberEnd)) {
-      return 0;
-    }
-    return 1;
-  };
-}
-function percentage(token, getNextToken, opts) {
-  if (token === null || token.type !== Percentage) {
-    return 0;
-  }
-  if (outOfRange(opts, token.value, token.value.length - 1)) {
-    return 0;
-  }
-  return 1;
-}
-function zero(next2) {
-  if (typeof next2 !== "function") {
-    next2 = function() {
-      return 0;
-    };
-  }
-  return function(token, getNextToken, opts) {
-    if (token !== null && token.type === Number2) {
-      if (Number(token.value) === 0) {
-        return 1;
-      }
-    }
-    return next2(token, getNextToken, opts);
-  };
-}
-function number(token, getNextToken, opts) {
-  if (token === null) {
-    return 0;
-  }
-  const numberEnd = consumeNumber(token.value, 0);
-  const isNumber2 = numberEnd === token.value.length;
-  if (!isNumber2 && !isPostfixIeHack(token.value, numberEnd)) {
-    return 0;
-  }
-  if (outOfRange(opts, token.value, numberEnd)) {
-    return 0;
-  }
-  return 1;
-}
-function integer(token, getNextToken, opts) {
-  if (token === null || token.type !== Number2) {
-    return 0;
-  }
-  let i = charCodeAt(token.value, 0) === 43 || // U+002B PLUS SIGN (+)
-  charCodeAt(token.value, 0) === 45 ? 1 : 0;
-  for (; i < token.value.length; i++) {
-    if (!isDigit(charCodeAt(token.value, i))) {
-      return 0;
-    }
-  }
-  if (outOfRange(opts, token.value, i)) {
-    return 0;
-  }
-  return 1;
-}
-function createDemensionTypes(units) {
-  const {
-    angle: angle2,
-    decibel: decibel2,
-    frequency: frequency2,
-    flex: flex2,
-    length: length2,
-    resolution: resolution2,
-    semitones: semitones2,
-    time: time2
-  } = units || {};
-  return {
-    "dimension": math(dimension(null), dimensionFunctionNames),
-    "angle": math(dimension(angle2), dimensionFunctionNames),
-    "decibel": math(dimension(decibel2), dimensionFunctionNames),
-    "frequency": math(dimension(frequency2), dimensionFunctionNames),
-    "flex": math(dimension(flex2), dimensionFunctionNames),
-    "length": math(zero(dimension(length2)), dimensionFunctionNames),
-    "resolution": math(dimension(resolution2), dimensionFunctionNames),
-    "semitones": math(dimension(semitones2), dimensionFunctionNames),
-    "time": math(dimension(time2), dimensionFunctionNames)
-  };
-}
-function createAttrUnit(units) {
-  const unitSet = /* @__PURE__ */ new Set();
-  for (const group of unitGroups) {
-    if (Array.isArray(units[group])) {
-      for (const unit of units[group]) {
-        unitSet.add(unit.toLowerCase());
-      }
-    }
-  }
-  return function attrUnit(token) {
-    if (token === null) {
-      return 0;
-    }
-    if (token.type === Delim && token.value === "%") {
-      return 1;
-    }
-    if (token.type === Ident && unitSet.has(token.value.toLowerCase())) {
-      return 1;
-    }
-    return 0;
-  };
-}
-function createGenericTypes(units) {
-  return {
-    ...tokenTypes,
-    ...productionTypes,
-    ...createDemensionTypes(units),
-    "attr-unit": createAttrUnit(units)
-  };
-}
-var calcFunctionNames, comparisonFunctionNames, steppedValueFunctionNames, trigNumberFunctionNames, trigAngleFunctionNames, otherNumberFunctionNames, expNumberDimensionPercentageFunctionNames, signFunctionNames, numberFunctionNames, percentageFunctionNames, dimensionFunctionNames, balancePair2, tokenTypes, productionTypes, unitGroups;
-var init_generic = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/generic.js"() {
-    init_generic_const();
-    init_generic_an_plus_b();
-    init_generic_urange();
-    init_tokenizer();
-    calcFunctionNames = [
-      "calc(",
-      "-moz-calc(",
-      "-webkit-calc("
-    ];
-    comparisonFunctionNames = [
-      "min(",
-      "max(",
-      "clamp("
-    ];
-    steppedValueFunctionNames = [
-      "round(",
-      "mod(",
-      "rem("
-    ];
-    trigNumberFunctionNames = [
-      "sin(",
-      "cos(",
-      "tan("
-    ];
-    trigAngleFunctionNames = [
-      "asin(",
-      "acos(",
-      "atan(",
-      "atan2("
-    ];
-    otherNumberFunctionNames = [
-      "pow(",
-      "sqrt(",
-      "log(",
-      "exp(",
-      "sign("
-    ];
-    expNumberDimensionPercentageFunctionNames = [
-      "hypot("
-    ];
-    signFunctionNames = [
-      "abs("
-    ];
-    numberFunctionNames = [
-      ...calcFunctionNames,
-      ...comparisonFunctionNames,
-      ...steppedValueFunctionNames,
-      ...trigNumberFunctionNames,
-      ...otherNumberFunctionNames,
-      ...expNumberDimensionPercentageFunctionNames,
-      ...signFunctionNames
-    ];
-    percentageFunctionNames = [
-      ...calcFunctionNames,
-      ...comparisonFunctionNames,
-      ...steppedValueFunctionNames,
-      ...expNumberDimensionPercentageFunctionNames,
-      ...signFunctionNames
-    ];
-    dimensionFunctionNames = [
-      ...calcFunctionNames,
-      ...comparisonFunctionNames,
-      ...steppedValueFunctionNames,
-      ...trigAngleFunctionNames,
-      ...expNumberDimensionPercentageFunctionNames,
-      ...signFunctionNames
-    ];
-    balancePair2 = /* @__PURE__ */ new Map([
-      [Function, RightParenthesis],
-      [LeftParenthesis, RightParenthesis],
-      [LeftSquareBracket, RightSquareBracket],
-      [LeftCurlyBracket, RightCurlyBracket]
-    ]);
-    tokenTypes = {
-      "ident-token": tokenType(Ident),
-      "function-token": tokenType(Function),
-      "at-keyword-token": tokenType(AtKeyword),
-      "hash-token": tokenType(Hash),
-      "string-token": tokenType(String2),
-      "bad-string-token": tokenType(BadString),
-      "url-token": tokenType(Url),
-      "bad-url-token": tokenType(BadUrl),
-      "delim-token": tokenType(Delim),
-      "number-token": tokenType(Number2),
-      "percentage-token": tokenType(Percentage),
-      "dimension-token": tokenType(Dimension),
-      "whitespace-token": tokenType(WhiteSpace),
-      "CDO-token": tokenType(CDO),
-      "CDC-token": tokenType(CDC),
-      "colon-token": tokenType(Colon),
-      "semicolon-token": tokenType(Semicolon),
-      "comma-token": tokenType(Comma),
-      "[-token": tokenType(LeftSquareBracket),
-      "]-token": tokenType(RightSquareBracket),
-      "(-token": tokenType(LeftParenthesis),
-      ")-token": tokenType(RightParenthesis),
-      "{-token": tokenType(LeftCurlyBracket),
-      "}-token": tokenType(RightCurlyBracket)
-    };
-    productionTypes = {
-      // token type aliases
-      "string": tokenType(String2),
-      "ident": tokenType(Ident),
-      // percentage
-      "percentage": math(percentage, percentageFunctionNames),
-      // numeric
-      "zero": zero(),
-      "number": math(number, numberFunctionNames),
-      "integer": math(integer, numberFunctionNames),
-      // complex types
-      "custom-ident": customIdent,
-      "dashed-ident": dashedIdent,
-      "custom-property-name": customPropertyName,
-      "hex-color": hexColor,
-      "id-selector": idSelector,
-      // element( <id-selector> )
-      "an-plus-b": anPlusB,
-      "urange": urange,
-      "declaration-value": declarationValue,
-      "any-value": anyValue
-    };
-    unitGroups = [
-      "length",
-      "angle",
-      "time",
-      "frequency",
-      "resolution",
-      "flex",
-      "decibel",
-      "semitones"
-    ];
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/units.js
-var units_exports = {};
-__export(units_exports, {
-  angle: () => angle,
-  decibel: () => decibel,
-  flex: () => flex,
-  frequency: () => frequency,
-  length: () => length,
-  resolution: () => resolution,
-  semitones: () => semitones,
-  time: () => time
-});
-var length, angle, time, frequency, resolution, flex, decibel, semitones;
-var init_units = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/units.js"() {
-    length = [
-      // absolute length units https://www.w3.org/TR/css-values-3/#lengths
-      "cm",
-      "mm",
-      "q",
-      "in",
-      "pt",
-      "pc",
-      "px",
-      // font-relative length units https://drafts.csswg.org/css-values-4/#font-relative-lengths
-      "em",
-      "rem",
-      "ex",
-      "rex",
-      "cap",
-      "rcap",
-      "ch",
-      "rch",
-      "ic",
-      "ric",
-      "lh",
-      "rlh",
-      // viewport-percentage lengths https://drafts.csswg.org/css-values-4/#viewport-relative-lengths
-      "vw",
-      "svw",
-      "lvw",
-      "dvw",
-      "vh",
-      "svh",
-      "lvh",
-      "dvh",
-      "vi",
-      "svi",
-      "lvi",
-      "dvi",
-      "vb",
-      "svb",
-      "lvb",
-      "dvb",
-      "vmin",
-      "svmin",
-      "lvmin",
-      "dvmin",
-      "vmax",
-      "svmax",
-      "lvmax",
-      "dvmax",
-      // container relative lengths https://drafts.csswg.org/css-contain-3/#container-lengths
-      "cqw",
-      "cqh",
-      "cqi",
-      "cqb",
-      "cqmin",
-      "cqmax"
-    ];
-    angle = ["deg", "grad", "rad", "turn"];
-    time = ["s", "ms"];
-    frequency = ["hz", "khz"];
-    resolution = ["dpi", "dpcm", "dppx", "x"];
-    flex = ["fr"];
-    decibel = ["db"];
-    semitones = ["st"];
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/definition-syntax/SyntaxError.js
-function SyntaxError3(message, input, offset) {
-  return Object.assign(createCustomError("SyntaxError", message), {
-    input,
-    offset,
-    rawMessage: message,
-    message: message + "\n  " + input + "\n--" + new Array((offset || input.length) + 1).join("-") + "^"
-  });
-}
-var init_SyntaxError2 = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/definition-syntax/SyntaxError.js"() {
-    init_create_custom_error();
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/definition-syntax/scanner.js
-var TAB, N3, F2, R2, SPACE, NAME_CHAR, Scanner;
-var init_scanner = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/definition-syntax/scanner.js"() {
-    init_SyntaxError2();
-    TAB = 9;
-    N3 = 10;
-    F2 = 12;
-    R2 = 13;
-    SPACE = 32;
-    NAME_CHAR = new Uint8Array(128).map(
-      (_, idx) => /[a-zA-Z0-9\-]/.test(String.fromCharCode(idx)) ? 1 : 0
-    );
-    Scanner = class {
-      constructor(str) {
-        this.str = str;
-        this.pos = 0;
-      }
-      charCodeAt(pos) {
-        return pos < this.str.length ? this.str.charCodeAt(pos) : 0;
-      }
-      charCode() {
-        return this.charCodeAt(this.pos);
-      }
-      isNameCharCode(code4 = this.charCode()) {
-        return code4 < 128 && NAME_CHAR[code4] === 1;
-      }
-      nextCharCode() {
-        return this.charCodeAt(this.pos + 1);
-      }
-      nextNonWsCode(pos) {
-        return this.charCodeAt(this.findWsEnd(pos));
-      }
-      skipWs() {
-        this.pos = this.findWsEnd(this.pos);
-      }
-      findWsEnd(pos) {
-        for (; pos < this.str.length; pos++) {
-          const code4 = this.str.charCodeAt(pos);
-          if (code4 !== R2 && code4 !== N3 && code4 !== F2 && code4 !== SPACE && code4 !== TAB) {
-            break;
-          }
-        }
-        return pos;
-      }
-      substringToPos(end) {
-        return this.str.substring(this.pos, this.pos = end);
-      }
-      eat(code4) {
-        if (this.charCode() !== code4) {
-          this.error("Expect `" + String.fromCharCode(code4) + "`");
-        }
-        this.pos++;
-      }
-      peek() {
-        return this.pos < this.str.length ? this.str.charAt(this.pos++) : "";
-      }
-      error(message) {
-        throw new SyntaxError3(message, this.str, this.pos);
-      }
-      scanSpaces() {
-        return this.substringToPos(this.findWsEnd(this.pos));
-      }
-      scanWord() {
-        let end = this.pos;
-        for (; end < this.str.length; end++) {
-          const code4 = this.str.charCodeAt(end);
-          if (code4 >= 128 || NAME_CHAR[code4] === 0) {
-            break;
-          }
-        }
-        if (this.pos === end) {
-          this.error("Expect a keyword");
-        }
-        return this.substringToPos(end);
-      }
-      scanNumber() {
-        let end = this.pos;
-        for (; end < this.str.length; end++) {
-          const code4 = this.str.charCodeAt(end);
-          if (code4 < 48 || code4 > 57) {
-            break;
-          }
-        }
-        if (this.pos === end) {
-          this.error("Expect a number");
-        }
-        return this.substringToPos(end);
-      }
-      scanString() {
-        const end = this.str.indexOf("'", this.pos + 1);
-        if (end === -1) {
-          this.pos = this.str.length;
-          this.error("Expect an apostrophe");
-        }
-        return this.substringToPos(end + 1);
-      }
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/definition-syntax/parse.js
-function readMultiplierRange(scanner) {
-  let min = null;
-  let max = null;
-  scanner.eat(LEFTCURLYBRACKET2);
-  scanner.skipWs();
-  min = scanner.scanNumber(scanner);
-  scanner.skipWs();
-  if (scanner.charCode() === COMMA) {
-    scanner.pos++;
-    scanner.skipWs();
-    if (scanner.charCode() !== RIGHTCURLYBRACKET) {
-      max = scanner.scanNumber(scanner);
-      scanner.skipWs();
-    }
-  } else {
-    max = min;
-  }
-  scanner.eat(RIGHTCURLYBRACKET);
-  return {
-    min: Number(min),
-    max: max ? Number(max) : 0
-  };
-}
-function readMultiplier(scanner) {
-  let range = null;
-  let comma = false;
-  switch (scanner.charCode()) {
-    case ASTERISK:
-      scanner.pos++;
-      range = {
-        min: 0,
-        max: 0
-      };
-      break;
-    case PLUSSIGN4:
-      scanner.pos++;
-      range = {
-        min: 1,
-        max: 0
-      };
-      break;
-    case QUESTIONMARK2:
-      scanner.pos++;
-      range = {
-        min: 0,
-        max: 1
-      };
-      break;
-    case NUMBERSIGN2:
-      scanner.pos++;
-      comma = true;
-      if (scanner.charCode() === LEFTCURLYBRACKET2) {
-        range = readMultiplierRange(scanner);
-      } else if (scanner.charCode() === QUESTIONMARK2) {
-        scanner.pos++;
-        range = {
-          min: 0,
-          max: 0
-        };
-      } else {
-        range = {
-          min: 1,
-          max: 0
-        };
-      }
-      break;
-    case LEFTCURLYBRACKET2:
-      range = readMultiplierRange(scanner);
-      break;
-    default:
-      return null;
-  }
-  return {
-    type: "Multiplier",
-    comma,
-    min: range.min,
-    max: range.max,
-    term: null
-  };
-}
-function maybeMultiplied(scanner, node2) {
-  const multiplier = readMultiplier(scanner);
-  if (multiplier !== null) {
-    multiplier.term = node2;
-    if (scanner.charCode() === NUMBERSIGN2 && scanner.charCodeAt(scanner.pos - 1) === PLUSSIGN4) {
-      return maybeMultiplied(scanner, multiplier);
-    }
-    if (scanner.charCode() === QUESTIONMARK2 && scanner.charCodeAt(scanner.pos - 1) === RIGHTCURLYBRACKET) {
-      return maybeMultiplied(scanner, multiplier);
-    }
-    return multiplier;
-  }
-  return node2;
-}
-function maybeToken(scanner) {
-  const ch = scanner.peek();
-  if (ch === "") {
-    return null;
-  }
-  return maybeMultiplied(scanner, {
-    type: "Token",
-    value: ch
-  });
-}
-function readProperty(scanner) {
-  let name50;
-  scanner.eat(LESSTHANSIGN);
-  scanner.eat(APOSTROPHE);
-  name50 = scanner.scanWord();
-  scanner.eat(APOSTROPHE);
-  scanner.eat(GREATERTHANSIGN);
-  return maybeMultiplied(scanner, {
-    type: "Property",
-    name: name50
-  });
-}
-function readTypeRange(scanner) {
-  let min = null;
-  let max = null;
-  let sign = 1;
-  scanner.eat(LEFTSQUAREBRACKET);
-  if (scanner.charCode() === HYPERMINUS) {
-    scanner.peek();
-    sign = -1;
-  }
-  if (sign == -1 && scanner.charCode() === INFINITY) {
-    scanner.peek();
-  } else {
-    min = sign * Number(scanner.scanNumber(scanner));
-    if (scanner.isNameCharCode()) {
-      min += scanner.scanWord();
-    }
-  }
-  scanner.skipWs();
-  scanner.eat(COMMA);
-  scanner.skipWs();
-  if (scanner.charCode() === INFINITY) {
-    scanner.peek();
-  } else {
-    sign = 1;
-    if (scanner.charCode() === HYPERMINUS) {
-      scanner.peek();
-      sign = -1;
-    }
-    max = sign * Number(scanner.scanNumber(scanner));
-    if (scanner.isNameCharCode()) {
-      max += scanner.scanWord();
-    }
-  }
-  scanner.eat(RIGHTSQUAREBRACKET);
-  return {
-    type: "Range",
-    min,
-    max
-  };
-}
-function readType(scanner) {
-  let name50;
-  let opts = null;
-  scanner.eat(LESSTHANSIGN);
-  name50 = scanner.scanWord();
-  if (name50 === "boolean-expr") {
-    scanner.eat(LEFTSQUAREBRACKET);
-    const implicitGroup = readImplicitGroup(scanner, RIGHTSQUAREBRACKET);
-    scanner.eat(RIGHTSQUAREBRACKET);
-    scanner.eat(GREATERTHANSIGN);
-    return maybeMultiplied(scanner, {
-      type: "Boolean",
-      term: implicitGroup.terms.length === 1 ? implicitGroup.terms[0] : implicitGroup
-    });
-  }
-  if (scanner.charCode() === LEFTPARENTHESIS && scanner.nextCharCode() === RIGHTPARENTHESIS) {
-    scanner.pos += 2;
-    name50 += "()";
-  }
-  if (scanner.charCodeAt(scanner.findWsEnd(scanner.pos)) === LEFTSQUAREBRACKET) {
-    scanner.skipWs();
-    opts = readTypeRange(scanner);
-  }
-  scanner.eat(GREATERTHANSIGN);
-  return maybeMultiplied(scanner, {
-    type: "Type",
-    name: name50,
-    opts
-  });
-}
-function readKeywordOrFunction(scanner) {
-  const name50 = scanner.scanWord();
-  if (scanner.charCode() === LEFTPARENTHESIS) {
-    scanner.pos++;
-    return {
-      type: "Function",
-      name: name50
-    };
-  }
-  return maybeMultiplied(scanner, {
-    type: "Keyword",
-    name: name50
-  });
-}
-function regroupTerms(terms, combinators) {
-  function createGroup(terms2, combinator2) {
-    return {
-      type: "Group",
-      terms: terms2,
-      combinator: combinator2,
-      disallowEmpty: false,
-      explicit: false
-    };
-  }
-  let combinator;
-  combinators = Object.keys(combinators).sort((a, b) => COMBINATOR_PRECEDENCE[a] - COMBINATOR_PRECEDENCE[b]);
-  while (combinators.length > 0) {
-    combinator = combinators.shift();
-    let i = 0;
-    let subgroupStart = 0;
-    for (; i < terms.length; i++) {
-      const term = terms[i];
-      if (term.type === "Combinator") {
-        if (term.value === combinator) {
-          if (subgroupStart === -1) {
-            subgroupStart = i - 1;
-          }
-          terms.splice(i, 1);
-          i--;
-        } else {
-          if (subgroupStart !== -1 && i - subgroupStart > 1) {
-            terms.splice(
-              subgroupStart,
-              i - subgroupStart,
-              createGroup(terms.slice(subgroupStart, i), combinator)
-            );
-            i = subgroupStart + 1;
-          }
-          subgroupStart = -1;
-        }
-      }
-    }
-    if (subgroupStart !== -1 && combinators.length) {
-      terms.splice(
-        subgroupStart,
-        i - subgroupStart,
-        createGroup(terms.slice(subgroupStart, i), combinator)
-      );
-    }
-  }
-  return combinator;
-}
-function readImplicitGroup(scanner, stopCharCode = -1) {
-  const combinators = /* @__PURE__ */ Object.create(null);
-  const terms = [];
-  let prevToken = null;
-  let prevTokenPos = scanner.pos;
-  let prevTokenIsFunction = false;
-  while (scanner.charCode() !== stopCharCode) {
-    let token = prevTokenIsFunction ? readImplicitGroup(scanner, RIGHTPARENTHESIS) : peek(scanner);
-    if (!token) {
-      break;
-    }
-    if (token.type === "Spaces") {
-      continue;
-    }
-    if (prevTokenIsFunction) {
-      if (token.terms.length === 0) {
-        prevTokenIsFunction = false;
-        continue;
-      }
-      if (token.combinator === " ") {
-        while (token.terms.length > 1) {
-          combinators[" "] = true;
-          terms.push({
-            type: "Combinator",
-            value: " "
-          }, token.terms.shift());
-        }
-        token = token.terms[0];
-      }
-    }
-    if (token.type === "Combinator") {
-      if (prevToken === null || prevToken.type === "Combinator") {
-        scanner.pos = prevTokenPos;
-        scanner.error("Unexpected combinator");
-      }
-      combinators[token.value] = true;
-    } else if (prevToken !== null && prevToken.type !== "Combinator") {
-      combinators[" "] = true;
-      terms.push({
-        type: "Combinator",
-        value: " "
-      });
-    }
-    terms.push(token);
-    prevToken = token;
-    prevTokenPos = scanner.pos;
-    prevTokenIsFunction = token.type === "Function";
-  }
-  if (prevToken !== null && prevToken.type === "Combinator") {
-    scanner.pos -= prevTokenPos;
-    scanner.error("Unexpected combinator");
-  }
-  return {
-    type: "Group",
-    terms,
-    combinator: regroupTerms(terms, combinators) || " ",
-    disallowEmpty: false,
-    explicit: false
-  };
-}
-function readGroup(scanner) {
-  let result;
-  scanner.eat(LEFTSQUAREBRACKET);
-  result = readImplicitGroup(scanner, RIGHTSQUAREBRACKET);
-  scanner.eat(RIGHTSQUAREBRACKET);
-  result.explicit = true;
-  if (scanner.charCode() === EXCLAMATIONMARK2) {
-    scanner.pos++;
-    result.disallowEmpty = true;
-  }
-  return result;
-}
-function peek(scanner) {
-  let code4 = scanner.charCode();
-  switch (code4) {
-    case RIGHTSQUAREBRACKET:
-      break;
-    case LEFTSQUAREBRACKET:
-      return maybeMultiplied(scanner, readGroup(scanner));
-    case LESSTHANSIGN:
-      return scanner.nextCharCode() === APOSTROPHE ? readProperty(scanner) : readType(scanner);
-    case VERTICALLINE:
-      return {
-        type: "Combinator",
-        value: scanner.substringToPos(
-          scanner.pos + (scanner.nextCharCode() === VERTICALLINE ? 2 : 1)
-        )
-      };
-    case AMPERSAND:
-      scanner.pos++;
-      scanner.eat(AMPERSAND);
-      return {
-        type: "Combinator",
-        value: "&&"
-      };
-    case COMMA:
-      scanner.pos++;
-      return {
-        type: "Comma"
-      };
-    case APOSTROPHE:
-      return maybeMultiplied(scanner, {
-        type: "String",
-        value: scanner.scanString()
-      });
-    case SPACE2:
-    case TAB2:
-    case N4:
-    case R3:
-    case F3:
-      return {
-        type: "Spaces",
-        value: scanner.scanSpaces()
-      };
-    case COMMERCIALAT:
-      code4 = scanner.nextCharCode();
-      if (scanner.isNameCharCode(code4)) {
-        scanner.pos++;
-        return {
-          type: "AtKeyword",
-          name: scanner.scanWord()
-        };
-      }
-      return maybeToken(scanner);
-    case ASTERISK:
-    case PLUSSIGN4:
-    case QUESTIONMARK2:
-    case NUMBERSIGN2:
-    case EXCLAMATIONMARK2:
-      break;
-    case LEFTCURLYBRACKET2:
-      code4 = scanner.nextCharCode();
-      if (code4 < 48 || code4 > 57) {
-        return maybeToken(scanner);
-      }
-      break;
-    default:
-      if (scanner.isNameCharCode(code4)) {
-        return readKeywordOrFunction(scanner);
-      }
-      return maybeToken(scanner);
-  }
-}
-function parse2(source) {
-  const scanner = new Scanner(source);
-  const result = readImplicitGroup(scanner);
-  if (scanner.pos !== source.length) {
-    scanner.error("Unexpected input");
-  }
-  if (result.terms.length === 1 && result.terms[0].type === "Group") {
-    return result.terms[0];
-  }
-  return result;
-}
-var TAB2, N4, F3, R3, SPACE2, EXCLAMATIONMARK2, NUMBERSIGN2, AMPERSAND, APOSTROPHE, LEFTPARENTHESIS, RIGHTPARENTHESIS, ASTERISK, PLUSSIGN4, COMMA, HYPERMINUS, LESSTHANSIGN, GREATERTHANSIGN, QUESTIONMARK2, COMMERCIALAT, LEFTSQUAREBRACKET, RIGHTSQUAREBRACKET, LEFTCURLYBRACKET2, VERTICALLINE, RIGHTCURLYBRACKET, INFINITY, COMBINATOR_PRECEDENCE;
-var init_parse = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/definition-syntax/parse.js"() {
-    init_scanner();
-    TAB2 = 9;
-    N4 = 10;
-    F3 = 12;
-    R3 = 13;
-    SPACE2 = 32;
-    EXCLAMATIONMARK2 = 33;
-    NUMBERSIGN2 = 35;
-    AMPERSAND = 38;
-    APOSTROPHE = 39;
-    LEFTPARENTHESIS = 40;
-    RIGHTPARENTHESIS = 41;
-    ASTERISK = 42;
-    PLUSSIGN4 = 43;
-    COMMA = 44;
-    HYPERMINUS = 45;
-    LESSTHANSIGN = 60;
-    GREATERTHANSIGN = 62;
-    QUESTIONMARK2 = 63;
-    COMMERCIALAT = 64;
-    LEFTSQUAREBRACKET = 91;
-    RIGHTSQUAREBRACKET = 93;
-    LEFTCURLYBRACKET2 = 123;
-    VERTICALLINE = 124;
-    RIGHTCURLYBRACKET = 125;
-    INFINITY = 8734;
-    COMBINATOR_PRECEDENCE = {
-      " ": 1,
-      "&&": 2,
-      "||": 3,
-      "|": 4
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/definition-syntax/walk.js
-function ensureFunction2(value) {
-  return typeof value === "function" ? value : noop3;
-}
-function walk(node2, options, context) {
-  function walk4(node3) {
-    enter.call(context, node3);
-    switch (node3.type) {
-      case "Group":
-        node3.terms.forEach(walk4);
-        break;
-      case "Multiplier":
-      case "Boolean":
-        walk4(node3.term);
-        break;
-      case "Type":
-      case "Property":
-      case "Keyword":
-      case "AtKeyword":
-      case "Function":
-      case "String":
-      case "Token":
-      case "Comma":
-        break;
-      default:
-        throw new Error("Unknown type: " + node3.type);
-    }
-    leave.call(context, node3);
-  }
-  let enter = noop3;
-  let leave = noop3;
-  if (typeof options === "function") {
-    enter = options;
-  } else if (options) {
-    enter = ensureFunction2(options.enter);
-    leave = ensureFunction2(options.leave);
-  }
-  if (enter === noop3 && leave === noop3) {
-    throw new Error("Neither `enter` nor `leave` walker handler is set or both aren't a function");
-  }
-  walk4(node2, context);
-}
-var noop3;
-var init_walk = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/definition-syntax/walk.js"() {
-    noop3 = function() {
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/definition-syntax/index.js
-var init_definition_syntax = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/definition-syntax/index.js"() {
-    init_generate();
-    init_parse();
-    init_walk();
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/prepare-tokens.js
-function stringToTokens(str) {
-  const tokens = [];
-  tokenize(
-    str,
-    (type, start, end) => tokens.push({
-      type,
-      value: str.slice(start, end),
-      node: null
-    })
-  );
-  return tokens;
-}
-function prepare_tokens_default(value, syntax) {
-  if (typeof value === "string") {
-    return stringToTokens(value);
-  }
-  return syntax.generate(value, astToTokens);
-}
-var astToTokens;
-var init_prepare_tokens = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/prepare-tokens.js"() {
-    init_tokenizer();
-    astToTokens = {
-      decorator(handlers) {
-        const tokens = [];
-        let curNode = null;
-        return {
-          ...handlers,
-          node(node2) {
-            const tmp = curNode;
-            curNode = node2;
-            handlers.node.call(this, node2);
-            curNode = tmp;
-          },
-          emit(value, type, auto) {
-            tokens.push({
-              type,
-              value,
-              node: auto ? null : curNode
-            });
-          },
-          result() {
-            return tokens;
-          }
-        };
-      }
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/match-graph.js
-function createCondition(match, thenBranch, elseBranch) {
-  if (thenBranch === MATCH && elseBranch === MISMATCH) {
-    return match;
-  }
-  if (match === MATCH && thenBranch === MATCH && elseBranch === MATCH) {
-    return match;
-  }
-  if (match.type === "If" && match.else === MISMATCH && thenBranch === MATCH) {
-    thenBranch = match.then;
-    match = match.match;
-  }
-  return {
-    type: "If",
-    match,
-    then: thenBranch,
-    else: elseBranch
-  };
-}
-function isFunctionType(name50) {
-  return name50.length > 2 && name50.charCodeAt(name50.length - 2) === LEFTPARENTHESIS2 && name50.charCodeAt(name50.length - 1) === RIGHTPARENTHESIS2;
-}
-function isEnumCapatible(term) {
-  return term.type === "Keyword" || term.type === "AtKeyword" || term.type === "Function" || term.type === "Type" && isFunctionType(term.name);
-}
-function groupNode(terms, combinator = " ", explicit = false) {
-  return {
-    type: "Group",
-    terms,
-    combinator,
-    disallowEmpty: false,
-    explicit
-  };
-}
-function replaceTypeInGraph(node2, replacements, visited = /* @__PURE__ */ new Set()) {
-  if (!visited.has(node2)) {
-    visited.add(node2);
-    switch (node2.type) {
-      case "If":
-        node2.match = replaceTypeInGraph(node2.match, replacements, visited);
-        node2.then = replaceTypeInGraph(node2.then, replacements, visited);
-        node2.else = replaceTypeInGraph(node2.else, replacements, visited);
-        break;
-      case "Type":
-        return replacements[node2.name] || node2;
-    }
-  }
-  return node2;
-}
-function buildGroupMatchGraph(combinator, terms, atLeastOneTermMatched) {
-  switch (combinator) {
-    case " ": {
-      let result = MATCH;
-      for (let i = terms.length - 1; i >= 0; i--) {
-        const term = terms[i];
-        result = createCondition(
-          term,
-          result,
-          MISMATCH
-        );
-      }
-      ;
-      return result;
-    }
-    case "|": {
-      let result = MISMATCH;
-      let map3 = null;
-      for (let i = terms.length - 1; i >= 0; i--) {
-        let term = terms[i];
-        if (isEnumCapatible(term)) {
-          if (map3 === null && i > 0 && isEnumCapatible(terms[i - 1])) {
-            map3 = /* @__PURE__ */ Object.create(null);
-            result = createCondition(
-              {
-                type: "Enum",
-                map: map3
-              },
-              MATCH,
-              result
-            );
-          }
-          if (map3 !== null) {
-            const key = (isFunctionType(term.name) ? term.name.slice(0, -1) : term.name).toLowerCase();
-            if (key in map3 === false) {
-              map3[key] = term;
-              continue;
-            }
-          }
-        }
-        map3 = null;
-        result = createCondition(
-          term,
-          MATCH,
-          result
-        );
-      }
-      ;
-      return result;
-    }
-    case "&&": {
-      if (terms.length > 5) {
-        return {
-          type: "MatchOnce",
-          terms,
-          all: true
-        };
-      }
-      let result = MISMATCH;
-      for (let i = terms.length - 1; i >= 0; i--) {
-        const term = terms[i];
-        let thenClause;
-        if (terms.length > 1) {
-          thenClause = buildGroupMatchGraph(
-            combinator,
-            terms.filter(function(newGroupTerm) {
-              return newGroupTerm !== term;
-            }),
-            false
-          );
-        } else {
-          thenClause = MATCH;
-        }
-        result = createCondition(
-          term,
-          thenClause,
-          result
-        );
-      }
-      ;
-      return result;
-    }
-    case "||": {
-      if (terms.length > 5) {
-        return {
-          type: "MatchOnce",
-          terms,
-          all: false
-        };
-      }
-      let result = atLeastOneTermMatched ? MATCH : MISMATCH;
-      for (let i = terms.length - 1; i >= 0; i--) {
-        const term = terms[i];
-        let thenClause;
-        if (terms.length > 1) {
-          thenClause = buildGroupMatchGraph(
-            combinator,
-            terms.filter(function(newGroupTerm) {
-              return newGroupTerm !== term;
-            }),
-            true
-          );
-        } else {
-          thenClause = MATCH;
-        }
-        result = createCondition(
-          term,
-          thenClause,
-          result
-        );
-      }
-      ;
-      return result;
-    }
-  }
-}
-function buildMultiplierMatchGraph(node2) {
-  let result = MATCH;
-  let matchTerm = buildMatchGraphInternal(node2.term);
-  if (node2.max === 0) {
-    matchTerm = createCondition(
-      matchTerm,
-      DISALLOW_EMPTY,
-      MISMATCH
-    );
-    result = createCondition(
-      matchTerm,
-      null,
-      // will be a loop
-      MISMATCH
-    );
-    result.then = createCondition(
-      MATCH,
-      MATCH,
-      result
-      // make a loop
-    );
-    if (node2.comma) {
-      result.then.else = createCondition(
-        { type: "Comma", syntax: node2 },
-        result,
-        MISMATCH
-      );
-    }
-  } else {
-    for (let i = node2.min || 1; i <= node2.max; i++) {
-      if (node2.comma && result !== MATCH) {
-        result = createCondition(
-          { type: "Comma", syntax: node2 },
-          result,
-          MISMATCH
-        );
-      }
-      result = createCondition(
-        matchTerm,
-        createCondition(
-          MATCH,
-          MATCH,
-          result
-        ),
-        MISMATCH
-      );
-    }
-  }
-  if (node2.min === 0) {
-    result = createCondition(
-      MATCH,
-      MATCH,
-      result
-    );
-  } else {
-    for (let i = 0; i < node2.min - 1; i++) {
-      if (node2.comma && result !== MATCH) {
-        result = createCondition(
-          { type: "Comma", syntax: node2 },
-          result,
-          MISMATCH
-        );
-      }
-      result = createCondition(
-        matchTerm,
-        result,
-        MISMATCH
-      );
-    }
-  }
-  return result;
-}
-function buildMatchGraphInternal(node2) {
-  if (typeof node2 === "function") {
-    return {
-      type: "Generic",
-      fn: node2
-    };
-  }
-  switch (node2.type) {
-    case "Group": {
-      let result = buildGroupMatchGraph(
-        node2.combinator,
-        node2.terms.map(buildMatchGraphInternal),
-        false
-      );
-      if (node2.disallowEmpty) {
-        result = createCondition(
-          result,
-          DISALLOW_EMPTY,
-          MISMATCH
-        );
-      }
-      return result;
-    }
-    case "Multiplier":
-      return buildMultiplierMatchGraph(node2);
-    // https://drafts.csswg.org/css-values-5/#boolean
-    case "Boolean": {
-      const term = buildMatchGraphInternal(node2.term);
-      const matchNode = buildMatchGraphInternal(groupNode([
-        groupNode([
-          { type: "Keyword", name: "not" },
-          { type: "Type", name: "!boolean-group" }
-        ]),
-        groupNode([
-          { type: "Type", name: "!boolean-group" },
-          groupNode([
-            { type: "Multiplier", comma: false, min: 0, max: 0, term: groupNode([
-              { type: "Keyword", name: "and" },
-              { type: "Type", name: "!boolean-group" }
-            ]) },
-            { type: "Multiplier", comma: false, min: 0, max: 0, term: groupNode([
-              { type: "Keyword", name: "or" },
-              { type: "Type", name: "!boolean-group" }
-            ]) }
-          ], "|")
-        ])
-      ], "|"));
-      const booleanGroup = buildMatchGraphInternal(
-        groupNode([
-          { type: "Type", name: "!term" },
-          groupNode([
-            { type: "Token", value: "(" },
-            { type: "Type", name: "!self" },
-            { type: "Token", value: ")" }
-          ]),
-          { type: "Type", name: "general-enclosed" }
-        ], "|")
-      );
-      replaceTypeInGraph(booleanGroup, { "!term": term, "!self": matchNode });
-      replaceTypeInGraph(matchNode, { "!boolean-group": booleanGroup });
-      return matchNode;
-    }
-    case "Type":
-    case "Property":
-      return {
-        type: node2.type,
-        name: node2.name,
-        syntax: node2
-      };
-    case "Keyword":
-      return {
-        type: node2.type,
-        name: node2.name.toLowerCase(),
-        syntax: node2
-      };
-    case "AtKeyword":
-      return {
-        type: node2.type,
-        name: "@" + node2.name.toLowerCase(),
-        syntax: node2
-      };
-    case "Function":
-      return {
-        type: node2.type,
-        name: node2.name.toLowerCase() + "(",
-        syntax: node2
-      };
-    case "String":
-      if (node2.value.length === 3) {
-        return {
-          type: "Token",
-          value: node2.value.charAt(1),
-          syntax: node2
-        };
-      }
-      return {
-        type: node2.type,
-        value: node2.value.substr(1, node2.value.length - 2).replace(/\\'/g, "'"),
-        syntax: node2
-      };
-    case "Token":
-      return {
-        type: node2.type,
-        value: node2.value,
-        syntax: node2
-      };
-    case "Comma":
-      return {
-        type: node2.type,
-        syntax: node2
-      };
-    default:
-      throw new Error("Unknown node type:", node2.type);
-  }
-}
-function buildMatchGraph(syntaxTree, ref) {
-  if (typeof syntaxTree === "string") {
-    syntaxTree = parse2(syntaxTree);
-  }
-  return {
-    type: "MatchGraph",
-    match: buildMatchGraphInternal(syntaxTree),
-    syntax: ref || null,
-    source: syntaxTree
-  };
-}
-var MATCH, MISMATCH, DISALLOW_EMPTY, LEFTPARENTHESIS2, RIGHTPARENTHESIS2;
-var init_match_graph = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/match-graph.js"() {
-    init_parse();
-    MATCH = { type: "Match" };
-    MISMATCH = { type: "Mismatch" };
-    DISALLOW_EMPTY = { type: "DisallowEmpty" };
-    LEFTPARENTHESIS2 = 40;
-    RIGHTPARENTHESIS2 = 41;
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/match.js
-function reverseList(list3) {
-  let prev = null;
-  let next2 = null;
-  let item = list3;
-  while (item !== null) {
-    next2 = item.prev;
-    item.prev = prev;
-    prev = item;
-    item = next2;
-  }
-  return prev;
-}
-function areStringsEqualCaseInsensitive(testStr, referenceStr) {
-  if (testStr.length !== referenceStr.length) {
-    return false;
-  }
-  for (let i = 0; i < testStr.length; i++) {
-    const referenceCode = referenceStr.charCodeAt(i);
-    let testCode = testStr.charCodeAt(i);
-    if (testCode >= 65 && testCode <= 90) {
-      testCode = testCode | 32;
-    }
-    if (testCode !== referenceCode) {
-      return false;
-    }
-  }
-  return true;
-}
-function isContextEdgeDelim(token) {
-  if (token.type !== Delim) {
-    return false;
-  }
-  return token.value !== "?";
-}
-function isCommaContextStart(token) {
-  if (token === null) {
-    return true;
-  }
-  return token.type === Comma || token.type === Function || token.type === LeftParenthesis || token.type === LeftSquareBracket || token.type === LeftCurlyBracket || isContextEdgeDelim(token);
-}
-function isCommaContextEnd(token) {
-  if (token === null) {
-    return true;
-  }
-  return token.type === RightParenthesis || token.type === RightSquareBracket || token.type === RightCurlyBracket || token.type === Delim && token.value === "/";
-}
-function internalMatch(tokens, state, syntaxes) {
-  function moveToNextToken() {
-    do {
-      tokenIndex++;
-      token = tokenIndex < tokens.length ? tokens[tokenIndex] : null;
-    } while (token !== null && (token.type === WhiteSpace || token.type === Comment));
-  }
-  function getNextToken(offset) {
-    const nextIndex = tokenIndex + offset;
-    return nextIndex < tokens.length ? tokens[nextIndex] : null;
-  }
-  function stateSnapshotFromSyntax(nextState, prev) {
-    return {
-      nextState,
-      matchStack,
-      syntaxStack,
-      thenStack,
-      tokenIndex,
-      prev
-    };
-  }
-  function pushThenStack(nextState) {
-    thenStack = {
-      nextState,
-      matchStack,
-      syntaxStack,
-      prev: thenStack
-    };
-  }
-  function pushElseStack(nextState) {
-    elseStack = stateSnapshotFromSyntax(nextState, elseStack);
-  }
-  function addTokenToMatch() {
-    matchStack = {
-      type: TOKEN,
-      syntax: state.syntax,
-      token,
-      prev: matchStack
-    };
-    moveToNextToken();
-    syntaxStash = null;
-    if (tokenIndex > longestMatch) {
-      longestMatch = tokenIndex;
-    }
-  }
-  function openSyntax() {
-    syntaxStack = {
-      syntax: state.syntax,
-      opts: state.syntax.opts || syntaxStack !== null && syntaxStack.opts || null,
-      prev: syntaxStack
-    };
-    matchStack = {
-      type: OPEN_SYNTAX,
-      syntax: state.syntax,
-      token: matchStack.token,
-      prev: matchStack
-    };
-  }
-  function closeSyntax() {
-    if (matchStack.type === OPEN_SYNTAX) {
-      matchStack = matchStack.prev;
-    } else {
-      matchStack = {
-        type: CLOSE_SYNTAX,
-        syntax: syntaxStack.syntax,
-        token: matchStack.token,
-        prev: matchStack
-      };
-    }
-    syntaxStack = syntaxStack.prev;
-  }
-  let syntaxStack = null;
-  let thenStack = null;
-  let elseStack = null;
-  let syntaxStash = null;
-  let iterationCount = 0;
-  let exitReason = null;
-  let token = null;
-  let tokenIndex = -1;
-  let longestMatch = 0;
-  let matchStack = {
-    type: STUB,
-    syntax: null,
-    token: null,
-    prev: null
-  };
-  moveToNextToken();
-  while (exitReason === null && ++iterationCount < ITERATION_LIMIT) {
-    switch (state.type) {
-      case "Match":
-        if (thenStack === null) {
-          if (token !== null) {
-            if (tokenIndex !== tokens.length - 1 || token.value !== "\\0" && token.value !== "\\9") {
-              state = MISMATCH;
-              break;
-            }
-          }
-          exitReason = EXIT_REASON_MATCH;
-          break;
-        }
-        state = thenStack.nextState;
-        if (state === DISALLOW_EMPTY) {
-          if (thenStack.matchStack === matchStack) {
-            state = MISMATCH;
-            break;
-          } else {
-            state = MATCH;
-          }
-        }
-        while (thenStack.syntaxStack !== syntaxStack) {
-          closeSyntax();
-        }
-        thenStack = thenStack.prev;
-        break;
-      case "Mismatch":
-        if (syntaxStash !== null && syntaxStash !== false) {
-          if (elseStack === null || tokenIndex > elseStack.tokenIndex) {
-            elseStack = syntaxStash;
-            syntaxStash = false;
-          }
-        } else if (elseStack === null) {
-          exitReason = EXIT_REASON_MISMATCH;
-          break;
-        }
-        state = elseStack.nextState;
-        thenStack = elseStack.thenStack;
-        syntaxStack = elseStack.syntaxStack;
-        matchStack = elseStack.matchStack;
-        tokenIndex = elseStack.tokenIndex;
-        token = tokenIndex < tokens.length ? tokens[tokenIndex] : null;
-        elseStack = elseStack.prev;
-        break;
-      case "MatchGraph":
-        state = state.match;
-        break;
-      case "If":
-        if (state.else !== MISMATCH) {
-          pushElseStack(state.else);
-        }
-        if (state.then !== MATCH) {
-          pushThenStack(state.then);
-        }
-        state = state.match;
-        break;
-      case "MatchOnce":
-        state = {
-          type: "MatchOnceBuffer",
-          syntax: state,
-          index: 0,
-          mask: 0
-        };
-        break;
-      case "MatchOnceBuffer": {
-        const terms = state.syntax.terms;
-        if (state.index === terms.length) {
-          if (state.mask === 0 || state.syntax.all) {
-            state = MISMATCH;
-            break;
-          }
-          state = MATCH;
-          break;
-        }
-        if (state.mask === (1 << terms.length) - 1) {
-          state = MATCH;
-          break;
-        }
-        for (; state.index < terms.length; state.index++) {
-          const matchFlag = 1 << state.index;
-          if ((state.mask & matchFlag) === 0) {
-            pushElseStack(state);
-            pushThenStack({
-              type: "AddMatchOnce",
-              syntax: state.syntax,
-              mask: state.mask | matchFlag
-            });
-            state = terms[state.index++];
-            break;
-          }
-        }
-        break;
-      }
-      case "AddMatchOnce":
-        state = {
-          type: "MatchOnceBuffer",
-          syntax: state.syntax,
-          index: 0,
-          mask: state.mask
-        };
-        break;
-      case "Enum":
-        if (token !== null) {
-          let name50 = token.value.toLowerCase();
-          if (name50.indexOf("\\") !== -1) {
-            name50 = name50.replace(/\\[09].*$/, "");
-          }
-          if (hasOwnProperty3.call(state.map, name50)) {
-            state = state.map[name50];
-            break;
-          }
-        }
-        state = MISMATCH;
-        break;
-      case "Generic": {
-        const opts = syntaxStack !== null ? syntaxStack.opts : null;
-        const lastTokenIndex2 = tokenIndex + Math.floor(state.fn(token, getNextToken, opts));
-        if (!isNaN(lastTokenIndex2) && lastTokenIndex2 > tokenIndex) {
-          while (tokenIndex < lastTokenIndex2) {
-            addTokenToMatch();
-          }
-          state = MATCH;
-        } else {
-          state = MISMATCH;
-        }
-        break;
-      }
-      case "Type":
-      case "Property": {
-        const syntaxDict = state.type === "Type" ? "types" : "properties";
-        const dictSyntax = hasOwnProperty3.call(syntaxes, syntaxDict) ? syntaxes[syntaxDict][state.name] : null;
-        if (!dictSyntax || !dictSyntax.match) {
-          throw new Error(
-            "Bad syntax reference: " + (state.type === "Type" ? "<" + state.name + ">" : "<'" + state.name + "'>")
-          );
-        }
-        if (syntaxStash !== false && token !== null && state.type === "Type") {
-          const lowPriorityMatching = (
-            // https://drafts.csswg.org/css-values-4/#custom-idents
-            // When parsing positionally-ambiguous keywords in a property value, a <custom-ident> production
-            // can only claim the keyword if no other unfulfilled production can claim it.
-            state.name === "custom-ident" && token.type === Ident || // https://drafts.csswg.org/css-values-4/#lengths
-            // ... if a `0` could be parsed as either a <number> or a <length> in a property (such as line-height),
-            // it must parse as a <number>
-            state.name === "length" && token.value === "0"
-          );
-          if (lowPriorityMatching) {
-            if (syntaxStash === null) {
-              syntaxStash = stateSnapshotFromSyntax(state, elseStack);
-            }
-            state = MISMATCH;
-            break;
-          }
-        }
-        openSyntax();
-        state = dictSyntax.matchRef || dictSyntax.match;
-        break;
-      }
-      case "Keyword": {
-        const name50 = state.name;
-        if (token !== null) {
-          let keywordName = token.value;
-          if (keywordName.indexOf("\\") !== -1) {
-            keywordName = keywordName.replace(/\\[09].*$/, "");
-          }
-          if (areStringsEqualCaseInsensitive(keywordName, name50)) {
-            addTokenToMatch();
-            state = MATCH;
-            break;
-          }
-        }
-        state = MISMATCH;
-        break;
-      }
-      case "AtKeyword":
-      case "Function":
-        if (token !== null && areStringsEqualCaseInsensitive(token.value, state.name)) {
-          addTokenToMatch();
-          state = MATCH;
-          break;
-        }
-        state = MISMATCH;
-        break;
-      case "Token":
-        if (token !== null && token.value === state.value) {
-          addTokenToMatch();
-          state = MATCH;
-          break;
-        }
-        state = MISMATCH;
-        break;
-      case "Comma":
-        if (token !== null && token.type === Comma) {
-          if (isCommaContextStart(matchStack.token)) {
-            state = MISMATCH;
-          } else {
-            addTokenToMatch();
-            state = isCommaContextEnd(token) ? MISMATCH : MATCH;
-          }
-        } else {
-          state = isCommaContextStart(matchStack.token) || isCommaContextEnd(token) ? MATCH : MISMATCH;
-        }
-        break;
-      case "String":
-        let string3 = "";
-        let lastTokenIndex = tokenIndex;
-        for (; lastTokenIndex < tokens.length && string3.length < state.value.length; lastTokenIndex++) {
-          string3 += tokens[lastTokenIndex].value;
-        }
-        if (areStringsEqualCaseInsensitive(string3, state.value)) {
-          while (tokenIndex < lastTokenIndex) {
-            addTokenToMatch();
-          }
-          state = MATCH;
-        } else {
-          state = MISMATCH;
-        }
-        break;
-      default:
-        throw new Error("Unknown node type: " + state.type);
-    }
-  }
-  totalIterationCount += iterationCount;
-  switch (exitReason) {
-    case null:
-      console.warn("[csstree-match] BREAK after " + ITERATION_LIMIT + " iterations");
-      exitReason = EXIT_REASON_ITERATION_LIMIT;
-      matchStack = null;
-      break;
-    case EXIT_REASON_MATCH:
-      while (syntaxStack !== null) {
-        closeSyntax();
-      }
-      break;
-    default:
-      matchStack = null;
-  }
-  return {
-    tokens,
-    reason: exitReason,
-    iterations: iterationCount,
-    match: matchStack,
-    longestMatch
-  };
-}
-function matchAsTree(tokens, matchGraph, syntaxes) {
-  const matchResult = internalMatch(tokens, matchGraph, syntaxes || {});
-  if (matchResult.match === null) {
-    return matchResult;
-  }
-  let item = matchResult.match;
-  let host = matchResult.match = {
-    syntax: matchGraph.syntax || null,
-    match: []
-  };
-  const hostStack = [host];
-  item = reverseList(item).prev;
-  while (item !== null) {
-    switch (item.type) {
-      case OPEN_SYNTAX:
-        host.match.push(host = {
-          syntax: item.syntax,
-          match: []
-        });
-        hostStack.push(host);
-        break;
-      case CLOSE_SYNTAX:
-        hostStack.pop();
-        host = hostStack[hostStack.length - 1];
-        break;
-      default:
-        host.match.push({
-          syntax: item.syntax || null,
-          token: item.token.value,
-          node: item.token.node
-        });
-    }
-    item = item.prev;
-  }
-  return matchResult;
-}
-var hasOwnProperty3, STUB, TOKEN, OPEN_SYNTAX, CLOSE_SYNTAX, EXIT_REASON_MATCH, EXIT_REASON_MISMATCH, EXIT_REASON_ITERATION_LIMIT, ITERATION_LIMIT, totalIterationCount;
-var init_match = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/match.js"() {
-    init_match_graph();
-    init_types();
-    ({ hasOwnProperty: hasOwnProperty3 } = Object.prototype);
-    STUB = 0;
-    TOKEN = 1;
-    OPEN_SYNTAX = 2;
-    CLOSE_SYNTAX = 3;
-    EXIT_REASON_MATCH = "Match";
-    EXIT_REASON_MISMATCH = "Mismatch";
-    EXIT_REASON_ITERATION_LIMIT = "Maximum iteration number exceeded (please fill an issue on https://github.com/csstree/csstree/issues)";
-    ITERATION_LIMIT = 15e3;
-    totalIterationCount = 0;
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/trace.js
-var trace_exports = {};
-__export(trace_exports, {
-  getTrace: () => getTrace,
-  isKeyword: () => isKeyword,
-  isProperty: () => isProperty,
-  isType: () => isType
-});
-function getTrace(node2) {
-  function shouldPutToTrace(syntax) {
-    if (syntax === null) {
-      return false;
-    }
-    return syntax.type === "Type" || syntax.type === "Property" || syntax.type === "Keyword";
-  }
-  function hasMatch(matchNode) {
-    if (Array.isArray(matchNode.match)) {
-      for (let i = 0; i < matchNode.match.length; i++) {
-        if (hasMatch(matchNode.match[i])) {
-          if (shouldPutToTrace(matchNode.syntax)) {
-            result.unshift(matchNode.syntax);
-          }
-          return true;
-        }
-      }
-    } else if (matchNode.node === node2) {
-      result = shouldPutToTrace(matchNode.syntax) ? [matchNode.syntax] : [];
-      return true;
-    }
-    return false;
-  }
-  let result = null;
-  if (this.matched !== null) {
-    hasMatch(this.matched);
-  }
-  return result;
-}
-function isType(node2, type) {
-  return testNode(this, node2, (match) => match.type === "Type" && match.name === type);
-}
-function isProperty(node2, property2) {
-  return testNode(this, node2, (match) => match.type === "Property" && match.name === property2);
-}
-function isKeyword(node2) {
-  return testNode(this, node2, (match) => match.type === "Keyword");
-}
-function testNode(match, node2, fn) {
-  const trace2 = getTrace.call(match, node2);
-  if (trace2 === null) {
-    return false;
-  }
-  return trace2.some(fn);
-}
-var init_trace = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/trace.js"() {
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/search.js
-function getFirstMatchNode(matchNode) {
-  if ("node" in matchNode) {
-    return matchNode.node;
-  }
-  return getFirstMatchNode(matchNode.match[0]);
-}
-function getLastMatchNode(matchNode) {
-  if ("node" in matchNode) {
-    return matchNode.node;
-  }
-  return getLastMatchNode(matchNode.match[matchNode.match.length - 1]);
-}
-function matchFragments(lexer2, ast, match, type, name50) {
-  function findFragments(matchNode) {
-    if (matchNode.syntax !== null && matchNode.syntax.type === type && matchNode.syntax.name === name50) {
-      const start = getFirstMatchNode(matchNode);
-      const end = getLastMatchNode(matchNode);
-      lexer2.syntax.walk(ast, function(node2, item, list3) {
-        if (node2 === start) {
-          const nodes = new List();
-          do {
-            nodes.appendData(item.data);
-            if (item.data === end) {
-              break;
-            }
-            item = item.next;
-          } while (item !== null);
-          fragments.push({
-            parent: list3,
-            nodes
-          });
-        }
-      });
-    }
-    if (Array.isArray(matchNode.match)) {
-      matchNode.match.forEach(findFragments);
-    }
-  }
-  const fragments = [];
-  if (match.matched !== null) {
-    findFragments(match.matched);
-  }
-  return fragments;
-}
-var init_search = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/search.js"() {
-    init_List();
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/structure.js
-function isValidNumber(value) {
-  return typeof value === "number" && isFinite(value) && Math.floor(value) === value && value >= 0;
-}
-function isValidLocation(loc) {
-  return Boolean(loc) && isValidNumber(loc.offset) && isValidNumber(loc.line) && isValidNumber(loc.column);
-}
-function createNodeStructureChecker(type, fields) {
-  return function checkNode(node2, warn) {
-    if (!node2 || node2.constructor !== Object) {
-      return warn(node2, "Type of node should be an Object");
-    }
-    for (let key in node2) {
-      let valid2 = true;
-      if (hasOwnProperty4.call(node2, key) === false) {
-        continue;
-      }
-      if (key === "type") {
-        if (node2.type !== type) {
-          warn(node2, "Wrong node type `" + node2.type + "`, expected `" + type + "`");
-        }
-      } else if (key === "loc") {
-        if (node2.loc === null) {
-          continue;
-        } else if (node2.loc && node2.loc.constructor === Object) {
-          if (typeof node2.loc.source !== "string") {
-            key += ".source";
-          } else if (!isValidLocation(node2.loc.start)) {
-            key += ".start";
-          } else if (!isValidLocation(node2.loc.end)) {
-            key += ".end";
-          } else {
-            continue;
-          }
-        }
-        valid2 = false;
-      } else if (fields.hasOwnProperty(key)) {
-        valid2 = false;
-        for (let i = 0; !valid2 && i < fields[key].length; i++) {
-          const fieldType = fields[key][i];
-          switch (fieldType) {
-            case String:
-              valid2 = typeof node2[key] === "string";
-              break;
-            case Boolean:
-              valid2 = typeof node2[key] === "boolean";
-              break;
-            case null:
-              valid2 = node2[key] === null;
-              break;
-            default:
-              if (typeof fieldType === "string") {
-                valid2 = node2[key] && node2[key].type === fieldType;
-              } else if (Array.isArray(fieldType)) {
-                valid2 = node2[key] instanceof List;
-              }
-          }
-        }
-      } else {
-        warn(node2, "Unknown field `" + key + "` for " + type + " node type");
-      }
-      if (!valid2) {
-        warn(node2, "Bad value for `" + type + "." + key + "`");
-      }
-    }
-    for (const key in fields) {
-      if (hasOwnProperty4.call(fields, key) && hasOwnProperty4.call(node2, key) === false) {
-        warn(node2, "Field `" + type + "." + key + "` is missed");
-      }
-    }
-  };
-}
-function genTypesList(fieldTypes, path2) {
-  const docsTypes = [];
-  for (let i = 0; i < fieldTypes.length; i++) {
-    const fieldType = fieldTypes[i];
-    if (fieldType === String || fieldType === Boolean) {
-      docsTypes.push(fieldType.name.toLowerCase());
-    } else if (fieldType === null) {
-      docsTypes.push("null");
-    } else if (typeof fieldType === "string") {
-      docsTypes.push(fieldType);
-    } else if (Array.isArray(fieldType)) {
-      docsTypes.push("List<" + (genTypesList(fieldType, path2) || "any") + ">");
-    } else {
-      throw new Error("Wrong value `" + fieldType + "` in `" + path2 + "` structure definition");
-    }
-  }
-  return docsTypes.join(" | ");
-}
-function processStructure(name50, nodeType) {
-  const structure50 = nodeType.structure;
-  const fields = {
-    type: String,
-    loc: true
-  };
-  const docs = {
-    type: '"' + name50 + '"'
-  };
-  for (const key in structure50) {
-    if (hasOwnProperty4.call(structure50, key) === false) {
-      continue;
-    }
-    const fieldTypes = fields[key] = Array.isArray(structure50[key]) ? structure50[key].slice() : [structure50[key]];
-    docs[key] = genTypesList(fieldTypes, name50 + "." + key);
-  }
-  return {
-    docs,
-    check: createNodeStructureChecker(name50, fields)
-  };
-}
-function getStructureFromConfig(config) {
-  const structure50 = {};
-  if (config.node) {
-    for (const name50 in config.node) {
-      if (hasOwnProperty4.call(config.node, name50)) {
-        const nodeType = config.node[name50];
-        if (nodeType.structure) {
-          structure50[name50] = processStructure(name50, nodeType);
-        } else {
-          throw new Error("Missed `structure` field in `" + name50 + "` node type definition");
-        }
-      }
-    }
-  }
-  return structure50;
-}
-var hasOwnProperty4;
-var init_structure = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/structure.js"() {
-    init_List();
-    ({ hasOwnProperty: hasOwnProperty4 } = Object.prototype);
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/Lexer.js
-function dumpMapSyntax(map3, compact, syntaxAsAst) {
-  const result = {};
-  for (const name50 in map3) {
-    if (map3[name50].syntax) {
-      result[name50] = syntaxAsAst ? map3[name50].syntax : generate(map3[name50].syntax, { compact });
-    }
-  }
-  return result;
-}
-function dumpAtruleMapSyntax(map3, compact, syntaxAsAst) {
-  const result = {};
-  for (const [name50, atrule] of Object.entries(map3)) {
-    result[name50] = {
-      prelude: atrule.prelude && (syntaxAsAst ? atrule.prelude.syntax : generate(atrule.prelude.syntax, { compact })),
-      descriptors: atrule.descriptors && dumpMapSyntax(atrule.descriptors, compact, syntaxAsAst)
-    };
-  }
-  return result;
-}
-function valueHasVar(tokens) {
-  for (let i = 0; i < tokens.length; i++) {
-    if (tokens[i].value.toLowerCase() === "var(") {
-      return true;
-    }
-  }
-  return false;
-}
-function syntaxHasTopLevelCommaMultiplier(syntax) {
-  const singleTerm = syntax.terms[0];
-  return syntax.explicit === false && syntax.terms.length === 1 && singleTerm.type === "Multiplier" && singleTerm.comma === true;
-}
-function buildMatchResult(matched, error, iterations) {
-  return {
-    matched,
-    iterations,
-    error,
-    ...trace_exports
-  };
-}
-function matchSyntax(lexer2, syntax, value, useCssWideKeywords) {
-  const tokens = prepare_tokens_default(value, lexer2.syntax);
-  let result;
-  if (valueHasVar(tokens)) {
-    return buildMatchResult(null, new Error("Matching for a tree with var() is not supported"));
-  }
-  if (useCssWideKeywords) {
-    result = matchAsTree(tokens, lexer2.cssWideKeywordsSyntax, lexer2);
-  }
-  if (!useCssWideKeywords || !result.match) {
-    result = matchAsTree(tokens, syntax.match, lexer2);
-    if (!result.match) {
-      return buildMatchResult(
-        null,
-        new SyntaxMatchError(result.reason, syntax.syntax, value, result),
-        result.iterations
-      );
-    }
-  }
-  return buildMatchResult(result.match, null, result.iterations);
-}
-var Lexer;
-var init_Lexer = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/lexer/Lexer.js"() {
-    init_error();
-    init_names2();
-    init_generic_const();
-    init_generic();
-    init_units();
-    init_definition_syntax();
-    init_prepare_tokens();
-    init_match_graph();
-    init_match();
-    init_trace();
-    init_search();
-    init_structure();
-    Lexer = class {
-      constructor(config, syntax, structure50) {
-        this.cssWideKeywords = cssWideKeywords;
-        this.syntax = syntax;
-        this.generic = false;
-        this.units = { ...units_exports };
-        this.atrules = /* @__PURE__ */ Object.create(null);
-        this.properties = /* @__PURE__ */ Object.create(null);
-        this.types = /* @__PURE__ */ Object.create(null);
-        this.structure = structure50 || getStructureFromConfig(config);
-        if (config) {
-          if (config.cssWideKeywords) {
-            this.cssWideKeywords = config.cssWideKeywords;
-          }
-          if (config.units) {
-            for (const group of Object.keys(units_exports)) {
-              if (Array.isArray(config.units[group])) {
-                this.units[group] = config.units[group];
-              }
-            }
-          }
-          if (config.types) {
-            for (const [name50, type] of Object.entries(config.types)) {
-              this.addType_(name50, type);
-            }
-          }
-          if (config.generic) {
-            this.generic = true;
-            for (const [name50, value] of Object.entries(createGenericTypes(this.units))) {
-              this.addType_(name50, value);
-            }
-          }
-          if (config.atrules) {
-            for (const [name50, atrule] of Object.entries(config.atrules)) {
-              this.addAtrule_(name50, atrule);
-            }
-          }
-          if (config.properties) {
-            for (const [name50, property2] of Object.entries(config.properties)) {
-              this.addProperty_(name50, property2);
-            }
-          }
-        }
-        this.cssWideKeywordsSyntax = buildMatchGraph(this.cssWideKeywords.join(" |  "));
-      }
-      checkStructure(ast) {
-        function collectWarning(node2, message) {
-          warns.push({ node: node2, message });
-        }
-        const structure50 = this.structure;
-        const warns = [];
-        this.syntax.walk(ast, function(node2) {
-          if (structure50.hasOwnProperty(node2.type)) {
-            structure50[node2.type].check(node2, collectWarning);
-          } else {
-            collectWarning(node2, "Unknown node type `" + node2.type + "`");
-          }
-        });
-        return warns.length ? warns : false;
-      }
-      createDescriptor(syntax, type, name50, parent = null) {
-        const ref = {
-          type,
-          name: name50
-        };
-        const descriptor = {
-          type,
-          name: name50,
-          parent,
-          serializable: typeof syntax === "string" || syntax && typeof syntax.type === "string",
-          syntax: null,
-          match: null,
-          matchRef: null
-          // used for properties when a syntax referenced as <'property'> in other syntax definitions
-        };
-        if (typeof syntax === "function") {
-          descriptor.match = buildMatchGraph(syntax, ref);
-        } else {
-          if (typeof syntax === "string") {
-            Object.defineProperty(descriptor, "syntax", {
-              get() {
-                Object.defineProperty(descriptor, "syntax", {
-                  value: parse2(syntax)
-                });
-                return descriptor.syntax;
-              }
-            });
-          } else {
-            descriptor.syntax = syntax;
-          }
-          Object.defineProperty(descriptor, "match", {
-            get() {
-              Object.defineProperty(descriptor, "match", {
-                value: buildMatchGraph(descriptor.syntax, ref)
-              });
-              return descriptor.match;
-            }
-          });
-          if (type === "Property") {
-            Object.defineProperty(descriptor, "matchRef", {
-              get() {
-                const syntax2 = descriptor.syntax;
-                const value = syntaxHasTopLevelCommaMultiplier(syntax2) ? buildMatchGraph({
-                  ...syntax2,
-                  terms: [syntax2.terms[0].term]
-                }, ref) : null;
-                Object.defineProperty(descriptor, "matchRef", {
-                  value
-                });
-                return value;
-              }
-            });
-          }
-        }
-        return descriptor;
-      }
-      addAtrule_(name50, syntax) {
-        if (!syntax) {
-          return;
-        }
-        this.atrules[name50] = {
-          type: "Atrule",
-          name: name50,
-          prelude: syntax.prelude ? this.createDescriptor(syntax.prelude, "AtrulePrelude", name50) : null,
-          descriptors: syntax.descriptors ? Object.keys(syntax.descriptors).reduce(
-            (map3, descName) => {
-              map3[descName] = this.createDescriptor(syntax.descriptors[descName], "AtruleDescriptor", descName, name50);
-              return map3;
-            },
-            /* @__PURE__ */ Object.create(null)
-          ) : null
-        };
-      }
-      addProperty_(name50, syntax) {
-        if (!syntax) {
-          return;
-        }
-        this.properties[name50] = this.createDescriptor(syntax, "Property", name50);
-      }
-      addType_(name50, syntax) {
-        if (!syntax) {
-          return;
-        }
-        this.types[name50] = this.createDescriptor(syntax, "Type", name50);
-      }
-      checkAtruleName(atruleName) {
-        if (!this.getAtrule(atruleName)) {
-          return new SyntaxReferenceError("Unknown at-rule", "@" + atruleName);
-        }
-      }
-      checkAtrulePrelude(atruleName, prelude) {
-        const error = this.checkAtruleName(atruleName);
-        if (error) {
-          return error;
-        }
-        const atrule = this.getAtrule(atruleName);
-        if (!atrule.prelude && prelude) {
-          return new SyntaxError("At-rule `@" + atruleName + "` should not contain a prelude");
-        }
-        if (atrule.prelude && !prelude) {
-          if (!matchSyntax(this, atrule.prelude, "", false).matched) {
-            return new SyntaxError("At-rule `@" + atruleName + "` should contain a prelude");
-          }
-        }
-      }
-      checkAtruleDescriptorName(atruleName, descriptorName) {
-        const error = this.checkAtruleName(atruleName);
-        if (error) {
-          return error;
-        }
-        const atrule = this.getAtrule(atruleName);
-        const descriptor = keyword(descriptorName);
-        if (!atrule.descriptors) {
-          return new SyntaxError("At-rule `@" + atruleName + "` has no known descriptors");
-        }
-        if (!atrule.descriptors[descriptor.name] && !atrule.descriptors[descriptor.basename]) {
-          return new SyntaxReferenceError("Unknown at-rule descriptor", descriptorName);
-        }
-      }
-      checkPropertyName(propertyName) {
-        if (!this.getProperty(propertyName)) {
-          return new SyntaxReferenceError("Unknown property", propertyName);
-        }
-      }
-      matchAtrulePrelude(atruleName, prelude) {
-        const error = this.checkAtrulePrelude(atruleName, prelude);
-        if (error) {
-          return buildMatchResult(null, error);
-        }
-        const atrule = this.getAtrule(atruleName);
-        if (!atrule.prelude) {
-          return buildMatchResult(null, null);
-        }
-        return matchSyntax(this, atrule.prelude, prelude || "", false);
-      }
-      matchAtruleDescriptor(atruleName, descriptorName, value) {
-        const error = this.checkAtruleDescriptorName(atruleName, descriptorName);
-        if (error) {
-          return buildMatchResult(null, error);
-        }
-        const atrule = this.getAtrule(atruleName);
-        const descriptor = keyword(descriptorName);
-        return matchSyntax(this, atrule.descriptors[descriptor.name] || atrule.descriptors[descriptor.basename], value, false);
-      }
-      matchDeclaration(node2) {
-        if (node2.type !== "Declaration") {
-          return buildMatchResult(null, new Error("Not a Declaration node"));
-        }
-        return this.matchProperty(node2.property, node2.value);
-      }
-      matchProperty(propertyName, value) {
-        if (property(propertyName).custom) {
-          return buildMatchResult(null, new Error("Lexer matching doesn't applicable for custom properties"));
-        }
-        const error = this.checkPropertyName(propertyName);
-        if (error) {
-          return buildMatchResult(null, error);
-        }
-        return matchSyntax(this, this.getProperty(propertyName), value, true);
-      }
-      matchType(typeName, value) {
-        const typeSyntax = this.getType(typeName);
-        if (!typeSyntax) {
-          return buildMatchResult(null, new SyntaxReferenceError("Unknown type", typeName));
-        }
-        return matchSyntax(this, typeSyntax, value, false);
-      }
-      match(syntax, value) {
-        if (typeof syntax !== "string" && (!syntax || !syntax.type)) {
-          return buildMatchResult(null, new SyntaxReferenceError("Bad syntax"));
-        }
-        if (typeof syntax === "string" || !syntax.match) {
-          syntax = this.createDescriptor(syntax, "Type", "anonymous");
-        }
-        return matchSyntax(this, syntax, value, false);
-      }
-      findValueFragments(propertyName, value, type, name50) {
-        return matchFragments(this, value, this.matchProperty(propertyName, value), type, name50);
-      }
-      findDeclarationValueFragments(declaration, type, name50) {
-        return matchFragments(this, declaration.value, this.matchDeclaration(declaration), type, name50);
-      }
-      findAllFragments(ast, type, name50) {
-        const result = [];
-        this.syntax.walk(ast, {
-          visit: "Declaration",
-          enter: (declaration) => {
-            result.push.apply(result, this.findDeclarationValueFragments(declaration, type, name50));
-          }
-        });
-        return result;
-      }
-      getAtrule(atruleName, fallbackBasename = true) {
-        const atrule = keyword(atruleName);
-        const atruleEntry = atrule.vendor && fallbackBasename ? this.atrules[atrule.name] || this.atrules[atrule.basename] : this.atrules[atrule.name];
-        return atruleEntry || null;
-      }
-      getAtrulePrelude(atruleName, fallbackBasename = true) {
-        const atrule = this.getAtrule(atruleName, fallbackBasename);
-        return atrule && atrule.prelude || null;
-      }
-      getAtruleDescriptor(atruleName, name50) {
-        return this.atrules.hasOwnProperty(atruleName) && this.atrules.declarators ? this.atrules[atruleName].declarators[name50] || null : null;
-      }
-      getProperty(propertyName, fallbackBasename = true) {
-        const property2 = property(propertyName);
-        const propertyEntry = property2.vendor && fallbackBasename ? this.properties[property2.name] || this.properties[property2.basename] : this.properties[property2.name];
-        return propertyEntry || null;
-      }
-      getType(name50) {
-        return hasOwnProperty.call(this.types, name50) ? this.types[name50] : null;
-      }
-      validate() {
-        function syntaxRef(name50, isType2) {
-          return isType2 ? `<${name50}>` : `<'${name50}'>`;
-        }
-        function validate(syntax, name50, broken, descriptor) {
-          if (broken.has(name50)) {
-            return broken.get(name50);
-          }
-          broken.set(name50, false);
-          if (descriptor.syntax !== null) {
-            walk(descriptor.syntax, function(node2) {
-              if (node2.type !== "Type" && node2.type !== "Property") {
-                return;
-              }
-              const map3 = node2.type === "Type" ? syntax.types : syntax.properties;
-              const brokenMap = node2.type === "Type" ? brokenTypes : brokenProperties;
-              if (!hasOwnProperty.call(map3, node2.name)) {
-                errors2.push(`${syntaxRef(name50, broken === brokenTypes)} used missed syntax definition ${syntaxRef(node2.name, node2.type === "Type")}`);
-                broken.set(name50, true);
-              } else if (validate(syntax, node2.name, brokenMap, map3[node2.name])) {
-                errors2.push(`${syntaxRef(name50, broken === brokenTypes)} used broken syntax definition ${syntaxRef(node2.name, node2.type === "Type")}`);
-                broken.set(name50, true);
-              }
-            }, this);
-          }
-        }
-        const errors2 = [];
-        let brokenTypes = /* @__PURE__ */ new Map();
-        let brokenProperties = /* @__PURE__ */ new Map();
-        for (const key in this.types) {
-          validate(this, key, brokenTypes, this.types[key]);
-        }
-        for (const key in this.properties) {
-          validate(this, key, brokenProperties, this.properties[key]);
-        }
-        const brokenTypesArray = [...brokenTypes.keys()].filter((name50) => brokenTypes.get(name50));
-        const brokenPropertiesArray = [...brokenProperties.keys()].filter((name50) => brokenProperties.get(name50));
-        if (brokenTypesArray.length || brokenPropertiesArray.length) {
-          return {
-            errors: errors2,
-            types: brokenTypesArray,
-            properties: brokenPropertiesArray
-          };
-        }
-        return null;
-      }
-      dump(syntaxAsAst, pretty) {
-        return {
-          generic: this.generic,
-          cssWideKeywords: this.cssWideKeywords,
-          units: this.units,
-          types: dumpMapSyntax(this.types, !pretty, syntaxAsAst),
-          properties: dumpMapSyntax(this.properties, !pretty, syntaxAsAst),
-          atrules: dumpAtruleMapSyntax(this.atrules, !pretty, syntaxAsAst)
-        };
-      }
-      toString() {
-        return JSON.stringify(this.dump());
-      }
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/config/mix.js
-function appendOrSet(a, b) {
-  if (typeof b === "string" && /^\s*\|/.test(b)) {
-    return typeof a === "string" ? a + b : b.replace(/^\s*\|\s*/, "");
-  }
-  return b || null;
-}
-function extractProps(obj, props) {
-  const result = /* @__PURE__ */ Object.create(null);
-  for (const prop of Object.keys(obj)) {
-    if (props.includes(prop)) {
-      result[prop] = obj[prop];
-    }
-  }
-  return result;
-}
-function mergeDicts(base2, ext, fields) {
-  const result = { ...base2 };
-  for (const [key, props] of Object.entries(ext)) {
-    result[key] = {
-      ...result[key],
-      ...fields ? extractProps(props, fields) : props
-    };
-  }
-  return result;
-}
-function mix(dest, src) {
-  const result = { ...dest };
-  for (const [prop, value] of Object.entries(src)) {
-    switch (prop) {
-      case "generic":
-        result[prop] = Boolean(value);
-        break;
-      case "cssWideKeywords":
-        result[prop] = dest[prop] ? [...dest[prop], ...value] : value || [];
-        break;
-      case "units":
-        result[prop] = { ...dest[prop] };
-        for (const [name50, patch3] of Object.entries(value)) {
-          result[prop][name50] = Array.isArray(patch3) ? patch3 : [];
-        }
-        break;
-      case "atrules":
-        result[prop] = { ...dest[prop] };
-        for (const [name50, atrule] of Object.entries(value)) {
-          const exists = result[prop][name50] || {};
-          const current = result[prop][name50] = {
-            prelude: exists.prelude || null,
-            descriptors: {
-              ...exists.descriptors
-            }
-          };
-          if (!atrule) {
-            continue;
-          }
-          current.prelude = atrule.prelude ? appendOrSet(current.prelude, atrule.prelude) : current.prelude || null;
-          for (const [descriptorName, descriptorValue] of Object.entries(atrule.descriptors || {})) {
-            current.descriptors[descriptorName] = descriptorValue ? appendOrSet(current.descriptors[descriptorName], descriptorValue) : null;
-          }
-          if (!Object.keys(current.descriptors).length) {
-            current.descriptors = null;
-          }
-        }
-        break;
-      case "types":
-      case "properties":
-        result[prop] = { ...dest[prop] };
-        for (const [name50, syntax] of Object.entries(value)) {
-          result[prop][name50] = appendOrSet(result[prop][name50], syntax);
-        }
-        break;
-      case "parseContext":
-        result[prop] = {
-          ...dest[prop],
-          ...value
-        };
-        break;
-      case "scope":
-      case "features":
-        result[prop] = mergeDicts(dest[prop], value);
-        break;
-      case "atrule":
-      case "pseudo":
-        result[prop] = mergeDicts(dest[prop], value, ["parse"]);
-        break;
-      case "node":
-        result[prop] = mergeDicts(dest[prop], value, ["name", "structure", "parse", "generate", "walkContext"]);
-        break;
-    }
-  }
-  return result;
-}
-var init_mix = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/config/mix.js"() {
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/create.js
-function createSyntax(config) {
-  const parse57 = createParser(config);
-  const walk4 = createWalker(config);
-  const generate52 = createGenerator(config);
-  const { fromPlainObject: fromPlainObject2, toPlainObject: toPlainObject2 } = createConvertor(walk4);
-  const syntax = {
-    lexer: null,
-    createLexer: (config2) => new Lexer(config2, syntax, syntax.lexer.structure),
-    tokenize,
-    parse: parse57,
-    generate: generate52,
-    walk: walk4,
-    find: walk4.find,
-    findLast: walk4.findLast,
-    findAll: walk4.findAll,
-    fromPlainObject: fromPlainObject2,
-    toPlainObject: toPlainObject2,
-    fork(extension2) {
-      const base2 = mix({}, config);
-      return createSyntax(
-        typeof extension2 === "function" ? extension2(base2) : mix(base2, extension2)
-      );
-    }
-  };
-  syntax.lexer = new Lexer({
-    generic: config.generic,
-    cssWideKeywords: config.cssWideKeywords,
-    units: config.units,
-    types: config.types,
-    atrules: config.atrules,
-    properties: config.properties,
-    node: config.node
-  }, syntax);
-  return syntax;
-}
-var create_default;
-var init_create5 = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/create.js"() {
-    init_tokenizer();
-    init_create();
-    init_create2();
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/generator/index.js
+var generator_default2;
+var init_generator2 = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/generator/index.js"() {
     init_create3();
-    init_create4();
-    init_Lexer();
-    init_mix();
-    create_default = (config) => createSyntax(mix({}, config));
+    init_generator();
+    generator_default2 = createGenerator(generator_default);
   }
 });
 
-// node_modules/.pnpm/mdn-data@2.27.1/node_modules/mdn-data/css/at-rules.json
-var at_rules_default;
-var init_at_rules = __esm({
-  "node_modules/.pnpm/mdn-data@2.27.1/node_modules/mdn-data/css/at-rules.json"() {
-    at_rules_default = {
-      "@charset": {
-        syntax: '@charset "<charset>";',
-        groups: [
-          "CSS Syntax"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@charset"
-      },
-      "@counter-style": {
-        syntax: "@counter-style <counter-style-name> {\n  [ system: <counter-system>; ] ||\n  [ symbols: <counter-symbols>; ] ||\n  [ additive-symbols: <additive-symbols>; ] ||\n  [ negative: <negative-symbol>; ] ||\n  [ prefix: <prefix>; ] ||\n  [ suffix: <suffix>; ] ||\n  [ range: <range>; ] ||\n  [ pad: <padding>; ] ||\n  [ speak-as: <speak-as>; ] ||\n  [ fallback: <counter-style-name>; ]\n}",
-        interfaces: [
-          "CSSCounterStyleRule"
-        ],
-        groups: [
-          "CSS Counter Styles"
-        ],
-        descriptors: {
-          "additive-symbols": {
-            syntax: "[ <integer [0,\u221E]> && <symbol> ]#",
-            media: "all",
-            initial: "n/a (required)",
-            percentages: "no",
-            computed: "asSpecified",
-            order: "orderOfAppearance",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@counter-style/additive-symbols"
-          },
-          fallback: {
-            syntax: "<counter-style-name>",
-            media: "all",
-            initial: "decimal",
-            percentages: "no",
-            computed: "asSpecified",
-            order: "uniqueOrder",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@counter-style/fallback"
-          },
-          negative: {
-            syntax: "<symbol> <symbol>?",
-            media: "all",
-            initial: '"-" hyphen-minus',
-            percentages: "no",
-            computed: "asSpecified",
-            order: "orderOfAppearance",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@counter-style/negative"
-          },
-          pad: {
-            syntax: "<integer [0,\u221E]> && <symbol>",
-            media: "all",
-            initial: '0 ""',
-            percentages: "no",
-            computed: "asSpecified",
-            order: "uniqueOrder",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@counter-style/pad"
-          },
-          prefix: {
-            syntax: "<symbol>",
-            media: "all",
-            initial: '""',
-            percentages: "no",
-            computed: "asSpecified",
-            order: "uniqueOrder",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@counter-style/prefix"
-          },
-          range: {
-            syntax: "[ [ <integer> | infinite ]{2} ]# | auto",
-            media: "all",
-            initial: "auto",
-            percentages: "no",
-            computed: "asSpecified",
-            order: "orderOfAppearance",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@counter-style/range"
-          },
-          "speak-as": {
-            syntax: "auto | bullets | numbers | words | spell-out | <counter-style-name>",
-            media: "all",
-            initial: "auto",
-            percentages: "no",
-            computed: "asSpecified",
-            order: "uniqueOrder",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@counter-style/speak-as"
-          },
-          suffix: {
-            syntax: "<symbol>",
-            media: "all",
-            initial: '". "',
-            percentages: "no",
-            computed: "asSpecified",
-            order: "uniqueOrder",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@counter-style/suffix"
-          },
-          symbols: {
-            syntax: "<symbol>+",
-            media: "all",
-            initial: "n/a (required)",
-            percentages: "no",
-            computed: "asSpecified",
-            order: "orderOfAppearance",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@counter-style/symbols"
-          },
-          system: {
-            syntax: "cyclic | numeric | alphabetic | symbolic | additive | [ fixed <integer>? ] | [ extends <counter-style-name> ]",
-            media: "all",
-            initial: "symbolic",
-            percentages: "no",
-            computed: "asSpecified",
-            order: "uniqueOrder",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@counter-style/system"
-          }
-        },
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@counter-style"
-      },
-      "@container": {
-        syntax: "@container <container-condition># {\n  <block-contents>\n}",
-        interfaces: [
-          "CSSContainerRule"
-        ],
-        groups: [
-          "CSS Conditional Rules"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@container"
-      },
-      "@document": {
-        syntax: "@document [ <url> | url-prefix(<string>) | domain(<string>) | media-document(<string>) | regexp(<string>) ]# {\n  <group-rule-body>\n}",
-        interfaces: [
-          "CSSDocumentRule"
-        ],
-        groups: [
-          "CSS Conditional Rules"
-        ],
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@document"
-      },
-      "@font-face": {
-        syntax: "@font-face {\n  [ font-family: <family-name>; ] ||\n  [ src: <src>; ] ||\n  [ unicode-range: <unicode-range>; ] ||\n  [ font-variant: <font-variant>; ] ||\n  [ font-feature-settings: <font-feature-settings>; ] ||\n  [ font-variation-settings: <font-variation-settings>; ] ||\n  [ font-stretch: <font-stretch>; ] ||\n  [ font-weight: <font-weight>; ] ||\n  [ font-style: <font-style>; ] ||\n  [ size-adjust: <size-adjust>; ] ||\n  [ ascent-override: <ascent-override>; ] ||\n  [ descent-override: <descent-override>; ] ||\n  [ line-gap-override: <line-gap-override>; ]\n}",
-        interfaces: [
-          "CSSFontFaceRule"
-        ],
-        groups: [
-          "CSS Fonts"
-        ],
-        descriptors: {
-          "ascent-override": {
-            syntax: "normal | <percentage>",
-            media: "all",
-            initial: "normal",
-            percentages: "asSpecified",
-            computed: "asSpecified",
-            order: "orderOfAppearance",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@font-face/ascent-override"
-          },
-          "descent-override": {
-            syntax: "normal | <percentage>",
-            media: "all",
-            initial: "normal",
-            percentages: "asSpecified",
-            computed: "asSpecified",
-            order: "orderOfAppearance",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@font-face/descent-override"
-          },
-          "font-display": {
-            syntax: "auto | block | swap | fallback | optional",
-            media: "visual",
-            percentages: "no",
-            initial: "auto",
-            computed: "asSpecified",
-            order: "uniqueOrder",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@font-face/font-display"
-          },
-          "font-family": {
-            syntax: "<family-name>",
-            media: "all",
-            initial: "n/a (required)",
-            percentages: "no",
-            computed: "asSpecified",
-            order: "uniqueOrder",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@font-face/font-family"
-          },
-          "font-feature-settings": {
-            syntax: "normal | <feature-tag-value>#",
-            media: "all",
-            initial: "normal",
-            percentages: "no",
-            computed: "asSpecified",
-            order: "orderOfAppearance",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@font-face/font-feature-settings"
-          },
-          "font-stretch": {
-            syntax: "<font-stretch-absolute>{1,2}",
-            media: "all",
-            initial: "normal",
-            percentages: "no",
-            computed: "asSpecified",
-            order: "uniqueOrder",
-            status: "obsolete",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@font-face/font-stretch"
-          },
-          "font-style": {
-            syntax: "normal | italic | oblique <angle>{0,2}",
-            media: "all",
-            initial: "normal",
-            percentages: "no",
-            computed: "asSpecified",
-            order: "uniqueOrder",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@font-face/font-style"
-          },
-          "font-variation-settings": {
-            syntax: "normal | [ <string> <number> ]#",
-            media: "all",
-            initial: "normal",
-            percentages: "no",
-            computed: "asSpecified",
-            order: "orderOfAppearance",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@font-face/font-variation-settings"
-          },
-          "font-weight": {
-            syntax: "<font-weight-absolute>{1,2}",
-            media: "all",
-            initial: "normal",
-            percentages: "no",
-            computed: "asSpecified",
-            order: "uniqueOrder",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@font-face/font-weight"
-          },
-          "line-gap-override": {
-            syntax: "normal | <percentage>",
-            media: "all",
-            initial: "normal",
-            percentages: "asSpecified",
-            computed: "asSpecified",
-            order: "orderOfAppearance",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@font-face/line-gap-override"
-          },
-          "size-adjust": {
-            syntax: "<percentage>",
-            media: "all",
-            initial: "100%",
-            percentages: "asSpecified",
-            computed: "asSpecified",
-            order: "orderOfAppearance",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@font-face/size-adjust"
-          },
-          src: {
-            syntax: "[ <url> [ format( <string># ) ]? | local( <family-name> ) ]#",
-            media: "all",
-            initial: "n/a (required)",
-            percentages: "no",
-            computed: "asSpecified",
-            order: "orderOfAppearance",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@font-face/src"
-          },
-          "unicode-range": {
-            syntax: "<unicode-range-token>#",
-            media: "all",
-            initial: "U+0-10FFFF",
-            percentages: "no",
-            computed: "asSpecified",
-            order: "orderOfAppearance",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@font-face/unicode-range"
-          }
-        },
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@font-face"
-      },
-      "@font-feature-values": {
-        syntax: "@font-feature-values <family-name># {\n  <feature-value-block-list>\n}",
-        interfaces: [
-          "CSSFontFeatureValuesRule"
-        ],
-        groups: [
-          "CSS Fonts"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@font-feature-values"
-      },
-      "@font-palette-values": {
-        syntax: "@font-palette-values <dashed-ident> {\n  <declaration-list>\n}",
-        interfaces: [
-          "CSSFontPaletteValuesRule"
-        ],
-        groups: [
-          "CSS Fonts"
-        ],
-        descriptors: {
-          "base-palette": {
-            syntax: "light | dark | <integer [0,\u221E]>",
-            media: "all",
-            initial: "n/a (required)",
-            percentages: "no",
-            computed: "asSpecified",
-            order: "uniqueOrder",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@font-palette-values/base-palette"
-          },
-          "font-family": {
-            syntax: "<family-name>#",
-            media: "all",
-            initial: "n/a (required)",
-            percentages: "no",
-            computed: "asSpecified",
-            order: "orderOfAppearance",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@font-palette-values/font-family"
-          },
-          "override-colors": {
-            syntax: "[ <integer [0,\u221E]> <color> ]#",
-            media: "all",
-            initial: "n/a (required)",
-            percentages: "no",
-            computed: "asSpecified",
-            order: "orderOfAppearance",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@font-palette-values/override-colors"
-          }
-        },
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@font-palette-values"
-      },
-      "@import": {
-        syntax: "@import [ <string> | <url> ]\n        [ layer | layer(<layer-name>) ]?\n        [ supports( [ <supports-condition> | <declaration> ] ) ]?\n        <media-query-list>? ;",
-        interfaces: [
-          "CSSImportRule"
-        ],
-        groups: [
-          "CSS Cascading and Inheritance"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@import"
-      },
-      "@keyframes": {
-        syntax: "@keyframes <keyframes-name> {\n  <qualified-rule-list>\n}",
-        interfaces: [
-          "CSSKeyframeRule",
-          "CSSKeyframesRule"
-        ],
-        groups: [
-          "CSS Animations"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@keyframes"
-      },
-      "@layer": {
-        syntax: "@layer [ <layer-name># | <layer-name>?  {\n  <stylesheet>\n} ]",
-        interfaces: [
-          "CSSLayerBlockRule",
-          "CSSLayerStatementRule"
-        ],
-        groups: [
-          "CSS Cascading and Inheritance"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@layer"
-      },
-      "@media": {
-        syntax: "@media <media-query-list> {\n  <group-rule-body>\n}",
-        interfaces: [
-          "CSSMediaRule"
-        ],
-        groups: [
-          "CSS Conditional Rules",
-          "Media Queries"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@media"
-      },
-      "@namespace": {
-        syntax: "@namespace <namespace-prefix>? [ <string> | <url> ];",
-        interfaces: [
-          "CSSNamespaceRule"
-        ],
-        groups: [
-          "CSS Namespaces"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@namespace"
-      },
-      "@page": {
-        syntax: "@page <page-selector-list> {\n  <page-body>\n}",
-        interfaces: [
-          "CSSPageRule"
-        ],
-        groups: [
-          "CSS Paged Media"
-        ],
-        descriptors: {
-          bleed: {
-            syntax: "auto | <length>",
-            media: [
-              "visual",
-              "paged"
-            ],
-            initial: "auto",
-            percentages: "no",
-            computed: "asSpecified",
-            order: "uniqueOrder",
-            status: "standard"
-          },
-          marks: {
-            syntax: "none | [ crop || cross ]",
-            media: [
-              "visual",
-              "paged"
-            ],
-            initial: "none",
-            percentages: "no",
-            computed: "asSpecified",
-            order: "orderOfAppearance",
-            status: "standard"
-          },
-          "page-orientation": {
-            syntax: "upright | rotate-left | rotate-right",
-            media: [
-              "visual",
-              "paged"
-            ],
-            initial: "upright",
-            percentages: "no",
-            computed: "asSpecified",
-            order: "orderOfAppearance",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@page/page-orientation"
-          },
-          size: {
-            syntax: "<length [0,\u221E]>{1,2} | auto | [ <page-size> || [ portrait | landscape ] ]",
-            media: [
-              "visual",
-              "paged"
-            ],
-            initial: "auto",
-            percentages: "no",
-            computed: "asSpecifiedRelativeToAbsoluteLengths",
-            order: "orderOfAppearance",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@page/size"
-          }
-        },
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@page"
-      },
-      "@position-try": {
-        syntax: "@position-try <dashed-ident> {\n  <declaration-list>\n}",
-        interfaces: [
-          "CSSPositionTryRule"
-        ],
-        groups: [
-          "CSS Anchor Positioning"
-        ],
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@position-try"
-      },
-      "@property": {
-        syntax: "@property <custom-property-name> {\n  <declaration-list>\n}",
-        interfaces: [
-          "CSSPropertyRule"
-        ],
-        groups: [
-          "CSS Houdini"
-        ],
-        descriptors: {
-          inherits: {
-            syntax: "true | false",
-            media: "all",
-            percentages: "no",
-            initial: "auto",
-            computed: "asSpecified",
-            order: "uniqueOrder",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@property/inherits"
-          },
-          "initial-value": {
-            syntax: "<declaration-value>?",
-            media: "all",
-            initial: "n/a (required)",
-            percentages: "no",
-            computed: "asSpecified",
-            order: "uniqueOrder",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@property/initial-value"
-          },
-          syntax: {
-            syntax: "<string>",
-            media: "all",
-            percentages: "no",
-            initial: "n/a (required)",
-            computed: "asSpecified",
-            order: "uniqueOrder",
-            status: "standard",
-            mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@property/syntax"
-          }
-        },
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@property"
-      },
-      "@scope": {
-        syntax: "@scope [(<scope-start>)]? [to (<scope-end>)]? {\n  <rule-list>\n}",
-        interfaces: [
-          "CSSScopeRule"
-        ],
-        groups: [
-          "CSS Conditional Rules"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@scope"
-      },
-      "@starting-style": {
-        syntax: "@starting-style {\n  <declaration-list> | <group-rule-body>\n}",
-        interfaces: [
-          "CSSStartingStyleRule"
-        ],
-        groups: [
-          "CSS Transitions"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@starting-style"
-      },
-      "@supports": {
-        syntax: "@supports <supports-condition> {\n  <group-rule-body>\n}",
-        interfaces: [
-          "CSSSupportsRule"
-        ],
-        groups: [
-          "CSS Conditional Rules"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@supports"
-      },
-      "@view-transition": {
-        syntax: "@view-transition {\n  <declaration-list>\n}",
-        interfaces: [
-          "CSSViewTransitionRule"
-        ],
-        groups: [
-          "CSS View Transitions"
-        ],
-        descriptors: {
-          navigation: {
-            syntax: "auto | none",
-            media: "all",
-            initial: "none",
-            percentages: "no",
-            computed: "asSpecified",
-            order: "uniqueOrder",
-            status: "standard"
-          },
-          types: {
-            syntax: "none | <custom-ident>+",
-            media: "all",
-            initial: "none",
-            percentages: "no",
-            computed: "asSpecified",
-            order: "uniqueOrder",
-            status: "standard"
-          }
-        },
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/@view-transition"
-      }
-    };
-  }
-});
-
-// node_modules/.pnpm/mdn-data@2.27.1/node_modules/mdn-data/css/properties.json
-var properties_default;
-var init_properties = __esm({
-  "node_modules/.pnpm/mdn-data@2.27.1/node_modules/mdn-data/css/properties.json"() {
-    properties_default = {
-      "--*": {
-        syntax: "<declaration-value>",
-        media: "all",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Custom Properties for Cascading Variables"
-        ],
-        initial: "seeProse",
-        appliesto: "allElements",
-        computed: "asSpecifiedWithVarsSubstituted",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/--*"
-      },
-      "-ms-accelerator": {
-        syntax: "false | true",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "false",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-block-progression": {
-        syntax: "tb | rl | bt | lr",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "tb",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-content-zoom-chaining": {
-        syntax: "none | chained",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "none",
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-content-zoom-limit": {
-        syntax: "<'-ms-content-zoom-limit-min'> <'-ms-content-zoom-limit-max'>",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: [
-          "-ms-content-zoom-limit-max",
-          "-ms-content-zoom-limit-min"
-        ],
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: [
-          "-ms-content-zoom-limit-max",
-          "-ms-content-zoom-limit-min"
-        ],
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: [
-          "-ms-content-zoom-limit-max",
-          "-ms-content-zoom-limit-min"
-        ],
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-content-zoom-limit-max": {
-        syntax: "<percentage>",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "maxZoomFactor",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "400%",
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-content-zoom-limit-min": {
-        syntax: "<percentage>",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "minZoomFactor",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "100%",
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-content-zoom-snap": {
-        syntax: "<'-ms-content-zoom-snap-type'> || <'-ms-content-zoom-snap-points'>",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: [
-          "-ms-content-zoom-snap-type",
-          "-ms-content-zoom-snap-points"
-        ],
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: [
-          "-ms-content-zoom-snap-type",
-          "-ms-content-zoom-snap-points"
-        ],
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-content-zoom-snap-points": {
-        syntax: "snapInterval( <percentage>, <percentage> ) | snapList( <percentage># )",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "snapInterval(0%, 100%)",
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-content-zoom-snap-type": {
-        syntax: "none | proximity | mandatory",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "none",
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-content-zooming": {
-        syntax: "none | zoom",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "zoomForTheTopLevelNoneForTheRest",
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-filter": {
-        syntax: "<string>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: '""',
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-flow-from": {
-        syntax: "[ none | <custom-ident> ]#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "none",
-        appliesto: "nonReplacedElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-flow-into": {
-        syntax: "[ none | <custom-ident> ]#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "none",
-        appliesto: "iframeElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-grid-columns": {
-        syntax: "none | <track-list> | <auto-track-list>",
-        media: "visual",
-        inherited: false,
-        animationType: "simpleListOfLpcDifferenceLpc",
-        percentages: "referToDimensionOfContentArea",
-        groups: [
-          "CSS Grid Layout"
-        ],
-        initial: "none",
-        appliesto: "gridContainers",
-        computed: "asSpecifiedRelativeToAbsoluteLengths",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-grid-rows": {
-        syntax: "none | <track-list> | <auto-track-list>",
-        media: "visual",
-        inherited: false,
-        animationType: "simpleListOfLpcDifferenceLpc",
-        percentages: "referToDimensionOfContentArea",
-        groups: [
-          "CSS Grid Layout"
-        ],
-        initial: "none",
-        appliesto: "gridContainers",
-        computed: "asSpecifiedRelativeToAbsoluteLengths",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-high-contrast-adjust": {
-        syntax: "auto | none",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-hyphenate-limit-chars": {
-        syntax: "auto | <integer>{1,3}",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-hyphenate-limit-lines": {
-        syntax: "no-limit | <integer>",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "no-limit",
-        appliesto: "blockContainerElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-hyphenate-limit-zone": {
-        syntax: "<percentage> | <length>",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "referToLineBoxWidth",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "0",
-        appliesto: "blockContainerElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-ime-align": {
-        syntax: "auto | after",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-overflow-style": {
-        syntax: "auto | none | scrollbar | -ms-autohiding-scrollbar",
-        media: "interactive",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "auto",
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-scroll-chaining": {
-        syntax: "chained | none",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "chained",
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-scroll-limit": {
-        syntax: "<'-ms-scroll-limit-x-min'> <'-ms-scroll-limit-y-min'> <'-ms-scroll-limit-x-max'> <'-ms-scroll-limit-y-max'>",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: [
-          "-ms-scroll-limit-x-min",
-          "-ms-scroll-limit-y-min",
-          "-ms-scroll-limit-x-max",
-          "-ms-scroll-limit-y-max"
-        ],
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: [
-          "-ms-scroll-limit-x-min",
-          "-ms-scroll-limit-y-min",
-          "-ms-scroll-limit-x-max",
-          "-ms-scroll-limit-y-max"
-        ],
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-scroll-limit-x-max": {
-        syntax: "auto | <length>",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "auto",
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-scroll-limit-x-min": {
-        syntax: "<length>",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "0",
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-scroll-limit-y-max": {
-        syntax: "auto | <length>",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "auto",
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-scroll-limit-y-min": {
-        syntax: "<length>",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "0",
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-scroll-rails": {
-        syntax: "none | railed",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "railed",
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-scroll-snap-points-x": {
-        syntax: "snapInterval( <length-percentage>, <length-percentage> ) | snapList( <length-percentage># )",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "snapInterval(0px, 100%)",
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-scroll-snap-points-y": {
-        syntax: "snapInterval( <length-percentage>, <length-percentage> ) | snapList( <length-percentage># )",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "snapInterval(0px, 100%)",
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-scroll-snap-type": {
-        syntax: "none | proximity | mandatory",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "none",
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-scroll-snap-x": {
-        syntax: "<'-ms-scroll-snap-type'> <'-ms-scroll-snap-points-x'>",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: [
-          "-ms-scroll-snap-type",
-          "-ms-scroll-snap-points-x"
-        ],
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: [
-          "-ms-scroll-snap-type",
-          "-ms-scroll-snap-points-x"
-        ],
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-scroll-snap-y": {
-        syntax: "<'-ms-scroll-snap-type'> <'-ms-scroll-snap-points-y'>",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: [
-          "-ms-scroll-snap-type",
-          "-ms-scroll-snap-points-y"
-        ],
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: [
-          "-ms-scroll-snap-type",
-          "-ms-scroll-snap-points-y"
-        ],
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-scroll-translation": {
-        syntax: "none | vertical-to-horizontal",
-        media: "interactive",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-scrollbar-3dlight-color": {
-        syntax: "<color>",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "dependsOnUserAgent",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-scrollbar-arrow-color": {
-        syntax: "<color>",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "ButtonText",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-scrollbar-base-color": {
-        syntax: "<color>",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "dependsOnUserAgent",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-scrollbar-darkshadow-color": {
-        syntax: "<color>",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "ThreeDDarkShadow",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-scrollbar-face-color": {
-        syntax: "<color>",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "ThreeDFace",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-scrollbar-highlight-color": {
-        syntax: "<color>",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "ThreeDHighlight",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-scrollbar-shadow-color": {
-        syntax: "<color>",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "ThreeDDarkShadow",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-scrollbar-track-color": {
-        syntax: "<color>",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "Scrollbar",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-text-autospace": {
-        syntax: "none | ideograph-alpha | ideograph-numeric | ideograph-parenthesis | ideograph-space",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-touch-select": {
-        syntax: "grippers | none",
-        media: "interactive",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "grippers",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-user-select": {
-        syntax: "none | element | text",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "text",
-        appliesto: "nonReplacedElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-wrap-flow": {
-        syntax: "auto | both | start | end | maximum | clear",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "auto",
-        appliesto: "blockLevelElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-wrap-margin": {
-        syntax: "<length>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "0",
-        appliesto: "exclusionElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-ms-wrap-through": {
-        syntax: "wrap | none",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Microsoft Extensions"
-        ],
-        initial: "wrap",
-        appliesto: "blockLevelElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-moz-appearance": {
-        syntax: "none | button | button-arrow-down | button-arrow-next | button-arrow-previous | button-arrow-up | button-bevel | button-focus | caret | checkbox | checkbox-container | checkbox-label | checkmenuitem | dualbutton | groupbox | listbox | listitem | menuarrow | menubar | menucheckbox | menuimage | menuitem | menuitemtext | menulist | menulist-button | menulist-text | menulist-textfield | menupopup | menuradio | menuseparator | meterbar | meterchunk | progressbar | progressbar-vertical | progresschunk | progresschunk-vertical | radio | radio-container | radio-label | radiomenuitem | range | range-thumb | resizer | resizerpanel | scale-horizontal | scalethumbend | scalethumb-horizontal | scalethumbstart | scalethumbtick | scalethumb-vertical | scale-vertical | scrollbarbutton-down | scrollbarbutton-left | scrollbarbutton-right | scrollbarbutton-up | scrollbarthumb-horizontal | scrollbarthumb-vertical | scrollbartrack-horizontal | scrollbartrack-vertical | searchfield | separator | sheet | spinner | spinner-downbutton | spinner-textfield | spinner-upbutton | splitter | statusbar | statusbarpanel | tab | tabpanel | tabpanels | tab-scroll-arrow-back | tab-scroll-arrow-forward | textfield | textfield-multiline | toolbar | toolbarbutton | toolbarbutton-dropdown | toolbargripper | toolbox | tooltip | treeheader | treeheadercell | treeheadersortarrow | treeitem | treeline | treetwisty | treetwistyopen | treeview | -moz-mac-unified-toolbar | -moz-win-borderless-glass | -moz-win-browsertabbar-toolbox | -moz-win-communicationstext | -moz-win-communications-toolbox | -moz-win-exclude-glass | -moz-win-glass | -moz-win-mediatext | -moz-win-media-toolbox | -moz-window-button-box | -moz-window-button-box-maximized | -moz-window-button-close | -moz-window-button-maximize | -moz-window-button-minimize | -moz-window-button-restore | -moz-window-frame-bottom | -moz-window-frame-left | -moz-window-frame-right | -moz-window-titlebar | -moz-window-titlebar-maximized",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions",
-          "WebKit Extensions"
-        ],
-        initial: "noneButOverriddenInUserAgentCSS",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/appearance"
-      },
-      "-moz-binding": {
-        syntax: "<url> | none",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions"
-        ],
-        initial: "none",
-        appliesto: "allElementsExceptGeneratedContentOrPseudoElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-moz-border-bottom-colors": {
-        syntax: "<color>+ | none",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-moz-border-left-colors": {
-        syntax: "<color>+ | none",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-moz-border-right-colors": {
-        syntax: "<color>+ | none",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-moz-border-top-colors": {
-        syntax: "<color>+ | none",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-moz-context-properties": {
-        syntax: "none | [ fill | fill-opacity | stroke | stroke-opacity ]#",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions"
-        ],
-        initial: "none",
-        appliesto: "allElementsThatCanReferenceImages",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-moz-float-edge": {
-        syntax: "border-box | content-box | margin-box | padding-box",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions"
-        ],
-        initial: "content-box",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/-moz-float-edge"
-      },
-      "-moz-force-broken-image-icon": {
-        syntax: "0 | 1",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions"
-        ],
-        initial: "0",
-        appliesto: "images",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/-moz-force-broken-image-icon"
-      },
-      "-moz-orient": {
-        syntax: "inline | block | horizontal | vertical",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions"
-        ],
-        initial: "inline",
-        appliesto: "anyElementEffectOnProgressAndMeter",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/-moz-orient"
-      },
-      "-moz-outline-radius": {
-        syntax: "<outline-radius>{1,4} [ / <outline-radius>{1,4} ]?",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "-moz-outline-radius-topleft",
-          "-moz-outline-radius-topright",
-          "-moz-outline-radius-bottomright",
-          "-moz-outline-radius-bottomleft"
-        ],
-        percentages: [
-          "-moz-outline-radius-topleft",
-          "-moz-outline-radius-topright",
-          "-moz-outline-radius-bottomright",
-          "-moz-outline-radius-bottomleft"
-        ],
-        groups: [
-          "Mozilla Extensions"
-        ],
-        initial: [
-          "-moz-outline-radius-topleft",
-          "-moz-outline-radius-topright",
-          "-moz-outline-radius-bottomright",
-          "-moz-outline-radius-bottomleft"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "-moz-outline-radius-topleft",
-          "-moz-outline-radius-topright",
-          "-moz-outline-radius-bottomright",
-          "-moz-outline-radius-bottomleft"
-        ],
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-moz-outline-radius-bottomleft": {
-        syntax: "<outline-radius>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "referToDimensionOfBorderBox",
-        groups: [
-          "Mozilla Extensions"
-        ],
-        initial: "0",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-moz-outline-radius-bottomright": {
-        syntax: "<outline-radius>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "referToDimensionOfBorderBox",
-        groups: [
-          "Mozilla Extensions"
-        ],
-        initial: "0",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-moz-outline-radius-topleft": {
-        syntax: "<outline-radius>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "referToDimensionOfBorderBox",
-        groups: [
-          "Mozilla Extensions"
-        ],
-        initial: "0",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-moz-outline-radius-topright": {
-        syntax: "<outline-radius>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "referToDimensionOfBorderBox",
-        groups: [
-          "Mozilla Extensions"
-        ],
-        initial: "0",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-moz-stack-sizing": {
-        syntax: "ignore | stretch-to-fit",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions"
-        ],
-        initial: "stretch-to-fit",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-moz-text-blink": {
-        syntax: "none | blink",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-moz-user-focus": {
-        syntax: "ignore | normal | select-after | select-before | select-menu | select-same | select-all | none",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/-moz-user-focus"
-      },
-      "-moz-user-input": {
-        syntax: "auto | none | enabled | disabled",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/-moz-user-input"
-      },
-      "-moz-user-modify": {
-        syntax: "read-only | read-write | write-only",
-        media: "interactive",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions"
-        ],
-        initial: "read-only",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/user-modify"
-      },
-      "-moz-window-dragging": {
-        syntax: "drag | no-drag",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions"
-        ],
-        initial: "drag",
-        appliesto: "allElementsCreatingNativeWindows",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-moz-window-shadow": {
-        syntax: "default | menu | tooltip | sheet | none",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions"
-        ],
-        initial: "default",
-        appliesto: "allElementsCreatingNativeWindows",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-webkit-appearance": {
-        syntax: "none | button | button-bevel | caret | checkbox | default-button | inner-spin-button | listbox | listitem | media-controls-background | media-controls-fullscreen-background | media-current-time-display | media-enter-fullscreen-button | media-exit-fullscreen-button | media-fullscreen-button | media-mute-button | media-overlay-play-button | media-play-button | media-seek-back-button | media-seek-forward-button | media-slider | media-sliderthumb | media-time-remaining-display | media-toggle-closed-captions-button | media-volume-slider | media-volume-slider-container | media-volume-sliderthumb | menulist | menulist-button | menulist-text | menulist-textfield | meter | progress-bar | progress-bar-value | push-button | radio | searchfield | searchfield-cancel-button | searchfield-decoration | searchfield-results-button | searchfield-results-decoration | slider-horizontal | slider-vertical | sliderthumb-horizontal | sliderthumb-vertical | square-button | textarea | textfield | -apple-pay-button",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: "noneButOverriddenInUserAgentCSS",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/appearance"
-      },
-      "-webkit-border-before": {
-        syntax: "<'border-width'> || <'border-style'> || <color>",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: [
-          "-webkit-border-before-width"
-        ],
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: [
-          "border-width",
-          "border-style",
-          "color"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "border-width",
-          "border-style",
-          "color"
-        ],
-        order: "uniqueOrder",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/-webkit-border-before"
-      },
-      "-webkit-border-before-color": {
-        syntax: "<color>",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: "currentcolor",
-        appliesto: "allElements",
-        computed: "computedColor",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-webkit-border-before-style": {
-        syntax: "<'border-style'>",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-webkit-border-before-width": {
-        syntax: "<'border-width'>",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "logicalWidthOfContainingBlock",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: "medium",
-        appliesto: "allElements",
-        computed: "absoluteLengthZeroIfBorderStyleNoneOrHidden",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-webkit-box-reflect": {
-        syntax: "[ above | below | right | left ]? <length>? <image>?",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/-webkit-box-reflect"
-      },
-      "-webkit-line-clamp": {
-        syntax: "none | <integer>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "WebKit Extensions",
-          "CSS Overflow"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/-webkit-line-clamp"
-      },
-      "-webkit-mask": {
-        syntax: "[ <mask-reference> || <position> [ / <bg-size> ]? || <repeat-style> || [ <visual-box> | border | padding | content | text ] || [ <visual-box> | border | padding | content ] ]#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: [
-          "-webkit-mask-image",
-          "-webkit-mask-repeat",
-          "-webkit-mask-attachment",
-          "-webkit-mask-position",
-          "-webkit-mask-origin",
-          "-webkit-mask-clip"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "-webkit-mask-image",
-          "-webkit-mask-repeat",
-          "-webkit-mask-attachment",
-          "-webkit-mask-position",
-          "-webkit-mask-origin",
-          "-webkit-mask-clip"
-        ],
-        order: "uniqueOrder",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/mask"
-      },
-      "-webkit-mask-attachment": {
-        syntax: "<attachment>#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: "scroll",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "orderOfAppearance",
-        status: "nonstandard"
-      },
-      "-webkit-mask-clip": {
-        syntax: "[ <coord-box> | no-clip | border | padding | content | text ]#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: "border",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "orderOfAppearance",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/mask-clip"
-      },
-      "-webkit-mask-composite": {
-        syntax: "<composite-style>#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: "source-over",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "orderOfAppearance",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-composite"
-      },
-      "-webkit-mask-image": {
-        syntax: "<mask-reference>#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "absoluteURIOrNone",
-        order: "orderOfAppearance",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/mask-image"
-      },
-      "-webkit-mask-origin": {
-        syntax: "[ <coord-box> | border | padding | content ]#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: "padding",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "orderOfAppearance",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/mask-origin"
-      },
-      "-webkit-mask-position": {
-        syntax: "<position>#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "referToSizeOfElement",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: "0% 0%",
-        appliesto: "allElements",
-        computed: "absoluteLengthOrPercentage",
-        order: "orderOfAppearance",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/mask-position"
-      },
-      "-webkit-mask-position-x": {
-        syntax: "[ <length-percentage> | left | center | right ]#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "referToSizeOfElement",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: "0%",
-        appliesto: "allElements",
-        computed: "absoluteLengthOrPercentage",
-        order: "orderOfAppearance",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-position-x"
-      },
-      "-webkit-mask-position-y": {
-        syntax: "[ <length-percentage> | top | center | bottom ]#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "referToSizeOfElement",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: "0%",
-        appliesto: "allElements",
-        computed: "absoluteLengthOrPercentage",
-        order: "orderOfAppearance",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-position-y"
-      },
-      "-webkit-mask-repeat": {
-        syntax: "<repeat-style>#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: "repeat",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "orderOfAppearance",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/mask-repeat"
-      },
-      "-webkit-mask-repeat-x": {
-        syntax: "repeat | no-repeat | space | round",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: "repeat",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "orderOfAppearance",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-repeat-x"
-      },
-      "-webkit-mask-repeat-y": {
-        syntax: "repeat | no-repeat | space | round",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: "repeat",
-        appliesto: "allElements",
-        computed: "absoluteLengthOrPercentage",
-        order: "orderOfAppearance",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-repeat-y"
-      },
-      "-webkit-mask-size": {
-        syntax: "<bg-size>#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "relativeToBackgroundPositioningArea",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: "auto auto",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "orderOfAppearance",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/mask-size"
-      },
-      "-webkit-overflow-scrolling": {
-        syntax: "auto | touch",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: "auto",
-        appliesto: "scrollingBoxes",
-        computed: "asSpecified",
-        order: "orderOfAppearance",
-        status: "nonstandard"
-      },
-      "-webkit-tap-highlight-color": {
-        syntax: "<color>",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: "black",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/-webkit-tap-highlight-color"
-      },
-      "-webkit-text-fill-color": {
-        syntax: "<color>",
-        media: "visual",
-        inherited: true,
-        animationType: "color",
-        percentages: "no",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: "currentcolor",
-        appliesto: "allElements",
-        computed: "computedColor",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/-webkit-text-fill-color"
-      },
-      "-webkit-text-stroke": {
-        syntax: "<length> || <color>",
-        media: "visual",
-        inherited: true,
-        animationType: [
-          "-webkit-text-stroke-width",
-          "-webkit-text-stroke-color"
-        ],
-        percentages: "no",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: [
-          "-webkit-text-stroke-width",
-          "-webkit-text-stroke-color"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "-webkit-text-stroke-width",
-          "-webkit-text-stroke-color"
-        ],
-        order: "canonicalOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/-webkit-text-stroke"
-      },
-      "-webkit-text-stroke-color": {
-        syntax: "<color>",
-        media: "visual",
-        inherited: true,
-        animationType: "color",
-        percentages: "no",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: "currentcolor",
-        appliesto: "allElements",
-        computed: "computedColor",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/-webkit-text-stroke-color"
-      },
-      "-webkit-text-stroke-width": {
-        syntax: "<length>",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: "0",
-        appliesto: "allElements",
-        computed: "absoluteLength",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/-webkit-text-stroke-width"
-      },
-      "-webkit-touch-callout": {
-        syntax: "default | none",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: "default",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/-webkit-touch-callout"
-      },
-      "-webkit-user-modify": {
-        syntax: "read-only | read-write | read-write-plaintext-only",
-        media: "interactive",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: "read-only",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "-webkit-user-select": {
-        syntax: "auto | text | none | all",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "WebKit Extensions"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/user-select"
-      },
-      "accent-color": {
-        syntax: "auto | <color>",
-        media: "interactive",
-        inherited: true,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Basic User Interface"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "asAutoOrColor",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/accent-color"
-      },
-      "align-content": {
-        syntax: "normal | <baseline-position> | <content-distribution> | <overflow-position>? <content-position>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Box Alignment",
-          "CSS Flexible Box Layout"
-        ],
-        initial: "normal",
-        appliesto: "blockContainersMultiColumnContainersFlexContainersGridContainers",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/align-content"
-      },
-      "align-items": {
-        syntax: "normal | stretch | <baseline-position> | [ <overflow-position>? <self-position> ] | anchor-center",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Box Alignment",
-          "CSS Flexible Box Layout"
-        ],
-        initial: "normal",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/align-items"
-      },
-      "align-self": {
-        syntax: "auto | normal | stretch | <baseline-position> | <overflow-position>? <self-position> | anchor-center",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Box Alignment",
-          "CSS Flexible Box Layout"
-        ],
-        initial: "auto",
-        appliesto: "flexItemsGridItemsAndAbsolutelyPositionedBoxes",
-        computed: "autoOnAbsolutelyPositionedElementsValueOfAlignItemsOnParent",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/align-self"
-      },
-      "align-tracks": {
-        syntax: "[ normal | <baseline-position> | <content-distribution> | <overflow-position>? <content-position> ]#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Grid Layout"
-        ],
-        initial: "normal",
-        appliesto: "gridContainersWithMasonryLayoutInTheirBlockAxis",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "alignment-baseline": {
-        syntax: "baseline | alphabetic | ideographic | middle | central | mathematical | text-before-edge | text-after-edge",
-        media: "none",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Inline"
-        ],
-        initial: "baseline",
-        appliesto: "inlineLevelBoxesFlexItemsGridItemsTableCellsAndSVGTextContentElements",
-        computed: "theSpecifiedKeyword",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/alignment-baseline"
-      },
-      all: {
-        syntax: "initial | inherit | unset | revert | revert-layer",
-        media: "noPracticalMedia",
-        inherited: false,
-        animationType: "eachOfShorthandPropertiesExceptUnicodeBiDiAndDirection",
-        percentages: "no",
-        groups: [
-          "CSS Cascading and Inheritance"
-        ],
-        initial: "noPracticalInitialValue",
-        appliesto: "allElements",
-        computed: "asSpecifiedAppliesToEachProperty",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/all"
-      },
-      "anchor-name": {
-        syntax: "none | <dashed-ident>#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Anchor Positioning"
-        ],
-        initial: "none",
-        appliesto: "allElementsThatGenerateAPrincipalBox",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/anchor-name"
-      },
-      "anchor-scope": {
-        syntax: "none | all | <dashed-ident>#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Anchor Positioning"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "experimental"
-      },
-      animation: {
-        syntax: "<single-animation>#",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Animations"
-        ],
-        initial: [
-          "animation-name",
-          "animation-duration",
-          "animation-timing-function",
-          "animation-delay",
-          "animation-iteration-count",
-          "animation-direction",
-          "animation-fill-mode",
-          "animation-play-state",
-          "animation-timeline"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "animation-name",
-          "animation-duration",
-          "animation-timing-function",
-          "animation-delay",
-          "animation-direction",
-          "animation-iteration-count",
-          "animation-fill-mode",
-          "animation-play-state",
-          "animation-timeline"
-        ],
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/animation"
-      },
-      "animation-composition": {
-        syntax: "<single-animation-composition>#",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Animations"
-        ],
-        initial: "replace",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/animation-composition"
-      },
-      "animation-delay": {
-        syntax: "<time>#",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Animations"
-        ],
-        initial: "0s",
-        appliesto: "allElementsAndPseudos",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/animation-delay"
-      },
-      "animation-direction": {
-        syntax: "<single-animation-direction>#",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Animations"
-        ],
-        initial: "normal",
-        appliesto: "allElementsAndPseudos",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/animation-direction"
-      },
-      "animation-duration": {
-        syntax: "[ auto | <time [0s,\u221E]> ]#",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Animations"
-        ],
-        initial: "0s",
-        appliesto: "allElementsAndPseudos",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/animation-duration"
-      },
-      "animation-fill-mode": {
-        syntax: "<single-animation-fill-mode>#",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Animations"
-        ],
-        initial: "none",
-        appliesto: "allElementsAndPseudos",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/animation-fill-mode"
-      },
-      "animation-iteration-count": {
-        syntax: "<single-animation-iteration-count>#",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Animations"
-        ],
-        initial: "1",
-        appliesto: "allElementsAndPseudos",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/animation-iteration-count"
-      },
-      "animation-name": {
-        syntax: "[ none | <keyframes-name> ]#",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Animations"
-        ],
-        initial: "none",
-        appliesto: "allElementsAndPseudos",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/animation-name"
-      },
-      "animation-play-state": {
-        syntax: "<single-animation-play-state>#",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Animations"
-        ],
-        initial: "running",
-        appliesto: "allElementsAndPseudos",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/animation-play-state"
-      },
-      "animation-range": {
-        syntax: "[ <'animation-range-start'> <'animation-range-end'>? ]#",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "animation-range-start",
-          "animation-range-end"
-        ],
-        percentages: "relativeToTimelineRangeIfSpecifiedOtherwiseEntireTimeline",
-        groups: [
-          "Scroll-driven Animations"
-        ],
-        initial: [
-          "animation-range-start",
-          "animation-range-end"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "animation-range-start",
-          "animation-range-end"
-        ],
-        order: "perGrammar",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/animation-range"
-      },
-      "animation-range-end": {
-        syntax: "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "relativeToTimelineRangeIfSpecifiedOtherwiseEntireTimeline",
-        groups: [
-          "Scroll-driven Animations"
-        ],
-        initial: "normal",
-        appliesto: "allElements",
-        computed: "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage",
-        order: "perGrammar",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/animation-range-end"
-      },
-      "animation-range-start": {
-        syntax: "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "relativeToTimelineRangeIfSpecifiedOtherwiseEntireTimeline",
-        groups: [
-          "Scroll-driven Animations"
-        ],
-        initial: "normal",
-        appliesto: "allElements",
-        computed: "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage",
-        order: "perGrammar",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/animation-range-start"
-      },
-      "animation-timeline": {
-        syntax: "<single-animation-timeline>#",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Animations"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "listEachItemIdentifierOrNoneAuto",
-        order: "perGrammar",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/animation-timeline"
-      },
-      "animation-timing-function": {
-        syntax: "<easing-function>#",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Animations"
-        ],
-        initial: "ease",
-        appliesto: "allElementsAndPseudos",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/animation-timing-function"
-      },
-      "animation-trigger": {
-        syntax: "[ none | [ <dashed-ident> <animation-action>+ ]+ ]#",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Animations"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/animation-trigger"
-      },
-      appearance: {
-        syntax: "none | auto | <compat-auto> | <compat-special>",
-        media: "all",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Basic User Interface"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/appearance"
-      },
-      "aspect-ratio": {
-        syntax: "auto || <ratio>",
-        media: "all",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Box Sizing"
-        ],
-        initial: "auto",
-        appliesto: "allElementsExceptInlineBoxesAndInternalRubyOrTableBoxes",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/aspect-ratio"
-      },
-      "backdrop-filter": {
-        syntax: "none | <filter-value-list>",
-        media: "visual",
-        inherited: false,
-        animationType: "filterList",
-        percentages: "no",
-        groups: [
-          "Filter Effects"
-        ],
-        initial: "none",
-        appliesto: "allElementsSVGContainerElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/backdrop-filter"
-      },
-      "backface-visibility": {
-        syntax: "visible | hidden",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Transforms"
-        ],
-        initial: "visible",
-        appliesto: "transformableElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/backface-visibility"
-      },
-      background: {
-        syntax: "<bg-layer>#? , <final-bg-layer>",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "background-color",
-          "background-image",
-          "background-clip",
-          "background-position",
-          "background-size",
-          "background-repeat",
-          "background-attachment"
-        ],
-        percentages: [
-          "background-position",
-          "background-size"
-        ],
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: [
-          "background-image",
-          "background-position",
-          "background-size",
-          "background-repeat",
-          "background-origin",
-          "background-clip",
-          "background-attachment",
-          "background-color"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "background-image",
-          "background-position",
-          "background-size",
-          "background-repeat",
-          "background-origin",
-          "background-clip",
-          "background-attachment",
-          "background-color"
-        ],
-        order: "orderOfAppearance",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/background"
-      },
-      "background-attachment": {
-        syntax: "<attachment>#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "scroll",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/background-attachment"
-      },
-      "background-blend-mode": {
-        syntax: "<blend-mode>#",
-        media: "none",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "Compositing and Blending"
-        ],
-        initial: "normal",
-        appliesto: "allElementsSVGContainerGraphicsAndGraphicsReferencingElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/background-blend-mode"
-      },
-      "background-clip": {
-        syntax: "<bg-clip>#",
-        media: "visual",
-        inherited: false,
-        animationType: "repeatableList",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "border-box",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/background-clip"
-      },
-      "background-color": {
-        syntax: "<color>",
-        media: "visual",
-        inherited: false,
-        animationType: "color",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "transparent",
-        appliesto: "allElements",
-        computed: "computedColor",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/background-color"
-      },
-      "background-image": {
-        syntax: "<bg-image>#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecifiedURLsAbsolute",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/background-image"
-      },
-      "background-origin": {
-        syntax: "<visual-box>#",
-        media: "visual",
-        inherited: false,
-        animationType: "repeatableList",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "padding-box",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/background-origin"
-      },
-      "background-position": {
-        syntax: "<bg-position>#",
-        media: "visual",
-        inherited: false,
-        animationType: "repeatableList",
-        percentages: "referToSizeOfBackgroundPositioningAreaMinusBackgroundImageSize",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "0% 0%",
-        appliesto: "allElements",
-        computed: [
-          "background-position-x",
-          "background-position-y"
-        ],
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/background-position"
-      },
-      "background-position-x": {
-        syntax: "[ center | [ [ left | right | x-start | x-end ]? <length-percentage>? ]! ]#",
-        media: "visual",
-        inherited: false,
-        animationType: "repeatableList",
-        percentages: "referToWidthOfBackgroundPositioningAreaMinusBackgroundImageWidth",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "0%",
-        appliesto: "allElements",
-        computed: "listEachItemConsistingOfAbsoluteLengthPercentageAndOrigin",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/background-position-x"
-      },
-      "background-position-y": {
-        syntax: "[ center | [ [ top | bottom | y-start | y-end ]? <length-percentage>? ]! ]#",
-        media: "visual",
-        inherited: false,
-        animationType: "repeatableList",
-        percentages: "referToHeightOfBackgroundPositioningAreaMinusBackgroundImageHeight",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "0%",
-        appliesto: "allElements",
-        computed: "listEachItemConsistingOfAbsoluteLengthPercentageAndOrigin",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/background-position-y"
-      },
-      "background-repeat": {
-        syntax: "<repeat-style>#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "repeat",
-        appliesto: "allElements",
-        computed: "listEachItemHasTwoKeywordsOnePerDimension",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/background-repeat"
-      },
-      "background-size": {
-        syntax: "<bg-size>#",
-        media: "visual",
-        inherited: false,
-        animationType: "repeatableList",
-        percentages: "relativeToBackgroundPositioningArea",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "auto auto",
-        appliesto: "allElements",
-        computed: "asSpecifiedRelativeToAbsoluteLengths",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/background-size"
-      },
-      "baseline-shift": {
-        syntax: "<length-percentage> | sub | super | baseline",
-        media: "none",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "referToTheUsedValueOfLineHeight",
-        groups: [
-          "CSS Inline"
-        ],
-        initial: "0",
-        appliesto: "inlineLevelBoxesAndSVGTextContentElements",
-        computed: "theSpecifiedKeywordOrAComputedLengthPercentageValue",
-        order: "perGrammar",
-        status: "standard"
-      },
-      "baseline-source": {
-        syntax: "auto | first | last",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Inline"
-        ],
-        initial: "auto",
-        appliesto: "inlineLevelBoxes",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/baseline-source"
-      },
-      "block-size": {
-        syntax: "<'width'>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "blockSizeOfContainingBlock",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "auto",
-        appliesto: "sameAsWidthAndHeight",
-        computed: "sameAsWidthAndHeight",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/block-size"
-      },
-      border: {
-        syntax: "<line-width> || <line-style> || <color>",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "border-width",
-          "border-style",
-          "border-color"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: [
-          "border-width",
-          "border-style",
-          "border-color"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "border-width",
-          "border-style",
-          "border-color"
-        ],
-        order: "orderOfAppearance",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border"
-      },
-      "border-block": {
-        syntax: "<'border-block-start'>",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "border-block-width",
-          "border-block-style",
-          "border-block-color"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: [
-          "border-block-width",
-          "border-block-style",
-          "border-block-color"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "border-block-width",
-          "border-block-style",
-          "border-block-color"
-        ],
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-block"
-      },
-      "border-block-color": {
-        syntax: "<'border-top-color'>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "currentcolor",
-        appliesto: "allElements",
-        computed: "computedColor",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-block-color"
-      },
-      "border-block-end": {
-        syntax: "<'border-top-width'> || <'border-top-style'> || <color>",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "border-block-end-color",
-          "border-block-end-style",
-          "border-block-end-width"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: [
-          "border-top-width",
-          "border-top-style",
-          "border-top-color"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "border-top-width",
-          "border-top-style",
-          "border-top-color"
-        ],
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-block-end"
-      },
-      "border-block-end-color": {
-        syntax: "<'border-top-color'>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "currentcolor",
-        appliesto: "allElements",
-        computed: "computedColor",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-block-end-color"
-      },
-      "border-block-end-style": {
-        syntax: "<'border-top-style'>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-block-end-style"
-      },
-      "border-block-end-width": {
-        syntax: "<'border-top-width'>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "logicalWidthOfContainingBlock",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "medium",
-        appliesto: "allElements",
-        computed: "absoluteLengthZeroIfBorderStyleNoneOrHidden",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-block-end-width"
-      },
-      "border-block-start": {
-        syntax: "<'border-top-width'> || <'border-top-style'> || <color>",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "border-block-start-color",
-          "border-block-start-style",
-          "border-block-start-width"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: [
-          "border-width",
-          "border-style",
-          "color"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "border-width",
-          "border-style",
-          "border-block-start-color"
-        ],
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-block-start"
-      },
-      "border-block-start-color": {
-        syntax: "<'border-top-color'>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "currentcolor",
-        appliesto: "allElements",
-        computed: "computedColor",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-block-start-color"
-      },
-      "border-block-start-style": {
-        syntax: "<'border-top-style'>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-block-start-style"
-      },
-      "border-block-start-width": {
-        syntax: "<'border-top-width'>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "logicalWidthOfContainingBlock",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "medium",
-        appliesto: "allElements",
-        computed: "absoluteLengthZeroIfBorderStyleNoneOrHidden",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-block-start-width"
-      },
-      "border-block-style": {
-        syntax: "<'border-top-style'>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-block-style"
-      },
-      "border-block-width": {
-        syntax: "<'border-top-width'>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "logicalWidthOfContainingBlock",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "medium",
-        appliesto: "allElements",
-        computed: "absoluteLengthZeroIfBorderStyleNoneOrHidden",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-block-width"
-      },
-      "border-bottom": {
-        syntax: "<line-width> || <line-style> || <color>",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "border-bottom-color",
-          "border-bottom-style",
-          "border-bottom-width"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: [
-          "border-bottom-width",
-          "border-bottom-style",
-          "border-bottom-color"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "border-bottom-width",
-          "border-bottom-style",
-          "border-bottom-color"
-        ],
-        order: "orderOfAppearance",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-bottom"
-      },
-      "border-bottom-color": {
-        syntax: "<'border-top-color'>",
-        media: "visual",
-        inherited: false,
-        animationType: "color",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "currentcolor",
-        appliesto: "allElements",
-        computed: "computedColor",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-bottom-color"
-      },
-      "border-bottom-left-radius": {
-        syntax: "<length-percentage [0,\u221E]>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "referToDimensionOfBorderBox",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "0",
-        appliesto: "allElementsUAsNotRequiredWhenCollapse",
-        computed: "twoAbsoluteLengthOrPercentages",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-bottom-left-radius"
-      },
-      "border-bottom-right-radius": {
-        syntax: "<length-percentage [0,\u221E]>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "referToDimensionOfBorderBox",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "0",
-        appliesto: "allElementsUAsNotRequiredWhenCollapse",
-        computed: "twoAbsoluteLengthOrPercentages",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-bottom-right-radius"
-      },
-      "border-bottom-style": {
-        syntax: "<line-style>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-bottom-style"
-      },
-      "border-bottom-width": {
-        syntax: "<line-width>",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "medium",
-        appliesto: "allElements",
-        computed: "absoluteLengthOr0IfBorderBottomStyleNoneOrHidden",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-bottom-width"
-      },
-      "border-collapse": {
-        syntax: "separate | collapse",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Table"
-        ],
-        initial: "separate",
-        appliesto: "tableElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-collapse"
-      },
-      "border-color": {
-        syntax: "<color>{1,4}",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "border-bottom-color",
-          "border-left-color",
-          "border-right-color",
-          "border-top-color"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: [
-          "border-top-color",
-          "border-right-color",
-          "border-bottom-color",
-          "border-left-color"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "border-bottom-color",
-          "border-left-color",
-          "border-right-color",
-          "border-top-color"
-        ],
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-color"
-      },
-      "border-end-end-radius": {
-        syntax: "<'border-top-left-radius'>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "referToDimensionOfBorderBox",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "0",
-        appliesto: "allElementsUAsNotRequiredWhenCollapse",
-        computed: "twoAbsoluteLengthOrPercentages",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-end-end-radius"
-      },
-      "border-end-start-radius": {
-        syntax: "<'border-top-left-radius'>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "referToDimensionOfBorderBox",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "0",
-        appliesto: "allElementsUAsNotRequiredWhenCollapse",
-        computed: "twoAbsoluteLengthOrPercentages",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-end-start-radius"
-      },
-      "border-image": {
-        syntax: "<'border-image-source'> || <'border-image-slice'> [ / <'border-image-width'> | / <'border-image-width'>? / <'border-image-outset'> ]? || <'border-image-repeat'>",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "border-image-outset",
-          "border-image-repeat",
-          "border-image-slice",
-          "border-image-source",
-          "border-image-width"
-        ],
-        percentages: [
-          "border-image-slice",
-          "border-image-width"
-        ],
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: [
-          "border-image-source",
-          "border-image-slice",
-          "border-image-width",
-          "border-image-outset",
-          "border-image-repeat"
-        ],
-        appliesto: "allElementsExceptTableElementsWhenCollapse",
-        computed: [
-          "border-image-outset",
-          "border-image-repeat",
-          "border-image-slice",
-          "border-image-source",
-          "border-image-width"
-        ],
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-image"
-      },
-      "border-image-outset": {
-        syntax: "[ <length [0,\u221E]> | <number [0,\u221E]> ]{1,4}",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "0",
-        appliesto: "allElementsExceptTableElementsWhenCollapse",
-        computed: "asSpecifiedRelativeToAbsoluteLengths",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-image-outset"
-      },
-      "border-image-repeat": {
-        syntax: "[ stretch | repeat | round | space ]{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "stretch",
-        appliesto: "allElementsExceptTableElementsWhenCollapse",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-image-repeat"
-      },
-      "border-image-slice": {
-        syntax: "[ <number [0,\u221E]> | <percentage [0,\u221E]> ]{1,4} && fill?",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "referToSizeOfBorderImage",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "100%",
-        appliesto: "allElementsExceptTableElementsWhenCollapse",
-        computed: "oneToFourPercentagesOrAbsoluteLengthsPlusFill",
-        order: "percentagesOrLengthsFollowedByFill",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-image-slice"
-      },
-      "border-image-source": {
-        syntax: "none | <image>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "none",
-        appliesto: "allElementsExceptTableElementsWhenCollapse",
-        computed: "noneOrImageWithAbsoluteURI",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-image-source"
-      },
-      "border-image-width": {
-        syntax: "[ <length-percentage [0,\u221E]> | <number [0,\u221E]> | auto ]{1,4}",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "referToWidthOrHeightOfBorderImageArea",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "1",
-        appliesto: "allElementsExceptTableElementsWhenCollapse",
-        computed: "asSpecifiedRelativeToAbsoluteLengths",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-image-width"
-      },
-      "border-inline": {
-        syntax: "<'border-block-start'>",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "border-inline-color",
-          "border-inline-style",
-          "border-inline-width"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: [
-          "border-inline-width",
-          "border-inline-style",
-          "border-inline-color"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "border-inline-width",
-          "border-inline-style",
-          "border-inline-color"
-        ],
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-inline"
-      },
-      "border-inline-color": {
-        syntax: "<'border-top-color'>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "currentcolor",
-        appliesto: "allElements",
-        computed: "computedColor",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-inline-color"
-      },
-      "border-inline-end": {
-        syntax: "<'border-top-width'> || <'border-top-style'> || <color>",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "border-inline-end-color",
-          "border-inline-end-style",
-          "border-inline-end-width"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: [
-          "border-width",
-          "border-style",
-          "color"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "border-width",
-          "border-style",
-          "border-inline-end-color"
-        ],
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-inline-end"
-      },
-      "border-inline-end-color": {
-        syntax: "<'border-top-color'>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "currentcolor",
-        appliesto: "allElements",
-        computed: "computedColor",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-inline-end-color"
-      },
-      "border-inline-end-style": {
-        syntax: "<'border-top-style'>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-inline-end-style"
-      },
-      "border-inline-end-width": {
-        syntax: "<'border-top-width'>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "logicalWidthOfContainingBlock",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "medium",
-        appliesto: "allElements",
-        computed: "absoluteLengthZeroIfBorderStyleNoneOrHidden",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-inline-end-width"
-      },
-      "border-inline-start": {
-        syntax: "<'border-top-width'> || <'border-top-style'> || <color>",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "border-inline-start-color",
-          "border-inline-start-style",
-          "border-inline-start-width"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: [
-          "border-width",
-          "border-style",
-          "color"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "border-width",
-          "border-style",
-          "border-inline-start-color"
-        ],
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-inline-start"
-      },
-      "border-inline-start-color": {
-        syntax: "<'border-top-color'>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "currentcolor",
-        appliesto: "allElements",
-        computed: "computedColor",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-inline-start-color"
-      },
-      "border-inline-start-style": {
-        syntax: "<'border-top-style'>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-inline-start-style"
-      },
-      "border-inline-start-width": {
-        syntax: "<'border-top-width'>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "logicalWidthOfContainingBlock",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "medium",
-        appliesto: "allElements",
-        computed: "absoluteLengthZeroIfBorderStyleNoneOrHidden",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-inline-start-width"
-      },
-      "border-inline-style": {
-        syntax: "<'border-top-style'>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-inline-style"
-      },
-      "border-inline-width": {
-        syntax: "<'border-top-width'>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "logicalWidthOfContainingBlock",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "medium",
-        appliesto: "allElements",
-        computed: "absoluteLengthZeroIfBorderStyleNoneOrHidden",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-inline-width"
-      },
-      "border-left": {
-        syntax: "<line-width> || <line-style> || <color>",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "border-left-color",
-          "border-left-style",
-          "border-left-width"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: [
-          "border-left-width",
-          "border-left-style",
-          "border-left-color"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "border-left-width",
-          "border-left-style",
-          "border-left-color"
-        ],
-        order: "orderOfAppearance",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-left"
-      },
-      "border-left-color": {
-        syntax: "<color>",
-        media: "visual",
-        inherited: false,
-        animationType: "color",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "currentcolor",
-        appliesto: "allElements",
-        computed: "computedColor",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-left-color"
-      },
-      "border-left-style": {
-        syntax: "<line-style>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-left-style"
-      },
-      "border-left-width": {
-        syntax: "<line-width>",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "medium",
-        appliesto: "allElements",
-        computed: "absoluteLengthOr0IfBorderLeftStyleNoneOrHidden",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-left-width"
-      },
-      "border-radius": {
-        syntax: "<length-percentage [0,\u221E]>{1,4} [ / <length-percentage [0,\u221E]>{1,4} ]?",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "border-top-left-radius",
-          "border-top-right-radius",
-          "border-bottom-right-radius",
-          "border-bottom-left-radius"
-        ],
-        percentages: "referToDimensionOfBorderBox",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: [
-          "border-top-left-radius",
-          "border-top-right-radius",
-          "border-bottom-right-radius",
-          "border-bottom-left-radius"
-        ],
-        appliesto: "allElementsUAsNotRequiredWhenCollapse",
-        computed: [
-          "border-bottom-left-radius",
-          "border-bottom-right-radius",
-          "border-top-left-radius",
-          "border-top-right-radius"
-        ],
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-radius"
-      },
-      "border-right": {
-        syntax: "<line-width> || <line-style> || <color>",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "border-right-color",
-          "border-right-style",
-          "border-right-width"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: [
-          "border-right-width",
-          "border-right-style",
-          "border-right-color"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "border-right-width",
-          "border-right-style",
-          "border-right-color"
-        ],
-        order: "orderOfAppearance",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-right"
-      },
-      "border-right-color": {
-        syntax: "<color>",
-        media: "visual",
-        inherited: false,
-        animationType: "color",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "currentcolor",
-        appliesto: "allElements",
-        computed: "computedColor",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-right-color"
-      },
-      "border-right-style": {
-        syntax: "<line-style>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-right-style"
-      },
-      "border-right-width": {
-        syntax: "<line-width>",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "medium",
-        appliesto: "allElements",
-        computed: "absoluteLengthOr0IfBorderRightStyleNoneOrHidden",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-right-width"
-      },
-      "border-spacing": {
-        syntax: "<length>{1,2}",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Table"
-        ],
-        initial: "0",
-        appliesto: "tableElements",
-        computed: "twoAbsoluteLengths",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-spacing"
-      },
-      "border-start-end-radius": {
-        syntax: "<'border-top-left-radius'>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "referToDimensionOfBorderBox",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "0",
-        appliesto: "allElementsUAsNotRequiredWhenCollapse",
-        computed: "twoAbsoluteLengthOrPercentages",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-start-end-radius"
-      },
-      "border-start-start-radius": {
-        syntax: "<'border-top-left-radius'>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "referToDimensionOfBorderBox",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "0",
-        appliesto: "allElementsUAsNotRequiredWhenCollapse",
-        computed: "twoAbsoluteLengthOrPercentages",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-start-start-radius"
-      },
-      "border-style": {
-        syntax: "<line-style>{1,4}",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: [
-          "border-top-style",
-          "border-right-style",
-          "border-bottom-style",
-          "border-left-style"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "border-bottom-style",
-          "border-left-style",
-          "border-right-style",
-          "border-top-style"
-        ],
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-style"
-      },
-      "border-top": {
-        syntax: "<line-width> || <line-style> || <color>",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "border-top-color",
-          "border-top-style",
-          "border-top-width"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: [
-          "border-top-width",
-          "border-top-style",
-          "border-top-color"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "border-top-width",
-          "border-top-style",
-          "border-top-color"
-        ],
-        order: "orderOfAppearance",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-top"
-      },
-      "border-top-color": {
-        syntax: "<color>",
-        media: "visual",
-        inherited: false,
-        animationType: "color",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "currentcolor",
-        appliesto: "allElements",
-        computed: "computedColor",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-top-color"
-      },
-      "border-top-left-radius": {
-        syntax: "<length-percentage [0,\u221E]>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "referToDimensionOfBorderBox",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "0",
-        appliesto: "allElementsUAsNotRequiredWhenCollapse",
-        computed: "twoAbsoluteLengthOrPercentages",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-top-left-radius"
-      },
-      "border-top-right-radius": {
-        syntax: "<length-percentage [0,\u221E]>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "referToDimensionOfBorderBox",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "0",
-        appliesto: "allElementsUAsNotRequiredWhenCollapse",
-        computed: "twoAbsoluteLengthOrPercentages",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-top-right-radius"
-      },
-      "border-top-style": {
-        syntax: "<line-style>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-top-style"
-      },
-      "border-top-width": {
-        syntax: "<line-width>",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "medium",
-        appliesto: "allElements",
-        computed: "absoluteLengthOr0IfBorderTopStyleNoneOrHidden",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-top-width"
-      },
-      "border-width": {
-        syntax: "<line-width>{1,4}",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "border-bottom-width",
-          "border-left-width",
-          "border-right-width",
-          "border-top-width"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: [
-          "border-top-width",
-          "border-right-width",
-          "border-bottom-width",
-          "border-left-width"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "border-bottom-width",
-          "border-left-width",
-          "border-right-width",
-          "border-top-width"
-        ],
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/border-width"
-      },
-      bottom: {
-        syntax: "auto | <length-percentage> | <anchor()> | <anchor-size()>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "referToContainingBlockHeight",
-        groups: [
-          "CSS Anchor Positioning",
-          "CSS Positioned Layout"
-        ],
-        initial: "auto",
-        appliesto: "positionedElements",
-        computed: "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/bottom"
-      },
-      "box-align": {
-        syntax: "start | center | end | baseline | stretch",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions",
-          "WebKit Extensions"
-        ],
-        initial: "stretch",
-        appliesto: "elementsWithDisplayBoxOrInlineBox",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/box-align"
-      },
-      "box-decoration-break": {
-        syntax: "slice | clone",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Fragmentation"
-        ],
-        initial: "slice",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/box-decoration-break"
-      },
-      "box-direction": {
-        syntax: "normal | reverse | inherit",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions",
-          "WebKit Extensions"
-        ],
-        initial: "normal",
-        appliesto: "elementsWithDisplayBoxOrInlineBox",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/box-direction"
-      },
-      "box-flex": {
-        syntax: "<number>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions",
-          "WebKit Extensions"
-        ],
-        initial: "0",
-        appliesto: "directChildrenOfElementsWithDisplayMozBoxMozInlineBox",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/box-flex"
-      },
-      "box-flex-group": {
-        syntax: "<integer>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions",
-          "WebKit Extensions"
-        ],
-        initial: "1",
-        appliesto: "inFlowChildrenOfBoxElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/box-flex-group"
-      },
-      "box-lines": {
-        syntax: "single | multiple",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions",
-          "WebKit Extensions"
-        ],
-        initial: "single",
-        appliesto: "boxElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/box-lines"
-      },
-      "box-ordinal-group": {
-        syntax: "<integer>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions",
-          "WebKit Extensions"
-        ],
-        initial: "1",
-        appliesto: "childrenOfBoxElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/box-ordinal-group"
-      },
-      "box-orient": {
-        syntax: "horizontal | vertical | inline-axis | block-axis | inherit",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions",
-          "WebKit Extensions"
-        ],
-        initial: "inline-axis",
-        appliesto: "elementsWithDisplayBoxOrInlineBox",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/box-orient"
-      },
-      "box-pack": {
-        syntax: "start | center | end | justify",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions",
-          "WebKit Extensions"
-        ],
-        initial: "start",
-        appliesto: "elementsWithDisplayMozBoxMozInlineBox",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/box-pack"
-      },
-      "box-shadow": {
-        syntax: "none | <shadow>#",
-        media: "visual",
-        inherited: false,
-        animationType: "shadowList",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "absoluteLengthsSpecifiedColorAsSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/box-shadow"
-      },
-      "box-sizing": {
-        syntax: "content-box | border-box",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Box Sizing"
-        ],
-        initial: "content-box",
-        appliesto: "allElementsAcceptingWidthOrHeight",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/box-sizing"
-      },
-      "break-after": {
-        syntax: "auto | avoid | always | all | avoid-page | page | left | right | recto | verso | avoid-column | column | avoid-region | region",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Fragmentation"
-        ],
-        initial: "auto",
-        appliesto: "blockLevelElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/break-after"
-      },
-      "break-before": {
-        syntax: "auto | avoid | always | all | avoid-page | page | left | right | recto | verso | avoid-column | column | avoid-region | region",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Fragmentation"
-        ],
-        initial: "auto",
-        appliesto: "blockLevelElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/break-before"
-      },
-      "break-inside": {
-        syntax: "auto | avoid | avoid-page | avoid-column | avoid-region",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Fragmentation"
-        ],
-        initial: "auto",
-        appliesto: "blockLevelElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/break-inside"
-      },
-      "caption-side": {
-        syntax: "top | bottom",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Table"
-        ],
-        initial: "top",
-        appliesto: "tableCaptionElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/caption-side"
-      },
-      caret: {
-        syntax: "<'caret-color'> || <'caret-animation'> || <'caret-shape'>",
-        media: "interactive",
-        inherited: true,
-        animationType: [
-          "caret-color",
-          "caret-animation",
-          "caret-shape"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Basic User Interface"
-        ],
-        initial: [
-          "caret-color",
-          "caret-animation",
-          "caret-shape"
-        ],
-        appliesto: "textOrElementsThatAcceptInput",
-        computed: [
-          "caret-color",
-          "caret-animation",
-          "caret-shape"
-        ],
-        order: "perGrammar",
-        status: "standard"
-      },
-      "caret-animation": {
-        syntax: "auto | manual",
-        media: "interactive",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Basic User Interface"
-        ],
-        initial: "auto",
-        appliesto: "textOrElementsThatAcceptInput",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/caret-animation"
-      },
-      "caret-color": {
-        syntax: "auto | <color>",
-        media: "interactive",
-        inherited: true,
-        animationType: "color",
-        percentages: "no",
-        groups: [
-          "CSS Basic User Interface"
-        ],
-        initial: "auto",
-        appliesto: "textOrElementsThatAcceptInput",
-        computed: "asAutoOrColor",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/caret-color"
-      },
-      "caret-shape": {
-        syntax: "auto | bar | block | underscore",
-        media: "interactive",
-        inherited: true,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Basic User Interface"
-        ],
-        initial: "auto",
-        appliesto: "textOrElementsThatAcceptInput",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard"
-      },
-      clear: {
-        syntax: "none | left | right | both | inline-start | inline-end",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Positioned Layout"
-        ],
-        initial: "none",
-        appliesto: "blockLevelElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/clear"
-      },
-      clip: {
-        syntax: "<shape> | auto",
-        media: "visual",
-        inherited: false,
-        animationType: "rectangle",
-        percentages: "no",
-        groups: [
-          "CSS Masking"
-        ],
-        initial: "auto",
-        appliesto: "absolutelyPositionedElements",
-        computed: "autoOrRectangle",
-        order: "uniqueOrder",
-        status: "obsolete",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/clip"
-      },
-      "clip-path": {
-        syntax: "<clip-source> | [ <basic-shape> || <geometry-box> ] | none",
-        media: "visual",
-        inherited: false,
-        animationType: "basicShapeOtherwiseNo",
-        percentages: "referToReferenceBoxWhenSpecifiedOtherwiseBorderBox",
-        groups: [
-          "CSS Masking"
-        ],
-        initial: "none",
-        appliesto: "allElementsSVGContainerElements",
-        computed: "asSpecifiedURLsAbsolute",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/clip-path"
-      },
-      "clip-rule": {
-        syntax: "nonzero | evenodd",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Masking"
-        ],
-        initial: "nonzero",
-        appliesto: "limitedSVGElementsGraphics",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/clip-rule"
-      },
-      color: {
-        syntax: "<color>",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Color"
-        ],
-        initial: "canvastext",
-        appliesto: "allElementsAndText",
-        computed: "computedColor",
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/color"
-      },
-      "color-interpolation-filters": {
-        syntax: "auto | sRGB | linearRGB",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Filter Effects"
-        ],
-        initial: "linearRGB",
-        appliesto: "limitedSVGElementsFilterPrimitives",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/color-interpolation-filters"
-      },
-      "color-scheme": {
-        syntax: "normal | [ light | dark | <custom-ident> ]+ && only?",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Color"
-        ],
-        initial: "normal",
-        appliesto: "allElementsAndText",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/color-scheme"
-      },
-      "column-count": {
-        syntax: "<integer> | auto",
-        media: "visual",
-        inherited: false,
-        animationType: "integer",
-        percentages: "no",
-        groups: [
-          "CSS Multi-column Layout"
-        ],
-        initial: "auto",
-        appliesto: "blockContainersExceptTableWrappers",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/column-count"
-      },
-      "column-fill": {
-        syntax: "auto | balance",
-        media: "visualInContinuousMediaNoEffectInOverflowColumns",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Multi-column Layout"
-        ],
-        initial: "balance",
-        appliesto: "multicolElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/column-fill"
-      },
-      "column-gap": {
-        syntax: "normal | <length-percentage>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "referToDimensionOfContentArea",
-        groups: [
-          "CSS Box Alignment",
-          "CSS Multi-column Layout"
-        ],
-        initial: "normal",
-        appliesto: "multiColumnElementsFlexContainersGridContainers",
-        computed: "asSpecifiedWithLengthsAbsoluteAndNormalComputingToZeroExceptMultiColumn",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/column-gap"
-      },
-      "column-height": {
-        syntax: "auto | <length [0,\u221E]>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Box Sizing",
-          "CSS Multi-column Layout"
-        ],
-        initial: "auto",
-        appliesto: "blockContainersExceptTableWrappers",
-        computed: "autoOrAbsoluteLength",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/column-height"
-      },
-      "column-rule": {
-        syntax: "<'column-rule-width'> || <'column-rule-style'> || <'column-rule-color'>",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "column-rule-color",
-          "column-rule-style",
-          "column-rule-width"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Multi-column Layout"
-        ],
-        initial: [
-          "column-rule-width",
-          "column-rule-style",
-          "column-rule-color"
-        ],
-        appliesto: "multicolElements",
-        computed: [
-          "column-rule-color",
-          "column-rule-style",
-          "column-rule-width"
-        ],
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/column-rule"
-      },
-      "column-rule-color": {
-        syntax: "<color>",
-        media: "visual",
-        inherited: false,
-        animationType: "color",
-        percentages: "no",
-        groups: [
-          "CSS Multi-column Layout"
-        ],
-        initial: "currentcolor",
-        appliesto: "multicolElements",
-        computed: "computedColor",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/column-rule-color"
-      },
-      "column-rule-style": {
-        syntax: "<'border-style'>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Multi-column Layout"
-        ],
-        initial: "none",
-        appliesto: "multicolElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/column-rule-style"
-      },
-      "column-rule-width": {
-        syntax: "<'border-width'>",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "no",
-        groups: [
-          "CSS Multi-column Layout"
-        ],
-        initial: "medium",
-        appliesto: "multicolElements",
-        computed: "absoluteLength0IfColumnRuleStyleNoneOrHidden",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/column-rule-width"
-      },
-      "column-span": {
-        syntax: "none | all",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Multi-column Layout"
-        ],
-        initial: "none",
-        appliesto: "inFlowBlockLevelElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/column-span"
-      },
-      "column-width": {
-        syntax: "auto | <length [0,\u221E]>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Box Sizing",
-          "CSS Multi-column Layout"
-        ],
-        initial: "auto",
-        appliesto: "blockContainersExceptTableWrappers",
-        computed: "autoOrAbsoluteLength",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/column-width"
-      },
-      "column-wrap": {
-        syntax: "auto | nowrap | wrap",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Box Sizing",
-          "CSS Multi-column Layout"
-        ],
-        initial: "auto",
-        appliesto: "multicolElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/column-wrap"
-      },
-      columns: {
-        syntax: "[ <'column-width'> || <'column-count'> ] [ / <'column-height'> ]?",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "column-width",
-          "column-count",
-          "column-height"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Multi-column Layout"
-        ],
-        initial: [
-          "column-width",
-          "column-count",
-          "column-height"
-        ],
-        appliesto: "blockContainersExceptTableWrappers",
-        computed: [
-          "column-width",
-          "column-count",
-          "column-height"
-        ],
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/columns"
-      },
-      contain: {
-        syntax: "none | strict | content | [ [ size || inline-size ] || layout || style || paint ]",
-        media: "all",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Containment"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/contain"
-      },
-      "contain-intrinsic-block-size": {
-        syntax: "auto? [ none | <length> ]",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Box Sizing"
-        ],
-        initial: "none",
-        appliesto: "elementsForWhichSizeContainmentCanApply",
-        computed: "asSpecifiedWithLengthValuesComputed",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-block-size"
-      },
-      "contain-intrinsic-height": {
-        syntax: "auto? [ none | <length> ]",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Box Sizing"
-        ],
-        initial: "none",
-        appliesto: "elementsForWhichSizeContainmentCanApply",
-        computed: "asSpecifiedWithLengthValuesComputed",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-height"
-      },
-      "contain-intrinsic-inline-size": {
-        syntax: "auto? [ none | <length> ]",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Box Sizing"
-        ],
-        initial: "none",
-        appliesto: "elementsForWhichSizeContainmentCanApply",
-        computed: "asSpecifiedWithLengthValuesComputed",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-inline-size"
-      },
-      "contain-intrinsic-size": {
-        syntax: "[ auto? [ none | <length> ] ]{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "contain-intrinsic-width",
-          "contain-intrinsic-height"
-        ],
-        percentages: [
-          "contain-intrinsic-width",
-          "contain-intrinsic-height"
-        ],
-        groups: [
-          "CSS Box Sizing"
-        ],
-        initial: [
-          "contain-intrinsic-width",
-          "contain-intrinsic-height"
-        ],
-        appliesto: "elementsForWhichSizeContainmentCanApply",
-        computed: [
-          "contain-intrinsic-width",
-          "contain-intrinsic-height"
-        ],
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-size"
-      },
-      "contain-intrinsic-width": {
-        syntax: "auto? [ none | <length> ]",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Box Sizing"
-        ],
-        initial: "none",
-        appliesto: "elementsForWhichSizeContainmentCanApply",
-        computed: "asSpecifiedWithLengthValuesComputed",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-width"
-      },
-      container: {
-        syntax: "<'container-name'> [ / <'container-type'> ]?",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "container-name",
-          "container-type"
-        ],
-        percentages: [
-          "container-name",
-          "container-type"
-        ],
-        groups: [
-          "CSS Conditional Rules"
-        ],
-        initial: [
-          "container-name",
-          "container-type"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "container-name",
-          "container-type"
-        ],
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/container"
-      },
-      "container-name": {
-        syntax: "none | <custom-ident>+",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Conditional Rules"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "noneOrOrderedListOfIdentifiers",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/container-name"
-      },
-      "container-type": {
-        syntax: "normal | [ [ size | inline-size ] || scroll-state ]",
-        media: "visual",
-        inherited: false,
-        animationType: "color",
-        percentages: "no",
-        groups: [
-          "CSS Conditional Rules"
-        ],
-        initial: "normal",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/container-type"
-      },
-      content: {
-        syntax: "normal | none | [ <content-replacement> | <content-list> ] [ / [ <string> | <counter> | <attr()> ]+ ]?",
-        media: "all",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Generated Content"
-        ],
-        initial: "normal",
-        appliesto: "allElementsTreeAbidingPseudoElementsPageMarginBoxes",
-        computed: "normalOnElementsForPseudosNoneAbsoluteURIStringOrAsSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/content"
-      },
-      "content-visibility": {
-        syntax: "visible | auto | hidden",
-        media: "all",
-        inherited: false,
-        animationType: "discreteButVisibleForDurationWhenAnimatedHidden",
-        percentages: "no",
-        groups: [
-          "CSS Containment"
-        ],
-        initial: "visible",
-        appliesto: "elementsForWhichSizeContainmentCanApply",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/content-visibility"
-      },
-      "corner-block-end-shape": {
-        syntax: "<corner-shape-value>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "corner-end-start-shape",
-          "corner-end-end-shape"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: [
-          "corner-end-start-shape",
-          "corner-end-end-shape"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "corner-end-start-shape",
-          "corner-end-end-shape"
-        ],
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/corner-block-end-shape"
-      },
-      "corner-block-start-shape": {
-        syntax: "<corner-shape-value>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "corner-start-start-shape",
-          "corner-start-end-shape"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: [
-          "corner-start-start-shape",
-          "corner-start-end-shape"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "corner-start-start-shape",
-          "corner-start-end-shape"
-        ],
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/corner-block-start-shape"
-      },
-      "corner-bottom-shape": {
-        syntax: "<corner-shape-value>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "corner-bottom-left-shape",
-          "corner-bottom-right-shape"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: [
-          "corner-bottom-left-shape",
-          "corner-bottom-right-shape"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "corner-bottom-left-shape",
-          "corner-bottom-right-shape"
-        ],
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/corner-bottom-shape"
-      },
-      "corner-bottom-left-shape": {
-        syntax: "<corner-shape-value>",
-        media: "visual",
-        inherited: false,
-        animationType: "superellipseInterpolation",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "round",
-        appliesto: "allElements",
-        computed: "correspondingSuperellipse",
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/corner-bottom-left-shape"
-      },
-      "corner-bottom-right-shape": {
-        syntax: "<corner-shape-value>",
-        media: "visual",
-        inherited: false,
-        animationType: "superellipseInterpolation",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "round",
-        appliesto: "allElements",
-        computed: "correspondingSuperellipse",
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/corner-bottom-right-shape"
-      },
-      "corner-end-end-shape": {
-        syntax: "<corner-shape-value>",
-        media: "visual",
-        inherited: false,
-        animationType: "superellipseInterpolation",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "round",
-        appliesto: "allElements",
-        computed: "correspondingSuperellipse",
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/corner-end-end-shape"
-      },
-      "corner-end-start-shape": {
-        syntax: "<corner-shape-value>",
-        media: "visual",
-        inherited: false,
-        animationType: "superellipseInterpolation",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "round",
-        appliesto: "allElements",
-        computed: "correspondingSuperellipse",
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/corner-end-start-shape"
-      },
-      "corner-inline-end-shape": {
-        syntax: "<corner-shape-value>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "corner-start-end-shape",
-          "corner-end-end-shape"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: [
-          "corner-start-end-shape",
-          "corner-end-end-shape"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "corner-start-end-shape",
-          "corner-end-end-shape"
-        ],
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/corner-inline-end-shape"
-      },
-      "corner-inline-start-shape": {
-        syntax: "<corner-shape-value>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "corner-start-start-shape",
-          "corner-start-end-shape"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: [
-          "corner-start-start-shape",
-          "corner-start-end-shape"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "corner-start-start-shape",
-          "corner-start-end-shape"
-        ],
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/corner-inline-start-shape"
-      },
-      "corner-left-shape": {
-        syntax: "<corner-shape-value>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "corner-top-left-shape",
-          "corner-bottom-left-shape"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: [
-          "corner-top-left-shape",
-          "corner-bottom-left-shape"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "corner-top-left-shape",
-          "corner-bottom-left-shape"
-        ],
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/corner-left-shape"
-      },
-      "corner-right-shape": {
-        syntax: "<corner-shape-value>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "corner-top-right-shape",
-          "corner-bottom-right-shape"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: [
-          "corner-top-right-shape",
-          "corner-bottom-right-shape"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "corner-top-right-shape",
-          "corner-bottom-right-shape"
-        ],
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/corner-right-shape"
-      },
-      "corner-shape": {
-        syntax: "<corner-shape-value>{1,4}",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "corner-top-left-shape",
-          "corner-top-right-shape",
-          "corner-bottom-left-shape",
-          "corner-bottom-right-shape"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: [
-          "corner-top-left-shape",
-          "corner-top-right-shape",
-          "corner-bottom-left-shape",
-          "corner-bottom-right-shape"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "corner-top-left-shape",
-          "corner-top-right-shape",
-          "corner-bottom-left-shape",
-          "corner-bottom-right-shape"
-        ],
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/corner-shape"
-      },
-      "corner-start-start-shape": {
-        syntax: "<corner-shape-value>",
-        media: "visual",
-        inherited: false,
-        animationType: "superellipseInterpolation",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "round",
-        appliesto: "allElements",
-        computed: "correspondingSuperellipse",
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/corner-start-start-shape"
-      },
-      "corner-start-end-shape": {
-        syntax: "<corner-shape-value>",
-        media: "visual",
-        inherited: false,
-        animationType: "superellipseInterpolation",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "round",
-        appliesto: "allElements",
-        computed: "correspondingSuperellipse",
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/corner-start-end-shape"
-      },
-      "corner-top-shape": {
-        syntax: "<corner-shape-value>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "corner-top-left-shape",
-          "corner-top-right-shape"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: [
-          "corner-top-left-shape",
-          "corner-top-right-shape"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "corner-top-left-shape",
-          "corner-top-right-shape"
-        ],
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/corner-top-shape"
-      },
-      "corner-top-left-shape": {
-        syntax: "<corner-shape-value>",
-        media: "visual",
-        inherited: false,
-        animationType: "superellipseInterpolation",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "round",
-        appliesto: "allElements",
-        computed: "correspondingSuperellipse",
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/corner-top-left-shape"
-      },
-      "corner-top-right-shape": {
-        syntax: "<corner-shape-value>",
-        media: "visual",
-        inherited: false,
-        animationType: "superellipseInterpolation",
-        percentages: "no",
-        groups: [
-          "CSS Backgrounds and Borders"
-        ],
-        initial: "round",
-        appliesto: "allElements",
-        computed: "correspondingSuperellipse",
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/corner-top-right-shape"
-      },
-      "counter-increment": {
-        syntax: "[ <counter-name> <integer>? ]+ | none",
-        media: "all",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Lists and Counters"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/counter-increment"
-      },
-      "counter-reset": {
-        syntax: "[ <counter-name> <integer>? | <reversed-counter-name> <integer>? ]+ | none",
-        media: "all",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Lists and Counters"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/counter-reset"
-      },
-      "counter-set": {
-        syntax: "[ <counter-name> <integer>? ]+ | none",
-        media: "all",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Lists and Counters"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/counter-set"
-      },
-      cursor: {
-        syntax: "[ [ <url> [ <x> <y> ]? , ]* <cursor-predefined> ]",
-        media: [
-          "visual",
-          "interactive"
-        ],
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Basic User Interface"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "asSpecifiedURLsAbsolute",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/cursor"
-      },
-      cx: {
-        syntax: "<length> | <percentage>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "referToSVGViewportWidth",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "0",
-        appliesto: "limitedSVGElementsEllipse",
-        computed: "percentageAsSpecifiedOrAbsoluteLength",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/cx"
-      },
-      cy: {
-        syntax: "<length> | <percentage>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "referToSVGViewportHeight",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "0",
-        appliesto: "limitedSVGElementsEllipse",
-        computed: "percentageAsSpecifiedOrAbsoluteLength",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/cy"
-      },
-      d: {
-        syntax: "none | path(<string>)",
-        media: "visual",
-        inherited: false,
-        animationType: "basicShapeOtherwiseNo",
-        percentages: "no",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "none",
-        appliesto: "limitedSVGElementsPath",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/d"
-      },
-      direction: {
-        syntax: "ltr | rtl",
-        media: "visual",
-        inherited: true,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Writing Modes"
-        ],
-        initial: "ltr",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/direction"
-      },
-      display: {
-        syntax: "[ <display-outside> || <display-inside> ] | <display-listitem> | <display-internal> | <display-box> | <display-legacy>",
-        media: "all",
-        inherited: false,
-        animationType: "discreteButVisibleForDurationWhenAnimatedNone",
-        percentages: "no",
-        groups: [
-          "CSS Display"
-        ],
-        initial: "inline",
-        appliesto: "allElements",
-        computed: "asSpecifiedExceptPositionedFloatingAndRootElementsKeywordMaybeDifferent",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/display"
-      },
-      "dominant-baseline": {
-        syntax: "auto | text-bottom | alphabetic | ideographic | middle | central | mathematical | hanging | text-top",
-        media: "all",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Inline",
-          "Scalable Vector Graphics"
-        ],
-        initial: "auto",
-        appliesto: "blockContainersFlexContainersGridContainersInlineBoxesTableRowsSVGTextContentElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/dominant-baseline"
-      },
-      "dynamic-range-limit": {
-        syntax: "standard | no-limit | constrained | <dynamic-range-limit-mix()>",
-        media: "visual",
-        inherited: true,
-        animationType: "byDynamicRangeLimitMix",
-        percentages: "no",
-        groups: [
-          "CSS Color"
-        ],
-        initial: "no-limit",
-        appliesto: "allElements",
-        computed: "computedValueForDynamicRangeLimit",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/dynamic-range-limit"
-      },
-      "empty-cells": {
-        syntax: "show | hide",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Table"
-        ],
-        initial: "show",
-        appliesto: "tableCellElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/empty-cells"
-      },
-      "field-sizing": {
-        syntax: "content | fixed",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Basic User Interface"
-        ],
-        initial: "fixed",
-        appliesto: "elementsWithDefaultPreferredSize",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/field-sizing"
-      },
-      fill: {
-        syntax: "<paint>",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "black",
-        appliesto: "limitedSVGElementsShapeText",
-        computed: "asColorOrAbsoluteURL",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/fill"
-      },
-      "fill-opacity": {
-        syntax: "<'opacity'>",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValueType",
-        percentages: "mapToRange0To1",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "1",
-        appliesto: "limitedSVGElementsShapeText",
-        computed: "specifiedValueNumberClipped0To1",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/fill-opacity"
-      },
-      "fill-rule": {
-        syntax: "nonzero | evenodd",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "nonzero",
-        appliesto: "limitedSVGElementsShapeText",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/fill-rule"
-      },
-      filter: {
-        syntax: "none | <filter-value-list>",
-        media: "visual",
-        inherited: false,
-        animationType: "filterList",
-        percentages: "no",
-        groups: [
-          "Filter Effects"
-        ],
-        initial: "none",
-        appliesto: "allElementsSVGContainerElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/filter"
-      },
-      flex: {
-        syntax: "none | [ <'flex-grow'> <'flex-shrink'>? || <'flex-basis'> ]",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "flex-grow",
-          "flex-shrink",
-          "flex-basis"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Flexible Box Layout"
-        ],
-        initial: [
-          "flex-grow",
-          "flex-shrink",
-          "flex-basis"
-        ],
-        appliesto: "flexItemsAndInFlowPseudos",
-        computed: [
-          "flex-grow",
-          "flex-shrink",
-          "flex-basis"
-        ],
-        order: "orderOfAppearance",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/flex"
-      },
-      "flex-basis": {
-        syntax: "content | <'width'>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "referToFlexContainersInnerMainSize",
-        groups: [
-          "CSS Flexible Box Layout"
-        ],
-        initial: "auto",
-        appliesto: "flexItemsAndInFlowPseudos",
-        computed: "asSpecifiedRelativeToAbsoluteLengths",
-        order: "lengthOrPercentageBeforeKeywordIfBothPresent",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/flex-basis"
-      },
-      "flex-direction": {
-        syntax: "row | row-reverse | column | column-reverse",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Flexible Box Layout"
-        ],
-        initial: "row",
-        appliesto: "flexContainers",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/flex-direction"
-      },
-      "flex-flow": {
-        syntax: "<'flex-direction'> || <'flex-wrap'>",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "flex-direction",
-          "flex-wrap"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Flexible Box Layout"
-        ],
-        initial: [
-          "flex-direction",
-          "flex-wrap"
-        ],
-        appliesto: "flexContainers",
-        computed: [
-          "flex-direction",
-          "flex-wrap"
-        ],
-        order: "orderOfAppearance",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/flex-flow"
-      },
-      "flex-grow": {
-        syntax: "<number>",
-        media: "visual",
-        inherited: false,
-        animationType: "number",
-        percentages: "no",
-        groups: [
-          "CSS Flexible Box Layout"
-        ],
-        initial: "0",
-        appliesto: "flexItemsAndInFlowPseudos",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/flex-grow"
-      },
-      "flex-shrink": {
-        syntax: "<number>",
-        media: "visual",
-        inherited: false,
-        animationType: "number",
-        percentages: "no",
-        groups: [
-          "CSS Flexible Box Layout"
-        ],
-        initial: "1",
-        appliesto: "flexItemsAndInFlowPseudos",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/flex-shrink"
-      },
-      "flex-wrap": {
-        syntax: "nowrap | wrap | wrap-reverse",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Flexible Box Layout"
-        ],
-        initial: "nowrap",
-        appliesto: "flexContainers",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/flex-wrap"
-      },
-      float: {
-        syntax: "left | right | none | inline-start | inline-end",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Positioned Layout"
-        ],
-        initial: "none",
-        appliesto: "allElementsNoEffectIfDisplayNone",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/float"
-      },
-      "flood-color": {
-        syntax: "<color>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValue",
-        percentages: "no",
-        groups: [
-          "Filter Effects"
-        ],
-        initial: "black",
-        appliesto: "limitedSVGElementsFloodAndDropShadow",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/flood-color"
-      },
-      "flood-opacity": {
-        syntax: "<'opacity'>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValue",
-        percentages: "no",
-        groups: [
-          "Filter Effects"
-        ],
-        initial: "black",
-        appliesto: "limitedSVGElementsFloodAndDropShadow",
-        computed: "specifiedValueClipped0To1",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/flood-opacity"
-      },
-      font: {
-        syntax: "[ [ <'font-style'> || <font-variant-css2> || <'font-weight'> || <font-width-css3> ]? <'font-size'> [ / <'line-height'> ]? <'font-family'># ] | <system-family-name>",
-        media: "visual",
-        inherited: true,
-        animationType: [
-          "font-style",
-          "font-variant",
-          "font-weight",
-          "font-stretch",
-          "font-size",
-          "line-height",
-          "font-family"
-        ],
-        percentages: [
-          "font-size",
-          "line-height"
-        ],
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: [
-          "font-style",
-          "font-variant",
-          "font-weight",
-          "font-stretch",
-          "font-size",
-          "line-height",
-          "font-family"
-        ],
-        appliesto: "allElementsAndText",
-        computed: [
-          "font-style",
-          "font-variant",
-          "font-weight",
-          "font-stretch",
-          "font-size",
-          "line-height",
-          "font-family"
-        ],
-        order: "orderOfAppearance",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font"
-      },
-      "font-family": {
-        syntax: "[ <family-name> | <generic-family> ]#",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "dependsOnUserAgent",
-        appliesto: "allElementsAndText",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-family"
-      },
-      "font-feature-settings": {
-        syntax: "normal | <feature-tag-value>#",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "normal",
-        appliesto: "allElementsAndText",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-feature-settings"
-      },
-      "font-kerning": {
-        syntax: "auto | normal | none",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "auto",
-        appliesto: "allElementsAndText",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-kerning"
-      },
-      "font-language-override": {
-        syntax: "normal | <string>",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "normal",
-        appliesto: "allElementsAndText",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-language-override"
-      },
-      "font-optical-sizing": {
-        syntax: "auto | none",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "auto",
-        appliesto: "allElementsAndText",
-        computed: "asSpecified",
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-optical-sizing"
-      },
-      "font-palette": {
-        syntax: "normal | light | dark | <palette-identifier> | <palette-mix()>",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValue",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "normal",
-        appliesto: "allElementsAndText",
-        computed: "asSpecified",
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-palette"
-      },
-      "font-size": {
-        syntax: "<absolute-size> | <relative-size> | <length-percentage [0,\u221E]> | math",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValueType",
-        percentages: "referToParentElementsFontSize",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "medium",
-        appliesto: "allElementsAndText",
-        computed: "absoluteLength",
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-size"
-      },
-      "font-size-adjust": {
-        syntax: "none | [ ex-height | cap-height | ch-width | ic-width | ic-height ]? [ from-font | <number> ]",
-        media: "visual",
-        inherited: true,
-        animationType: "number",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "none",
-        appliesto: "allElementsAndText",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-size-adjust"
-      },
-      "font-smooth": {
-        syntax: "auto | never | always | <absolute-size> | <length>",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-smooth"
-      },
-      "font-stretch": {
-        syntax: "<font-stretch-absolute>",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "normal",
-        appliesto: "allElementsAndText",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "obsolete",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-stretch"
-      },
-      "font-style": {
-        syntax: "normal | italic | oblique <angle>?",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValueTypeNormalAnimatesAsObliqueZeroDeg",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "normal",
-        appliesto: "allElementsAndText",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-style"
-      },
-      "font-synthesis": {
-        syntax: "none | [ weight || style || small-caps || position]",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "weight style small-caps position ",
-        appliesto: "allElementsAndText",
-        computed: "asSpecified",
-        order: "orderOfAppearance",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-synthesis"
-      },
-      "font-synthesis-position": {
-        syntax: "auto | none",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "none",
-        appliesto: "allElementsAndText",
-        computed: "asSpecified",
-        order: "orderOfAppearance",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-synthesis-position"
-      },
-      "font-synthesis-small-caps": {
-        syntax: "auto | none",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "auto",
-        appliesto: "allElementsAndText",
-        computed: "asSpecified",
-        order: "orderOfAppearance",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-synthesis-small-caps"
-      },
-      "font-synthesis-style": {
-        syntax: "auto | none",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "auto",
-        appliesto: "allElementsAndText",
-        computed: "asSpecified",
-        order: "orderOfAppearance",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-synthesis-style"
-      },
-      "font-synthesis-weight": {
-        syntax: "auto | none",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "auto",
-        appliesto: "allElementsAndText",
-        computed: "asSpecified",
-        order: "orderOfAppearance",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-synthesis-weight"
-      },
-      "font-variant": {
-        syntax: "normal | none | [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> || stylistic( <feature-value-name> ) || historical-forms || styleset( <feature-value-name># ) || character-variant( <feature-value-name># ) || swash( <feature-value-name> ) || ornaments( <feature-value-name> ) || annotation( <feature-value-name> ) || [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ] || <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero || <east-asian-variant-values> || <east-asian-width-values> || ruby ]",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "normal",
-        appliesto: "allElementsAndText",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-variant"
-      },
-      "font-variant-alternates": {
-        syntax: "normal | [ stylistic( <feature-value-name> ) || historical-forms || styleset( <feature-value-name># ) || character-variant( <feature-value-name># ) || swash( <feature-value-name> ) || ornaments( <feature-value-name> ) || annotation( <feature-value-name> ) ]",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "normal",
-        appliesto: "allElementsAndText",
-        computed: "asSpecified",
-        order: "orderOfAppearance",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates"
-      },
-      "font-variant-caps": {
-        syntax: "normal | small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "normal",
-        appliesto: "allElementsAndText",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-variant-caps"
-      },
-      "font-variant-east-asian": {
-        syntax: "normal | [ <east-asian-variant-values> || <east-asian-width-values> || ruby ]",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "normal",
-        appliesto: "allElementsAndText",
-        computed: "asSpecified",
-        order: "orderOfAppearance",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-variant-east-asian"
-      },
-      "font-variant-emoji": {
-        syntax: "normal | text | emoji | unicode",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "normal",
-        appliesto: "allElementsAndText",
-        computed: "asSpecified",
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-variant-emoji"
-      },
-      "font-variant-ligatures": {
-        syntax: "normal | none | [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ]",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "normal",
-        appliesto: "allElementsAndText",
-        computed: "asSpecified",
-        order: "orderOfAppearance",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-variant-ligatures"
-      },
-      "font-variant-numeric": {
-        syntax: "normal | [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ]",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "normal",
-        appliesto: "allElementsAndText",
-        computed: "asSpecified",
-        order: "orderOfAppearance",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-variant-numeric"
-      },
-      "font-variant-position": {
-        syntax: "normal | sub | super",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "normal",
-        appliesto: "allElementsAndText",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-variant-position"
-      },
-      "font-variation-settings": {
-        syntax: "normal | [ <string> <number> ]#",
-        media: "visual",
-        inherited: true,
-        animationType: "transform",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "normal",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-variation-settings"
-      },
-      "font-weight": {
-        syntax: "<font-weight-absolute> | bolder | lighter",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "normal",
-        appliesto: "allElementsAndText",
-        computed: "keywordOrNumericalValueBolderLighterTransformedToRealValue",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/font-weight"
-      },
-      "font-width": {
-        syntax: "normal | <percentage [0,\u221E]> | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Fonts"
-        ],
-        initial: "normal",
-        appliesto: "allElementsAndText",
-        computed: "percentage",
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "experimental"
-      },
-      "forced-color-adjust": {
-        syntax: "auto | none | preserve-parent-color",
-        media: "visual",
-        inherited: true,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Color"
-        ],
-        initial: "auto",
-        appliesto: "allElementsAndText",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/forced-color-adjust"
-      },
-      gap: {
-        syntax: "<'row-gap'> <'column-gap'>?",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "row-gap",
-          "column-gap"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Box Alignment"
-        ],
-        initial: [
-          "row-gap",
-          "column-gap"
-        ],
-        appliesto: "multiColumnElementsFlexContainersGridContainers",
-        computed: [
-          "row-gap",
-          "column-gap"
-        ],
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/gap"
-      },
-      grid: {
-        syntax: "<'grid-template'> | <'grid-template-rows'> / [ auto-flow && dense? ] <'grid-auto-columns'>? | [ auto-flow && dense? ] <'grid-auto-rows'>? / <'grid-template-columns'>",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "grid-template-rows",
-          "grid-template-columns",
-          "grid-template-areas",
-          "grid-auto-rows",
-          "grid-auto-columns",
-          "grid-auto-flow",
-          "grid-column-gap",
-          "grid-row-gap",
-          "column-gap",
-          "row-gap"
-        ],
-        percentages: [
-          "grid-template-rows",
-          "grid-template-columns",
-          "grid-auto-rows",
-          "grid-auto-columns"
-        ],
-        groups: [
-          "CSS Grid Layout"
-        ],
-        initial: [
-          "grid-template-rows",
-          "grid-template-columns",
-          "grid-template-areas",
-          "grid-auto-rows",
-          "grid-auto-columns",
-          "grid-auto-flow",
-          "grid-column-gap",
-          "grid-row-gap",
-          "column-gap",
-          "row-gap"
-        ],
-        appliesto: "gridContainers",
-        computed: [
-          "grid-template-rows",
-          "grid-template-columns",
-          "grid-template-areas",
-          "grid-auto-rows",
-          "grid-auto-columns",
-          "grid-auto-flow",
-          "grid-column-gap",
-          "grid-row-gap",
-          "column-gap",
-          "row-gap"
-        ],
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/grid"
-      },
-      "grid-area": {
-        syntax: "<grid-line> [ / <grid-line> ]{0,3}",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Grid Layout"
-        ],
-        initial: [
-          "grid-row-start",
-          "grid-column-start",
-          "grid-row-end",
-          "grid-column-end"
-        ],
-        appliesto: "gridItemsAndBoxesWithinGridContainer",
-        computed: [
-          "grid-row-start",
-          "grid-column-start",
-          "grid-row-end",
-          "grid-column-end"
-        ],
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/grid-area"
-      },
-      "grid-auto-columns": {
-        syntax: "<track-size>+",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "referToDimensionOfContentArea",
-        groups: [
-          "CSS Grid Layout"
-        ],
-        initial: "auto",
-        appliesto: "gridContainers",
-        computed: "percentageAsSpecifiedOrAbsoluteLength",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/grid-auto-columns"
-      },
-      "grid-auto-flow": {
-        syntax: "[ row | column ] || dense",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Grid Layout"
-        ],
-        initial: "row",
-        appliesto: "gridContainers",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/grid-auto-flow"
-      },
-      "grid-auto-rows": {
-        syntax: "<track-size>+",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "referToDimensionOfContentArea",
-        groups: [
-          "CSS Grid Layout"
-        ],
-        initial: "auto",
-        appliesto: "gridContainers",
-        computed: "percentageAsSpecifiedOrAbsoluteLength",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/grid-auto-rows"
-      },
-      "grid-column": {
-        syntax: "<grid-line> [ / <grid-line> ]?",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Grid Layout"
-        ],
-        initial: [
-          "grid-column-start",
-          "grid-column-end"
-        ],
-        appliesto: "gridItemsAndBoxesWithinGridContainer",
-        computed: [
-          "grid-column-start",
-          "grid-column-end"
-        ],
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/grid-column"
-      },
-      "grid-column-end": {
-        syntax: "<grid-line>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Grid Layout"
-        ],
-        initial: "auto",
-        appliesto: "gridItemsAndBoxesWithinGridContainer",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/grid-column-end"
-      },
-      "grid-column-gap": {
-        syntax: "<length-percentage>",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "referToDimensionOfContentArea",
-        groups: [
-          "CSS Grid Layout"
-        ],
-        initial: "0",
-        appliesto: "gridContainers",
-        computed: "percentageAsSpecifiedOrAbsoluteLength",
-        order: "uniqueOrder",
-        status: "obsolete",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/column-gap"
-      },
-      "grid-column-start": {
-        syntax: "<grid-line>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Grid Layout"
-        ],
-        initial: "auto",
-        appliesto: "gridItemsAndBoxesWithinGridContainer",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/grid-column-start"
-      },
-      "grid-gap": {
-        syntax: "<'grid-row-gap'> <'grid-column-gap'>?",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "grid-row-gap",
-          "grid-column-gap"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Grid Layout"
-        ],
-        initial: [
-          "grid-row-gap",
-          "grid-column-gap"
-        ],
-        appliesto: "gridContainers",
-        computed: [
-          "grid-row-gap",
-          "grid-column-gap"
-        ],
-        order: "uniqueOrder",
-        status: "obsolete",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/gap"
-      },
-      "grid-row": {
-        syntax: "<grid-line> [ / <grid-line> ]?",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Grid Layout"
-        ],
-        initial: [
-          "grid-row-start",
-          "grid-row-end"
-        ],
-        appliesto: "gridItemsAndBoxesWithinGridContainer",
-        computed: [
-          "grid-row-start",
-          "grid-row-end"
-        ],
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/grid-row"
-      },
-      "grid-row-end": {
-        syntax: "<grid-line>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Grid Layout"
-        ],
-        initial: "auto",
-        appliesto: "gridItemsAndBoxesWithinGridContainer",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/grid-row-end"
-      },
-      "grid-row-gap": {
-        syntax: "<length-percentage>",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "referToDimensionOfContentArea",
-        groups: [
-          "CSS Grid Layout"
-        ],
-        initial: "0",
-        appliesto: "gridContainers",
-        computed: "percentageAsSpecifiedOrAbsoluteLength",
-        order: "uniqueOrder",
-        status: "obsolete",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/row-gap"
-      },
-      "grid-row-start": {
-        syntax: "<grid-line>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Grid Layout"
-        ],
-        initial: "auto",
-        appliesto: "gridItemsAndBoxesWithinGridContainer",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/grid-row-start"
-      },
-      "grid-template": {
-        syntax: "none | [ <'grid-template-rows'> / <'grid-template-columns'> ] | [ <line-names>? <string> <track-size>? <line-names>? ]+ [ / <explicit-track-list> ]?",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "grid-template-columns",
-          "grid-template-rows",
-          "grid-template-areas"
-        ],
-        percentages: [
-          "grid-template-columns",
-          "grid-template-rows"
-        ],
-        groups: [
-          "CSS Grid Layout"
-        ],
-        initial: [
-          "grid-template-columns",
-          "grid-template-rows",
-          "grid-template-areas"
-        ],
-        appliesto: "gridContainers",
-        computed: [
-          "grid-template-columns",
-          "grid-template-rows",
-          "grid-template-areas"
-        ],
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/grid-template"
-      },
-      "grid-template-areas": {
-        syntax: "none | <string>+",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Grid Layout"
-        ],
-        initial: "none",
-        appliesto: "gridContainers",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/grid-template-areas"
-      },
-      "grid-template-columns": {
-        syntax: "none | <track-list> | <auto-track-list> | subgrid <line-name-list>?",
-        media: "visual",
-        inherited: false,
-        animationType: "simpleListOfLpcDifferenceLpc",
-        percentages: "referToDimensionOfContentArea",
-        groups: [
-          "CSS Grid Layout"
-        ],
-        initial: "none",
-        appliesto: "gridContainers",
-        computed: "asSpecifiedRelativeToAbsoluteLengths",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/grid-template-columns"
-      },
-      "grid-template-rows": {
-        syntax: "none | <track-list> | <auto-track-list> | subgrid <line-name-list>?",
-        media: "visual",
-        inherited: false,
-        animationType: "simpleListOfLpcDifferenceLpc",
-        percentages: "referToDimensionOfContentArea",
-        groups: [
-          "CSS Grid Layout"
-        ],
-        initial: "none",
-        appliesto: "gridContainers",
-        computed: "asSpecifiedRelativeToAbsoluteLengths",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/grid-template-rows"
-      },
-      "hanging-punctuation": {
-        syntax: "none | [ first || [ force-end | allow-end ] || last ]",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Text"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/hanging-punctuation"
-      },
-      height: {
-        syntax: "auto | <length-percentage [0,\u221E]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,\u221E]>) | <calc-size()> | <anchor-size()>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "regardingHeightOfGeneratedBoxContainingBlockPercentagesRelativeToContainingBlock",
-        groups: [
-          "CSS Box Sizing"
-        ],
-        initial: "auto",
-        appliesto: "allElementsButNonReplacedAndTableColumns",
-        computed: "percentageAutoOrAbsoluteLength",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/height"
-      },
-      "hyphenate-character": {
-        syntax: "auto | <string>",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Text"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/hyphenate-character"
-      },
-      "hyphenate-limit-chars": {
-        syntax: "[ auto | <integer> ]{1,3}",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Text"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/hyphenate-limit-chars"
-      },
-      hyphens: {
-        syntax: "none | manual | auto",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Text"
-        ],
-        initial: "manual",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/hyphens"
-      },
-      "image-orientation": {
-        syntax: "from-image | <angle> | [ <angle>? flip ]",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Images"
-        ],
-        initial: "from-image",
-        appliesto: "allElements",
-        computed: "angleRoundedToNextQuarter",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/image-orientation"
-      },
-      "image-rendering": {
-        syntax: "auto | crisp-edges | pixelated | smooth",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Images"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/image-rendering"
-      },
-      "image-resolution": {
-        syntax: "[ from-image || <resolution> ] && snap?",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Images"
-        ],
-        initial: "1dppx",
-        appliesto: "allElements",
-        computed: "asSpecifiedWithExceptionOfResolution",
-        order: "uniqueOrder",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/image-resolution"
-      },
-      "ime-mode": {
-        syntax: "auto | normal | active | inactive | disabled",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Basic User Interface"
-        ],
-        initial: "auto",
-        appliesto: "textFields",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "obsolete"
-      },
-      "initial-letter": {
-        syntax: "normal | [ <number> <integer>? ]",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Inline"
-        ],
-        initial: "normal",
-        appliesto: "firstLetterPseudoElementsAndInlineLevelFirstChildren",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/initial-letter"
-      },
-      "initial-letter-align": {
-        syntax: "[ auto | alphabetic | hanging | ideographic ]",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Inline"
-        ],
-        initial: "auto",
-        appliesto: "firstLetterPseudoElementsAndInlineLevelFirstChildren",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "experimental"
-      },
-      "inline-size": {
-        syntax: "<'width'>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "inlineSizeOfContainingBlock",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "auto",
-        appliesto: "sameAsWidthAndHeight",
-        computed: "sameAsWidthAndHeight",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/inline-size"
-      },
-      inset: {
-        syntax: "<'top'>{1,4}",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "logicalHeightOrWidthOfContainingBlock",
-        groups: [
-          "CSS Logical Properties and Values",
-          "CSS Positioned Layout"
-        ],
-        initial: [
-          "top",
-          "bottom",
-          "left",
-          "right"
-        ],
-        appliesto: "positionedElements",
-        computed: [
-          "top",
-          "bottom",
-          "left",
-          "right"
-        ],
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/inset"
-      },
-      "inset-block": {
-        syntax: "<'top'>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "logicalHeightOfContainingBlock",
-        groups: [
-          "CSS Logical Properties and Values",
-          "CSS Positioned Layout"
-        ],
-        initial: [
-          "inset-block-start",
-          "inset-block-end"
-        ],
-        appliesto: "positionedElements",
-        computed: [
-          "inset-block-start",
-          "inset-block-end"
-        ],
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/inset-block"
-      },
-      "inset-block-end": {
-        syntax: "<'top'>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "logicalHeightOfContainingBlock",
-        groups: [
-          "CSS Logical Properties and Values",
-          "CSS Positioned Layout"
-        ],
-        initial: "auto",
-        appliesto: "positionedElements",
-        computed: "sameAsBoxOffsets",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/inset-block-end"
-      },
-      "inset-block-start": {
-        syntax: "<'top'>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "logicalHeightOfContainingBlock",
-        groups: [
-          "CSS Logical Properties and Values",
-          "CSS Positioned Layout"
-        ],
-        initial: "auto",
-        appliesto: "positionedElements",
-        computed: "sameAsBoxOffsets",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/inset-block-start"
-      },
-      "inset-inline": {
-        syntax: "<'top'>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "logicalWidthOfContainingBlock",
-        groups: [
-          "CSS Logical Properties and Values",
-          "CSS Positioned Layout"
-        ],
-        initial: [
-          "inset-inline-start",
-          "inset-inline-end"
-        ],
-        appliesto: "positionedElements",
-        computed: [
-          "inset-inline-start",
-          "inset-inline-end"
-        ],
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/inset-inline"
-      },
-      "inset-inline-end": {
-        syntax: "<'top'>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "logicalWidthOfContainingBlock",
-        groups: [
-          "CSS Logical Properties and Values",
-          "CSS Positioned Layout"
-        ],
-        initial: "auto",
-        appliesto: "positionedElements",
-        computed: "sameAsBoxOffsets",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/inset-inline-end"
-      },
-      "inset-inline-start": {
-        syntax: "<'top'>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "logicalWidthOfContainingBlock",
-        groups: [
-          "CSS Logical Properties and Values",
-          "CSS Positioned Layout"
-        ],
-        initial: "auto",
-        appliesto: "positionedElements",
-        computed: "sameAsBoxOffsets",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/inset-inline-start"
-      },
-      "interpolate-size": {
-        syntax: "numeric-only | allow-keywords",
-        media: "none",
-        inherited: true,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Values and Units"
-        ],
-        initial: "numeric-only",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/interpolate-size"
-      },
-      isolation: {
-        syntax: "auto | isolate",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "Compositing and Blending"
-        ],
-        initial: "auto",
-        appliesto: "allElementsSVGContainerGraphicsAndGraphicsReferencingElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/isolation"
-      },
-      interactivity: {
-        syntax: "auto | inert",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Basic User Interface"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/interactivity"
-      },
-      "interest-delay": {
-        syntax: "<'interest-delay-start'>{1,2}",
-        media: "visual",
-        inherited: true,
-        animationType: [
-          "interest-delay-start",
-          "interest-delay-end"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Basic User Interface"
-        ],
-        initial: [
-          "interest-delay-start",
-          "interest-delay-end"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "interest-delay-start",
-          "interest-delay-end"
-        ],
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/interest-delay-end"
-      },
-      "interest-delay-end": {
-        syntax: "normal | <time>",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Basic User Interface"
-        ],
-        initial: "normal",
-        appliesto: "allElements",
-        computed: "normalOrComputedTime",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/interest-delay-end"
-      },
-      "interest-delay-start": {
-        syntax: "normal | <time>",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Basic User Interface"
-        ],
-        initial: "normal",
-        appliesto: "allElements",
-        computed: "normalOrComputedTime",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/interest-delay-start"
-      },
-      "justify-content": {
-        syntax: "normal | <content-distribution> | <overflow-position>? [ <content-position> | left | right ]",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Box Alignment",
-          "CSS Flexible Box Layout"
-        ],
-        initial: "normal",
-        appliesto: "flexContainers",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/justify-content"
-      },
-      "justify-items": {
-        syntax: "normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | legacy | legacy && [ left | right | center ] | anchor-center",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Box Alignment"
-        ],
-        initial: "legacy",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/justify-items"
-      },
-      "justify-self": {
-        syntax: "auto | normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | anchor-center",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Box Alignment"
-        ],
-        initial: "auto",
-        appliesto: "blockLevelBoxesAndAbsolutelyPositionedBoxesAndGridItems",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/justify-self"
-      },
-      "justify-tracks": {
-        syntax: "[ normal | <content-distribution> | <overflow-position>? [ <content-position> | left | right ] ]#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Grid Layout"
-        ],
-        initial: "normal",
-        appliesto: "gridContainersWithMasonryLayoutInTheirInlineAxis",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      left: {
-        syntax: "auto | <length-percentage> | <anchor()> | <anchor-size()>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "referToWidthOfContainingBlock",
-        groups: [
-          "CSS Anchor Positioning",
-          "CSS Positioned Layout"
-        ],
-        initial: "auto",
-        appliesto: "positionedElements",
-        computed: "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/left"
-      },
-      "letter-spacing": {
-        syntax: "normal | <length>",
-        media: "visual",
-        inherited: true,
-        animationType: "length",
-        percentages: "no",
-        groups: [
-          "CSS Text"
-        ],
-        initial: "normal",
-        appliesto: "allElements",
-        computed: "optimumValueOfAbsoluteLengthOrNormal",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/letter-spacing"
-      },
-      "lighting-color": {
-        syntax: "<color>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValue",
-        percentages: "no",
-        groups: [
-          "Filter Effects"
-        ],
-        initial: "white",
-        appliesto: "limitedSVGElementsLightSource",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/lighting-color"
-      },
-      "line-break": {
-        syntax: "auto | loose | normal | strict | anywhere",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Text"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/line-break"
-      },
-      "line-clamp": {
-        syntax: "none | <integer>",
-        media: "visual",
-        inherited: false,
-        animationType: "integer",
-        percentages: "no",
-        groups: [
-          "CSS Overflow"
-        ],
-        initial: "none",
-        appliesto: "blockContainersExceptMultiColumnContainers",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/line-clamp"
-      },
-      "line-height": {
-        syntax: "normal | <number> | <length> | <percentage>",
-        media: "visual",
-        inherited: true,
-        animationType: "numberOrLength",
-        percentages: "referToElementFontSize",
-        groups: [
-          "CSS Inline"
-        ],
-        initial: "normal",
-        appliesto: "allElements",
-        computed: "absoluteLengthOrAsSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/line-height"
-      },
-      "line-height-step": {
-        syntax: "<length>",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Rhythmic Sizing"
-        ],
-        initial: "0",
-        appliesto: "blockContainers",
-        computed: "absoluteLength",
-        order: "perGrammar",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/line-height-step"
-      },
-      "list-style": {
-        syntax: "<'list-style-type'> || <'list-style-position'> || <'list-style-image'>",
-        media: "visual",
-        inherited: true,
-        animationType: [
-          "list-style-image",
-          "list-style-position",
-          "list-style-type"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Lists and Counters"
-        ],
-        initial: [
-          "list-style-type",
-          "list-style-position",
-          "list-style-image"
-        ],
-        appliesto: "listItems",
-        computed: [
-          "list-style-image",
-          "list-style-position",
-          "list-style-type"
-        ],
-        order: "orderOfAppearance",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/list-style"
-      },
-      "list-style-image": {
-        syntax: "<image> | none",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Lists and Counters"
-        ],
-        initial: "none",
-        appliesto: "listItems",
-        computed: "theKeywordListStyleImageNoneOrComputedValue",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/list-style-image"
-      },
-      "list-style-position": {
-        syntax: "inside | outside",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Lists and Counters"
-        ],
-        initial: "outside",
-        appliesto: "listItems",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/list-style-position"
-      },
-      "list-style-type": {
-        syntax: "<counter-style> | <string> | none",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Lists and Counters"
-        ],
-        initial: "disc",
-        appliesto: "listItems",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/list-style-type"
-      },
-      margin: {
-        syntax: "<'margin-top'>{1,4}",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "referToWidthOfContainingBlock",
-        groups: [
-          "CSS Box Model"
-        ],
-        initial: [
-          "margin-bottom",
-          "margin-left",
-          "margin-right",
-          "margin-top"
-        ],
-        appliesto: "allElementsExceptTableDisplayTypes",
-        computed: [
-          "margin-bottom",
-          "margin-left",
-          "margin-right",
-          "margin-top"
-        ],
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/margin"
-      },
-      "margin-block": {
-        syntax: "<'margin-top'>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "dependsOnLayoutModel",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: [
-          "margin-block-start",
-          "margin-block-end"
-        ],
-        appliesto: "sameAsMargin",
-        computed: [
-          "margin-block-start",
-          "margin-block-end"
-        ],
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/margin-block"
-      },
-      "margin-block-end": {
-        syntax: "<'margin-top'>",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "dependsOnLayoutModel",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "0",
-        appliesto: "sameAsMargin",
-        computed: "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/margin-block-end"
-      },
-      "margin-block-start": {
-        syntax: "<'margin-top'>",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "dependsOnLayoutModel",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "0",
-        appliesto: "sameAsMargin",
-        computed: "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/margin-block-start"
-      },
-      "margin-bottom": {
-        syntax: "<length-percentage> | auto | <anchor-size()>",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "referToWidthOfContainingBlock",
-        groups: [
-          "CSS Anchor Positioning",
-          "CSS Box Model"
-        ],
-        initial: "0",
-        appliesto: "allElementsExceptTableDisplayTypes",
-        computed: "percentageAsSpecifiedOrAbsoluteLength",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/margin-bottom"
-      },
-      "margin-inline": {
-        syntax: "<'margin-top'>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "dependsOnLayoutModel",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: [
-          "margin-inline-start",
-          "margin-inline-end"
-        ],
-        appliesto: "sameAsMargin",
-        computed: [
-          "margin-inline-start",
-          "margin-inline-end"
-        ],
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/margin-inline"
-      },
-      "margin-inline-end": {
-        syntax: "<'margin-top'>",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "dependsOnLayoutModel",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "0",
-        appliesto: "sameAsMargin",
-        computed: "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/margin-inline-end"
-      },
-      "margin-inline-start": {
-        syntax: "<'margin-top'>",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "dependsOnLayoutModel",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "0",
-        appliesto: "sameAsMargin",
-        computed: "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/margin-inline-start"
-      },
-      "margin-left": {
-        syntax: "<length-percentage> | auto | <anchor-size()>",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "referToWidthOfContainingBlock",
-        groups: [
-          "CSS Anchor Positioning",
-          "CSS Box Model"
-        ],
-        initial: "0",
-        appliesto: "allElementsExceptTableDisplayTypes",
-        computed: "percentageAsSpecifiedOrAbsoluteLength",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/margin-left"
-      },
-      "margin-right": {
-        syntax: "<length-percentage> | auto | <anchor-size()>",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "referToWidthOfContainingBlock",
-        groups: [
-          "CSS Anchor Positioning",
-          "CSS Box Model"
-        ],
-        initial: "0",
-        appliesto: "allElementsExceptTableDisplayTypes",
-        computed: "percentageAsSpecifiedOrAbsoluteLength",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/margin-right"
-      },
-      "margin-top": {
-        syntax: "<length-percentage> | auto | <anchor-size()>",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "referToWidthOfContainingBlock",
-        groups: [
-          "CSS Anchor Positioning",
-          "CSS Box Model"
-        ],
-        initial: "0",
-        appliesto: "allElementsExceptTableDisplayTypes",
-        computed: "percentageAsSpecifiedOrAbsoluteLength",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/margin-top"
-      },
-      "margin-trim": {
-        syntax: "none | in-flow | all",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Box Model"
-        ],
-        initial: "none",
-        appliesto: "blockContainersAndMultiColumnContainers",
-        computed: "asSpecified",
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter"
-        ],
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/margin-trim"
-      },
-      marker: {
-        syntax: "none | <url>",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: [
-          "marker-start",
-          "marker-mid",
-          "marker-end"
-        ],
-        appliesto: "limitedSVGElementsShapes",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/marker"
-      },
-      "marker-end": {
-        syntax: "none | <url>",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "none",
-        appliesto: "limitedSVGElementsShapes",
-        computed: "asSpecifiedURLsAbsolute",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/marker-end"
-      },
-      "marker-mid": {
-        syntax: "none | <url>",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "none",
-        appliesto: "limitedSVGElementsShapes",
-        computed: "asSpecifiedURLsAbsolute",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/marker-mid"
-      },
-      "marker-start": {
-        syntax: "none | <url>",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "none",
-        appliesto: "limitedSVGElementsShapes",
-        computed: "asSpecifiedURLsAbsolute",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/marker-start"
-      },
-      mask: {
-        syntax: "<mask-layer>#",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "mask-image",
-          "mask-mode",
-          "mask-repeat",
-          "mask-position",
-          "mask-clip",
-          "mask-origin",
-          "mask-size",
-          "mask-composite"
-        ],
-        percentages: [
-          "mask-position"
-        ],
-        groups: [
-          "CSS Masking"
-        ],
-        initial: [
-          "mask-image",
-          "mask-mode",
-          "mask-repeat",
-          "mask-position",
-          "mask-clip",
-          "mask-origin",
-          "mask-size",
-          "mask-composite"
-        ],
-        appliesto: "allElementsSVGContainerElements",
-        computed: [
-          "mask-image",
-          "mask-mode",
-          "mask-repeat",
-          "mask-position",
-          "mask-clip",
-          "mask-origin",
-          "mask-size",
-          "mask-composite"
-        ],
-        order: "perGrammar",
-        stacking: true,
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/mask"
-      },
-      "mask-border": {
-        syntax: "<'mask-border-source'> || <'mask-border-slice'> [ / <'mask-border-width'>? [ / <'mask-border-outset'> ]? ]? || <'mask-border-repeat'> || <'mask-border-mode'>",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "mask-border-mode",
-          "mask-border-outset",
-          "mask-border-repeat",
-          "mask-border-slice",
-          "mask-border-source",
-          "mask-border-width"
-        ],
-        percentages: [
-          "mask-border-slice",
-          "mask-border-width"
-        ],
-        groups: [
-          "CSS Masking"
-        ],
-        initial: [
-          "mask-border-mode",
-          "mask-border-outset",
-          "mask-border-repeat",
-          "mask-border-slice",
-          "mask-border-source",
-          "mask-border-width"
-        ],
-        appliesto: "allElementsSVGContainerElements",
-        computed: [
-          "mask-border-mode",
-          "mask-border-outset",
-          "mask-border-repeat",
-          "mask-border-slice",
-          "mask-border-source",
-          "mask-border-width"
-        ],
-        order: "perGrammar",
-        stacking: true,
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/mask-border"
-      },
-      "mask-border-mode": {
-        syntax: "luminance | alpha",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Masking"
-        ],
-        initial: "alpha",
-        appliesto: "allElementsSVGContainerElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/mask-border-mode"
-      },
-      "mask-border-outset": {
-        syntax: "[ <length> | <number> ]{1,4}",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Masking"
-        ],
-        initial: "0",
-        appliesto: "allElementsSVGContainerElements",
-        computed: "asSpecifiedRelativeToAbsoluteLengths",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/mask-border-outset"
-      },
-      "mask-border-repeat": {
-        syntax: "[ stretch | repeat | round | space ]{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Masking"
-        ],
-        initial: "stretch",
-        appliesto: "allElementsSVGContainerElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/mask-border-repeat"
-      },
-      "mask-border-slice": {
-        syntax: "<number-percentage>{1,4} fill?",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "referToSizeOfMaskBorderImage",
-        groups: [
-          "CSS Masking"
-        ],
-        initial: "0",
-        appliesto: "allElementsSVGContainerElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/mask-border-slice"
-      },
-      "mask-border-source": {
-        syntax: "none | <image>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Masking"
-        ],
-        initial: "none",
-        appliesto: "allElementsSVGContainerElements",
-        computed: "asSpecifiedURLsAbsolute",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/mask-border-source"
-      },
-      "mask-border-width": {
-        syntax: "[ <length-percentage> | <number> | auto ]{1,4}",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "relativeToMaskBorderImageArea",
-        groups: [
-          "CSS Masking"
-        ],
-        initial: "auto",
-        appliesto: "allElementsSVGContainerElements",
-        computed: "asSpecifiedRelativeToAbsoluteLengths",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/mask-border-width"
-      },
-      "mask-clip": {
-        syntax: "[ <coord-box> | no-clip ]#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Masking"
-        ],
-        initial: "border-box",
-        appliesto: "allElementsSVGContainerElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/mask-clip"
-      },
-      "mask-composite": {
-        syntax: "<compositing-operator>#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Masking"
-        ],
-        initial: "add",
-        appliesto: "allElementsSVGContainerElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/mask-composite"
-      },
-      "mask-image": {
-        syntax: "<mask-reference>#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Masking"
-        ],
-        initial: "none",
-        appliesto: "allElementsSVGContainerElements",
-        computed: "asSpecifiedURLsAbsolute",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/mask-image"
-      },
-      "mask-mode": {
-        syntax: "<masking-mode>#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Masking"
-        ],
-        initial: "match-source",
-        appliesto: "allElementsSVGContainerElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/mask-mode"
-      },
-      "mask-origin": {
-        syntax: "<coord-box>#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Masking"
-        ],
-        initial: "border-box",
-        appliesto: "allElementsSVGContainerElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/mask-origin"
-      },
-      "mask-position": {
-        syntax: "<position>#",
-        media: "visual",
-        inherited: false,
-        animationType: "repeatableList",
-        percentages: "referToSizeOfMaskPaintingArea",
-        groups: [
-          "CSS Masking"
-        ],
-        initial: "0% 0%",
-        appliesto: "allElementsSVGContainerElements",
-        computed: "consistsOfTwoKeywordsForOriginAndOffsets",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/mask-position"
-      },
-      "mask-repeat": {
-        syntax: "<repeat-style>#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Masking"
-        ],
-        initial: "repeat",
-        appliesto: "allElementsSVGContainerElements",
-        computed: "consistsOfTwoDimensionKeywords",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/mask-repeat"
-      },
-      "mask-size": {
-        syntax: "<bg-size>#",
-        media: "visual",
-        inherited: false,
-        animationType: "repeatableList",
-        percentages: "no",
-        groups: [
-          "CSS Masking"
-        ],
-        initial: "auto",
-        appliesto: "allElementsSVGContainerElements",
-        computed: "asSpecifiedRelativeToAbsoluteLengths",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/mask-size"
-      },
-      "mask-type": {
-        syntax: "luminance | alpha",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Masking"
-        ],
-        initial: "luminance",
-        appliesto: "maskElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/mask-type"
-      },
-      "masonry-auto-flow": {
-        syntax: "[ pack | next ] || [ definite-first | ordered ]",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Grid Layout"
-        ],
-        initial: "pack",
-        appliesto: "gridContainersWithMasonryLayout",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/grid-auto-flow"
-      },
-      "math-depth": {
-        syntax: "auto-add | add(<integer>) | <integer>",
-        media: "visual",
-        inherited: true,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "MathML"
-        ],
-        initial: "0",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/math-depth"
-      },
-      "math-shift": {
-        syntax: "normal | compact",
-        media: "visual",
-        inherited: true,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "MathML"
-        ],
-        initial: "normal",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/math-shift"
-      },
-      "math-style": {
-        syntax: "normal | compact",
-        media: "visual",
-        inherited: true,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "MathML"
-        ],
-        initial: "normal",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/math-style"
-      },
-      "max-block-size": {
-        syntax: "<'max-width'>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "blockSizeOfContainingBlock",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "none",
-        appliesto: "sameAsWidthAndHeight",
-        computed: "sameAsMaxWidthAndMaxHeight",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/max-block-size"
-      },
-      "max-height": {
-        syntax: "none | <length-percentage [0,\u221E]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,\u221E]>) | <calc-size()> | <anchor-size()>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "regardingHeightOfGeneratedBoxContainingBlockPercentagesNone",
-        groups: [
-          "CSS Box Sizing"
-        ],
-        initial: "none",
-        appliesto: "allElementsButNonReplacedAndTableColumns",
-        computed: "percentageAsSpecifiedAbsoluteLengthOrNone",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/max-height"
-      },
-      "max-inline-size": {
-        syntax: "<'max-width'>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "inlineSizeOfContainingBlock",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "none",
-        appliesto: "sameAsWidthAndHeight",
-        computed: "sameAsMaxWidthAndMaxHeight",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/max-inline-size"
-      },
-      "max-lines": {
-        syntax: "none | <integer>",
-        media: "visual",
-        inherited: false,
-        animationType: "integer",
-        percentages: "no",
-        groups: [
-          "CSS Overflow"
-        ],
-        initial: "none",
-        appliesto: "blockContainersExceptMultiColumnContainers",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "experimental"
-      },
-      "max-width": {
-        syntax: "none | <length-percentage [0,\u221E]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,\u221E]>) | <calc-size()> | <anchor-size()>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "referToWidthOfContainingBlock",
-        groups: [
-          "CSS Box Sizing"
-        ],
-        initial: "none",
-        appliesto: "allElementsButNonReplacedAndTableRows",
-        computed: "percentageAsSpecifiedAbsoluteLengthOrNone",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/max-width"
-      },
-      "min-block-size": {
-        syntax: "<'min-width'>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "blockSizeOfContainingBlock",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "0",
-        appliesto: "sameAsWidthAndHeight",
-        computed: "sameAsMinWidthAndMinHeight",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/min-block-size"
-      },
-      "min-height": {
-        syntax: "auto | <length-percentage [0,\u221E]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,\u221E]>) | <calc-size()> | <anchor-size()>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "regardingHeightOfGeneratedBoxContainingBlockPercentages0",
-        groups: [
-          "CSS Box Sizing"
-        ],
-        initial: "auto",
-        appliesto: "allElementsButNonReplacedAndTableColumns",
-        computed: "percentageAsSpecifiedOrAbsoluteLength",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/min-height"
-      },
-      "min-inline-size": {
-        syntax: "<'min-width'>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "inlineSizeOfContainingBlock",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "0",
-        appliesto: "sameAsWidthAndHeight",
-        computed: "sameAsMinWidthAndMinHeight",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/min-inline-size"
-      },
-      "min-width": {
-        syntax: "auto | <length-percentage [0,\u221E]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,\u221E]>) | <calc-size()> | <anchor-size()>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "referToWidthOfContainingBlock",
-        groups: [
-          "CSS Box Sizing"
-        ],
-        initial: "auto",
-        appliesto: "allElementsButNonReplacedAndTableRows",
-        computed: "percentageAsSpecifiedOrAbsoluteLength",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/min-width"
-      },
-      "mix-blend-mode": {
-        syntax: "<blend-mode> | plus-darker | plus-lighter",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "Compositing and Blending"
-        ],
-        initial: "normal",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        stacking: true,
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/mix-blend-mode"
-      },
-      "object-fit": {
-        syntax: "fill | contain | cover | none | scale-down",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Images"
-        ],
-        initial: "fill",
-        appliesto: "replacedElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/object-fit"
-      },
-      "object-position": {
-        syntax: "<position>",
-        media: "visual",
-        inherited: true,
-        animationType: "repeatableList",
-        percentages: "referToWidthAndHeightOfElement",
-        groups: [
-          "CSS Images"
-        ],
-        initial: "50% 50%",
-        appliesto: "replacedElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/object-position"
-      },
-      "object-view-box": {
-        syntax: "none | <basic-shape-rect>",
-        media: "visual",
-        inherited: false,
-        animationType: "asIfPossibleOtherwiseDiscrete",
-        percentages: "no",
-        groups: [
-          "CSS Images"
-        ],
-        initial: "none",
-        appliesto: "replacedElements",
-        computed: "specifiedKeywordOrComputedFunction",
-        order: "perGrammar",
-        status: "experimental"
-      },
-      offset: {
-        syntax: "[ <'offset-position'>? [ <'offset-path'> [ <'offset-distance'> || <'offset-rotate'> ]? ]? ]! [ / <'offset-anchor'> ]?",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "offset-position",
-          "offset-path",
-          "offset-distance",
-          "offset-anchor",
-          "offset-rotate"
-        ],
-        percentages: [
-          "offset-position",
-          "offset-distance",
-          "offset-anchor"
-        ],
-        groups: [
-          "Motion Path"
-        ],
-        initial: [
-          "offset-position",
-          "offset-path",
-          "offset-distance",
-          "offset-anchor",
-          "offset-rotate"
-        ],
-        appliesto: "transformableElements",
-        computed: [
-          "offset-position",
-          "offset-path",
-          "offset-distance",
-          "offset-anchor",
-          "offset-rotate"
-        ],
-        order: "perGrammar",
-        stacking: true,
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/offset"
-      },
-      "offset-anchor": {
-        syntax: "auto | <position>",
-        media: "visual",
-        inherited: false,
-        animationType: "position",
-        percentages: "relativeToWidthAndHeight",
-        groups: [
-          "Motion Path"
-        ],
-        initial: "auto",
-        appliesto: "transformableElements",
-        computed: "forLengthAbsoluteValueOtherwisePercentage",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/offset-anchor"
-      },
-      "offset-distance": {
-        syntax: "<length-percentage>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "referToTotalPathLength",
-        groups: [
-          "Motion Path"
-        ],
-        initial: "0",
-        appliesto: "transformableElements",
-        computed: "forLengthAbsoluteValueOtherwisePercentage",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/offset-distance"
-      },
-      "offset-path": {
-        syntax: "none | <offset-path> || <coord-box>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "Motion Path"
-        ],
-        initial: "none",
-        appliesto: "transformableElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        stacking: true,
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/offset-path"
-      },
-      "offset-position": {
-        syntax: "normal | auto | <position>",
-        media: "visual",
-        inherited: false,
-        animationType: "position",
-        percentages: "referToSizeOfContainingBlock",
-        groups: [
-          "Motion Path"
-        ],
-        initial: "normal",
-        appliesto: "transformableElements",
-        computed: "forLengthAbsoluteValueOtherwisePercentage",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/offset-position"
-      },
-      "offset-rotate": {
-        syntax: "[ auto | reverse ] || <angle>",
-        media: "visual",
-        inherited: false,
-        animationType: "angleOrBasicShapeOrPath",
-        percentages: "no",
-        groups: [
-          "Motion Path"
-        ],
-        initial: "auto",
-        appliesto: "transformableElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/offset-rotate"
-      },
-      opacity: {
-        syntax: "<opacity-value>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "mapToRange0To1",
-        groups: [
-          "CSS Color"
-        ],
-        initial: "1",
-        appliesto: "allElements",
-        computed: "specifiedValueNumberClipped0To1",
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/opacity"
-      },
-      order: {
-        syntax: "<integer>",
-        media: "visual",
-        inherited: false,
-        animationType: "integer",
-        percentages: "no",
-        groups: [
-          "CSS Display"
-        ],
-        initial: "0",
-        appliesto: "flexItemsGridItemsAbsolutelyPositionedContainerChildren",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/order"
-      },
-      orphans: {
-        syntax: "<integer>",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Fragmentation"
-        ],
-        initial: "2",
-        appliesto: "blockContainerElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/orphans"
-      },
-      outline: {
-        syntax: "<'outline-width'> || <'outline-style'> || <'outline-color'>",
-        media: [
-          "visual",
-          "interactive"
-        ],
-        inherited: false,
-        animationType: [
-          "outline-width",
-          "outline-style",
-          "outline-color"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Basic User Interface"
-        ],
-        initial: [
-          "outline-width",
-          "outline-style",
-          "outline-color"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "outline-width",
-          "outline-style",
-          "outline-color"
-        ],
-        order: "orderOfAppearance",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/outline"
-      },
-      "outline-color": {
-        syntax: "auto | <color>",
-        media: [
-          "visual",
-          "interactive"
-        ],
-        inherited: false,
-        animationType: "color",
-        percentages: "no",
-        groups: [
-          "CSS Basic User Interface"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "autoForTranslucentColorRGBAOtherwiseRGB",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/outline-color"
-      },
-      "outline-offset": {
-        syntax: "<length>",
-        media: [
-          "visual",
-          "interactive"
-        ],
-        inherited: false,
-        animationType: "length",
-        percentages: "no",
-        groups: [
-          "CSS Basic User Interface"
-        ],
-        initial: "0",
-        appliesto: "allElements",
-        computed: "asSpecifiedRelativeToAbsoluteLengths",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/outline-offset"
-      },
-      "outline-style": {
-        syntax: "auto | <outline-line-style>",
-        media: [
-          "visual",
-          "interactive"
-        ],
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Basic User Interface"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/outline-style"
-      },
-      "outline-width": {
-        syntax: "<line-width>",
-        media: [
-          "visual",
-          "interactive"
-        ],
-        inherited: false,
-        animationType: "length",
-        percentages: "no",
-        groups: [
-          "CSS Basic User Interface"
-        ],
-        initial: "medium",
-        appliesto: "allElements",
-        computed: "absoluteLength0ForNone",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/outline-width"
-      },
-      overflow: {
-        syntax: "[ visible | hidden | clip | scroll | auto ]{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Overflow"
-        ],
-        initial: "visible",
-        appliesto: "blockContainersFlexContainersGridContainers",
-        computed: [
-          "overflow-x",
-          "overflow-y"
-        ],
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/overflow"
-      },
-      "overflow-anchor": {
-        syntax: "auto | none",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Scroll Anchoring"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/overflow-anchor"
-      },
-      "overflow-block": {
-        syntax: "visible | hidden | clip | scroll | auto",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Overflow"
-        ],
-        initial: "auto",
-        appliesto: "blockContainersFlexContainersGridContainers",
-        computed: "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/overflow-block"
-      },
-      "overflow-clip-box": {
-        syntax: "padding-box | content-box",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Mozilla Extensions"
-        ],
-        initial: "padding-box",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "nonstandard"
-      },
-      "overflow-clip-margin": {
-        syntax: "<visual-box> || <length [0,\u221E]>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Overflow"
-        ],
-        initial: "0px",
-        appliesto: "allElements",
-        computed: "theComputedLengthAndVisualBox",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/overflow-clip-margin"
-      },
-      "overflow-inline": {
-        syntax: "visible | hidden | clip | scroll | auto",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Overflow"
-        ],
-        initial: "auto",
-        appliesto: "blockContainersFlexContainersGridContainers",
-        computed: "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/overflow-inline"
-      },
-      "overflow-wrap": {
-        syntax: "normal | break-word | anywhere",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Text"
-        ],
-        initial: "normal",
-        appliesto: "textElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/overflow-wrap"
-      },
-      "overflow-x": {
-        syntax: "visible | hidden | clip | scroll | auto",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Overflow"
-        ],
-        initial: "visible",
-        appliesto: "blockContainersFlexContainersGridContainers",
-        computed: "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/overflow-x"
-      },
-      "overflow-y": {
-        syntax: "visible | hidden | clip | scroll | auto",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Overflow"
-        ],
-        initial: "visible",
-        appliesto: "blockContainersFlexContainersGridContainers",
-        computed: "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/overflow-y"
-      },
-      overlay: {
-        syntax: "none | auto",
-        media: "visual",
-        inherited: false,
-        animationType: "discreteButVisibleForDurationWhenAnimatedNone",
-        percentages: "no",
-        groups: [
-          "CSS Positioned Layout"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/overlay"
-      },
-      "overscroll-behavior": {
-        syntax: "[ contain | none | auto ]{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Overscroll Behavior"
-        ],
-        initial: "auto",
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: [
-          "overscroll-behavior-x",
-          "overscroll-behavior-y"
-        ],
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior"
-      },
-      "overscroll-behavior-block": {
-        syntax: "contain | none | auto",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Overscroll Behavior"
-        ],
-        initial: "auto",
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-block"
-      },
-      "overscroll-behavior-inline": {
-        syntax: "contain | none | auto",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Overscroll Behavior"
-        ],
-        initial: "auto",
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-inline"
-      },
-      "overscroll-behavior-x": {
-        syntax: "contain | none | auto",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Overscroll Behavior"
-        ],
-        initial: "auto",
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-x"
-      },
-      "overscroll-behavior-y": {
-        syntax: "contain | none | auto",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Overscroll Behavior"
-        ],
-        initial: "auto",
-        appliesto: "nonReplacedBlockAndInlineBlockElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-y"
-      },
-      padding: {
-        syntax: "<'padding-top'>{1,4}",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "referToWidthOfContainingBlock",
-        groups: [
-          "CSS Box Model"
-        ],
-        initial: [
-          "padding-bottom",
-          "padding-left",
-          "padding-right",
-          "padding-top"
-        ],
-        appliesto: "allElementsExceptInternalTableDisplayTypes",
-        computed: [
-          "padding-bottom",
-          "padding-left",
-          "padding-right",
-          "padding-top"
-        ],
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/padding"
-      },
-      "padding-block": {
-        syntax: "<'padding-top'>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "logicalWidthOfContainingBlock",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: [
-          "padding-block-start",
-          "padding-block-end"
-        ],
-        appliesto: "allElementsExceptInternalTableDisplayTypes",
-        computed: [
-          "padding-block-start",
-          "padding-block-end"
-        ],
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/padding-block"
-      },
-      "padding-block-end": {
-        syntax: "<'padding-top'>",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "logicalWidthOfContainingBlock",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "0",
-        appliesto: "allElementsExceptInternalTableDisplayTypes",
-        computed: "asLength",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/padding-block-end"
-      },
-      "padding-block-start": {
-        syntax: "<'padding-top'>",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "logicalWidthOfContainingBlock",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "0",
-        appliesto: "allElementsExceptInternalTableDisplayTypes",
-        computed: "asLength",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/padding-block-start"
-      },
-      "padding-bottom": {
-        syntax: "<length-percentage [0,\u221E]>",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "referToWidthOfContainingBlock",
-        groups: [
-          "CSS Box Model"
-        ],
-        initial: "0",
-        appliesto: "allElementsExceptInternalTableDisplayTypes",
-        computed: "percentageAsSpecifiedOrAbsoluteLength",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/padding-bottom"
-      },
-      "padding-inline": {
-        syntax: "<'padding-top'>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "logicalWidthOfContainingBlock",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: [
-          "padding-inline-start",
-          "padding-inline-end"
-        ],
-        appliesto: "allElementsExceptInternalTableDisplayTypes",
-        computed: [
-          "padding-inline-start",
-          "padding-inline-end"
-        ],
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/padding-inline"
-      },
-      "padding-inline-end": {
-        syntax: "<'padding-top'>",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "logicalWidthOfContainingBlock",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "0",
-        appliesto: "allElementsExceptInternalTableDisplayTypes",
-        computed: "asLength",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/padding-inline-end"
-      },
-      "padding-inline-start": {
-        syntax: "<'padding-top'>",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "logicalWidthOfContainingBlock",
-        groups: [
-          "CSS Logical Properties and Values"
-        ],
-        initial: "0",
-        appliesto: "allElementsExceptInternalTableDisplayTypes",
-        computed: "asLength",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/padding-inline-start"
-      },
-      "padding-left": {
-        syntax: "<length-percentage [0,\u221E]>",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "referToWidthOfContainingBlock",
-        groups: [
-          "CSS Box Model"
-        ],
-        initial: "0",
-        appliesto: "allElementsExceptInternalTableDisplayTypes",
-        computed: "percentageAsSpecifiedOrAbsoluteLength",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/padding-left"
-      },
-      "padding-right": {
-        syntax: "<length-percentage [0,\u221E]>",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "referToWidthOfContainingBlock",
-        groups: [
-          "CSS Box Model"
-        ],
-        initial: "0",
-        appliesto: "allElementsExceptInternalTableDisplayTypes",
-        computed: "percentageAsSpecifiedOrAbsoluteLength",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/padding-right"
-      },
-      "padding-top": {
-        syntax: "<length-percentage [0,\u221E]>",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "referToWidthOfContainingBlock",
-        groups: [
-          "CSS Box Model"
-        ],
-        initial: "0",
-        appliesto: "allElementsExceptInternalTableDisplayTypes",
-        computed: "percentageAsSpecifiedOrAbsoluteLength",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/padding-top"
-      },
-      page: {
-        syntax: "auto | <custom-ident>",
-        media: "paged",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Paged Media"
-        ],
-        initial: "auto",
-        appliesto: "blockElementsInNormalFlow",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/page"
-      },
-      "page-break-after": {
-        syntax: "auto | always | avoid | left | right | recto | verso",
-        media: [
-          "visual",
-          "paged"
-        ],
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Paged Media"
-        ],
-        initial: "auto",
-        appliesto: "blockElementsInNormalFlow",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "obsolete",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/page-break-after"
-      },
-      "page-break-before": {
-        syntax: "auto | always | avoid | left | right | recto | verso",
-        media: [
-          "visual",
-          "paged"
-        ],
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Paged Media"
-        ],
-        initial: "auto",
-        appliesto: "blockElementsInNormalFlow",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "obsolete",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/page-break-before"
-      },
-      "page-break-inside": {
-        syntax: "auto | avoid",
-        media: [
-          "visual",
-          "paged"
-        ],
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Paged Media"
-        ],
-        initial: "auto",
-        appliesto: "blockElementsInNormalFlow",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "obsolete",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/page-break-inside"
-      },
-      "paint-order": {
-        syntax: "normal | [ fill || stroke || markers ]",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "normal",
-        appliesto: "textElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/paint-order"
-      },
-      perspective: {
-        syntax: "none | <length>",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "no",
-        groups: [
-          "CSS Transforms"
-        ],
-        initial: "none",
-        appliesto: "transformableElements",
-        computed: "absoluteLengthOrNone",
-        order: "uniqueOrder",
-        stacking: true,
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/perspective"
-      },
-      "perspective-origin": {
-        syntax: "<position>",
-        media: "visual",
-        inherited: false,
-        animationType: "simpleListOfLpc",
-        percentages: "referToSizeOfBoundingBox",
-        groups: [
-          "CSS Transforms"
-        ],
-        initial: "50% 50%",
-        appliesto: "transformableElements",
-        computed: "forLengthAbsoluteValueOtherwisePercentage",
-        order: "oneOrTwoValuesLengthAbsoluteKeywordsPercentages",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/perspective-origin"
-      },
-      "place-content": {
-        syntax: "<'align-content'> <'justify-content'>?",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Box Alignment"
-        ],
-        initial: [
-          "align-content",
-          "justify-content"
-        ],
-        appliesto: "multilineFlexContainers",
-        computed: [
-          "align-content",
-          "justify-content"
-        ],
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/place-content"
-      },
-      "place-items": {
-        syntax: "<'align-items'> <'justify-items'>?",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Box Alignment"
-        ],
-        initial: [
-          "align-items",
-          "justify-items"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "align-items",
-          "justify-items"
-        ],
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/place-items"
-      },
-      "place-self": {
-        syntax: "<'align-self'> <'justify-self'>?",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Box Alignment"
-        ],
-        initial: [
-          "align-self",
-          "justify-self"
-        ],
-        appliesto: "blockLevelBoxesAndAbsolutelyPositionedBoxesAndGridItems",
-        computed: [
-          "align-self",
-          "justify-self"
-        ],
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/place-self"
-      },
-      "pointer-events": {
-        syntax: "auto | none | visiblePainted | visibleFill | visibleStroke | visible | painted | fill | stroke | all | inherit",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Basic User Interface"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/pointer-events"
-      },
-      position: {
-        syntax: "static | relative | absolute | sticky | fixed",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Positioned Layout"
-        ],
-        initial: "static",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        stacking: true,
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/position"
-      },
-      "position-anchor": {
-        syntax: "auto | none | <anchor-name>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Anchor Positioning"
-        ],
-        initial: "none",
-        appliesto: "absolutelyPositionedElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/position-anchor"
-      },
-      "position-area": {
-        syntax: "none | <position-area>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Anchor Positioning"
-        ],
-        initial: "none",
-        appliesto: "positionedElementsWithADefaultAnchorElement",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/position-area"
-      },
-      "position-try": {
-        syntax: "<'position-try-order'>? <'position-try-fallbacks'>",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "position-try-fallbacks",
-          "position-try-order"
-        ],
-        percentages: [
-          "position-try-fallbacks",
-          "position-try-order"
-        ],
-        groups: [
-          "CSS Anchor Positioning"
-        ],
-        initial: [
-          "position-try-fallbacks",
-          "position-try-order"
-        ],
-        appliesto: "absolutelyPositionedElements",
-        computed: [
-          "position-try-fallbacks",
-          "position-try-order"
-        ],
-        order: "perGrammar",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/position-try"
-      },
-      "position-try-fallbacks": {
-        syntax: "none | [ [<dashed-ident> || <try-tactic>] | <'position-area'> ]#",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Anchor Positioning"
-        ],
-        initial: "none",
-        appliesto: "absolutelyPositionedElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/position-try-fallbacks"
-      },
-      "position-try-order": {
-        syntax: "normal | <try-size>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Anchor Positioning"
-        ],
-        initial: "normal",
-        appliesto: "absolutelyPositionedElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/position-try-order"
-      },
-      "position-visibility": {
-        syntax: "always | [ anchors-valid || anchors-visible || no-overflow ]",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Anchor Positioning"
-        ],
-        initial: "anchors-visible",
-        appliesto: "absolutelyPositionedElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/position-visibility"
-      },
-      "print-color-adjust": {
-        syntax: "economy | exact",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Color"
-        ],
-        initial: "economy",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/print-color-adjust"
-      },
-      quotes: {
-        syntax: "none | auto | [ <string> <string> ]+",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Generated Content"
-        ],
-        initial: "dependsOnUserAgent",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/quotes"
-      },
-      r: {
-        syntax: "<length> | <percentage>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "referToSVGViewportSize",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "0",
-        appliesto: "limitedSVGElementsCircle",
-        computed: "percentageAsSpecifiedOrAbsoluteLength",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/r"
-      },
-      "reading-flow": {
-        syntax: "normal | source-order | flex-visual | flex-flow | grid-rows | grid-columns | grid-order",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Display"
-        ],
-        initial: "normal",
-        appliesto: "blockContainersFlexContainersGridContainers",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/reading-flow"
-      },
-      "reading-order": {
-        syntax: "<integer>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Display"
-        ],
-        initial: "0",
-        appliesto: "blockContainersFlexContainersGridContainers",
-        computed: "specifiedInteger",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/reading-order"
-      },
-      resize: {
-        syntax: "none | both | horizontal | vertical | block | inline",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Basic User Interface"
-        ],
-        initial: "none",
-        appliesto: "elementsWithOverflowNotVisibleAndReplacedElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/resize"
-      },
-      right: {
-        syntax: "auto | <length-percentage> | <anchor()> | <anchor-size()>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "referToWidthOfContainingBlock",
-        groups: [
-          "CSS Anchor Positioning",
-          "CSS Positioned Layout"
-        ],
-        initial: "auto",
-        appliesto: "positionedElements",
-        computed: "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/right"
-      },
-      rotate: {
-        syntax: "none | <angle> | [ x | y | z | <number>{3} ] && <angle>",
-        media: "visual",
-        inherited: false,
-        animationType: "transform",
-        percentages: "no",
-        groups: [
-          "CSS Transforms"
-        ],
-        initial: "none",
-        appliesto: "transformableElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        stacking: true,
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/rotate"
-      },
-      "row-gap": {
-        syntax: "normal | <length-percentage>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "referToDimensionOfContentArea",
-        groups: [
-          "CSS Box Alignment"
-        ],
-        initial: "normal",
-        appliesto: "multiColumnElementsFlexContainersGridContainers",
-        computed: "asSpecifiedWithLengthsAbsoluteAndNormalComputingToZeroExceptMultiColumn",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/row-gap"
-      },
-      "ruby-align": {
-        syntax: "start | center | space-between | space-around",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Ruby"
-        ],
-        initial: "space-around",
-        appliesto: "rubyBasesAnnotationsBaseAnnotationContainers",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/ruby-align"
-      },
-      "ruby-merge": {
-        syntax: "separate | collapse | auto",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Ruby"
-        ],
-        initial: "separate",
-        appliesto: "rubyAnnotationContainers",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "experimental"
-      },
-      "ruby-overhang": {
-        syntax: "auto | none",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Ruby"
-        ],
-        initial: "auto",
-        appliesto: "rubyAnnotationContainers",
-        computed: "theSpecifiedKeyword",
-        order: "perGrammar",
-        status: "standard"
-      },
-      "ruby-position": {
-        syntax: "[ alternate || [ over | under ] ] | inter-character",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Ruby"
-        ],
-        initial: "alternate",
-        appliesto: "rubyAnnotationContainers",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/ruby-position"
-      },
-      rx: {
-        syntax: "<length> | <percentage>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "referToSVGViewportWidth",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "0",
-        appliesto: "limitedSVGElementsEllipseRect",
-        computed: "percentageAsSpecifiedOrAbsoluteLength",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/rx"
-      },
-      ry: {
-        syntax: "<length> | <percentage>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "referToSVGViewportHeight",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "0",
-        appliesto: "limitedSVGElementsEllipseRect",
-        computed: "percentageAsSpecifiedOrAbsoluteLength",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/ry"
-      },
-      scale: {
-        syntax: "none | [ <number> | <percentage> ]{1,3}",
-        media: "visual",
-        inherited: false,
-        animationType: "transform",
-        percentages: "no",
-        groups: [
-          "CSS Transforms"
-        ],
-        initial: "none",
-        appliesto: "transformableElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        stacking: true,
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scale"
-      },
-      "scroll-behavior": {
-        syntax: "auto | smooth",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Overflow"
-        ],
-        initial: "auto",
-        appliesto: "scrollingBoxes",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-behavior"
-      },
-      "scroll-initial-target": {
-        syntax: "none | nearest",
-        media: "noPracticalMedia",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "theSpecifiedKeyword",
-        order: "perGrammar",
-        status: "experimental"
-      },
-      "scroll-margin": {
-        syntax: "<length>{1,4}",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: [
-          "scroll-margin-bottom",
-          "scroll-margin-left",
-          "scroll-margin-right",
-          "scroll-margin-top"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "scroll-margin-bottom",
-          "scroll-margin-left",
-          "scroll-margin-right",
-          "scroll-margin-top"
-        ],
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-margin"
-      },
-      "scroll-margin-block": {
-        syntax: "<length>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: [
-          "scroll-margin-block-start",
-          "scroll-margin-block-end"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "scroll-margin-block-start",
-          "scroll-margin-block-end"
-        ],
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-block"
-      },
-      "scroll-margin-block-end": {
-        syntax: "<length>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "0",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-block-end"
-      },
-      "scroll-margin-block-start": {
-        syntax: "<length>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "0",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-block-start"
-      },
-      "scroll-margin-bottom": {
-        syntax: "<length>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "0",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-bottom"
-      },
-      "scroll-margin-inline": {
-        syntax: "<length>{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: [
-          "scroll-margin-inline-start",
-          "scroll-margin-inline-end"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "scroll-margin-inline-start",
-          "scroll-margin-inline-end"
-        ],
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-inline"
-      },
-      "scroll-margin-inline-end": {
-        syntax: "<length>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "0",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-inline-end"
-      },
-      "scroll-margin-inline-start": {
-        syntax: "<length>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "0",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-inline-start"
-      },
-      "scroll-margin-left": {
-        syntax: "<length>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "0",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-left"
-      },
-      "scroll-margin-right": {
-        syntax: "<length>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "0",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-right"
-      },
-      "scroll-margin-top": {
-        syntax: "<length>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "0",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-top"
-      },
-      "scroll-marker-group": {
-        syntax: "none | before | after",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Overflow"
-        ],
-        initial: "none",
-        appliesto: "scrollContainers",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-marker-group"
-      },
-      "scroll-padding": {
-        syntax: "[ auto | <length-percentage> ]{1,4}",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "relativeToTheScrollContainersScrollport",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: [
-          "scroll-padding-bottom",
-          "scroll-padding-left",
-          "scroll-padding-right",
-          "scroll-padding-top"
-        ],
-        appliesto: "scrollContainers",
-        computed: [
-          "scroll-padding-bottom",
-          "scroll-padding-left",
-          "scroll-padding-right",
-          "scroll-padding-top"
-        ],
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-padding"
-      },
-      "scroll-padding-block": {
-        syntax: "[ auto | <length-percentage> ]{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "relativeToTheScrollContainersScrollport",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: [
-          "scroll-padding-block-start",
-          "scroll-padding-block-end"
-        ],
-        appliesto: "scrollContainers",
-        computed: [
-          "scroll-padding-block-start",
-          "scroll-padding-block-end"
-        ],
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block"
-      },
-      "scroll-padding-block-end": {
-        syntax: "auto | <length-percentage>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "relativeToTheScrollContainersScrollport",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "auto",
-        appliesto: "scrollContainers",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block-end"
-      },
-      "scroll-padding-block-start": {
-        syntax: "auto | <length-percentage>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "relativeToTheScrollContainersScrollport",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "auto",
-        appliesto: "scrollContainers",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block-start"
-      },
-      "scroll-padding-bottom": {
-        syntax: "auto | <length-percentage>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "relativeToTheScrollContainersScrollport",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "auto",
-        appliesto: "scrollContainers",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-bottom"
-      },
-      "scroll-padding-inline": {
-        syntax: "[ auto | <length-percentage> ]{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "relativeToTheScrollContainersScrollport",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: [
-          "scroll-padding-inline-start",
-          "scroll-padding-inline-end"
-        ],
-        appliesto: "scrollContainers",
-        computed: [
-          "scroll-padding-inline-start",
-          "scroll-padding-inline-end"
-        ],
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline"
-      },
-      "scroll-padding-inline-end": {
-        syntax: "auto | <length-percentage>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "relativeToTheScrollContainersScrollport",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "auto",
-        appliesto: "scrollContainers",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline-end"
-      },
-      "scroll-padding-inline-start": {
-        syntax: "auto | <length-percentage>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "relativeToTheScrollContainersScrollport",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "auto",
-        appliesto: "scrollContainers",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline-start"
-      },
-      "scroll-padding-left": {
-        syntax: "auto | <length-percentage>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "relativeToTheScrollContainersScrollport",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "auto",
-        appliesto: "scrollContainers",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-left"
-      },
-      "scroll-padding-right": {
-        syntax: "auto | <length-percentage>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "relativeToTheScrollContainersScrollport",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "auto",
-        appliesto: "scrollContainers",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-right"
-      },
-      "scroll-padding-top": {
-        syntax: "auto | <length-percentage>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "relativeToTheScrollContainersScrollport",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "auto",
-        appliesto: "scrollContainers",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-top"
-      },
-      "scroll-snap-align": {
-        syntax: "[ none | start | end | center ]{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-snap-align"
-      },
-      "scroll-snap-coordinate": {
-        syntax: "none | <position>#",
-        media: "interactive",
-        inherited: false,
-        animationType: "position",
-        percentages: "referToBorderBox",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecifiedRelativeToAbsoluteLengths",
-        order: "uniqueOrder",
-        status: "obsolete"
-      },
-      "scroll-snap-destination": {
-        syntax: "<position>",
-        media: "interactive",
-        inherited: false,
-        animationType: "position",
-        percentages: "relativeToScrollContainerPaddingBoxAxis",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "0px 0px",
-        appliesto: "scrollContainers",
-        computed: "asSpecifiedRelativeToAbsoluteLengths",
-        order: "uniqueOrder",
-        status: "obsolete"
-      },
-      "scroll-snap-points-x": {
-        syntax: "none | repeat( <length-percentage> )",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "relativeToScrollContainerPaddingBoxAxis",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "none",
-        appliesto: "scrollContainers",
-        computed: "asSpecifiedRelativeToAbsoluteLengths",
-        order: "uniqueOrder",
-        status: "obsolete"
-      },
-      "scroll-snap-points-y": {
-        syntax: "none | repeat( <length-percentage> )",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "relativeToScrollContainerPaddingBoxAxis",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "none",
-        appliesto: "scrollContainers",
-        computed: "asSpecifiedRelativeToAbsoluteLengths",
-        order: "uniqueOrder",
-        status: "obsolete"
-      },
-      "scroll-snap-stop": {
-        syntax: "normal | always",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "normal",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-snap-stop"
-      },
-      "scroll-snap-type": {
-        syntax: "none | [ x | y | block | inline | both ] [ mandatory | proximity ]?",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-snap-type"
-      },
-      "scroll-snap-type-x": {
-        syntax: "none | mandatory | proximity",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "none",
-        appliesto: "scrollContainers",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "obsolete"
-      },
-      "scroll-snap-type-y": {
-        syntax: "none | mandatory | proximity",
-        media: "interactive",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Scroll Snap"
-        ],
-        initial: "none",
-        appliesto: "scrollContainers",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "obsolete"
-      },
-      "scroll-target-group": {
-        syntax: "none | auto",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Overflow"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-target-group"
-      },
-      "scroll-timeline": {
-        syntax: "[ <'scroll-timeline-name'> <'scroll-timeline-axis'>? ]#",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "scroll-timeline-name",
-          "scroll-timeline-axis"
-        ],
-        percentages: "no",
-        groups: [
-          "Scroll-driven Animations"
-        ],
-        initial: [
-          "scroll-timeline-name",
-          "scroll-timeline-axis"
-        ],
-        appliesto: "scrollContainers",
-        computed: [
-          "scroll-timeline-name",
-          "scroll-timeline-axis"
-        ],
-        order: "perGrammar",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-timeline"
-      },
-      "scroll-timeline-axis": {
-        syntax: "[ block | inline | x | y ]#",
-        media: "interactive",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "Scroll-driven Animations"
-        ],
-        initial: "block",
-        appliesto: "scrollContainers",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-timeline-axis"
-      },
-      "scroll-timeline-name": {
-        syntax: "[ none | <dashed-ident> ]#",
-        media: "interactive",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "Scroll-driven Animations"
-        ],
-        initial: "none",
-        appliesto: "scrollContainers",
-        computed: "noneOrOrderedListOfIdentifiers",
-        order: "perGrammar",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scroll-timeline-name"
-      },
-      "scrollbar-color": {
-        syntax: "auto | <color>{2}",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Scrollbars Styling"
-        ],
-        initial: "auto",
-        appliesto: "scrollingBoxes",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scrollbar-color"
-      },
-      "scrollbar-gutter": {
-        syntax: "auto | stable && both-edges?",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Overflow"
-        ],
-        initial: "auto",
-        appliesto: "scrollingBoxes",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scrollbar-gutter"
-      },
-      "scrollbar-width": {
-        syntax: "auto | thin | none",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Scrollbars Styling"
-        ],
-        initial: "auto",
-        appliesto: "scrollingBoxes",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/scrollbar-width"
-      },
-      "shape-image-threshold": {
-        syntax: "<opacity-value>",
-        media: "visual",
-        inherited: false,
-        animationType: "number",
-        percentages: "no",
-        groups: [
-          "CSS Shapes"
-        ],
-        initial: "0.0",
-        appliesto: "floats",
-        computed: "specifiedValueNumberClipped0To1",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/shape-image-threshold"
-      },
-      "shape-margin": {
-        syntax: "<length-percentage>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "referToWidthOfContainingBlock",
-        groups: [
-          "CSS Shapes"
-        ],
-        initial: "0",
-        appliesto: "floats",
-        computed: "asSpecifiedRelativeToAbsoluteLengths",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/shape-margin"
-      },
-      "shape-outside": {
-        syntax: "none | [ <shape-box> || <basic-shape> ] | <image>",
-        media: "visual",
-        inherited: false,
-        animationType: "basicShapeOtherwiseNo",
-        percentages: "no",
-        groups: [
-          "CSS Shapes"
-        ],
-        initial: "none",
-        appliesto: "floats",
-        computed: "asDefinedForBasicShapeWithAbsoluteURIOtherwiseAsSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/shape-outside"
-      },
-      "shape-rendering": {
-        syntax: "auto | optimizeSpeed | crispEdges | geometricPrecision",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "auto",
-        appliesto: "limitedSVGElementsShapes",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/shape-rendering"
-      },
-      "speak-as": {
-        syntax: "normal | spell-out || digits || [ literal-punctuation | no-punctuation ]",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Speech"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "specifiedValue",
-        order: "perGrammar",
-        status: "experimental"
-      },
-      "stop-color": {
-        syntax: "<'color'>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "black",
-        appliesto: "limitedSVGElementsStop",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/stop-color"
-      },
-      "stop-opacity": {
-        syntax: "<'opacity'>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "black",
-        appliesto: "limitedSVGElementsStop",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/stop-opacity"
-      },
-      stroke: {
-        syntax: "<paint>",
-        media: "visual",
-        inherited: true,
-        animationType: [
-          "stroke-dasharray",
-          "stroke-dashoffset",
-          "stroke-linecap",
-          "stroke-linejoin",
-          "stroke-miterlimit",
-          "stroke-opacity",
-          "stroke-width"
-        ],
-        percentages: "no",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: [
-          "stroke-dasharray",
-          "stroke-dashoffset",
-          "stroke-linecap",
-          "stroke-linejoin",
-          "stroke-miterlimit",
-          "stroke-opacity",
-          "stroke-width"
-        ],
-        appliesto: "asLonghands",
-        computed: "asLonghands",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/stroke"
-      },
-      "stroke-color": {
-        syntax: "<color>",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValue",
-        percentages: "no",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "transparent",
-        appliesto: "textAndSVGShapes",
-        computed: "computedColor",
-        order: "perGrammar",
-        status: "experimental"
-      },
-      "stroke-dasharray": {
-        syntax: "none | <dasharray>",
-        media: "visual",
-        inherited: true,
-        animationType: "repeatableList",
-        percentages: "referToSVGViewportDiagonal",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "none",
-        appliesto: "limitedSVGElementsShapes",
-        computed: "listEachItemConsistingOfAbsoluteLengthPercentageOrKeyword",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/stroke-dasharray"
-      },
-      "stroke-dashoffset": {
-        syntax: "<length-percentage> | <number>",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValueType",
-        percentages: "referToSVGViewportDiagonal",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "0",
-        appliesto: "limitedSVGElementsShapes",
-        computed: "absoluteLengthOrPercentageNumbersConverted",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/stroke-dashoffset"
-      },
-      "stroke-linecap": {
-        syntax: "butt | round | square",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "butt",
-        appliesto: "limitedSVGElementsShapes",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/stroke-linecap"
-      },
-      "stroke-linejoin": {
-        syntax: "miter | miter-clip | round | bevel | arcs",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "miter",
-        appliesto: "limitedSVGElementsShapes",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/stroke-linejoin"
-      },
-      "stroke-miterlimit": {
-        syntax: "<number>",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "4",
-        appliesto: "limitedSVGElementsShapes",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/stroke-miterlimit"
-      },
-      "stroke-opacity": {
-        syntax: "<'opacity'>",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "1",
-        appliesto: "limitedSVGElementsShapes",
-        computed: "specifiedValueClipped0To1",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/stroke-opacity"
-      },
-      "stroke-width": {
-        syntax: "<length-percentage> | <number>",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValueType",
-        percentages: "referToSVGViewportDiagonal",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "1px",
-        appliesto: "limitedSVGElementsShapes",
-        computed: "absoluteLengthOrPercentageNumbersConverted",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/stroke-width"
-      },
-      "tab-size": {
-        syntax: "<integer> | <length>",
-        media: "visual",
-        inherited: true,
-        animationType: "length",
-        percentages: "no",
-        groups: [
-          "CSS Text"
-        ],
-        initial: "8",
-        appliesto: "blockContainers",
-        computed: "specifiedIntegerOrAbsoluteLength",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/tab-size"
-      },
-      "table-layout": {
-        syntax: "auto | fixed",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Table"
-        ],
-        initial: "auto",
-        appliesto: "tableElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/table-layout"
-      },
-      "text-align": {
-        syntax: "start | end | left | right | center | justify | match-parent",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Text"
-        ],
-        initial: "startOrNamelessValueIfLTRRightIfRTL",
-        appliesto: "blockContainers",
-        computed: "asSpecifiedExceptMatchParent",
-        order: "orderOfAppearance",
-        alsoAppliesTo: [
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-align"
-      },
-      "text-align-last": {
-        syntax: "auto | start | end | left | right | center | justify",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Text"
-        ],
-        initial: "auto",
-        appliesto: "blockContainers",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-align-last"
-      },
-      "text-anchor": {
-        syntax: "start | middle | end",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "start",
-        appliesto: "limitedSVGElementsTextContent",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-anchor"
-      },
-      "text-autospace": {
-        syntax: "normal | <autospace> | auto",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Text"
-        ],
-        initial: "normal",
-        appliesto: "textElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-autospace"
-      },
-      "text-box": {
-        syntax: "normal | <'text-box-trim'> || <'text-box-edge'>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Inline"
-        ],
-        initial: "normal",
-        appliesto: "blockContainersAndInlineBoxes",
-        computed: "theSpecifiedKeyword",
-        order: "perGrammar",
-        status: "standard"
-      },
-      "text-box-edge": {
-        syntax: "auto | <text-edge>",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Inline"
-        ],
-        initial: "auto",
-        appliesto: "blockContainersAndInlineBoxes",
-        computed: "theSpecifiedKeyword",
-        order: "perGrammar",
-        status: "standard"
-      },
-      "text-box-trim": {
-        syntax: "none | trim-start | trim-end | trim-both",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Inline"
-        ],
-        initial: "none",
-        appliesto: "blockContainersAndInlineBoxes",
-        computed: "theSpecifiedKeyword",
-        order: "perGrammar",
-        status: "standard"
-      },
-      "text-combine-upright": {
-        syntax: "none | all | [ digits <integer>? ]",
-        media: "visual",
-        inherited: true,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Writing Modes"
-        ],
-        initial: "none",
-        appliesto: "nonReplacedInlineElements",
-        computed: "keywordPlusIntegerIfDigits",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-combine-upright"
-      },
-      "text-decoration": {
-        syntax: "<'text-decoration-line'> || <'text-decoration-style'> || <'text-decoration-color'> || <'text-decoration-thickness'>",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "text-decoration-color",
-          "text-decoration-style",
-          "text-decoration-line",
-          "text-decoration-thickness"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Text Decoration"
-        ],
-        initial: [
-          "text-decoration-color",
-          "text-decoration-style",
-          "text-decoration-line"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "text-decoration-line",
-          "text-decoration-style",
-          "text-decoration-color",
-          "text-decoration-thickness"
-        ],
-        order: "orderOfAppearance",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-decoration"
-      },
-      "text-decoration-color": {
-        syntax: "<color>",
-        media: "visual",
-        inherited: false,
-        animationType: "color",
-        percentages: "no",
-        groups: [
-          "CSS Text Decoration"
-        ],
-        initial: "currentcolor",
-        appliesto: "allElements",
-        computed: "computedColor",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-decoration-color"
-      },
-      "text-decoration-inset": {
-        syntax: "<length>{1,2} | auto",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValue",
-        percentages: "no",
-        groups: [
-          "CSS Text Decoration"
-        ],
-        initial: "0",
-        appliesto: "allElements",
-        computed: "absoluteLengthOrKeyword",
-        order: "perGrammar",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-decoration-inset"
-      },
-      "text-decoration-line": {
-        syntax: "none | [ underline || overline || line-through || blink ] | spelling-error | grammar-error",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Text Decoration"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "orderOfAppearance",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-decoration-line"
-      },
-      "text-decoration-skip": {
-        syntax: "none | [ objects || [ spaces | [ leading-spaces || trailing-spaces ] ] || edges || box-decoration ]",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Text Decoration"
-        ],
-        initial: "objects",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "orderOfAppearance",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-decoration-skip"
-      },
-      "text-decoration-skip-ink": {
-        syntax: "auto | all | none",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Text Decoration"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "orderOfAppearance",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-decoration-skip-ink"
-      },
-      "text-decoration-style": {
-        syntax: "solid | double | dotted | dashed | wavy",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Text Decoration"
-        ],
-        initial: "solid",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-decoration-style"
-      },
-      "text-decoration-thickness": {
-        syntax: "auto | from-font | <length> | <percentage>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "referToElementFontSize",
-        groups: [
-          "CSS Text Decoration"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-decoration-thickness"
-      },
-      "text-emphasis": {
-        syntax: "<'text-emphasis-style'> || <'text-emphasis-color'>",
-        media: "visual",
-        inherited: true,
-        animationType: [
-          "text-emphasis-color",
-          "text-emphasis-style"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Text Decoration"
-        ],
-        initial: [
-          "text-emphasis-style",
-          "text-emphasis-color"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "text-emphasis-style",
-          "text-emphasis-color"
-        ],
-        order: "orderOfAppearance",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-emphasis"
-      },
-      "text-emphasis-color": {
-        syntax: "<color>",
-        media: "visual",
-        inherited: true,
-        animationType: "color",
-        percentages: "no",
-        groups: [
-          "CSS Text Decoration"
-        ],
-        initial: "currentcolor",
-        appliesto: "allElements",
-        computed: "computedColor",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-emphasis-color"
-      },
-      "text-emphasis-position": {
-        syntax: "auto | [ over | under ] && [ right | left ]?",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Text Decoration"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-emphasis-position"
-      },
-      "text-emphasis-style": {
-        syntax: "none | [ [ filled | open ] || [ dot | circle | double-circle | triangle | sesame ] ] | <string>",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Text Decoration"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-emphasis-style"
-      },
-      "text-indent": {
-        syntax: "<length-percentage> && hanging? && each-line?",
-        media: "visual",
-        inherited: true,
-        animationType: "lpc",
-        percentages: "referToWidthOfContainingBlock",
-        groups: [
-          "CSS Text"
-        ],
-        initial: "0",
-        appliesto: "blockContainers",
-        computed: "percentageOrAbsoluteLengthPlusKeywords",
-        order: "lengthOrPercentageBeforeKeywords",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-indent"
-      },
-      "text-justify": {
-        syntax: "auto | inter-character | inter-word | none",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Text"
-        ],
-        initial: "auto",
-        appliesto: "inlineLevelAndTableCellElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-justify"
-      },
-      "text-orientation": {
-        syntax: "mixed | upright | sideways",
-        media: "visual",
-        inherited: true,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Writing Modes"
-        ],
-        initial: "mixed",
-        appliesto: "allElementsExceptTableRowGroupsRowsColumnGroupsAndColumns",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-orientation"
-      },
-      "text-overflow": {
-        syntax: "[ clip | ellipsis | <string> ]{1,2}",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Overflow"
-        ],
-        initial: "clip",
-        appliesto: "blockContainerElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-overflow"
-      },
-      "text-rendering": {
-        syntax: "auto | optimizeSpeed | optimizeLegibility | geometricPrecision",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "auto",
-        appliesto: "textElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-rendering"
-      },
-      "text-shadow": {
-        syntax: "none | <shadow-t>#",
-        media: "visual",
-        inherited: true,
-        animationType: "shadowList",
-        percentages: "no",
-        groups: [
-          "CSS Text Decoration"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "colorPlusThreeAbsoluteLengths",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-shadow"
-      },
-      "text-size-adjust": {
-        syntax: "none | auto | <percentage>",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValueType",
-        percentages: "referToSizeOfFont",
-        groups: [
-          "CSS Mobile Text Size Adjustment"
-        ],
-        initial: "autoForSmartphoneBrowsersSupportingInflation",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-size-adjust"
-      },
-      "text-spacing-trim": {
-        syntax: "space-all | normal | space-first | trim-start",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Text"
-        ],
-        initial: "normal",
-        appliesto: "textElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-spacing-trim"
-      },
-      "text-transform": {
-        syntax: "none | [ capitalize | uppercase | lowercase ] || full-width || full-size-kana | math-auto",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Text",
-          "MathML"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-transform"
-      },
-      "text-underline-offset": {
-        syntax: "auto | <length> | <percentage>",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValueType",
-        percentages: "referToElementFontSize",
-        groups: [
-          "CSS Text Decoration"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-underline-offset"
-      },
-      "text-underline-position": {
-        syntax: "auto | from-font | [ under || [ left | right ] ]",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Text Decoration"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "orderOfAppearance",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-underline-position"
-      },
-      "text-wrap": {
-        syntax: "<'text-wrap-mode'> || <'text-wrap-style'>",
-        media: "visual",
-        inherited: true,
-        animationType: [
-          "text-wrap-mode",
-          "text-wrap-style"
-        ],
-        percentages: [
-          "text-wrap-mode",
-          "text-wrap-style"
-        ],
-        groups: [
-          "CSS Text"
-        ],
-        initial: "wrap",
-        appliesto: "textAndBlockContainers",
-        computed: [
-          "text-wrap-mode",
-          "text-wrap-style"
-        ],
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-wrap"
-      },
-      "text-wrap-mode": {
-        syntax: "wrap | nowrap",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Text"
-        ],
-        initial: "wrap",
-        appliesto: "textAndBlockContainers",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-wrap-mode"
-      },
-      "text-wrap-style": {
-        syntax: "auto | balance | stable | pretty",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Text"
-        ],
-        initial: "auto",
-        appliesto: "textAndBlockContainers",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/text-wrap-style"
-      },
-      "timeline-scope": {
-        syntax: "none | <dashed-ident>#",
-        media: "interactive",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "Scroll-driven Animations"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "noneOrOrderedListOfIdentifiers",
-        order: "perGrammar",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/timeline-scope"
-      },
-      "timeline-trigger": {
-        syntax: "none | [ <'timeline-trigger-name'> <'timeline-trigger-source'> <'timeline-trigger-range'> [ '/' <'timeline-trigger-exit-range'> ]? ]#",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "timeline-trigger-name",
-          "timeline-trigger-source",
-          "timeline-trigger-range",
-          "timeline-trigger-exit-range"
-        ],
-        percentages: "no",
-        groups: [
-          "CSS Animations"
-        ],
-        initial: [
-          "timeline-trigger-name",
-          "timeline-trigger-source",
-          "timeline-trigger-range",
-          "timeline-trigger-exit-range"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "timeline-trigger-name",
-          "timeline-trigger-source",
-          "timeline-trigger-range",
-          "timeline-trigger-exit-range"
-        ],
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger"
-      },
-      "timeline-trigger-name": {
-        syntax: "none | <dashed-ident>#",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Animations"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-name"
-      },
-      "timeline-trigger-exit-range": {
-        syntax: "[ <'timeline-trigger-exit-range-start'> <'timeline-trigger-exit-range-end'>? ]#",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: [
-          "timeline-trigger-exit-range-start",
-          "timeline-trigger-exit-range-end"
-        ],
-        groups: [
-          "CSS Animations"
-        ],
-        initial: [
-          "timeline-trigger-exit-range-start",
-          "timeline-trigger-exit-range-end"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "timeline-trigger-exit-range-start",
-          "timeline-trigger-exit-range-end"
-        ],
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-exit-range"
-      },
-      "timeline-trigger-exit-range-end": {
-        syntax: "[ auto | normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "relativeToTimelineRangeIfSpecifiedOtherwiseEntireTimeline",
-        groups: [
-          "CSS Animations"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-exit-range-end"
-      },
-      "timeline-trigger-exit-range-start": {
-        syntax: "[ auto | normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "relativeToTimelineRangeIfSpecifiedOtherwiseEntireTimeline",
-        groups: [
-          "CSS Animations"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-exit-range-start"
-      },
-      "timeline-trigger-range": {
-        syntax: "[ <'timeline-trigger-range-start'> <'timeline-trigger-range-end'>? ]#",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: [
-          "timeline-trigger-range-start",
-          "timeline-trigger-range-end"
-        ],
-        groups: [
-          "CSS Animations"
-        ],
-        initial: [
-          "timeline-trigger-range-start",
-          "timeline-trigger-range-end"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "timeline-trigger-range-start",
-          "timeline-trigger-range-end"
-        ],
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-range"
-      },
-      "timeline-trigger-range-end": {
-        syntax: "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "relativeToTimelineRangeIfSpecifiedOtherwiseEntireTimeline",
-        groups: [
-          "CSS Animations"
-        ],
-        initial: "normal",
-        appliesto: "allElements",
-        computed: "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-range-end"
-      },
-      "timeline-trigger-range-start": {
-        syntax: "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "relativeToTimelineRangeIfSpecifiedOtherwiseEntireTimeline",
-        groups: [
-          "CSS Animations"
-        ],
-        initial: "normal",
-        appliesto: "allElements",
-        computed: "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-range-start"
-      },
-      "timeline-trigger-source": {
-        syntax: "<single-animation-timeline>#",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Animations"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "listOfNoneAutoIdentScrollOrView",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-source"
-      },
-      top: {
-        syntax: "auto | <length-percentage> | <anchor()> | <anchor-size()>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "referToContainingBlockHeight",
-        groups: [
-          "CSS Anchor Positioning",
-          "CSS Positioned Layout"
-        ],
-        initial: "auto",
-        appliesto: "positionedElements",
-        computed: "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/top"
-      },
-      "touch-action": {
-        syntax: "auto | none | [ [ pan-x | pan-left | pan-right ] || [ pan-y | pan-up | pan-down ] || pinch-zoom ] | manipulation",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "Pointer Events"
-        ],
-        initial: "auto",
-        appliesto: "allElementsExceptNonReplacedInlineElementsTableRowsColumnsRowColumnGroups",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/touch-action"
-      },
-      transform: {
-        syntax: "none | <transform-list>",
-        media: "visual",
-        inherited: false,
-        animationType: "transform",
-        percentages: "referToSizeOfBoundingBox",
-        groups: [
-          "CSS Transforms"
-        ],
-        initial: "none",
-        appliesto: "transformableElements",
-        computed: "asSpecifiedRelativeToAbsoluteLengths",
-        order: "uniqueOrder",
-        stacking: true,
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/transform"
-      },
-      "transform-box": {
-        syntax: "content-box | border-box | fill-box | stroke-box | view-box",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Transforms"
-        ],
-        initial: "view-box",
-        appliesto: "transformableElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/transform-box"
-      },
-      "transform-origin": {
-        syntax: "[ <length-percentage> | left | center | right | top | bottom ] | [ [ <length-percentage> | left | center | right ] && [ <length-percentage> | top | center | bottom ] ] <length>?",
-        media: "visual",
-        inherited: false,
-        animationType: "simpleListOfLpc",
-        percentages: "referToSizeOfBoundingBox",
-        groups: [
-          "CSS Transforms"
-        ],
-        initial: "50% 50% 0",
-        appliesto: "transformableElements",
-        computed: "forLengthAbsoluteValueOtherwisePercentage",
-        order: "oneOrTwoValuesLengthAbsoluteKeywordsPercentages",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/transform-origin"
-      },
-      "transform-style": {
-        syntax: "flat | preserve-3d",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Transforms"
-        ],
-        initial: "flat",
-        appliesto: "transformableElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        stacking: true,
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/transform-style"
-      },
-      transition: {
-        syntax: "<single-transition>#",
-        media: "interactive",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Transitions"
-        ],
-        initial: [
-          "transition-delay",
-          "transition-duration",
-          "transition-property",
-          "transition-timing-function",
-          "transition-behavior"
-        ],
-        appliesto: "allElementsAndPseudos",
-        computed: [
-          "transition-delay",
-          "transition-duration",
-          "transition-property",
-          "transition-timing-function",
-          "transition-behavior"
-        ],
-        order: "orderOfAppearance",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/transition"
-      },
-      "transition-behavior": {
-        syntax: "<transition-behavior-value>#",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Transitions"
-        ],
-        initial: "normal",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/transition-behavior"
-      },
-      "transition-delay": {
-        syntax: "<time>#",
-        media: "interactive",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Transitions"
-        ],
-        initial: "0s",
-        appliesto: "allElementsAndPseudos",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/transition-delay"
-      },
-      "transition-duration": {
-        syntax: "<time>#",
-        media: "interactive",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Transitions"
-        ],
-        initial: "0s",
-        appliesto: "allElementsAndPseudos",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/transition-duration"
-      },
-      "transition-property": {
-        syntax: "none | <single-transition-property>#",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Transitions"
-        ],
-        initial: "all",
-        appliesto: "allElementsAndPseudos",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/transition-property"
-      },
-      "transition-timing-function": {
-        syntax: "<easing-function>#",
-        media: "interactive",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Transitions"
-        ],
-        initial: "ease",
-        appliesto: "allElementsAndPseudos",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/transition-timing-function"
-      },
-      translate: {
-        syntax: "none | <length-percentage> [ <length-percentage> <length>? ]?",
-        media: "visual",
-        inherited: false,
-        animationType: "transform",
-        percentages: "referToSizeOfBoundingBox",
-        groups: [
-          "CSS Transforms"
-        ],
-        initial: "none",
-        appliesto: "transformableElements",
-        computed: "asSpecifiedRelativeToAbsoluteLengths",
-        order: "perGrammar",
-        stacking: true,
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/translate"
-      },
-      "trigger-scope": {
-        syntax: "none | all | <dashed-ident>#",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Animations"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/trigger-scope"
-      },
-      "unicode-bidi": {
-        syntax: "normal | embed | isolate | bidi-override | isolate-override | plaintext",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Writing Modes"
-        ],
-        initial: "normal",
-        appliesto: "allElementsSomeValuesNoEffectOnNonInlineElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/unicode-bidi"
-      },
-      "user-select": {
-        syntax: "auto | text | none | all",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Basic User Interface"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/user-select"
-      },
-      "vector-effect": {
-        syntax: "none | non-scaling-stroke | non-scaling-size | non-rotation | fixed-position",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "none",
-        appliesto: "limitedSVGElementsGraphicsAndUse",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/vector-effect"
-      },
-      "vertical-align": {
-        syntax: "baseline | sub | super | text-top | text-bottom | middle | top | bottom | <percentage> | <length>",
-        media: "visual",
-        inherited: false,
-        animationType: "length",
-        percentages: "referToLineHeight",
-        groups: [
-          "CSS Inline"
-        ],
-        initial: "baseline",
-        appliesto: "inlineLevelAndTableCellElements",
-        computed: "absoluteLengthOrKeyword",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/vertical-align"
-      },
-      "view-timeline": {
-        syntax: "[ <'view-timeline-name'> [ <'view-timeline-axis'> || <'view-timeline-inset'> ]? ]#",
-        media: "visual",
-        inherited: false,
-        animationType: [
-          "view-timeline-name",
-          "view-timeline-axis"
-        ],
-        percentages: "no",
-        groups: [
-          "Scroll-driven Animations"
-        ],
-        initial: [
-          "view-timeline-name",
-          "view-timeline-axis"
-        ],
-        appliesto: "allElements",
-        computed: [
-          "view-timeline-name",
-          "view-timeline-axis"
-        ],
-        order: "perGrammar",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/view-timeline"
-      },
-      "view-timeline-axis": {
-        syntax: "[ block | inline | x | y ]#",
-        media: "interactive",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "Scroll-driven Animations"
-        ],
-        initial: "block",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/view-timeline-axis"
-      },
-      "view-timeline-inset": {
-        syntax: "[ [ auto | <length-percentage> ]{1,2} ]#",
-        media: "interactive",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "relativeToCorrespondingDimensionOfRelevantScrollport",
-        groups: [
-          "Scroll-driven Animations"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "listEachItemConsistingOfPairsOfAutoOrLengthPercentage",
-        order: "perGrammar",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/view-timeline-inset"
-      },
-      "view-timeline-name": {
-        syntax: "[ none | <dashed-ident> ]#",
-        media: "interactive",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "Scroll-driven Animations"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "noneOrOrderedListOfIdentifiers",
-        order: "perGrammar",
-        status: "experimental",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/view-timeline-name"
-      },
-      "view-transition-class": {
-        syntax: "none | <custom-ident>+",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS View Transitions"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard"
-      },
-      "view-transition-name": {
-        syntax: "none | <custom-ident> | match-element",
-        media: "visual",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS View Transitions"
-        ],
-        initial: "none",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/view-transition-name"
-      },
-      visibility: {
-        syntax: "visible | hidden | collapse",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Display",
-          "Scalable Vector Graphics"
-        ],
-        initial: "visible",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/visibility"
-      },
-      "white-space": {
-        syntax: "normal | pre | pre-wrap | pre-line | <'white-space-collapse'> || <'text-wrap-mode'>",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Text"
-        ],
-        initial: "normal",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/white-space"
-      },
-      "white-space-collapse": {
-        syntax: "collapse | preserve | preserve-breaks | preserve-spaces | break-spaces",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Text"
-        ],
-        initial: "collapse",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/white-space-collapse"
-      },
-      widows: {
-        syntax: "<integer>",
-        media: "visual",
-        inherited: true,
-        animationType: "byComputedValueType",
-        percentages: "no",
-        groups: [
-          "CSS Fragmentation"
-        ],
-        initial: "2",
-        appliesto: "blockContainerElements",
-        computed: "asSpecified",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/widows"
-      },
-      width: {
-        syntax: "auto | <length-percentage [0,\u221E]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,\u221E]>) | <calc-size()> | <anchor-size()>",
-        media: "visual",
-        inherited: false,
-        animationType: "lpc",
-        percentages: "referToWidthOfContainingBlock",
-        groups: [
-          "CSS Box Sizing"
-        ],
-        initial: "auto",
-        appliesto: "allElementsButNonReplacedAndTableRows",
-        computed: "percentageAutoOrAbsoluteLength",
-        order: "lengthOrPercentageBeforeKeywordIfBothPresent",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/width"
-      },
-      "will-change": {
-        syntax: "auto | <animateable-feature>#",
-        media: "all",
-        inherited: false,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Will Change"
-        ],
-        initial: "auto",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/will-change"
-      },
-      "word-break": {
-        syntax: "normal | break-all | keep-all | break-word | auto-phrase",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Text"
-        ],
-        initial: "normal",
-        appliesto: "allElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/word-break"
-      },
-      "word-spacing": {
-        syntax: "normal | <length>",
-        media: "visual",
-        inherited: true,
-        animationType: "length",
-        percentages: "referToWidthOfAffectedGlyph",
-        groups: [
-          "CSS Text"
-        ],
-        initial: "normal",
-        appliesto: "allElements",
-        computed: "absoluteLength",
-        order: "uniqueOrder",
-        alsoAppliesTo: [
-          "::first-letter",
-          "::first-line",
-          "::placeholder"
-        ],
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/word-spacing"
-      },
-      "word-wrap": {
-        syntax: "normal | break-word",
-        media: "visual",
-        inherited: true,
-        animationType: "discrete",
-        percentages: "no",
-        groups: [
-          "CSS Text"
-        ],
-        initial: "normal",
-        appliesto: "nonReplacedInlineElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/overflow-wrap"
-      },
-      "writing-mode": {
-        syntax: "horizontal-tb | vertical-rl | vertical-lr | sideways-rl | sideways-lr",
-        media: "visual",
-        inherited: true,
-        animationType: "notAnimatable",
-        percentages: "no",
-        groups: [
-          "CSS Writing Modes"
-        ],
-        initial: "horizontal-tb",
-        appliesto: "allElementsExceptTableRowColumnGroupsTableRowsColumns",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/writing-mode"
-      },
-      x: {
-        syntax: "<length> | <percentage>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "referToSVGViewportWidth",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "0",
-        appliesto: "limitedSVGElementsGeometry",
-        computed: "percentageAsSpecifiedOrAbsoluteLength",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/x"
-      },
-      y: {
-        syntax: "<length> | <percentage>",
-        media: "visual",
-        inherited: false,
-        animationType: "byComputedValueType",
-        percentages: "referToSVGViewportHeight",
-        groups: [
-          "Scalable Vector Graphics"
-        ],
-        initial: "0",
-        appliesto: "limitedSVGElementsGeometry",
-        computed: "percentageAsSpecifiedOrAbsoluteLength",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/y"
-      },
-      "z-index": {
-        syntax: "auto | <integer>",
-        media: "visual",
-        inherited: false,
-        animationType: "integer",
-        percentages: "no",
-        groups: [
-          "CSS Positioned Layout"
-        ],
-        initial: "auto",
-        appliesto: "positionedElements",
-        computed: "asSpecified",
-        order: "uniqueOrder",
-        stacking: true,
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/z-index"
-      },
-      zoom: {
-        syntax: "normal | reset | <number [0,\u221E]> || <percentage [0,\u221E]>",
-        media: "visual",
-        inherited: false,
-        animationType: "notAnimatable",
-        percentages: "convertedToNumber",
-        groups: [
-          "CSS Viewport"
-        ],
-        initial: "1",
-        appliesto: "allElements",
-        computed: "asSpecifiedButWithPercentageConvertedToTheEquivalentNumber",
-        order: "perGrammar",
-        status: "standard",
-        mdn_url: "https://developer.mozilla.org/docs/Web/CSS/zoom"
-      }
-    };
-  }
-});
-
-// node_modules/.pnpm/mdn-data@2.27.1/node_modules/mdn-data/css/syntaxes.json
-var syntaxes_default;
-var init_syntaxes = __esm({
-  "node_modules/.pnpm/mdn-data@2.27.1/node_modules/mdn-data/css/syntaxes.json"() {
-    syntaxes_default = {
-      "abs()": {
-        syntax: "abs( <calc-sum> )"
-      },
-      "absolute-size": {
-        syntax: "xx-small | x-small | small | medium | large | x-large | xx-large | xxx-large"
-      },
-      "acos()": {
-        syntax: "acos( <calc-sum> )"
-      },
-      "alpha-value": {
-        syntax: "<number> | <percentage>"
-      },
-      "an+b": {
-        syntax: "odd | even | <integer> | <n-dimension> | '+'?\u2020 n | -n | <ndashdigit-dimension> | '+'?\u2020 <ndashdigit-ident> | <dashndashdigit-ident> | <n-dimension> <signed-integer> | '+'?\u2020 n <signed-integer> | -n <signed-integer> | <ndash-dimension> <signless-integer> | '+'?\u2020 n- <signless-integer> | -n- <signless-integer> | <n-dimension> ['+' | '-'] <signless-integer> | '+'?\u2020 n ['+' | '-'] <signless-integer> | -n ['+' | '-'] <signless-integer>"
-      },
-      "anchor()": {
-        syntax: "anchor( <anchor-name>? && <anchor-side>, <length-percentage>? )"
-      },
-      "anchor-name": {
-        syntax: "<dashed-ident>"
-      },
-      "anchor-side": {
-        syntax: "inside | outside | top | left | right | bottom | start | end | self-start | self-end | <percentage> | center"
-      },
-      "anchor-size": {
-        syntax: "width | height | block | inline | self-block | self-inline"
-      },
-      "anchor-size()": {
-        syntax: "anchor-size( [ <anchor-name> || <anchor-size> ]? , <length-percentage>? )"
-      },
-      "angle-percentage": {
-        syntax: "<angle> | <percentage>"
-      },
-      "angular-color-hint": {
-        syntax: "<angle-percentage> | <zero>"
-      },
-      "angular-color-stop": {
-        syntax: "<color> <color-stop-angle>?"
-      },
-      "angular-color-stop-list": {
-        syntax: "<angular-color-stop> , [ <angular-color-hint>? , <angular-color-stop> ]#?"
-      },
-      "animateable-feature": {
-        syntax: "scroll-position | contents | <custom-ident>"
-      },
-      "animation-action": {
-        syntax: "none | play | play-once | play-forwards | play-backwards | pause | reset | replay"
-      },
-      "asin()": {
-        syntax: "asin( <calc-sum> )"
-      },
-      "atan()": {
-        syntax: "atan( <calc-sum> )"
-      },
-      "atan2()": {
-        syntax: "atan2( <calc-sum>, <calc-sum> )"
-      },
-      attachment: {
-        syntax: "scroll | fixed | local"
-      },
-      "attr()": {
-        syntax: "attr( <attr-name> <attr-type>? , <declaration-value>? )"
-      },
-      "attr-matcher": {
-        syntax: "[ '~' | '|' | '^' | '$' | '*' ]? '='"
-      },
-      "attr-modifier": {
-        syntax: "i | s"
-      },
-      "attr-type": {
-        syntax: "type( <syntax> ) | raw-string | number | <attr-unit>"
-      },
-      "attribute-selector": {
-        syntax: "'[' <wq-name> ']' | '[' <wq-name> <attr-matcher> [ <string-token> | <ident-token> ] <attr-modifier>? ']'"
-      },
-      "auto-repeat": {
-        syntax: "repeat( [ auto-fill | auto-fit ] , [ <line-names>? <fixed-size> ]+ <line-names>? )"
-      },
-      "auto-track-list": {
-        syntax: "[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>? <auto-repeat>\n[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>?"
-      },
-      axis: {
-        syntax: "block | inline | x | y"
-      },
-      "baseline-position": {
-        syntax: "[ first | last ]? baseline"
-      },
-      "basic-shape": {
-        syntax: "<inset()> | <xywh()> | <rect()> | <circle()> | <ellipse()> | <polygon()> | <path()>"
-      },
-      "basic-shape-rect": {
-        syntax: "<inset()> | <rect()> | <xywh()>"
-      },
-      "bg-clip": {
-        syntax: "<visual-box> | border-area | text"
-      },
-      "bg-image": {
-        syntax: "<image> | none"
-      },
-      "bg-layer": {
-        syntax: "<bg-image> || <bg-position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <visual-box> || <visual-box>"
-      },
-      "bg-position": {
-        syntax: "[ [ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] | [ center | [ left | right ] <length-percentage>? ] && [ center | [ top | bottom ] <length-percentage>? ] ]"
-      },
-      "bg-size": {
-        syntax: "[ <length-percentage [0,\u221E]> | auto ]{1,2} | cover | contain"
-      },
-      "blend-mode": {
-        syntax: "normal | multiply | screen | overlay | darken | lighten | color-dodge | color-burn | hard-light | soft-light | difference | exclusion | hue | saturation | color | luminosity"
-      },
-      "blur()": {
-        syntax: "blur( <length>? )"
-      },
-      "brightness()": {
-        syntax: "brightness( [ <number> | <percentage> ]? )"
-      },
-      "calc()": {
-        syntax: "calc( <calc-sum> )"
-      },
-      "calc-constant": {
-        syntax: "e | pi | infinity | -infinity | NaN"
-      },
-      "calc-product": {
-        syntax: "<calc-value> [ '*' <calc-value> | '/' <number> ]*"
-      },
-      "calc-size()": {
-        syntax: "calc-size( <calc-size-basis>, <calc-sum> )"
-      },
-      "calc-size-basis": {
-        syntax: "<intrinsic-size-keyword> | <calc-size()> | any | <calc-sum>"
-      },
-      "calc-sum": {
-        syntax: "<calc-product> [ [ '+' | '-' ] <calc-product> ]*"
-      },
-      "calc-value": {
-        syntax: "<number> | <dimension> | <percentage> | <calc-constant> | ( <calc-sum> )"
-      },
-      "cf-final-image": {
-        syntax: "<image> | <color>"
-      },
-      "cf-mixing-image": {
-        syntax: "<percentage>? && <image>"
-      },
-      "circle()": {
-        syntax: "circle( <radial-size>? [ at <position> ]? )"
-      },
-      "clamp()": {
-        syntax: "clamp( <calc-sum>#{3} )"
-      },
-      "class-selector": {
-        syntax: "'.' <ident-token>"
-      },
-      "clip-source": {
-        syntax: "<url>"
-      },
-      color: {
-        syntax: "<color-base> | currentColor | <system-color> | <light-dark()> | <deprecated-system-color>"
-      },
-      "color()": {
-        syntax: "color( [ from <color> ]? <colorspace-params> [ / [ <alpha-value> | none ] ]? )"
-      },
-      "color-base": {
-        syntax: "<hex-color> | <color-function> | <named-color> | <color-mix()> | transparent"
-      },
-      "color-function": {
-        syntax: "<rgb()> | <rgba()> | <hsl()> | <hsla()> | <hwb()> | <lab()> | <lch()> | <oklab()> | <oklch()> | <color()>"
-      },
-      "color-interpolation-method": {
-        syntax: "in [ <rectangular-color-space> | <polar-color-space> <hue-interpolation-method>? | <custom-color-space> ]"
-      },
-      "color-mix()": {
-        syntax: "color-mix( <color-interpolation-method> , [ <color> && <percentage [0,100]>? ]#{2})"
-      },
-      "color-stop": {
-        syntax: "<color-stop-length> | <color-stop-angle>"
-      },
-      "color-stop-angle": {
-        syntax: "[ <angle-percentage> | <zero> ]{1,2}"
-      },
-      "color-stop-length": {
-        syntax: "<length-percentage>{1,2}"
-      },
-      "color-stop-list": {
-        syntax: "<linear-color-stop> , [ <linear-color-hint>? , <linear-color-stop> ]#?"
-      },
-      "colorspace-params": {
-        syntax: "[<custom-params> | <predefined-rgb-params> | <xyz-params>]"
-      },
-      combinator: {
-        syntax: "'>' | '+' | '~' | [ '||' ]"
-      },
-      "common-lig-values": {
-        syntax: "[ common-ligatures | no-common-ligatures ]"
-      },
-      "compat-auto": {
-        syntax: "searchfield | textarea | checkbox | radio | menulist | listbox | meter | progress-bar | button"
-      },
-      "compat-special": {
-        syntax: "textfield | menulist-button"
-      },
-      "complex-selector": {
-        syntax: "<compound-selector> [ <combinator>? <compound-selector> ]*"
-      },
-      "complex-selector-list": {
-        syntax: "<complex-selector>#"
-      },
-      "composite-style": {
-        syntax: "clear | copy | source-over | source-in | source-out | source-atop | destination-over | destination-in | destination-out | destination-atop | xor"
-      },
-      "compositing-operator": {
-        syntax: "add | subtract | intersect | exclude"
-      },
-      "compound-selector": {
-        syntax: "[ <type-selector>? <subclass-selector>* [ <pseudo-element-selector> <pseudo-class-selector>* ]* ]!"
-      },
-      "compound-selector-list": {
-        syntax: "<compound-selector>#"
-      },
-      "conic-gradient()": {
-        syntax: "conic-gradient( [ <conic-gradient-syntax> ] )"
-      },
-      "conic-gradient-syntax": {
-        syntax: "[ [ [ from [ <angle> | <zero> ] ]? [ at <position> ]? ] || <color-interpolation-method> ]? , <angular-color-stop-list>"
-      },
-      "container-condition": {
-        syntax: "[ <container-name>? <container-query>? ]!"
-      },
-      "container-name": {
-        syntax: "<custom-ident>"
-      },
-      "container-query": {
-        syntax: "not <query-in-parens> | <query-in-parens> [ [ and <query-in-parens> ]* | [ or <query-in-parens> ]* ]"
-      },
-      "content-distribution": {
-        syntax: "space-between | space-around | space-evenly | stretch"
-      },
-      "content-list": {
-        syntax: "[ <string> | <image> | <attr()> | <quote> | <counter> ]+"
-      },
-      "content-position": {
-        syntax: "center | start | end | flex-start | flex-end"
-      },
-      "content-replacement": {
-        syntax: "<image>"
-      },
-      "contextual-alt-values": {
-        syntax: "[ contextual | no-contextual ]"
-      },
-      "contrast()": {
-        syntax: "contrast( [ <number> | <percentage> ]? )"
-      },
-      "coord-box": {
-        syntax: "<paint-box> | view-box"
-      },
-      "corner-shape-value": {
-        syntax: "round | scoop | bevel | notch | square | squircle | <superellipse()>"
-      },
-      "cos()": {
-        syntax: "cos( <calc-sum> )"
-      },
-      counter: {
-        syntax: "<counter()> | <counters()>"
-      },
-      "counter()": {
-        syntax: "counter( <counter-name>, <counter-style>? )"
-      },
-      "counter-name": {
-        syntax: "<custom-ident>"
-      },
-      "counter-style": {
-        syntax: "<counter-style-name> | symbols()"
-      },
-      "counter-style-name": {
-        syntax: "<custom-ident>"
-      },
-      "counters()": {
-        syntax: "counters( <counter-name>, <string>, <counter-style>? )"
-      },
-      "cross-fade()": {
-        syntax: "cross-fade( <cf-mixing-image> , <cf-final-image>? )"
-      },
-      "cubic-bezier()": {
-        syntax: "cubic-bezier( [ <number [0,1]>, <number> ]#{2} )"
-      },
-      "cubic-bezier-easing-function": {
-        syntax: "ease | ease-in | ease-out | ease-in-out | <cubic-bezier()>"
-      },
-      "cursor-predefined": {
-        syntax: "auto | default | none | context-menu | help | pointer | progress | wait | cell | crosshair | text | vertical-text | alias | copy | move | no-drop | not-allowed | e-resize | n-resize | ne-resize | nw-resize | s-resize | se-resize | sw-resize | w-resize | ew-resize | ns-resize | nesw-resize | nwse-resize | col-resize | row-resize | all-scroll | zoom-in | zoom-out | grab | grabbing"
-      },
-      "custom-color-space": {
-        syntax: "<dashed-ident>"
-      },
-      "custom-params": {
-        syntax: "<dashed-ident> [ <number> | <percentage> | none ]+"
-      },
-      dasharray: {
-        syntax: "[ [ <length-percentage> | <number> ]+ ]#"
-      },
-      "dashndashdigit-ident": {
-        syntax: "<ident-token>"
-      },
-      "deprecated-system-color": {
-        syntax: "ActiveBorder | ActiveCaption | AppWorkspace | Background | ButtonHighlight | ButtonShadow | CaptionText | InactiveBorder | InactiveCaption | InactiveCaptionText | InfoBackground | InfoText | Menu | MenuText | Scrollbar | ThreeDDarkShadow | ThreeDFace | ThreeDHighlight | ThreeDLightShadow | ThreeDShadow | Window | WindowFrame | WindowText"
-      },
-      "discretionary-lig-values": {
-        syntax: "[ discretionary-ligatures | no-discretionary-ligatures ]"
-      },
-      "display-box": {
-        syntax: "contents | none"
-      },
-      "display-inside": {
-        syntax: "flow | flow-root | table | flex | grid | ruby"
-      },
-      "display-internal": {
-        syntax: "table-row-group | table-header-group | table-footer-group | table-row | table-cell | table-column-group | table-column | table-caption | ruby-base | ruby-text | ruby-base-container | ruby-text-container"
-      },
-      "display-legacy": {
-        syntax: "inline-block | inline-list-item | inline-table | inline-flex | inline-grid"
-      },
-      "display-listitem": {
-        syntax: "<display-outside>? && [ flow | flow-root ]? && list-item"
-      },
-      "display-outside": {
-        syntax: "block | inline | run-in"
-      },
-      "drop-shadow()": {
-        syntax: "drop-shadow( [ <color>? && <length>{2,3} ] )"
-      },
-      "dynamic-range-limit-mix()": {
-        syntax: "dynamic-range-limit-mix( [ <'dynamic-range-limit'> && <percentage [0,100]> ]#{2,} )"
-      },
-      "easing-function": {
-        syntax: "<linear-easing-function> | <cubic-bezier-easing-function> | <step-easing-function>"
-      },
-      "east-asian-variant-values": {
-        syntax: "[ jis78 | jis83 | jis90 | jis04 | simplified | traditional ]"
-      },
-      "east-asian-width-values": {
-        syntax: "[ full-width | proportional-width ]"
-      },
-      "element()": {
-        syntax: "element( <id-selector> )"
-      },
-      "ellipse()": {
-        syntax: "ellipse( <radial-size>? [ at <position> ]? )"
-      },
-      "env()": {
-        syntax: "env( <custom-ident> , <declaration-value>? )"
-      },
-      "exp()": {
-        syntax: "exp( <calc-sum> )"
-      },
-      "explicit-track-list": {
-        syntax: "[ <line-names>? <track-size> ]+ <line-names>?"
-      },
-      "family-name": {
-        syntax: "<string> | <custom-ident>+"
-      },
-      "feature-tag-value": {
-        syntax: "<string> [ <integer> | on | off ]?"
-      },
-      "feature-type": {
-        syntax: "@stylistic | @historical-forms | @styleset | @character-variant | @swash | @ornaments | @annotation"
-      },
-      "feature-value-block": {
-        syntax: "<feature-type> '{' <feature-value-declaration-list> '}'"
-      },
-      "feature-value-block-list": {
-        syntax: "<feature-value-block>+"
-      },
-      "feature-value-declaration": {
-        syntax: "<custom-ident>: <integer>+;"
-      },
-      "feature-value-declaration-list": {
-        syntax: "<feature-value-declaration>"
-      },
-      "feature-value-name": {
-        syntax: "<custom-ident>"
-      },
-      "filter-function": {
-        syntax: "<blur()> | <brightness()> | <contrast()> | <drop-shadow()> | <grayscale()> | <hue-rotate()> | <invert()> | <opacity()> | <saturate()> | <sepia()>"
-      },
-      "filter-value-list": {
-        syntax: "[ <filter-function> | <url> ]+"
-      },
-      "final-bg-layer": {
-        syntax: "<bg-image> || <bg-position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <visual-box> || <visual-box> || <'background-color'>"
-      },
-      "fit-content()": {
-        syntax: "fit-content( <length-percentage [0,\u221E]> )"
-      },
-      "fixed-breadth": {
-        syntax: "<length-percentage>"
-      },
-      "fixed-repeat": {
-        syntax: "repeat( [ <integer [1,\u221E]> ] , [ <line-names>? <fixed-size> ]+ <line-names>? )"
-      },
-      "fixed-size": {
-        syntax: "<fixed-breadth> | minmax( <fixed-breadth> , <track-breadth> ) | minmax( <inflexible-breadth> , <fixed-breadth> )"
-      },
-      "font-stretch-absolute": {
-        syntax: "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded | <percentage>"
-      },
-      "font-variant-css2": {
-        syntax: "normal | small-caps"
-      },
-      "font-weight-absolute": {
-        syntax: "normal | bold | <number [1,1000]>"
-      },
-      "font-width-css3": {
-        syntax: "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded"
-      },
-      "form-control-identifier": {
-        syntax: "select"
-      },
-      "frequency-percentage": {
-        syntax: "<frequency> | <percentage>"
-      },
-      "generic-complete": {
-        syntax: "serif | sans-serif | system-ui | cursive | fantasy | math | monospace"
-      },
-      "general-enclosed": {
-        syntax: "[ <function-token> <any-value> ) ] | ( <ident> <any-value> )"
-      },
-      "generic-family": {
-        syntax: "<generic-complete> | <generic-incomplete> | emoji | fangsong"
-      },
-      "generic-incomplete": {
-        syntax: "ui-serif | ui-sans-serif | ui-monospace | ui-rounded"
-      },
-      "geometry-box": {
-        syntax: "<shape-box> | fill-box | stroke-box | view-box"
-      },
-      gradient: {
-        syntax: "<linear-gradient()> | <repeating-linear-gradient()> | <radial-gradient()> | <repeating-radial-gradient()> | <conic-gradient()> | <repeating-conic-gradient()>"
-      },
-      "grayscale()": {
-        syntax: "grayscale( [ <number> | <percentage> ]? )"
-      },
-      "grid-line": {
-        syntax: "auto | <custom-ident> | [ <integer> && <custom-ident>? ] | [ span && [ <integer> || <custom-ident> ] ]"
-      },
-      "historical-lig-values": {
-        syntax: "[ historical-ligatures | no-historical-ligatures ]"
-      },
-      "hsl()": {
-        syntax: "hsl( <hue>, <percentage>, <percentage>, <alpha-value>? ) | hsl( [ <hue> | none ] [ <percentage> | <number> | none ] [ <percentage> | <number> | none ] [ / [ <alpha-value> | none ] ]? )"
-      },
-      "hsla()": {
-        syntax: "hsla( <hue>, <percentage>, <percentage>, <alpha-value>? ) | hsla( [ <hue> | none ] [ <percentage> | <number> | none ] [ <percentage> | <number> | none ] [ / [ <alpha-value> | none ] ]? )"
-      },
-      hue: {
-        syntax: "<number> | <angle>"
-      },
-      "hue-interpolation-method": {
-        syntax: "[ shorter | longer | increasing | decreasing ] hue"
-      },
-      "hue-rotate()": {
-        syntax: "hue-rotate( [ <angle> | <zero> ]? )"
-      },
-      "hwb()": {
-        syntax: "hwb( [ <hue> | none ] [ <percentage> | <number> | none ] [ <percentage> | <number> | none ] [ / [ <alpha-value> | none ] ]? )"
-      },
-      "hypot()": {
-        syntax: "hypot( <calc-sum># )"
-      },
-      "id-selector": {
-        syntax: "<hash-token>"
-      },
-      image: {
-        syntax: "<url> | <image()> | <image-set()> | <element()> | <paint()> | <cross-fade()> | <gradient>"
-      },
-      "image()": {
-        syntax: "image( <image-tags>? [ <image-src>? , <color>? ]! )"
-      },
-      "image-set()": {
-        syntax: "image-set( <image-set-option># )"
-      },
-      "image-set-option": {
-        syntax: "[ <image> | <string> ] [ <resolution> || type(<string>) ]"
-      },
-      "image-src": {
-        syntax: "<url> | <string>"
-      },
-      "image-tags": {
-        syntax: "ltr | rtl"
-      },
-      "inflexible-breadth": {
-        syntax: "<length-percentage> | min-content | max-content | auto"
-      },
-      "inset()": {
-        syntax: "inset( <length-percentage>{1,4} [ round <'border-radius'> ]? )"
-      },
-      integer: {
-        syntax: "<number-token>"
-      },
-      "invert()": {
-        syntax: "invert( [ <number> | <percentage> ]? )"
-      },
-      "keyframe-block": {
-        syntax: "<keyframe-selector># {\n  <declaration-list>\n}"
-      },
-      "keyframe-selector": {
-        syntax: "from | to | <percentage [0,100]> | <timeline-range-name> <percentage>"
-      },
-      "keyframes-name": {
-        syntax: "<custom-ident> | <string>"
-      },
-      "lab()": {
-        syntax: "lab( [<percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
-      },
-      "layer()": {
-        syntax: "layer( <layer-name> )"
-      },
-      "layer-name": {
-        syntax: "<ident> [ '.' <ident> ]*"
-      },
-      "lch()": {
-        syntax: "lch( [<percentage> | <number> | none] [ <percentage> | <number> | none] [ <hue> | none] [ / [<alpha-value> | none] ]? )"
-      },
-      "leader()": {
-        syntax: "leader( <leader-type> )"
-      },
-      "leader-type": {
-        syntax: "dotted | solid | space | <string>"
-      },
-      "length-percentage": {
-        syntax: "<length> | <percentage>"
-      },
-      "light-dark()": {
-        syntax: "light-dark( <color>, <color> )"
-      },
-      "line-name-list": {
-        syntax: "[ <line-names> | <name-repeat> ]+"
-      },
-      "line-names": {
-        syntax: "'[' <custom-ident>* ']'"
-      },
-      "line-style": {
-        syntax: "none | hidden | dotted | dashed | solid | double | groove | ridge | inset | outset"
-      },
-      "line-width": {
-        syntax: "<length> | thin | medium | thick"
-      },
-      "linear()": {
-        syntax: "linear( [ <number> && <percentage>{0,2} ]# )"
-      },
-      "linear-color-hint": {
-        syntax: "<length-percentage>"
-      },
-      "linear-color-stop": {
-        syntax: "<color> <color-stop-length>?"
-      },
-      "linear-easing-function": {
-        syntax: "linear | <linear()>"
-      },
-      "linear-gradient()": {
-        syntax: "linear-gradient( [ <linear-gradient-syntax> ] )"
-      },
-      "linear-gradient-syntax": {
-        syntax: "[ [ <angle> | <zero> | to <side-or-corner> ] || <color-interpolation-method> ]? , <color-stop-list>"
-      },
-      "log()": {
-        syntax: "log( <calc-sum>, <calc-sum>? )"
-      },
-      "mask-layer": {
-        syntax: "<mask-reference> || <position> [ / <bg-size> ]? || <repeat-style> || <geometry-box> || [ <geometry-box> | no-clip ] || <compositing-operator> || <masking-mode>"
-      },
-      "mask-position": {
-        syntax: "[ <length-percentage> | left | center | right ] [ <length-percentage> | top | center | bottom ]?"
-      },
-      "mask-reference": {
-        syntax: "none | <image> | <mask-source>"
-      },
-      "mask-source": {
-        syntax: "<url>"
-      },
-      "masking-mode": {
-        syntax: "alpha | luminance | match-source"
-      },
-      "matrix()": {
-        syntax: "matrix( <number>#{6} )"
-      },
-      "matrix3d()": {
-        syntax: "matrix3d( <number>#{16} )"
-      },
-      "max()": {
-        syntax: "max( <calc-sum># )"
-      },
-      "media-and": {
-        syntax: "<media-in-parens> [ and <media-in-parens> ]+"
-      },
-      "media-condition": {
-        syntax: "<media-not> | <media-and> | <media-or> | <media-in-parens>"
-      },
-      "media-condition-without-or": {
-        syntax: "<media-not> | <media-and> | <media-in-parens>"
-      },
-      "media-feature": {
-        syntax: "( [ <mf-plain> | <mf-boolean> | <mf-range> ] )"
-      },
-      "media-in-parens": {
-        syntax: "( <media-condition> ) | <media-feature> | <general-enclosed>"
-      },
-      "media-not": {
-        syntax: "not <media-in-parens>"
-      },
-      "media-or": {
-        syntax: "<media-in-parens> [ or <media-in-parens> ]+"
-      },
-      "media-query": {
-        syntax: "<media-condition> | [ not | only ]? <media-type> [ and <media-condition-without-or> ]?"
-      },
-      "media-query-list": {
-        syntax: "<media-query>#"
-      },
-      "media-type": {
-        syntax: "<ident>"
-      },
-      "mf-boolean": {
-        syntax: "<mf-name>"
-      },
-      "mf-name": {
-        syntax: "<ident>"
-      },
-      "mf-plain": {
-        syntax: "<mf-name> : <mf-value>"
-      },
-      "mf-range": {
-        syntax: "<mf-name> [ '<' | '>' ]? '='? <mf-value>\n| <mf-value> [ '<' | '>' ]? '='? <mf-name>\n| <mf-value> '<' '='? <mf-name> '<' '='? <mf-value>\n| <mf-value> '>' '='? <mf-name> '>' '='? <mf-value>"
-      },
-      "mf-value": {
-        syntax: "<number> | <dimension> | <ident> | <ratio>"
-      },
-      "min()": {
-        syntax: "min( <calc-sum># )"
-      },
-      "minmax()": {
-        syntax: "minmax( [ <length-percentage> | min-content | max-content | auto ] , [ <length-percentage> | <flex> | min-content | max-content | auto ] )"
-      },
-      "mod()": {
-        syntax: "mod( <calc-sum>, <calc-sum> )"
-      },
-      "n-dimension": {
-        syntax: "<dimension-token>"
-      },
-      "name-repeat": {
-        syntax: "repeat( [ <integer [1,\u221E]> | auto-fill ], <line-names>+ )"
-      },
-      "named-color": {
-        syntax: "aliceblue | antiquewhite | aqua | aquamarine | azure | beige | bisque | black | blanchedalmond | blue | blueviolet | brown | burlywood | cadetblue | chartreuse | chocolate | coral | cornflowerblue | cornsilk | crimson | cyan | darkblue | darkcyan | darkgoldenrod | darkgray | darkgreen | darkgrey | darkkhaki | darkmagenta | darkolivegreen | darkorange | darkorchid | darkred | darksalmon | darkseagreen | darkslateblue | darkslategray | darkslategrey | darkturquoise | darkviolet | deeppink | deepskyblue | dimgray | dimgrey | dodgerblue | firebrick | floralwhite | forestgreen | fuchsia | gainsboro | ghostwhite | gold | goldenrod | gray | green | greenyellow | grey | honeydew | hotpink | indianred | indigo | ivory | khaki | lavender | lavenderblush | lawngreen | lemonchiffon | lightblue | lightcoral | lightcyan | lightgoldenrodyellow | lightgray | lightgreen | lightgrey | lightpink | lightsalmon | lightseagreen | lightskyblue | lightslategray | lightslategrey | lightsteelblue | lightyellow | lime | limegreen | linen | magenta | maroon | mediumaquamarine | mediumblue | mediumorchid | mediumpurple | mediumseagreen | mediumslateblue | mediumspringgreen | mediumturquoise | mediumvioletred | midnightblue | mintcream | mistyrose | moccasin | navajowhite | navy | oldlace | olive | olivedrab | orange | orangered | orchid | palegoldenrod | palegreen | paleturquoise | palevioletred | papayawhip | peachpuff | peru | pink | plum | powderblue | purple | rebeccapurple | red | rosybrown | royalblue | saddlebrown | salmon | sandybrown | seagreen | seashell | sienna | silver | skyblue | slateblue | slategray | slategrey | snow | springgreen | steelblue | tan | teal | thistle | tomato | turquoise | violet | wheat | white | whitesmoke | yellow | yellowgreen"
-      },
-      "namespace-prefix": {
-        syntax: "<ident>"
-      },
-      "ndash-dimension": {
-        syntax: "<dimension-token>"
-      },
-      "ndashdigit-dimension": {
-        syntax: "<dimension-token>"
-      },
-      "ndashdigit-ident": {
-        syntax: "<ident-token>"
-      },
-      "ns-prefix": {
-        syntax: "[ <ident-token> | '*' ]? '|'"
-      },
-      "number-percentage": {
-        syntax: "<number> | <percentage>"
-      },
-      "numeric-figure-values": {
-        syntax: "[ lining-nums | oldstyle-nums ]"
-      },
-      "numeric-fraction-values": {
-        syntax: "[ diagonal-fractions | stacked-fractions ]"
-      },
-      "numeric-spacing-values": {
-        syntax: "[ proportional-nums | tabular-nums ]"
-      },
-      "offset-path": {
-        syntax: "<ray()> | <url> | <basic-shape>"
-      },
-      "oklab()": {
-        syntax: "oklab( [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
-      },
-      "oklch()": {
-        syntax: "oklch( [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ <hue> | none] [ / [<alpha-value> | none] ]? )"
-      },
-      "opacity()": {
-        syntax: "opacity( [ <number> | <percentage> ]? )"
-      },
-      "opacity-value": {
-        syntax: "<number> | <percentage>"
-      },
-      "outline-line-style": {
-        syntax: "none | dotted | dashed | solid | double | groove | ridge | inset | outset"
-      },
-      "outline-radius": {
-        syntax: "<length> | <percentage>"
-      },
-      "overflow-position": {
-        syntax: "unsafe | safe"
-      },
-      "page-body": {
-        syntax: "<declaration>? [ ; <page-body> ]? | <page-margin-box> <page-body>"
-      },
-      "page-margin-box": {
-        syntax: "<page-margin-box-type> '{' <declaration-list> '}'"
-      },
-      "page-margin-box-type": {
-        syntax: "@top-left-corner | @top-left | @top-center | @top-right | @top-right-corner | @bottom-left-corner | @bottom-left | @bottom-center | @bottom-right | @bottom-right-corner | @left-top | @left-middle | @left-bottom | @right-top | @right-middle | @right-bottom"
-      },
-      "page-selector": {
-        syntax: "<pseudo-page>+ | <ident> <pseudo-page>*"
-      },
-      "page-selector-list": {
-        syntax: "[ <page-selector># ]?"
-      },
-      "page-size": {
-        syntax: "A5 | A4 | A3 | B5 | B4 | JIS-B5 | JIS-B4 | letter | legal | ledger"
-      },
-      paint: {
-        syntax: "none | <color> | <url> [none | <color>]? | context-fill | context-stroke"
-      },
-      "paint()": {
-        syntax: "paint( <ident>, <declaration-value>? )"
-      },
-      "paint-box": {
-        syntax: "<visual-box> | fill-box | stroke-box"
-      },
-      "palette-identifier": {
-        syntax: "<dashed-ident>"
-      },
-      "palette-mix()": {
-        syntax: "palette-mix(<color-interpolation-method> , [ [normal | light | dark | <palette-identifier> | <palette-mix()> ] && <percentage [0,100]>? ]#{2})"
-      },
-      "path()": {
-        syntax: "path( <'fill-rule'>? , <string> )"
-      },
-      "perspective()": {
-        syntax: "perspective( [ <length [0,\u221E]> | none ] )"
-      },
-      "polar-color-space": {
-        syntax: "hsl | hwb | lch | oklch"
-      },
-      "polygon()": {
-        syntax: "polygon( <'fill-rule'>? , [ <length-percentage> <length-percentage> ]# )"
-      },
-      position: {
-        syntax: "[ [ left | center | right ] || [ top | center | bottom ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ]? | [ [ left | right ] <length-percentage> ] && [ [ top | bottom ] <length-percentage> ] ]"
-      },
-      "position-area": {
-        syntax: "[ left | center | right | span-left | span-right | x-start | x-end | span-x-start | span-x-end | x-self-start | x-self-end | span-x-self-start | span-x-self-end | span-all ] || [ top | center | bottom | span-top | span-bottom | y-start | y-end | span-y-start | span-y-end | y-self-start | y-self-end | span-y-self-start | span-y-self-end | span-all ] | [ block-start | center | block-end | span-block-start | span-block-end | span-all ] || [ inline-start | center | inline-end | span-inline-start | span-inline-end | span-all ] | [ self-block-start | center | self-block-end | span-self-block-start | span-self-block-end | span-all ] || [ self-inline-start | center | self-inline-end | span-self-inline-start | span-self-inline-end | span-all ] | [ start | center | end | span-start | span-end | span-all ]{1,2} | [ self-start | center | self-end | span-self-start | span-self-end | span-all ]{1,2}"
-      },
-      "pow()": {
-        syntax: "pow( <calc-sum>, <calc-sum> )"
-      },
-      "predefined-rgb": {
-        syntax: "srgb | srgb-linear | display-p3 | display-p3-linear | a98-rgb | prophoto-rgb | rec2020"
-      },
-      "predefined-rgb-params": {
-        syntax: "<predefined-rgb> [ <number> | <percentage> | none ]{3}"
-      },
-      "pseudo-class-selector": {
-        syntax: "':' <ident-token> | ':' <function-token> <any-value> ')'"
-      },
-      "pseudo-element-selector": {
-        syntax: "':' <pseudo-class-selector>"
-      },
-      "pseudo-page": {
-        syntax: ": [ left | right | first | blank ]"
-      },
-      "query-in-parens": {
-        syntax: "( <container-query> ) | ( <size-feature> ) | style( <style-query> ) | scroll-state( <scroll-state-query> ) | <general-enclosed>"
-      },
-      quote: {
-        syntax: "open-quote | close-quote | no-open-quote | no-close-quote"
-      },
-      "radial-extent": {
-        syntax: "closest-corner | closest-side | farthest-corner | farthest-side"
-      },
-      "radial-gradient()": {
-        syntax: "radial-gradient( [ <radial-gradient-syntax> ] )"
-      },
-      "radial-gradient-syntax": {
-        syntax: "[ [ [ <radial-shape> || <radial-size> ]? [ at <position> ]? ] || <color-interpolation-method> ]? , <color-stop-list>"
-      },
-      "radial-shape": {
-        syntax: "circle | ellipse"
-      },
-      "radial-size": {
-        syntax: "<radial-extent> | <length [0,\u221E]> | <length-percentage [0,\u221E]>{2}"
-      },
-      ratio: {
-        syntax: "<number [0,\u221E]> [ / <number [0,\u221E]> ]?"
-      },
-      "ray()": {
-        syntax: "ray( <angle> && <ray-size>? && contain? && [at <position>]? )"
-      },
-      "ray-size": {
-        syntax: "closest-side | closest-corner | farthest-side | farthest-corner | sides"
-      },
-      "rect()": {
-        syntax: "rect( [ <length-percentage> | auto ]{4} [ round <'border-radius'> ]? )"
-      },
-      "rectangular-color-space": {
-        syntax: "srgb | srgb-linear | display-p3 | display-p3-linear | a98-rgb | prophoto-rgb | rec2020 | lab | oklab | xyz | xyz-d50 | xyz-d65"
-      },
-      "relative-selector": {
-        syntax: "<combinator>? <complex-selector>"
-      },
-      "relative-selector-list": {
-        syntax: "<relative-selector>#"
-      },
-      "relative-size": {
-        syntax: "larger | smaller"
-      },
-      "rem()": {
-        syntax: "rem( <calc-sum>, <calc-sum> )"
-      },
-      "repeat-style": {
-        syntax: "repeat-x | repeat-y | [ repeat | space | round | no-repeat ]{1,2}"
-      },
-      "repeating-conic-gradient()": {
-        syntax: "repeating-conic-gradient( [ <conic-gradient-syntax> ] )"
-      },
-      "repeating-linear-gradient()": {
-        syntax: "repeating-linear-gradient( [ <linear-gradient-syntax> ] )"
-      },
-      "repeating-radial-gradient()": {
-        syntax: "repeating-radial-gradient( [ <radial-gradient-syntax> ] )"
-      },
-      "reversed-counter-name": {
-        syntax: "reversed( <counter-name> )"
-      },
-      "rgb()": {
-        syntax: "rgb( <percentage>#{3} , <alpha-value>? ) | rgb( <number>#{3} , <alpha-value>? ) | rgb( [ <number> | <percentage> | none ]{3} [ / [ <alpha-value> | none ] ]? )"
-      },
-      "rgba()": {
-        syntax: "rgba( <percentage>#{3} , <alpha-value>? ) | rgba( <number>#{3} , <alpha-value>? ) | rgba( [ <number> | <percentage> | none ]{3} [ / [ <alpha-value> | none ] ]? )"
-      },
-      "rotate()": {
-        syntax: "rotate( [ <angle> | <zero> ] )"
-      },
-      "rotate3d()": {
-        syntax: "rotate3d( <number> , <number> , <number> , [ <angle> | <zero> ] )"
-      },
-      "rotateX()": {
-        syntax: "rotateX( [ <angle> | <zero> ] )"
-      },
-      "rotateY()": {
-        syntax: "rotateY( [ <angle> | <zero> ] )"
-      },
-      "rotateZ()": {
-        syntax: "rotateZ( [ <angle> | <zero> ] )"
-      },
-      "round()": {
-        syntax: "round( <rounding-strategy>?, <calc-sum>, <calc-sum> )"
-      },
-      "rounding-strategy": {
-        syntax: "nearest | up | down | to-zero"
-      },
-      "saturate()": {
-        syntax: "saturate( [ <number> | <percentage> ]? )"
-      },
-      "scale()": {
-        syntax: "scale( [ <number> | <percentage> ]#{1,2} )"
-      },
-      "scale3d()": {
-        syntax: "scale3d( [ <number> | <percentage> ]#{3} )"
-      },
-      "scaleX()": {
-        syntax: "scaleX( [ <number> | <percentage> ] )"
-      },
-      "scaleY()": {
-        syntax: "scaleY( [ <number> | <percentage> ] )"
-      },
-      "scaleZ()": {
-        syntax: "scaleZ( [ <number> | <percentage> ] )"
-      },
-      "scope-end": {
-        syntax: "<selector-list>"
-      },
-      "scope-start": {
-        syntax: "<selector-list>"
-      },
-      "scroll()": {
-        syntax: "scroll( [ <scroller> || <axis> ]? )"
-      },
-      scroller: {
-        syntax: "root | nearest | self"
-      },
-      "scroll-state-feature": {
-        syntax: "<media-query-list>"
-      },
-      "scroll-state-in-parens": {
-        syntax: "( <scroll-state-query> ) | ( <scroll-state-feature> ) | <general-enclosed>"
-      },
-      "scroll-state-query": {
-        syntax: "not <scroll-state-in-parens> | <scroll-state-in-parens> [ [ and <scroll-state-in-parens> ]* | [ or <scroll-state-in-parens> ]* ] | <scroll-state-feature>"
-      },
-      "selector-list": {
-        syntax: "<complex-selector-list>"
-      },
-      "self-position": {
-        syntax: "center | start | end | self-start | self-end | flex-start | flex-end"
-      },
-      "sepia()": {
-        syntax: "sepia( [ <number> | <percentage> ]? )"
-      },
-      shadow: {
-        syntax: "inset? && <length>{2,4} && <color>?"
-      },
-      "shadow-t": {
-        syntax: "[ <length>{2,3} && <color>? ]"
-      },
-      shape: {
-        syntax: "rect(<top>, <right>, <bottom>, <left>)"
-      },
-      "shape-box": {
-        syntax: "<visual-box> | margin-box"
-      },
-      "side-or-corner": {
-        syntax: "[ left | right ] || [ top | bottom ]"
-      },
-      "sign()": {
-        syntax: "sign( <calc-sum> )"
-      },
-      "signed-integer": {
-        syntax: "<number-token>"
-      },
-      "signless-integer": {
-        syntax: "<number-token>"
-      },
-      "sin()": {
-        syntax: "sin( <calc-sum> )"
-      },
-      "single-animation": {
-        syntax: "<'animation-duration'> || <easing-function> || <'animation-delay'> || <single-animation-iteration-count> || <single-animation-direction> || <single-animation-fill-mode> || <single-animation-play-state> || [ none | <keyframes-name> ] || <single-animation-timeline>"
-      },
-      "single-animation-composition": {
-        syntax: "replace | add | accumulate"
-      },
-      "single-animation-direction": {
-        syntax: "normal | reverse | alternate | alternate-reverse"
-      },
-      "single-animation-fill-mode": {
-        syntax: "none | forwards | backwards | both"
-      },
-      "single-animation-iteration-count": {
-        syntax: "infinite | <number>"
-      },
-      "single-animation-play-state": {
-        syntax: "running | paused"
-      },
-      "single-animation-timeline": {
-        syntax: "auto | none | <dashed-ident> | <scroll()> | <view()>"
-      },
-      "single-transition": {
-        syntax: "[ none | <single-transition-property> ] || <time> || <easing-function> || <time> || <transition-behavior-value>"
-      },
-      "single-transition-property": {
-        syntax: "all | <custom-ident>"
-      },
-      size: {
-        syntax: "closest-side | farthest-side | closest-corner | farthest-corner | <length> | <length-percentage>{2}"
-      },
-      "size-feature": {
-        syntax: "<media-query-list>"
-      },
-      "skew()": {
-        syntax: "skew( [ <angle> | <zero> ] , [ <angle> | <zero> ]? )"
-      },
-      "skewX()": {
-        syntax: "skewX( [ <angle> | <zero> ] )"
-      },
-      "skewY()": {
-        syntax: "skewY( [ <angle> | <zero> ] )"
-      },
-      "sqrt()": {
-        syntax: "sqrt( <calc-sum> )"
-      },
-      "step-position": {
-        syntax: "jump-start | jump-end | jump-none | jump-both | start | end"
-      },
-      "step-easing-function": {
-        syntax: "step-start | step-end | <steps()>"
-      },
-      "steps()": {
-        syntax: "steps( <integer>, <step-position>? )"
-      },
-      "style-feature": {
-        syntax: "<declaration>"
-      },
-      "style-in-parens": {
-        syntax: "( <style-query> ) | ( <style-feature> ) | <general-enclosed>"
-      },
-      "style-query": {
-        syntax: "not <style-in-parens> | <style-in-parens> [ [ and <style-in-parens> ]* | [ or <style-in-parens> ]* ] | <style-feature>"
-      },
-      "subclass-selector": {
-        syntax: "<id-selector> | <class-selector> | <attribute-selector> | <pseudo-class-selector>"
-      },
-      "superellipse()": {
-        syntax: "superellipse( [ <number> | infinity | -infinity ] )"
-      },
-      "supports-condition": {
-        syntax: "not <supports-in-parens> | <supports-in-parens> [ and <supports-in-parens> ]* | <supports-in-parens> [ or <supports-in-parens> ]*"
-      },
-      "supports-decl": {
-        syntax: "( <declaration> )"
-      },
-      "supports-feature": {
-        syntax: "<supports-decl> | <supports-selector-fn>"
-      },
-      "supports-in-parens": {
-        syntax: "( <supports-condition> ) | <supports-feature> | <general-enclosed>"
-      },
-      "supports-selector-fn": {
-        syntax: "selector( <complex-selector> )"
-      },
-      symbol: {
-        syntax: "<string> | <image> | <custom-ident>"
-      },
-      "symbols()": {
-        syntax: "symbols( <symbols-type>? [ <string> | <image> ]+ )"
-      },
-      "symbols-type": {
-        syntax: "cyclic | numeric | alphabetic | symbolic | fixed"
-      },
-      "system-color": {
-        syntax: "AccentColor | AccentColorText | ActiveText | ButtonBorder | ButtonFace | ButtonText | Canvas | CanvasText | Field | FieldText | GrayText | Highlight | HighlightText | LinkText | Mark | MarkText | SelectedItem | SelectedItemText | VisitedText"
-      },
-      "system-family-name": {
-        syntax: "caption | icon | menu | message-box | small-caption | status-bar"
-      },
-      "tan()": {
-        syntax: "tan( <calc-sum> )"
-      },
-      target: {
-        syntax: "<target-counter()> | <target-counters()> | <target-text()>"
-      },
-      "target-counter()": {
-        syntax: "target-counter( [ <string> | <url> ] , <custom-ident> , <counter-style>? )"
-      },
-      "target-counters()": {
-        syntax: "target-counters( [ <string> | <url> ] , <custom-ident> , <string> , <counter-style>? )"
-      },
-      "target-text()": {
-        syntax: "target-text( [ <string> | <url> ] , [ content | before | after | first-letter ]? )"
-      },
-      "text-edge": {
-        syntax: "[ text | cap | ex | ideographic | ideographic-ink ] [ text | alphabetic | ideographic | ideographic-ink ]?"
-      },
-      "time-percentage": {
-        syntax: "<time> | <percentage>"
-      },
-      "timeline-range-name": {
-        syntax: "cover | contain | entry | exit | entry-crossing | exit-crossing"
-      },
-      "track-breadth": {
-        syntax: "<length-percentage> | <flex> | min-content | max-content | auto"
-      },
-      "track-list": {
-        syntax: "[ <line-names>? [ <track-size> | <track-repeat> ] ]+ <line-names>?"
-      },
-      "track-repeat": {
-        syntax: "repeat( [ <integer [1,\u221E]> ] , [ <line-names>? <track-size> ]+ <line-names>? )"
-      },
-      "track-size": {
-        syntax: "<track-breadth> | minmax( <inflexible-breadth> , <track-breadth> ) | fit-content( <length-percentage> )"
-      },
-      "transform-function": {
-        syntax: "<matrix()> | <translate()> | <translateX()> | <translateY()> | <scale()> | <scaleX()> | <scaleY()> | <rotate()> | <skew()> | <skewX()> | <skewY()> | <matrix3d()> | <translate3d()> | <translateZ()> | <scale3d()> | <scaleZ()> | <rotate3d()> | <rotateX()> | <rotateY()> | <rotateZ()> | <perspective()>"
-      },
-      "transform-list": {
-        syntax: "<transform-function>+"
-      },
-      "transition-behavior-value": {
-        syntax: "normal | allow-discrete"
-      },
-      "translate()": {
-        syntax: "translate( <length-percentage> , <length-percentage>? )"
-      },
-      "translate3d()": {
-        syntax: "translate3d( <length-percentage> , <length-percentage> , <length> )"
-      },
-      "translateX()": {
-        syntax: "translateX( <length-percentage> )"
-      },
-      "translateY()": {
-        syntax: "translateY( <length-percentage> )"
-      },
-      "translateZ()": {
-        syntax: "translateZ( <length> )"
-      },
-      "try-size": {
-        syntax: "most-width | most-height | most-block-size | most-inline-size"
-      },
-      "try-tactic": {
-        syntax: "flip-block || flip-inline || flip-start"
-      },
-      "type-or-unit": {
-        syntax: "string | color | url | integer | number | length | angle | time | frequency | cap | ch | em | ex | ic | lh | rlh | rem | vb | vi | vw | vh | vmin | vmax | mm | Q | cm | in | pt | pc | px | deg | grad | rad | turn | ms | s | Hz | kHz | %"
-      },
-      "type-selector": {
-        syntax: "<wq-name> | <ns-prefix>? '*'"
-      },
-      "var()": {
-        syntax: "var( <custom-property-name> , <declaration-value>? )"
-      },
-      "view()": {
-        syntax: "view([<axis> || <'view-timeline-inset'>]?)"
-      },
-      "viewport-length": {
-        syntax: "auto | <length-percentage>"
-      },
-      "visual-box": {
-        syntax: "content-box | padding-box | border-box"
-      },
-      "wq-name": {
-        syntax: "<ns-prefix>? <ident-token>"
-      },
-      "xywh()": {
-        syntax: "xywh( <length-percentage>{2} <length-percentage [0,\u221E]>{2} [ round <'border-radius'> ]? )"
-      },
-      xyz: {
-        syntax: "xyz | xyz-d50 | xyz-d65"
-      },
-      "xyz-params": {
-        syntax: "<xyz> [ <number> | <percentage> | none ]{3}"
-      }
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/data/patch.json
-var patch_default;
-var init_patch = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/data/patch.json"() {
-    patch_default = {
-      atrules: {
-        charset: {
-          prelude: "<string>"
-        },
-        container: {
-          prelude: "[ <container-name> ]? <container-condition>"
-        },
-        "font-face": {
-          descriptors: {
-            "unicode-range": {
-              comment: "replaces <unicode-range>, an old production name",
-              syntax: "<urange>#"
-            }
-          }
-        },
-        "font-features-values": {
-          comment: "The features values syntax is defined in https://www.w3.org/TR/css-fonts-4/#at-ruledef-font-feature-values",
-          prelude: "[<string> | <custom-ident>]+",
-          descriptors: {
-            "font-display": "auto | block | swap | fallback | optional"
-          }
-        },
-        scope: {
-          prelude: "[ ( <scope-start> ) ]? [ to ( <scope-end> ) ]?"
-        },
-        "position-try": {
-          comment: "The list of descriptors: https://developer.mozilla.org/en-US/docs/Web/CSS/@position-try",
-          descriptors: {
-            top: "<'top'>",
-            left: "<'left'>",
-            bottom: "<'bottom'>",
-            right: "<'right'>",
-            "inset-block-start": "<'inset-block-start'>",
-            "inset-block-end": "<'inset-block-end'>",
-            "inset-inline-start": "<'inset-inline-start'>",
-            "inset-inline-end": "<'inset-inline-end'>",
-            "inset-block": "<'inset-block'>",
-            "inset-inline": "<'inset-inline'>",
-            inset: "<'inset'>",
-            "margin-top": "<'margin-top'>",
-            "margin-left": "<'margin-left'>",
-            "margin-bottom": "<'margin-bottom'>",
-            "margin-right": "<'margin-right'>",
-            "margin-block-start": "<'margin-block-start'>",
-            "margin-block-end": "<'margin-block-end'>",
-            "margin-inline-start": "<'margin-inline-start'>",
-            "margin-inline-end": "<'margin-inline-end'>",
-            margin: "<'margin'>",
-            "margin-block": "<'margin-block'>",
-            "margin-inline": "<'margin-inline'>",
-            width: "<'width'>",
-            height: "<'height'>",
-            "min-width": "<'min-width'>",
-            "min-height": "<'min-height'>",
-            "max-width": "<'max-width'>",
-            "max-height": "<'max-height'>",
-            "block-size": "<'block-size'>",
-            "inline-size": "<'inline-size'>",
-            "min-block-size": "<'min-block-size'>",
-            "min-inline-size": "<'min-inline-size'>",
-            "max-block-size": "<'max-block-size'>",
-            "max-inline-size": "<'max-inline-size'>",
-            "align-self": "<'align-self'> | anchor-center",
-            "justify-self": "<'justify-self'> | anchor-center"
-          }
-        }
-      },
-      properties: {
-        "-moz-background-clip": {
-          comment: "deprecated syntax in old Firefox, https://developer.mozilla.org/en/docs/Web/CSS/background-clip",
-          syntax: "padding | border"
-        },
-        "-moz-border-radius-bottomleft": {
-          comment: "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-left-radius",
-          syntax: "<'border-bottom-left-radius'>"
-        },
-        "-moz-border-radius-bottomright": {
-          comment: "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-right-radius",
-          syntax: "<'border-bottom-right-radius'>"
-        },
-        "-moz-border-radius-topleft": {
-          comment: "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-left-radius",
-          syntax: "<'border-top-left-radius'>"
-        },
-        "-moz-border-radius-topright": {
-          comment: "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-right-radius",
-          syntax: "<'border-bottom-right-radius'>"
-        },
-        "-moz-control-character-visibility": {
-          comment: "firefox specific keywords, https://bugzilla.mozilla.org/show_bug.cgi?id=947588",
-          syntax: "visible | hidden"
-        },
-        "-moz-osx-font-smoothing": {
-          comment: "misssed old syntax https://developer.mozilla.org/en-US/docs/Web/CSS/font-smooth",
-          syntax: "auto | grayscale"
-        },
-        "-moz-user-select": {
-          comment: "https://developer.mozilla.org/en-US/docs/Web/CSS/user-select",
-          syntax: "none | text | all | -moz-none"
-        },
-        "-ms-flex-align": {
-          comment: "misssed old syntax implemented in IE, https://www.w3.org/TR/2012/WD-css3-flexbox-20120322/#flex-align",
-          syntax: "start | end | center | baseline | stretch"
-        },
-        "-ms-flex-item-align": {
-          comment: "misssed old syntax implemented in IE, https://www.w3.org/TR/2012/WD-css3-flexbox-20120322/#flex-align",
-          syntax: "auto | start | end | center | baseline | stretch"
-        },
-        "-ms-flex-line-pack": {
-          comment: "misssed old syntax implemented in IE, https://www.w3.org/TR/2012/WD-css3-flexbox-20120322/#flex-line-pack",
-          syntax: "start | end | center | justify | distribute | stretch"
-        },
-        "-ms-flex-negative": {
-          comment: "misssed old syntax implemented in IE; TODO: find references for comfirmation",
-          syntax: "<'flex-shrink'>"
-        },
-        "-ms-flex-pack": {
-          comment: "misssed old syntax implemented in IE, https://www.w3.org/TR/2012/WD-css3-flexbox-20120322/#flex-pack",
-          syntax: "start | end | center | justify | distribute"
-        },
-        "-ms-flex-order": {
-          comment: "misssed old syntax implemented in IE; https://msdn.microsoft.com/en-us/library/jj127303(v=vs.85).aspx",
-          syntax: "<integer>"
-        },
-        "-ms-flex-positive": {
-          comment: "misssed old syntax implemented in IE; TODO: find references for comfirmation",
-          syntax: "<'flex-grow'>"
-        },
-        "-ms-flex-preferred-size": {
-          comment: "misssed old syntax implemented in IE; TODO: find references for comfirmation",
-          syntax: "<'flex-basis'>"
-        },
-        "-ms-interpolation-mode": {
-          comment: "https://msdn.microsoft.com/en-us/library/ff521095(v=vs.85).aspx",
-          syntax: "nearest-neighbor | bicubic"
-        },
-        "-ms-grid-column-align": {
-          comment: "add this property first since it uses as fallback for flexbox, https://msdn.microsoft.com/en-us/library/windows/apps/hh466338.aspx",
-          syntax: "start | end | center | stretch"
-        },
-        "-ms-grid-row-align": {
-          comment: "add this property first since it uses as fallback for flexbox, https://msdn.microsoft.com/en-us/library/windows/apps/hh466348.aspx",
-          syntax: "start | end | center | stretch"
-        },
-        "-ms-hyphenate-limit-last": {
-          comment: "misssed old syntax implemented in IE; https://www.w3.org/TR/css-text-4/#hyphenate-line-limits",
-          syntax: "none | always | column | page | spread"
-        },
-        "-webkit-appearance": {
-          comment: "webkit specific keywords",
-          references: [
-            "http://css-infos.net/property/-webkit-appearance"
-          ],
-          syntax: "none | button | button-bevel | caps-lock-indicator | caret | checkbox | default-button | inner-spin-button | listbox | listitem | media-controls-background | media-controls-fullscreen-background | media-current-time-display | media-enter-fullscreen-button | media-exit-fullscreen-button | media-fullscreen-button | media-mute-button | media-overlay-play-button | media-play-button | media-seek-back-button | media-seek-forward-button | media-slider | media-sliderthumb | media-time-remaining-display | media-toggle-closed-captions-button | media-volume-slider | media-volume-slider-container | media-volume-sliderthumb | menulist | menulist-button | menulist-text | menulist-textfield | meter | progress-bar | progress-bar-value | push-button | radio | scrollbarbutton-down | scrollbarbutton-left | scrollbarbutton-right | scrollbarbutton-up | scrollbargripper-horizontal | scrollbargripper-vertical | scrollbarthumb-horizontal | scrollbarthumb-vertical | scrollbartrack-horizontal | scrollbartrack-vertical | searchfield | searchfield-cancel-button | searchfield-decoration | searchfield-results-button | searchfield-results-decoration | slider-horizontal | slider-vertical | sliderthumb-horizontal | sliderthumb-vertical | square-button | textarea | textfield | -apple-pay-button"
-        },
-        "-webkit-background-clip": {
-          comment: "https://developer.mozilla.org/en/docs/Web/CSS/background-clip",
-          syntax: "[ <visual-box> | border | padding | content | text ]#"
-        },
-        "-webkit-column-break-after": {
-          comment: "added, http://help.dottoro.com/lcrthhhv.php",
-          syntax: "always | auto | avoid"
-        },
-        "-webkit-column-break-before": {
-          comment: "added, http://help.dottoro.com/lcxquvkf.php",
-          syntax: "always | auto | avoid"
-        },
-        "-webkit-column-break-inside": {
-          comment: "added, http://help.dottoro.com/lclhnthl.php",
-          syntax: "always | auto | avoid"
-        },
-        "-webkit-font-smoothing": {
-          comment: "https://developer.mozilla.org/en-US/docs/Web/CSS/font-smooth",
-          syntax: "auto | none | antialiased | subpixel-antialiased"
-        },
-        "-webkit-mask-box-image": {
-          comment: "missed; https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-mask-box-image",
-          syntax: "[ <url> | <gradient> | none ] [ <length-percentage>{4} <-webkit-mask-box-repeat>{2} ]?"
-        },
-        "-webkit-print-color-adjust": {
-          comment: "missed",
-          references: [
-            "https://developer.mozilla.org/en/docs/Web/CSS/-webkit-print-color-adjust"
-          ],
-          syntax: "economy | exact"
-        },
-        "-webkit-text-security": {
-          comment: "missed; http://help.dottoro.com/lcbkewgt.php",
-          syntax: "none | circle | disc | square"
-        },
-        "-webkit-user-drag": {
-          comment: "missed; http://help.dottoro.com/lcbixvwm.php",
-          syntax: "none | element | auto"
-        },
-        "-webkit-user-select": {
-          comment: "auto is supported by old webkit, https://developer.mozilla.org/en-US/docs/Web/CSS/user-select",
-          syntax: "auto | none | text | all"
-        },
-        "alignment-baseline": {
-          comment: "added SVG property",
-          references: [
-            "https://www.w3.org/TR/SVG/text.html#AlignmentBaselineProperty"
-          ],
-          syntax: "auto | baseline | before-edge | text-before-edge | middle | central | after-edge | text-after-edge | ideographic | alphabetic | hanging | mathematical"
-        },
-        "baseline-shift": {
-          comment: "added SVG property",
-          references: [
-            "https://www.w3.org/TR/SVG/text.html#BaselineShiftProperty"
-          ],
-          syntax: "baseline | sub | super | <svg-length>"
-        },
-        behavior: {
-          comment: "added old IE property https://msdn.microsoft.com/en-us/library/ms530723(v=vs.85).aspx",
-          syntax: "<url>+"
-        },
-        "container-type": {
-          comment: "https://www.w3.org/TR/css-contain-3/#propdef-container-type",
-          syntax: "normal || [ size | inline-size ]"
-        },
-        cue: {
-          comment: "https://www.w3.org/TR/css3-speech/#property-index",
-          syntax: "<'cue-before'> <'cue-after'>?"
-        },
-        "cue-after": {
-          comment: "https://www.w3.org/TR/css3-speech/#property-index",
-          syntax: "<url> <decibel>? | none"
-        },
-        "cue-before": {
-          comment: "https://www.w3.org/TR/css3-speech/#property-index",
-          syntax: "<url> <decibel>? | none"
-        },
-        cursor: {
-          comment: "added legacy keywords: hand, -webkit-grab. -webkit-grabbing, -webkit-zoom-in, -webkit-zoom-out, -moz-grab, -moz-grabbing, -moz-zoom-in, -moz-zoom-out",
-          references: [
-            "https://www.sitepoint.com/css3-cursor-styles/"
-          ],
-          syntax: "[ [ <url> [ <x> <y> ]? , ]* [ auto | default | none | context-menu | help | pointer | progress | wait | cell | crosshair | text | vertical-text | alias | copy | move | no-drop | not-allowed | e-resize | n-resize | ne-resize | nw-resize | s-resize | se-resize | sw-resize | w-resize | ew-resize | ns-resize | nesw-resize | nwse-resize | col-resize | row-resize | all-scroll | zoom-in | zoom-out | grab | grabbing | hand | -webkit-grab | -webkit-grabbing | -webkit-zoom-in | -webkit-zoom-out | -moz-grab | -moz-grabbing | -moz-zoom-in | -moz-zoom-out ] ]"
-        },
-        display: {
-          comment: "extended with -ms-flexbox",
-          syntax: "| <-non-standard-display>"
-        },
-        position: {
-          comment: "extended with -webkit-sticky",
-          syntax: "| -webkit-sticky"
-        },
-        "dominant-baseline": {
-          comment: "added SVG property",
-          references: [
-            "https://www.w3.org/TR/SVG/text.html#DominantBaselineProperty"
-          ],
-          syntax: "auto | use-script | no-change | reset-size | ideographic | alphabetic | hanging | mathematical | central | middle | text-after-edge | text-before-edge"
-        },
-        "image-rendering": {
-          comment: "extended with <-non-standard-image-rendering>, added SVG keywords optimizeSpeed and optimizeQuality",
-          references: [
-            "https://developer.mozilla.org/en/docs/Web/CSS/image-rendering",
-            "https://www.w3.org/TR/SVG/painting.html#ImageRenderingProperty"
-          ],
-          syntax: "| optimizeSpeed | optimizeQuality | <-non-standard-image-rendering>"
-        },
-        "fill-opacity": {
-          comment: "added SVG property",
-          references: [
-            "https://developer.mozilla.org/en-US/docs/Web/CSS/fill-opacity",
-            "https://www.w3.org/TR/SVG/painting.html#FillProperty"
-          ],
-          syntax: "<number-zero-one> | <percentage>"
-        },
-        filter: {
-          comment: "extend with IE legacy syntaxes",
-          syntax: "| <-ms-filter-function-list>"
-        },
-        font: {
-          comment: "align with font-4, fix <'font-family'>#, add non standard fonts",
-          references: [
-            "https://drafts.csswg.org/css-fonts-4/#font-prop",
-            "https://github.com/w3c/csswg-drafts/pull/10832",
-            "https://webkit.org/blog/3709/using-the-system-font-in-web-content/"
-          ],
-          syntax: "[ [ <'font-style'> || <font-variant-css2> || <'font-weight'> || <font-width-css3> ]? <'font-size'> [ / <'line-height'> ]? <'font-family'># ] | <system-family-name> | <-non-standard-font>"
-        },
-        "glyph-orientation-horizontal": {
-          comment: "added SVG property",
-          references: [
-            "https://www.w3.org/TR/SVG/text.html#GlyphOrientationHorizontalProperty"
-          ],
-          syntax: "<angle>"
-        },
-        "glyph-orientation-vertical": {
-          comment: "added SVG property",
-          references: [
-            "https://www.w3.org/TR/SVG/text.html#GlyphOrientationVerticalProperty"
-          ],
-          syntax: "<angle>"
-        },
-        kerning: {
-          comment: "added SVG property",
-          references: [
-            "https://www.w3.org/TR/SVG/text.html#KerningProperty"
-          ],
-          syntax: "auto | <svg-length>"
-        },
-        "letter-spacing": {
-          comment: "fix syntax <length> -> <length-percentage>",
-          references: [
-            "https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/letter-spacing"
-          ],
-          syntax: "normal | <length-percentage>"
-        },
-        "max-width": {
-          comment: "extend by non-standard size keywords https://developer.mozilla.org/en-US/docs/Web/CSS/width",
-          syntax: "| stretch | <-non-standard-size>"
-        },
-        "max-height": {
-          comment: "extend by non-standard size keywords https://developer.mozilla.org/en-US/docs/Web/CSS/width",
-          syntax: "| stretch | <-non-standard-size>"
-        },
-        width: {
-          references: [
-            "https://developer.mozilla.org/en-US/docs/Web/CSS/width",
-            "https://github.com/csstree/stylelint-validator/issues/29"
-          ],
-          syntax: "| stretch | <-non-standard-size>"
-        },
-        height: {
-          syntax: "| stretch | <-non-standard-size>"
-        },
-        "min-width": {
-          comment: "extend by non-standard width keywords https://developer.mozilla.org/en-US/docs/Web/CSS/width",
-          syntax: "| stretch | <-non-standard-size>"
-        },
-        "min-height": {
-          syntax: "| stretch | <-non-standard-size>"
-        },
-        overflow: {
-          comment: "extend by vendor keywords https://developer.mozilla.org/en-US/docs/Web/CSS/overflow",
-          syntax: "| <-non-standard-overflow>"
-        },
-        "overflow-x": {
-          comment: "extend by vendor keywords https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-x",
-          syntax: "| <-non-standard-overflow>"
-        },
-        "overflow-y": {
-          comment: "extend by vendor keywords https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-y",
-          syntax: "| <-non-standard-overflow>"
-        },
-        "overflow-block": {
-          comment: "extend by vendor keywords https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-y",
-          syntax: "| <-non-standard-overflow>"
-        },
-        "overflow-inline": {
-          comment: "extend by vendor keywords https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-x",
-          syntax: "| <-non-standard-overflow>"
-        },
-        pause: {
-          comment: "https://www.w3.org/TR/css3-speech/#property-index",
-          syntax: "<'pause-before'> <'pause-after'>?"
-        },
-        "pause-after": {
-          comment: "https://www.w3.org/TR/css3-speech/#property-index",
-          syntax: "<time> | none | x-weak | weak | medium | strong | x-strong"
-        },
-        "pause-before": {
-          comment: "https://www.w3.org/TR/css3-speech/#property-index",
-          syntax: "<time> | none | x-weak | weak | medium | strong | x-strong"
-        },
-        "position-try-options": {
-          comment: "https://developer.mozilla.org/en-US/docs/Web/CSS/position-try-fallbacks",
-          syntax: "<'position-try-fallbacks'>"
-        },
-        rest: {
-          comment: "https://www.w3.org/TR/css3-speech/#property-index",
-          syntax: "<'rest-before'> <'rest-after'>?"
-        },
-        "rest-after": {
-          comment: "https://www.w3.org/TR/css3-speech/#property-index",
-          syntax: "<time> | none | x-weak | weak | medium | strong | x-strong"
-        },
-        "rest-before": {
-          comment: "https://www.w3.org/TR/css3-speech/#property-index",
-          syntax: "<time> | none | x-weak | weak | medium | strong | x-strong"
-        },
-        speak: {
-          comment: "https://www.w3.org/TR/css3-speech/#property-index",
-          syntax: "auto | never | always"
-        },
-        "stroke-dasharray": {
-          comment: "added SVG property; a list of comma and/or white space separated <length>s and <percentage>s",
-          references: [
-            "https://www.w3.org/TR/SVG/painting.html#StrokeProperties"
-          ],
-          syntax: "none | [ <svg-length>+ ]#"
-        },
-        "stroke-dashoffset": {
-          comment: "added SVG property",
-          references: [
-            "https://www.w3.org/TR/SVG/painting.html#StrokeProperties"
-          ],
-          syntax: "<svg-length>"
-        },
-        "stroke-linejoin": {
-          comment: "added SVG property",
-          references: [
-            "https://www.w3.org/TR/SVG/painting.html#StrokeProperties"
-          ],
-          syntax: "miter | round | bevel"
-        },
-        "stroke-miterlimit": {
-          comment: "added SVG property (<miterlimit> = <number-one-or-greater>) ",
-          references: [
-            "https://www.w3.org/TR/SVG/painting.html#StrokeProperties"
-          ],
-          syntax: "<number-one-or-greater>"
-        },
-        "stroke-width": {
-          comment: "added SVG property",
-          references: [
-            "https://www.w3.org/TR/SVG/painting.html#StrokeProperties"
-          ],
-          syntax: "<svg-length>"
-        },
-        "unicode-bidi": {
-          comment: "added prefixed keywords https://developer.mozilla.org/en-US/docs/Web/CSS/unicode-bidi",
-          syntax: "| -moz-isolate | -moz-isolate-override | -moz-plaintext | -webkit-isolate | -webkit-isolate-override | -webkit-plaintext"
-        },
-        "voice-balance": {
-          comment: "https://www.w3.org/TR/css3-speech/#property-index",
-          syntax: "<number> | left | center | right | leftwards | rightwards"
-        },
-        "voice-duration": {
-          comment: "https://www.w3.org/TR/css3-speech/#property-index",
-          syntax: "auto | <time>"
-        },
-        "voice-family": {
-          comment: "<name> -> <family-name>, https://www.w3.org/TR/css3-speech/#property-index",
-          syntax: "[ [ <family-name> | <generic-voice> ] , ]* [ <family-name> | <generic-voice> ] | preserve"
-        },
-        "voice-pitch": {
-          comment: "https://www.w3.org/TR/css3-speech/#property-index",
-          syntax: "<frequency> && absolute | [ [ x-low | low | medium | high | x-high ] || [ <frequency> | <semitones> | <percentage> ] ]"
-        },
-        "voice-range": {
-          comment: "https://www.w3.org/TR/css3-speech/#property-index",
-          syntax: "<frequency> && absolute | [ [ x-low | low | medium | high | x-high ] || [ <frequency> | <semitones> | <percentage> ] ]"
-        },
-        "voice-rate": {
-          comment: "https://www.w3.org/TR/css3-speech/#property-index",
-          syntax: "[ normal | x-slow | slow | medium | fast | x-fast ] || <percentage>"
-        },
-        "voice-stress": {
-          comment: "https://www.w3.org/TR/css3-speech/#property-index",
-          syntax: "normal | strong | moderate | none | reduced"
-        },
-        "voice-volume": {
-          comment: "https://www.w3.org/TR/css3-speech/#property-index",
-          syntax: "silent | [ [ x-soft | soft | medium | loud | x-loud ] || <decibel> ]"
-        },
-        "writing-mode": {
-          comment: "extend with SVG keywords",
-          syntax: "| <svg-writing-mode>"
-        },
-        "white-space-trim": {
-          syntax: "none | discard-before || discard-after || discard-inner",
-          comment: "missed, https://www.w3.org/TR/css-text-4/#white-space-trim"
-        }
-      },
-      types: {
-        "-legacy-gradient": {
-          comment: "added collection of legacy gradient syntaxes",
-          syntax: "<-webkit-gradient()> | <-legacy-linear-gradient> | <-legacy-repeating-linear-gradient> | <-legacy-radial-gradient> | <-legacy-repeating-radial-gradient>"
-        },
-        "-legacy-linear-gradient": {
-          comment: "like standard syntax but w/o `to` keyword https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient",
-          syntax: "-moz-linear-gradient( <-legacy-linear-gradient-arguments> ) | -webkit-linear-gradient( <-legacy-linear-gradient-arguments> ) | -o-linear-gradient( <-legacy-linear-gradient-arguments> )"
-        },
-        "-legacy-repeating-linear-gradient": {
-          comment: "like standard syntax but w/o `to` keyword https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient",
-          syntax: "-moz-repeating-linear-gradient( <-legacy-linear-gradient-arguments> ) | -webkit-repeating-linear-gradient( <-legacy-linear-gradient-arguments> ) | -o-repeating-linear-gradient( <-legacy-linear-gradient-arguments> )"
-        },
-        "-legacy-linear-gradient-arguments": {
-          comment: "like standard syntax but w/o `to` keyword https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient",
-          syntax: "[ <angle> | <side-or-corner> ]? , <color-stop-list>"
-        },
-        "-legacy-radial-gradient": {
-          comment: "deprecated syntax that implemented by some browsers https://www.w3.org/TR/2011/WD-css3-images-20110908/#radial-gradients",
-          syntax: "-moz-radial-gradient( <-legacy-radial-gradient-arguments> ) | -webkit-radial-gradient( <-legacy-radial-gradient-arguments> ) | -o-radial-gradient( <-legacy-radial-gradient-arguments> )"
-        },
-        "-legacy-repeating-radial-gradient": {
-          comment: "deprecated syntax that implemented by some browsers https://www.w3.org/TR/2011/WD-css3-images-20110908/#radial-gradients",
-          syntax: "-moz-repeating-radial-gradient( <-legacy-radial-gradient-arguments> ) | -webkit-repeating-radial-gradient( <-legacy-radial-gradient-arguments> ) | -o-repeating-radial-gradient( <-legacy-radial-gradient-arguments> )"
-        },
-        "-legacy-radial-gradient-arguments": {
-          comment: "deprecated syntax that implemented by some browsers https://www.w3.org/TR/2011/WD-css3-images-20110908/#radial-gradients",
-          syntax: "[ <position> , ]? [ [ [ <-legacy-radial-gradient-shape> || <-legacy-radial-gradient-size> ] | [ <length> | <percentage> ]{2} ] , ]? <color-stop-list>"
-        },
-        "-legacy-radial-gradient-size": {
-          comment: "before a standard it contains 2 extra keywords (`contain` and `cover`) https://www.w3.org/TR/2011/WD-css3-images-20110908/#ltsize",
-          syntax: "closest-side | closest-corner | farthest-side | farthest-corner | contain | cover"
-        },
-        "-legacy-radial-gradient-shape": {
-          comment: "define to double sure it doesn't extends in future https://www.w3.org/TR/2011/WD-css3-images-20110908/#ltshape",
-          syntax: "circle | ellipse"
-        },
-        "-non-standard-font": {
-          comment: "non standard fonts",
-          references: [
-            "https://webkit.org/blog/3709/using-the-system-font-in-web-content/"
-          ],
-          syntax: "-apple-system-body | -apple-system-headline | -apple-system-subheadline | -apple-system-caption1 | -apple-system-caption2 | -apple-system-footnote | -apple-system-short-body | -apple-system-short-headline | -apple-system-short-subheadline | -apple-system-short-caption1 | -apple-system-short-footnote | -apple-system-tall-body"
-        },
-        "-non-standard-color": {
-          comment: "non standard colors",
-          references: [
-            "http://cssdot.ru/%D0%A1%D0%BF%D1%80%D0%B0%D0%B2%D0%BE%D1%87%D0%BD%D0%B8%D0%BA_CSS/color-i305.html",
-            "https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#Mozilla_Color_Preference_Extensions"
-          ],
-          syntax: "-moz-ButtonDefault | -moz-ButtonHoverFace | -moz-ButtonHoverText | -moz-CellHighlight | -moz-CellHighlightText | -moz-Combobox | -moz-ComboboxText | -moz-Dialog | -moz-DialogText | -moz-dragtargetzone | -moz-EvenTreeRow | -moz-Field | -moz-FieldText | -moz-html-CellHighlight | -moz-html-CellHighlightText | -moz-mac-accentdarkestshadow | -moz-mac-accentdarkshadow | -moz-mac-accentface | -moz-mac-accentlightesthighlight | -moz-mac-accentlightshadow | -moz-mac-accentregularhighlight | -moz-mac-accentregularshadow | -moz-mac-chrome-active | -moz-mac-chrome-inactive | -moz-mac-focusring | -moz-mac-menuselect | -moz-mac-menushadow | -moz-mac-menutextselect | -moz-MenuHover | -moz-MenuHoverText | -moz-MenuBarText | -moz-MenuBarHoverText | -moz-nativehyperlinktext | -moz-OddTreeRow | -moz-win-communicationstext | -moz-win-mediatext | -moz-activehyperlinktext | -moz-default-background-color | -moz-default-color | -moz-hyperlinktext | -moz-visitedhyperlinktext | -webkit-activelink | -webkit-focus-ring-color | -webkit-link | -webkit-text"
-        },
-        "-non-standard-image-rendering": {
-          comment: "non-standard keywords http://phrogz.net/tmp/canvas_image_zoom.html",
-          syntax: "optimize-contrast | -moz-crisp-edges | -o-crisp-edges | -webkit-optimize-contrast"
-        },
-        "-non-standard-overflow": {
-          comment: "non-standard keywords https://developer.mozilla.org/en-US/docs/Web/CSS/overflow",
-          syntax: "overlay | -moz-scrollbars-none | -moz-scrollbars-horizontal | -moz-scrollbars-vertical | -moz-hidden-unscrollable"
-        },
-        "-non-standard-size": {
-          comment: "non-standard keywords https://developer.mozilla.org/en-US/docs/Web/CSS/width",
-          syntax: "intrinsic | min-intrinsic | -webkit-fill-available | -webkit-fit-content | -webkit-min-content | -webkit-max-content  | -moz-available | -moz-fit-content | -moz-min-content | -moz-max-content"
-        },
-        "-webkit-gradient()": {
-          comment: "first Apple proposal gradient syntax https://webkit.org/blog/175/introducing-css-gradients/ - TODO: simplify when after match algorithm improvement ( [, point, radius | , point] -> [, radius]? , point )",
-          syntax: "-webkit-gradient( <-webkit-gradient-type>, <-webkit-gradient-point> [, <-webkit-gradient-point> | , <-webkit-gradient-radius>, <-webkit-gradient-point> ] [, <-webkit-gradient-radius>]? [, <-webkit-gradient-color-stop>]* )"
-        },
-        "-webkit-gradient-color-stop": {
-          comment: "first Apple proposal gradient syntax https://webkit.org/blog/175/introducing-css-gradients/",
-          syntax: "from( <color> ) | color-stop( [ <number-zero-one> | <percentage> ] , <color> ) | to( <color> )"
-        },
-        "-webkit-gradient-point": {
-          comment: "first Apple proposal gradient syntax https://webkit.org/blog/175/introducing-css-gradients/",
-          syntax: "[ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ]"
-        },
-        "-webkit-gradient-radius": {
-          comment: "first Apple proposal gradient syntax https://webkit.org/blog/175/introducing-css-gradients/",
-          syntax: "<length> | <percentage>"
-        },
-        "-webkit-gradient-type": {
-          comment: "first Apple proposal gradient syntax https://webkit.org/blog/175/introducing-css-gradients/",
-          syntax: "linear | radial"
-        },
-        "-webkit-mask-box-repeat": {
-          comment: "missed; https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-mask-box-image",
-          syntax: "repeat | stretch | round"
-        },
-        "-ms-filter-function-list": {
-          comment: "https://developer.mozilla.org/en-US/docs/Web/CSS/-ms-filter",
-          syntax: "<-ms-filter-function>+"
-        },
-        "-ms-filter-function": {
-          comment: "https://developer.mozilla.org/en-US/docs/Web/CSS/-ms-filter",
-          syntax: "<-ms-filter-function-progid> | <-ms-filter-function-legacy>"
-        },
-        "-ms-filter-function-progid": {
-          comment: "https://developer.mozilla.org/en-US/docs/Web/CSS/-ms-filter",
-          syntax: "'progid:' [ <ident-token> '.' ]* [ <ident-token> | <function-token> <any-value>? ) ]"
-        },
-        "-ms-filter-function-legacy": {
-          comment: "https://developer.mozilla.org/en-US/docs/Web/CSS/-ms-filter",
-          syntax: "<ident-token> | <function-token> <any-value>? )"
-        },
-        age: {
-          comment: "https://www.w3.org/TR/css3-speech/#voice-family",
-          syntax: "child | young | old"
-        },
-        "attr-name": {
-          syntax: "<wq-name>"
-        },
-        "attr-fallback": {
-          syntax: "<any-value>"
-        },
-        autospace: {
-          syntax: "no-autospace | [ ideograph-alpha || ideograph-numeric || punctuation ] || [ insert | replace ]"
-        },
-        bottom: {
-          comment: "missed; not sure we should add it, but no others except `shape` is using it so it's ok for now; https://drafts.fxtf.org/css-masking-1/#funcdef-clip-rect",
-          syntax: "<length> | auto"
-        },
-        "content-list": {
-          comment: "added attr(), see https://github.com/csstree/csstree/issues/201",
-          syntax: "[ <string> | contents | <image> | <counter> | <quote> | <target> | <leader()> | <attr()> ]+"
-        },
-        "container-condition": {
-          comment: "missed, https://drafts.csswg.org/css-contain-3/#container-rule",
-          syntax: "not <query-in-parens> | <query-in-parens> [ [ and <query-in-parens> ]* | [ or <query-in-parens> ]* ]"
-        },
-        "coord-box": {
-          syntax: "content-box | padding-box | border-box | fill-box | stroke-box | view-box"
-        },
-        "cubic-bezier-easing-function": {
-          comment: "missed, https://drafts.csswg.org/css-easing-1/#cubic-bezier-easing-function",
-          syntax: "ease | ease-in | ease-out | ease-in-out | cubic-bezier( <number [0,1]> , <number> , <number [0,1]> , <number> )"
-        },
-        "element()": {
-          comment: "https://drafts.csswg.org/css-gcpm/#element-syntax & https://drafts.csswg.org/css-images-4/#element-notation",
-          syntax: "element( <custom-ident> , [ first | start | last | first-except ]? ) | element( <id-selector> )"
-        },
-        "generic-voice": {
-          comment: "https://www.w3.org/TR/css3-speech/#voice-family",
-          syntax: "[ <age>? <gender> <integer>? ]"
-        },
-        gender: {
-          comment: "https://www.w3.org/TR/css3-speech/#voice-family",
-          syntax: "male | female | neutral"
-        },
-        "general-enclosed": {
-          comment: "remove ident-token, optional any-value, brackets (see https://drafts.csswg.org/mediaqueries-5/#typedef-general-enclosed)",
-          syntax: "[ <function-token> <any-value>? ) ] | [ ( <any-value>? ) ]"
-        },
-        "generic-family": {
-          comment: "new definition on font-4, https://drafts.csswg.org/css-fonts-4/#typedef-generic-family",
-          syntax: "<generic-script-specific>| <generic-complete> | <generic-incomplete> | <-non-standard-generic-family>"
-        },
-        "generic-script-specific": {
-          syntax: "generic(kai) | generic(fangsong) | generic(nastaliq)"
-        },
-        "-non-standard-generic-family": {
-          syntax: "-apple-system | BlinkMacSystemFont",
-          references: [
-            "https://css-tricks.com/snippets/css/system-font-stack/",
-            "https://webkit.org/blog/3709/using-the-system-font-in-web-content/"
-          ]
-        },
-        gradient: {
-          comment: "added legacy syntaxes support",
-          syntax: "| <-legacy-gradient>"
-        },
-        "intrinsic-size-keyword": {
-          comment: "Missing from mdn-data. 4.3. Intrinsic Size Keywords https://www.w3.org/TR/css-sizing-4/#intrinsic-size-keywords",
-          syntax: "min-content | max-content | fit-content"
-        },
-        left: {
-          comment: "missed; not sure we should add it, but no others except `shape` is using it so it's ok for now; https://drafts.fxtf.org/css-masking-1/#funcdef-clip-rect",
-          syntax: "<length> | auto"
-        },
-        color: {
-          comment: "css-color-5, added non standard color names",
-          syntax: "<color-base> | currentColor | <system-color> | <device-cmyk()>  | <light-dark()> | <-non-standard-color>"
-        },
-        "device-cmyk()": {
-          syntax: "<legacy-device-cmyk-syntax> | <modern-device-cmyk-syntax>"
-        },
-        "legacy-device-cmyk-syntax": {
-          syntax: "device-cmyk( <number>#{4} )"
-        },
-        "modern-device-cmyk-syntax": {
-          syntax: "device-cmyk( <cmyk-component>{4} [ / [ <alpha-value> | none ] ]? )"
-        },
-        "cmyk-component": {
-          syntax: "<number> | <percentage> | none"
-        },
-        "color-mix()": {
-          syntax: "color-mix( <color-interpolation-method> , [ <color> && <percentage [0,100]>? ]#{2} )"
-        },
-        "color-space": {
-          syntax: "<rectangular-color-space> | <polar-color-space> | <custom-color-space>"
-        },
-        paint: {
-          comment: "used by SVG https://www.w3.org/TR/SVG/painting.html#SpecifyingPaint",
-          syntax: "none | <color> | <url> [ none | <color> ]? | context-fill | context-stroke"
-        },
-        right: {
-          comment: "missed; not sure we should add it, but no others except `shape` is using it so it's ok for now; https://drafts.fxtf.org/css-masking-1/#funcdef-clip-rect",
-          syntax: "<length> | auto"
-        },
-        shape: {
-          comment: "missed spaces in function body and add backwards compatible syntax",
-          syntax: "rect( <top>, <right>, <bottom>, <left> ) | rect( <top> <right> <bottom> <left> )"
-        },
-        "scope-start": {
-          syntax: "<forgiving-selector-list>"
-        },
-        "scope-end": {
-          syntax: "<forgiving-selector-list>"
-        },
-        "forgiving-selector-list": {
-          syntax: "<complex-real-selector-list>"
-        },
-        "forgiving-relative-selector-list": {
-          syntax: "<relative-real-selector-list>"
-        },
-        "complex-real-selector-list": {
-          syntax: "<complex-real-selector>#"
-        },
-        "simple-selector-list": {
-          syntax: "<simple-selector>#"
-        },
-        "relative-real-selector-list": {
-          syntax: "<relative-real-selector>#"
-        },
-        "complex-selector": {
-          syntax: "<complex-selector-unit> [ <combinator>? <complex-selector-unit> ]*"
-        },
-        "complex-selector-unit": {
-          syntax: "[ <compound-selector>? <pseudo-compound-selector>* ]!"
-        },
-        "complex-real-selector": {
-          syntax: "<compound-selector> [ <combinator>? <compound-selector> ]*"
-        },
-        "relative-real-selector": {
-          syntax: "<combinator>? <complex-real-selector>"
-        },
-        "compound-selector": {
-          syntax: "[ <type-selector>? <subclass-selector>* ]!"
-        },
-        "pseudo-compound-selector": {
-          syntax: " <pseudo-element-selector> <pseudo-class-selector>*"
-        },
-        "simple-selector": {
-          syntax: "<type-selector> | <subclass-selector>"
-        },
-        combinator: {
-          syntax: "'>' | '+' | '~' | [ '|' '|' ]"
-        },
-        "pseudo-element-selector": {
-          syntax: "':' <pseudo-class-selector> | <legacy-pseudo-element-selector>"
-        },
-        "legacy-pseudo-element-selector": {
-          syntax: " ':' [before | after | first-line | first-letter]"
-        },
-        "svg-length": {
-          comment: "All coordinates and lengths in SVG can be specified with or without a unit identifier",
-          references: [
-            "https://www.w3.org/TR/SVG11/coords.html#Units"
-          ],
-          syntax: "<percentage> | <length> | <number>"
-        },
-        "svg-writing-mode": {
-          comment: "SVG specific keywords (deprecated for CSS)",
-          references: [
-            "https://developer.mozilla.org/en/docs/Web/CSS/writing-mode",
-            "https://www.w3.org/TR/SVG/text.html#WritingModeProperty"
-          ],
-          syntax: "lr-tb | rl-tb | tb-rl | lr | rl | tb"
-        },
-        top: {
-          comment: "missed; not sure we should add it, but no others except `shape` is using it so it's ok for now; https://drafts.fxtf.org/css-masking-1/#funcdef-clip-rect",
-          syntax: "<length> | auto"
-        },
-        x: {
-          comment: "missed; not sure we should add it, but no others except `cursor` is using it so it's ok for now; https://drafts.csswg.org/css-ui-3/#cursor",
-          syntax: "<number>"
-        },
-        y: {
-          comment: "missed; not sure we should add it, but no others except `cursor` is using so it's ok for now; https://drafts.csswg.org/css-ui-3/#cursor",
-          syntax: "<number>"
-        },
-        declaration: {
-          comment: "missed, restored by https://drafts.csswg.org/css-syntax",
-          syntax: "<ident-token> : <declaration-value>? [ '!' important ]?"
-        },
-        "declaration-list": {
-          comment: "missed, restored by https://drafts.csswg.org/css-syntax",
-          syntax: "[ <declaration>? ';' ]* <declaration>?"
-        },
-        url: {
-          comment: "https://drafts.csswg.org/css-values-4/#urls",
-          syntax: "url( <string> <url-modifier>* ) | <url-token>"
-        },
-        "url-modifier": {
-          comment: "https://drafts.csswg.org/css-values-4/#typedef-url-modifier",
-          syntax: "<ident> | <function-token> <any-value> )"
-        },
-        "number-zero-one": {
-          syntax: "<number [0,1]>"
-        },
-        "number-one-or-greater": {
-          syntax: "<number [1,\u221E]>"
-        },
-        "color()": {
-          syntax: "color( <colorspace-params> [ / [ <alpha-value> | none ] ]? )"
-        },
-        "colorspace-params": {
-          syntax: "[ <predefined-rgb-params> | <xyz-params>]"
-        },
-        "xyz-params": {
-          syntax: "<xyz-space> [ <number> | <percentage> | none ]{3}"
-        },
-        "xyz-space": {
-          syntax: "xyz | xyz-d50 | xyz-d65"
-        },
-        "query-in-parens": {
-          comment: "missed, https://drafts.csswg.org/css-contain-3/#container-rule",
-          syntax: "( <container-condition> ) | ( <size-feature> ) | style( <style-query> ) | <general-enclosed>"
-        },
-        "size-feature": {
-          comment: "missed, https://drafts.csswg.org/css-contain-3/#typedef-size-feature",
-          syntax: "<mf-plain> | <mf-boolean> | <mf-range>"
-        },
-        "style-query": {
-          comment: "missed, https://drafts.csswg.org/css-contain-3/#container-rule",
-          syntax: "<style-condition> | <style-feature>"
-        },
-        "style-condition": {
-          comment: "missed, https://drafts.csswg.org/css-contain-3/#container-rule",
-          syntax: "not <style-in-parens> | <style-in-parens> [ [ and <style-in-parens> ]* | [ or <style-in-parens> ]* ]"
-        },
-        "style-in-parens": {
-          comment: "missed, https://drafts.csswg.org/css-contain-3/#container-rule",
-          syntax: "( <style-condition> ) | ( <style-feature> ) | <general-enclosed>"
-        },
-        "-non-standard-display": {
-          syntax: "-ms-inline-flexbox | -ms-grid | -ms-inline-grid | -webkit-flex | -webkit-inline-flex | -webkit-box | -webkit-inline-box | -moz-inline-stack | -moz-box | -moz-inline-box"
-        },
-        "inset-area": {
-          syntax: "[ [ left | center | right | span-left | span-right | x-start | x-end | span-x-start | span-x-end | x-self-start | x-self-end | span-x-self-start | span-x-self-end | span-all ] || [ top | center | bottom | span-top | span-bottom | y-start | y-end | span-y-start | span-y-end | y-self-start | y-self-end | span-y-self-start | span-y-self-end | span-all ] | [ block-start | center | block-end | span-block-start | span-block-end | span-all ] || [ inline-start | center | inline-end | span-inline-start | span-inline-end | span-all ] | [ self-block-start | self-block-end | span-self-block-start | span-self-block-end | span-all ] || [ self-inline-start | self-inline-end | span-self-inline-start | span-self-inline-end | span-all ] | [ start | center | end | span-start | span-end | span-all ]{1,2} | [ self-start | center | self-end | span-self-start | span-self-end | span-all ]{1,2} ]",
-          comment: "initial name for <position-area> before renamed",
-          references: [
-            "https://www.w3.org/TR/css-anchor-position-1/#inset-area"
-          ]
-        },
-        "position-area": {
-          syntax: "[ [ left | center | right | span-left | span-right | x-start | x-end | span-x-start | span-x-end | x-self-start | x-self-end | span-x-self-start | span-x-self-end | span-all ] || [ top | center | bottom | span-top | span-bottom | y-start | y-end | span-y-start | span-y-end | y-self-start | y-self-end | span-y-self-start | span-y-self-end | span-all ] | [ block-start | center | block-end | span-block-start | span-block-end | span-all ] || [ inline-start | center | inline-end | span-inline-start | span-inline-end | span-all ] | [ self-block-start | center | self-block-end | span-self-block-start | span-self-block-end | span-all ] || [ self-inline-start | center | self-inline-end | span-self-inline-start | span-self-inline-end | span-all ] | [ start | center | end | span-start | span-end | span-all ]{1,2} | [ self-start | center | self-end | span-self-start | span-self-end | span-all ]{1,2} ]",
-          comment: "replaced <inset-area>",
-          references: [
-            "https://drafts.csswg.org/css-anchor-position-1/#typedef-position-area"
-          ]
-        },
-        syntax: {
-          syntax: "'*' | <syntax-component> [ <syntax-combinator> <syntax-component> ]* | <syntax-string>"
-        },
-        "syntax-component": {
-          syntax: "<syntax-single-component> <syntax-multiplier>? | '<' transform-list '>'"
-        },
-        "syntax-single-component": {
-          syntax: "'<' <syntax-type-name> '>' | <ident>"
-        },
-        "syntax-type-name": {
-          syntax: "angle | color | custom-ident | image | integer | length | length-percentage | number | percentage | resolution | string | time | url | transform-function"
-        },
-        "syntax-combinator": {
-          syntax: "'|'"
-        },
-        "syntax-multiplier": {
-          syntax: "'#' | '+'"
-        },
-        "syntax-string": {
-          syntax: "<string>"
-        }
-      }
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/data-patch.js
-import { createRequire } from "module";
-var require2, patch, data_patch_default;
-var init_data_patch = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/data-patch.js"() {
-    init_patch();
-    require2 = createRequire(import.meta.url);
-    patch = patch_default;
-    data_patch_default = patch;
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/data.js
-import { createRequire as createRequire2 } from "module";
-function preprocessAtrules(dict) {
-  const result = /* @__PURE__ */ Object.create(null);
-  for (const [atruleName, atrule] of Object.entries(dict)) {
-    let descriptors = null;
-    if (atrule.descriptors) {
-      descriptors = /* @__PURE__ */ Object.create(null);
-      for (const [name50, descriptor] of Object.entries(atrule.descriptors)) {
-        descriptors[name50] = descriptor.syntax;
-      }
-    }
-    result[atruleName.substr(1)] = {
-      prelude: atrule.syntax.trim().replace(/\{(.|\s)+\}/, "").match(/^@\S+\s+([^;\{]*)/)[1].trim() || null,
-      descriptors
-    };
-  }
-  return result;
-}
-function patchDictionary(dict, patchDict) {
-  const result = /* @__PURE__ */ Object.create(null);
-  for (const [key, value] of Object.entries(dict)) {
-    if (value) {
-      result[key] = value.syntax || value;
-    }
-  }
-  for (const key of Object.keys(patchDict)) {
-    if (hasOwn(dict, key)) {
-      if (patchDict[key].syntax) {
-        result[key] = extendSyntax.test(patchDict[key].syntax) ? result[key] + " " + patchDict[key].syntax.trim() : patchDict[key].syntax;
-      } else {
-        delete result[key];
-      }
-    } else {
-      if (patchDict[key].syntax) {
-        result[key] = patchDict[key].syntax.replace(extendSyntax, "");
-      }
-    }
-  }
-  return result;
-}
-function preprocessPatchAtrulesDescritors(declarations) {
-  const result = {};
-  for (const [key, value] of Object.entries(declarations || {})) {
-    result[key] = typeof value === "string" ? { syntax: value } : value;
-  }
-  return result;
-}
-function patchAtrules(dict, patchDict) {
-  const result = {};
-  for (const key in dict) {
-    if (patchDict[key] === null) {
-      continue;
-    }
-    const atrulePatch = patchDict[key] || {};
-    result[key] = {
-      prelude: key in patchDict && "prelude" in atrulePatch ? atrulePatch.prelude : dict[key].prelude || null,
-      descriptors: patchDictionary(
-        dict[key].descriptors || {},
-        preprocessPatchAtrulesDescritors(atrulePatch.descriptors)
-      )
-    };
-  }
-  for (const [key, atrulePatch] of Object.entries(patchDict)) {
-    if (atrulePatch && !hasOwn(dict, key)) {
-      result[key] = {
-        prelude: atrulePatch.prelude || null,
-        descriptors: atrulePatch.descriptors ? patchDictionary({}, preprocessPatchAtrulesDescritors(atrulePatch.descriptors)) : null
-      };
-    }
-  }
-  return result;
-}
-var require3, mdnAtrules, mdnProperties, mdnSyntaxes, hasOwn, extendSyntax, data_default;
-var init_data = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/data.js"() {
-    init_at_rules();
-    init_properties();
-    init_syntaxes();
-    init_data_patch();
-    require3 = createRequire2(import.meta.url);
-    mdnAtrules = at_rules_default;
-    mdnProperties = properties_default;
-    mdnSyntaxes = syntaxes_default;
-    hasOwn = Object.hasOwn || ((object, property2) => Object.prototype.hasOwnProperty.call(object, property2));
-    extendSyntax = /^\s*\|\s*/;
-    data_default = {
-      types: patchDictionary(mdnSyntaxes, data_patch_default.types),
-      atrules: patchAtrules(preprocessAtrules(mdnAtrules), data_patch_default.atrules),
-      properties: patchDictionary(mdnProperties, data_patch_default.properties)
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/AnPlusB.js
-var AnPlusB_exports = {};
-__export(AnPlusB_exports, {
-  generate: () => generate2,
-  name: () => name,
-  parse: () => parse3,
-  structure: () => structure
-});
-function checkInteger2(offset, disallowSign) {
-  let pos = this.tokenStart + offset;
-  const code4 = this.charCodeAt(pos);
-  if (code4 === PLUSSIGN5 || code4 === HYPHENMINUS5) {
-    if (disallowSign) {
-      this.error("Number sign is not allowed");
-    }
-    pos++;
-  }
-  for (; pos < this.tokenEnd; pos++) {
-    if (!isDigit(this.charCodeAt(pos))) {
-      this.error("Integer is expected", pos);
-    }
-  }
-}
-function checkTokenIsInteger(disallowSign) {
-  return checkInteger2.call(this, 0, disallowSign);
-}
-function expectCharCode(offset, code4) {
-  if (!this.cmpChar(this.tokenStart + offset, code4)) {
-    let msg = "";
-    switch (code4) {
-      case N5:
-        msg = "N is expected";
-        break;
-      case HYPHENMINUS5:
-        msg = "HyphenMinus is expected";
-        break;
-    }
-    this.error(msg, this.tokenStart + offset);
-  }
-}
-function consumeB2() {
-  let offset = 0;
-  let sign = 0;
-  let type = this.tokenType;
-  while (type === WhiteSpace || type === Comment) {
-    type = this.lookupType(++offset);
-  }
-  if (type !== Number2) {
-    if (this.isDelim(PLUSSIGN5, offset) || this.isDelim(HYPHENMINUS5, offset)) {
-      sign = this.isDelim(PLUSSIGN5, offset) ? PLUSSIGN5 : HYPHENMINUS5;
-      do {
-        type = this.lookupType(++offset);
-      } while (type === WhiteSpace || type === Comment);
-      if (type !== Number2) {
-        this.skip(offset);
-        checkTokenIsInteger.call(this, DISALLOW_SIGN2);
-      }
-    } else {
-      return null;
-    }
-  }
-  if (offset > 0) {
-    this.skip(offset);
-  }
-  if (sign === 0) {
-    type = this.charCodeAt(this.tokenStart);
-    if (type !== PLUSSIGN5 && type !== HYPHENMINUS5) {
-      this.error("Number sign is expected");
-    }
-  }
-  checkTokenIsInteger.call(this, sign !== 0);
-  return sign === HYPHENMINUS5 ? "-" + this.consume(Number2) : this.consume(Number2);
-}
-function parse3() {
-  const start = this.tokenStart;
-  let a = null;
-  let b = null;
-  if (this.tokenType === Number2) {
-    checkTokenIsInteger.call(this, ALLOW_SIGN2);
-    b = this.consume(Number2);
-  } else if (this.tokenType === Ident && this.cmpChar(this.tokenStart, HYPHENMINUS5)) {
-    a = "-1";
-    expectCharCode.call(this, 1, N5);
-    switch (this.tokenEnd - this.tokenStart) {
-      // -n
-      // -n <signed-integer>
-      // -n ['+' | '-'] <signless-integer>
-      case 2:
-        this.next();
-        b = consumeB2.call(this);
-        break;
-      // -n- <signless-integer>
-      case 3:
-        expectCharCode.call(this, 2, HYPHENMINUS5);
-        this.next();
-        this.skipSC();
-        checkTokenIsInteger.call(this, DISALLOW_SIGN2);
-        b = "-" + this.consume(Number2);
-        break;
-      // <dashndashdigit-ident>
-      default:
-        expectCharCode.call(this, 2, HYPHENMINUS5);
-        checkInteger2.call(this, 3, DISALLOW_SIGN2);
-        this.next();
-        b = this.substrToCursor(start + 2);
-    }
-  } else if (this.tokenType === Ident || this.isDelim(PLUSSIGN5) && this.lookupType(1) === Ident) {
-    let sign = 0;
-    a = "1";
-    if (this.isDelim(PLUSSIGN5)) {
-      sign = 1;
-      this.next();
-    }
-    expectCharCode.call(this, 0, N5);
-    switch (this.tokenEnd - this.tokenStart) {
-      // '+'? n
-      // '+'? n <signed-integer>
-      // '+'? n ['+' | '-'] <signless-integer>
-      case 1:
-        this.next();
-        b = consumeB2.call(this);
-        break;
-      // '+'? n- <signless-integer>
-      case 2:
-        expectCharCode.call(this, 1, HYPHENMINUS5);
-        this.next();
-        this.skipSC();
-        checkTokenIsInteger.call(this, DISALLOW_SIGN2);
-        b = "-" + this.consume(Number2);
-        break;
-      // '+'? <ndashdigit-ident>
-      default:
-        expectCharCode.call(this, 1, HYPHENMINUS5);
-        checkInteger2.call(this, 2, DISALLOW_SIGN2);
-        this.next();
-        b = this.substrToCursor(start + sign + 1);
-    }
-  } else if (this.tokenType === Dimension) {
-    const code4 = this.charCodeAt(this.tokenStart);
-    const sign = code4 === PLUSSIGN5 || code4 === HYPHENMINUS5;
-    let i = this.tokenStart + sign;
-    for (; i < this.tokenEnd; i++) {
-      if (!isDigit(this.charCodeAt(i))) {
-        break;
-      }
-    }
-    if (i === this.tokenStart + sign) {
-      this.error("Integer is expected", this.tokenStart + sign);
-    }
-    expectCharCode.call(this, i - this.tokenStart, N5);
-    a = this.substring(start, i);
-    if (i + 1 === this.tokenEnd) {
-      this.next();
-      b = consumeB2.call(this);
-    } else {
-      expectCharCode.call(this, i - this.tokenStart + 1, HYPHENMINUS5);
-      if (i + 2 === this.tokenEnd) {
-        this.next();
-        this.skipSC();
-        checkTokenIsInteger.call(this, DISALLOW_SIGN2);
-        b = "-" + this.consume(Number2);
-      } else {
-        checkInteger2.call(this, i - this.tokenStart + 2, DISALLOW_SIGN2);
-        this.next();
-        b = this.substrToCursor(i + 1);
-      }
-    }
-  } else {
-    this.error();
-  }
-  if (a !== null && a.charCodeAt(0) === PLUSSIGN5) {
-    a = a.substr(1);
-  }
-  if (b !== null && b.charCodeAt(0) === PLUSSIGN5) {
-    b = b.substr(1);
-  }
-  return {
-    type: "AnPlusB",
-    loc: this.getLocation(start, this.tokenStart),
-    a,
-    b
-  };
-}
-function generate2(node2) {
-  if (node2.a) {
-    const a = node2.a === "+1" && "n" || node2.a === "1" && "n" || node2.a === "-1" && "-n" || node2.a + "n";
-    if (node2.b) {
-      const b = node2.b[0] === "-" || node2.b[0] === "+" ? node2.b : "+" + node2.b;
-      this.tokenize(a + b);
-    } else {
-      this.tokenize(a);
-    }
-  } else {
-    this.tokenize(node2.b);
-  }
-}
-var PLUSSIGN5, HYPHENMINUS5, N5, DISALLOW_SIGN2, ALLOW_SIGN2, name, structure;
-var init_AnPlusB = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/AnPlusB.js"() {
-    init_tokenizer();
-    PLUSSIGN5 = 43;
-    HYPHENMINUS5 = 45;
-    N5 = 110;
-    DISALLOW_SIGN2 = true;
-    ALLOW_SIGN2 = false;
-    name = "AnPlusB";
-    structure = {
-      a: [String, null],
-      b: [String, null]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Atrule.js
-var Atrule_exports = {};
-__export(Atrule_exports, {
-  generate: () => generate3,
-  name: () => name2,
-  parse: () => parse4,
-  structure: () => structure2,
-  walkContext: () => walkContext
-});
-function consumeRaw() {
-  return this.Raw(this.consumeUntilLeftCurlyBracketOrSemicolon, true);
-}
-function isDeclarationBlockAtrule() {
-  for (let offset = 1, type; type = this.lookupType(offset); offset++) {
-    if (type === RightCurlyBracket) {
-      return true;
-    }
-    if (type === LeftCurlyBracket || type === AtKeyword) {
-      return false;
-    }
-  }
-  return false;
-}
-function parse4(isDeclaration = false) {
-  const start = this.tokenStart;
-  let name50;
-  let nameLowerCase;
-  let prelude = null;
-  let block = null;
-  this.eat(AtKeyword);
-  name50 = this.substrToCursor(start + 1);
-  nameLowerCase = name50.toLowerCase();
-  this.skipSC();
-  if (this.eof === false && this.tokenType !== LeftCurlyBracket && this.tokenType !== Semicolon) {
-    if (this.parseAtrulePrelude) {
-      prelude = this.parseWithFallback(this.AtrulePrelude.bind(this, name50, isDeclaration), consumeRaw);
-    } else {
-      prelude = consumeRaw.call(this, this.tokenIndex);
-    }
-    this.skipSC();
-  }
-  switch (this.tokenType) {
-    case Semicolon:
-      this.next();
-      break;
-    case LeftCurlyBracket:
-      if (hasOwnProperty.call(this.atrule, nameLowerCase) && typeof this.atrule[nameLowerCase].block === "function") {
-        block = this.atrule[nameLowerCase].block.call(this, isDeclaration);
-      } else {
-        block = this.Block(isDeclarationBlockAtrule.call(this));
-      }
-      break;
-  }
-  return {
-    type: "Atrule",
-    loc: this.getLocation(start, this.tokenStart),
-    name: name50,
-    prelude,
-    block
-  };
-}
-function generate3(node2) {
-  this.token(AtKeyword, "@" + node2.name);
-  if (node2.prelude !== null) {
-    this.node(node2.prelude);
-  }
-  if (node2.block) {
-    this.node(node2.block);
-  } else {
-    this.token(Semicolon, ";");
-  }
-}
-var name2, walkContext, structure2;
-var init_Atrule = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Atrule.js"() {
-    init_tokenizer();
-    name2 = "Atrule";
-    walkContext = "atrule";
-    structure2 = {
-      name: String,
-      prelude: ["AtrulePrelude", "Raw", null],
-      block: ["Block", null]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/AtrulePrelude.js
-var AtrulePrelude_exports = {};
-__export(AtrulePrelude_exports, {
-  generate: () => generate4,
-  name: () => name3,
-  parse: () => parse5,
-  structure: () => structure3,
-  walkContext: () => walkContext2
-});
-function parse5(name50) {
-  let children = null;
-  if (name50 !== null) {
-    name50 = name50.toLowerCase();
-  }
-  this.skipSC();
-  if (hasOwnProperty.call(this.atrule, name50) && typeof this.atrule[name50].prelude === "function") {
-    children = this.atrule[name50].prelude.call(this);
-  } else {
-    children = this.readSequence(this.scope.AtrulePrelude);
-  }
-  this.skipSC();
-  if (this.eof !== true && this.tokenType !== LeftCurlyBracket && this.tokenType !== Semicolon) {
-    this.error("Semicolon or block is expected");
-  }
-  return {
-    type: "AtrulePrelude",
-    loc: this.getLocationFromList(children),
-    children
-  };
-}
-function generate4(node2) {
-  this.children(node2);
-}
-var name3, walkContext2, structure3;
-var init_AtrulePrelude = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/AtrulePrelude.js"() {
-    init_tokenizer();
-    name3 = "AtrulePrelude";
-    walkContext2 = "atrulePrelude";
-    structure3 = {
-      children: [[]]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/AttributeSelector.js
-var AttributeSelector_exports = {};
-__export(AttributeSelector_exports, {
-  generate: () => generate5,
-  name: () => name4,
-  parse: () => parse6,
-  structure: () => structure4
-});
-function getAttributeName() {
-  if (this.eof) {
-    this.error("Unexpected end of input");
-  }
-  const start = this.tokenStart;
-  let expectIdent = false;
-  if (this.isDelim(ASTERISK2)) {
-    expectIdent = true;
-    this.next();
-  } else if (!this.isDelim(VERTICALLINE2)) {
-    this.eat(Ident);
-  }
-  if (this.isDelim(VERTICALLINE2)) {
-    if (this.charCodeAt(this.tokenStart + 1) !== EQUALSSIGN) {
-      this.next();
-      this.eat(Ident);
-    } else if (expectIdent) {
-      this.error("Identifier is expected", this.tokenEnd);
-    }
-  } else if (expectIdent) {
-    this.error("Vertical line is expected");
-  }
-  return {
-    type: "Identifier",
-    loc: this.getLocation(start, this.tokenStart),
-    name: this.substrToCursor(start)
-  };
-}
-function getOperator() {
-  const start = this.tokenStart;
-  const code4 = this.charCodeAt(start);
-  if (code4 !== EQUALSSIGN && // =
-  code4 !== TILDE && // ~=
-  code4 !== CIRCUMFLEXACCENT && // ^=
-  code4 !== DOLLARSIGN && // $=
-  code4 !== ASTERISK2 && // *=
-  code4 !== VERTICALLINE2) {
-    this.error("Attribute selector (=, ~=, ^=, $=, *=, |=) is expected");
-  }
-  this.next();
-  if (code4 !== EQUALSSIGN) {
-    if (!this.isDelim(EQUALSSIGN)) {
-      this.error("Equal sign is expected");
-    }
-    this.next();
-  }
-  return this.substrToCursor(start);
-}
-function parse6() {
-  const start = this.tokenStart;
-  let name50;
-  let matcher = null;
-  let value = null;
-  let flags = null;
-  this.eat(LeftSquareBracket);
-  this.skipSC();
-  name50 = getAttributeName.call(this);
-  this.skipSC();
-  if (this.tokenType !== RightSquareBracket) {
-    if (this.tokenType !== Ident) {
-      matcher = getOperator.call(this);
-      this.skipSC();
-      value = this.tokenType === String2 ? this.String() : this.Identifier();
-      this.skipSC();
-    }
-    if (this.tokenType === Ident) {
-      flags = this.consume(Ident);
-      this.skipSC();
-    }
-  }
-  this.eat(RightSquareBracket);
-  return {
-    type: "AttributeSelector",
-    loc: this.getLocation(start, this.tokenStart),
-    name: name50,
-    matcher,
-    value,
-    flags
-  };
-}
-function generate5(node2) {
-  this.token(Delim, "[");
-  this.node(node2.name);
-  if (node2.matcher !== null) {
-    this.tokenize(node2.matcher);
-    this.node(node2.value);
-  }
-  if (node2.flags !== null) {
-    this.token(Ident, node2.flags);
-  }
-  this.token(Delim, "]");
-}
-var DOLLARSIGN, ASTERISK2, EQUALSSIGN, CIRCUMFLEXACCENT, VERTICALLINE2, TILDE, name4, structure4;
-var init_AttributeSelector = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/AttributeSelector.js"() {
-    init_tokenizer();
-    DOLLARSIGN = 36;
-    ASTERISK2 = 42;
-    EQUALSSIGN = 61;
-    CIRCUMFLEXACCENT = 94;
-    VERTICALLINE2 = 124;
-    TILDE = 126;
-    name4 = "AttributeSelector";
-    structure4 = {
-      name: "Identifier",
-      matcher: [String, null],
-      value: ["String", "Identifier", null],
-      flags: [String, null]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Block.js
-var Block_exports = {};
-__export(Block_exports, {
-  generate: () => generate6,
-  name: () => name5,
-  parse: () => parse7,
-  structure: () => structure5,
-  walkContext: () => walkContext3
-});
-function consumeRaw2() {
-  return this.Raw(null, true);
-}
-function consumeRule() {
-  return this.parseWithFallback(this.Rule, consumeRaw2);
-}
-function consumeRawDeclaration() {
-  return this.Raw(this.consumeUntilSemicolonIncluded, true);
-}
-function consumeDeclaration() {
-  if (this.tokenType === Semicolon) {
-    return consumeRawDeclaration.call(this, this.tokenIndex);
-  }
-  const node2 = this.parseWithFallback(this.Declaration, consumeRawDeclaration);
-  if (this.tokenType === Semicolon) {
-    this.next();
-  }
-  return node2;
-}
-function parse7(isStyleBlock) {
-  const consumer = isStyleBlock ? consumeDeclaration : consumeRule;
-  const start = this.tokenStart;
-  let children = this.createList();
-  this.eat(LeftCurlyBracket);
-  scan:
-    while (!this.eof) {
-      switch (this.tokenType) {
-        case RightCurlyBracket:
-          break scan;
-        case WhiteSpace:
-        case Comment:
-          this.next();
-          break;
-        case AtKeyword:
-          children.push(this.parseWithFallback(this.Atrule.bind(this, isStyleBlock), consumeRaw2));
-          break;
-        default:
-          if (isStyleBlock && this.isDelim(AMPERSAND2)) {
-            children.push(consumeRule.call(this));
-          } else {
-            children.push(consumer.call(this));
-          }
-      }
-    }
-  if (!this.eof) {
-    this.eat(RightCurlyBracket);
-  }
-  return {
-    type: "Block",
-    loc: this.getLocation(start, this.tokenStart),
-    children
-  };
-}
-function generate6(node2) {
-  this.token(LeftCurlyBracket, "{");
-  this.children(node2, (prev) => {
-    if (prev.type === "Declaration") {
-      this.token(Semicolon, ";");
-    }
-  });
-  this.token(RightCurlyBracket, "}");
-}
-var AMPERSAND2, name5, walkContext3, structure5;
-var init_Block = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Block.js"() {
-    init_tokenizer();
-    AMPERSAND2 = 38;
-    name5 = "Block";
-    walkContext3 = "block";
-    structure5 = {
-      children: [[
-        "Atrule",
-        "Rule",
-        "Declaration"
-      ]]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Brackets.js
-var Brackets_exports = {};
-__export(Brackets_exports, {
-  generate: () => generate7,
-  name: () => name6,
-  parse: () => parse8,
-  structure: () => structure6
-});
-function parse8(readSequence2, recognizer) {
-  const start = this.tokenStart;
-  let children = null;
-  this.eat(LeftSquareBracket);
-  children = readSequence2.call(this, recognizer);
-  if (!this.eof) {
-    this.eat(RightSquareBracket);
-  }
-  return {
-    type: "Brackets",
-    loc: this.getLocation(start, this.tokenStart),
-    children
-  };
-}
-function generate7(node2) {
-  this.token(Delim, "[");
-  this.children(node2);
-  this.token(Delim, "]");
-}
-var name6, structure6;
-var init_Brackets = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Brackets.js"() {
-    init_tokenizer();
-    name6 = "Brackets";
-    structure6 = {
-      children: [[]]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/CDC.js
-var CDC_exports = {};
-__export(CDC_exports, {
-  generate: () => generate8,
-  name: () => name7,
-  parse: () => parse9,
-  structure: () => structure7
-});
-function parse9() {
-  const start = this.tokenStart;
-  this.eat(CDC);
-  return {
-    type: "CDC",
-    loc: this.getLocation(start, this.tokenStart)
-  };
-}
-function generate8() {
-  this.token(CDC, "-->");
-}
-var name7, structure7;
-var init_CDC = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/CDC.js"() {
-    init_tokenizer();
-    name7 = "CDC";
-    structure7 = [];
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/CDO.js
-var CDO_exports = {};
-__export(CDO_exports, {
-  generate: () => generate9,
-  name: () => name8,
-  parse: () => parse10,
-  structure: () => structure8
-});
-function parse10() {
-  const start = this.tokenStart;
-  this.eat(CDO);
-  return {
-    type: "CDO",
-    loc: this.getLocation(start, this.tokenStart)
-  };
-}
-function generate9() {
-  this.token(CDO, "<!--");
-}
-var name8, structure8;
-var init_CDO = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/CDO.js"() {
-    init_tokenizer();
-    name8 = "CDO";
-    structure8 = [];
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/ClassSelector.js
-var ClassSelector_exports = {};
-__export(ClassSelector_exports, {
-  generate: () => generate10,
-  name: () => name9,
-  parse: () => parse11,
-  structure: () => structure9
-});
-function parse11() {
-  this.eatDelim(FULLSTOP);
-  return {
-    type: "ClassSelector",
-    loc: this.getLocation(this.tokenStart - 1, this.tokenEnd),
-    name: this.consume(Ident)
-  };
-}
-function generate10(node2) {
-  this.token(Delim, ".");
-  this.token(Ident, node2.name);
-}
-var FULLSTOP, name9, structure9;
-var init_ClassSelector = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/ClassSelector.js"() {
-    init_tokenizer();
-    FULLSTOP = 46;
-    name9 = "ClassSelector";
-    structure9 = {
-      name: String
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Combinator.js
-var Combinator_exports = {};
-__export(Combinator_exports, {
-  generate: () => generate11,
-  name: () => name10,
-  parse: () => parse12,
-  structure: () => structure10
-});
-function parse12() {
-  const start = this.tokenStart;
-  let name50;
-  switch (this.tokenType) {
-    case WhiteSpace:
-      name50 = " ";
-      break;
-    case Delim:
-      switch (this.charCodeAt(this.tokenStart)) {
-        case GREATERTHANSIGN2:
-        case PLUSSIGN6:
-        case TILDE2:
-          this.next();
-          break;
-        case SOLIDUS:
-          this.next();
-          this.eatIdent("deep");
-          this.eatDelim(SOLIDUS);
-          break;
-        default:
-          this.error("Combinator is expected");
-      }
-      name50 = this.substrToCursor(start);
-      break;
-  }
-  return {
-    type: "Combinator",
-    loc: this.getLocation(start, this.tokenStart),
-    name: name50
-  };
-}
-function generate11(node2) {
-  this.tokenize(node2.name);
-}
-var PLUSSIGN6, SOLIDUS, GREATERTHANSIGN2, TILDE2, name10, structure10;
-var init_Combinator = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Combinator.js"() {
-    init_tokenizer();
-    PLUSSIGN6 = 43;
-    SOLIDUS = 47;
-    GREATERTHANSIGN2 = 62;
-    TILDE2 = 126;
-    name10 = "Combinator";
-    structure10 = {
-      name: String
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Comment.js
-var Comment_exports = {};
-__export(Comment_exports, {
-  generate: () => generate12,
-  name: () => name11,
-  parse: () => parse13,
-  structure: () => structure11
-});
-function parse13() {
-  const start = this.tokenStart;
-  let end = this.tokenEnd;
-  this.eat(Comment);
-  if (end - start + 2 >= 2 && this.charCodeAt(end - 2) === ASTERISK3 && this.charCodeAt(end - 1) === SOLIDUS2) {
-    end -= 2;
-  }
-  return {
-    type: "Comment",
-    loc: this.getLocation(start, this.tokenStart),
-    value: this.substring(start + 2, end)
-  };
-}
-function generate12(node2) {
-  this.token(Comment, "/*" + node2.value + "*/");
-}
-var ASTERISK3, SOLIDUS2, name11, structure11;
-var init_Comment = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Comment.js"() {
-    init_tokenizer();
-    ASTERISK3 = 42;
-    SOLIDUS2 = 47;
-    name11 = "Comment";
-    structure11 = {
-      value: String
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Condition.js
-var Condition_exports = {};
-__export(Condition_exports, {
-  generate: () => generate13,
-  name: () => name12,
-  parse: () => parse14,
-  structure: () => structure12
-});
-function featureOrRange(kind2) {
-  if (this.lookupTypeNonSC(1) === Ident && likelyFeatureToken.has(this.lookupTypeNonSC(2))) {
-    return this.Feature(kind2);
-  }
-  return this.FeatureRange(kind2);
-}
-function parse14(kind2 = "media") {
-  const children = this.createList();
-  scan: while (!this.eof) {
-    switch (this.tokenType) {
-      case Comment:
-      case WhiteSpace:
-        this.next();
-        continue;
-      case Ident:
-        children.push(this.Identifier());
-        break;
-      case LeftParenthesis: {
-        let term = this.parseWithFallback(
-          () => parentheses[kind2].call(this, kind2),
-          () => null
-        );
-        if (!term) {
-          term = this.parseWithFallback(
-            () => {
-              this.eat(LeftParenthesis);
-              const res = this.Condition(kind2);
-              this.eat(RightParenthesis);
-              return res;
-            },
-            () => {
-              return this.GeneralEnclosed(kind2);
-            }
-          );
-        }
-        children.push(term);
-        break;
-      }
-      case Function: {
-        let term = this.parseWithFallback(
-          () => this.FeatureFunction(kind2),
-          () => null
-        );
-        if (!term) {
-          term = this.GeneralEnclosed(kind2);
-        }
-        children.push(term);
-        break;
-      }
-      default:
-        break scan;
-    }
-  }
-  if (children.isEmpty) {
-    this.error("Condition is expected");
-  }
-  return {
-    type: "Condition",
-    loc: this.getLocationFromList(children),
-    kind: kind2,
-    children
-  };
-}
-function generate13(node2) {
-  node2.children.forEach((child) => {
-    if (child.type === "Condition") {
-      this.token(LeftParenthesis, "(");
-      this.node(child);
-      this.token(RightParenthesis, ")");
-    } else {
-      this.node(child);
-    }
-  });
-}
-var likelyFeatureToken, name12, structure12, parentheses;
-var init_Condition = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Condition.js"() {
-    init_tokenizer();
-    likelyFeatureToken = /* @__PURE__ */ new Set([Colon, RightParenthesis, EOF]);
-    name12 = "Condition";
-    structure12 = {
-      kind: String,
-      children: [[
-        "Identifier",
-        "Feature",
-        "FeatureFunction",
-        "FeatureRange",
-        "SupportsDeclaration"
-      ]]
-    };
-    parentheses = {
-      media: featureOrRange,
-      container: featureOrRange,
-      supports() {
-        return this.SupportsDeclaration();
-      }
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Declaration.js
-var Declaration_exports = {};
-__export(Declaration_exports, {
-  generate: () => generate14,
-  name: () => name13,
-  parse: () => parse15,
-  structure: () => structure13,
-  walkContext: () => walkContext4
-});
-function consumeValueRaw() {
-  return this.Raw(this.consumeUntilExclamationMarkOrSemicolon, true);
-}
-function consumeCustomPropertyRaw() {
-  return this.Raw(this.consumeUntilExclamationMarkOrSemicolon, false);
-}
-function consumeValue() {
-  const startValueToken = this.tokenIndex;
-  const value = this.Value();
-  if (value.type !== "Raw" && this.eof === false && this.tokenType !== Semicolon && this.isDelim(EXCLAMATIONMARK3) === false && this.isBalanceEdge(startValueToken) === false) {
-    this.error();
-  }
-  return value;
-}
-function parse15() {
-  const start = this.tokenStart;
-  const startToken = this.tokenIndex;
-  const property2 = readProperty2.call(this);
-  const customProperty = isCustomProperty(property2);
-  const parseValue = customProperty ? this.parseCustomProperty : this.parseValue;
-  const consumeRaw6 = customProperty ? consumeCustomPropertyRaw : consumeValueRaw;
-  let important = false;
-  let value;
-  this.skipSC();
-  this.eat(Colon);
-  const valueStart = this.tokenIndex;
-  if (!customProperty) {
-    this.skipSC();
-  }
-  if (parseValue) {
-    value = this.parseWithFallback(consumeValue, consumeRaw6);
-  } else {
-    value = consumeRaw6.call(this, this.tokenIndex);
-  }
-  if (customProperty && value.type === "Value" && value.children.isEmpty) {
-    for (let offset = valueStart - this.tokenIndex; offset <= 0; offset++) {
-      if (this.lookupType(offset) === WhiteSpace) {
-        value.children.appendData({
-          type: "WhiteSpace",
-          loc: null,
-          value: " "
-        });
-        break;
-      }
-    }
-  }
-  if (this.isDelim(EXCLAMATIONMARK3)) {
-    important = getImportant.call(this);
-    this.skipSC();
-  }
-  if (this.eof === false && this.tokenType !== Semicolon && this.isBalanceEdge(startToken) === false) {
-    this.error();
-  }
-  return {
-    type: "Declaration",
-    loc: this.getLocation(start, this.tokenStart),
-    important,
-    property: property2,
-    value
-  };
-}
-function generate14(node2) {
-  this.token(Ident, node2.property);
-  this.token(Colon, ":");
-  this.node(node2.value);
-  if (node2.important) {
-    this.token(Delim, "!");
-    this.token(Ident, node2.important === true ? "important" : node2.important);
-  }
-}
-function readProperty2() {
-  const start = this.tokenStart;
-  if (this.tokenType === Delim) {
-    switch (this.charCodeAt(this.tokenStart)) {
-      case ASTERISK4:
-      case DOLLARSIGN2:
-      case PLUSSIGN7:
-      case NUMBERSIGN3:
-      case AMPERSAND3:
-        this.next();
-        break;
-      // TODO: not sure we should support this hack
-      case SOLIDUS3:
-        this.next();
-        if (this.isDelim(SOLIDUS3)) {
-          this.next();
-        }
-        break;
-    }
-  }
-  if (this.tokenType === Hash) {
-    this.eat(Hash);
-  } else {
-    this.eat(Ident);
-  }
-  return this.substrToCursor(start);
-}
-function getImportant() {
-  this.eat(Delim);
-  this.skipSC();
-  const important = this.consume(Ident);
-  return important === "important" ? true : important;
-}
-var EXCLAMATIONMARK3, NUMBERSIGN3, DOLLARSIGN2, AMPERSAND3, ASTERISK4, PLUSSIGN7, SOLIDUS3, name13, walkContext4, structure13;
-var init_Declaration = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Declaration.js"() {
-    init_names2();
-    init_tokenizer();
-    EXCLAMATIONMARK3 = 33;
-    NUMBERSIGN3 = 35;
-    DOLLARSIGN2 = 36;
-    AMPERSAND3 = 38;
-    ASTERISK4 = 42;
-    PLUSSIGN7 = 43;
-    SOLIDUS3 = 47;
-    name13 = "Declaration";
-    walkContext4 = "declaration";
-    structure13 = {
-      important: [Boolean, String],
-      property: String,
-      value: ["Value", "Raw"]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/DeclarationList.js
-var DeclarationList_exports = {};
-__export(DeclarationList_exports, {
-  generate: () => generate15,
-  name: () => name14,
-  parse: () => parse16,
-  structure: () => structure14
-});
-function consumeRaw3() {
-  return this.Raw(this.consumeUntilSemicolonIncluded, true);
-}
-function parse16() {
-  const children = this.createList();
-  scan:
-    while (!this.eof) {
-      switch (this.tokenType) {
-        case WhiteSpace:
-        case Comment:
-        case Semicolon:
-          this.next();
-          break;
-        case AtKeyword:
-          children.push(this.parseWithFallback(this.Atrule.bind(this, true), consumeRaw3));
-          break;
-        default:
-          if (this.isDelim(AMPERSAND4)) {
-            children.push(this.parseWithFallback(this.Rule, consumeRaw3));
-          } else {
-            children.push(this.parseWithFallback(this.Declaration, consumeRaw3));
-          }
-      }
-    }
-  return {
-    type: "DeclarationList",
-    loc: this.getLocationFromList(children),
-    children
-  };
-}
-function generate15(node2) {
-  this.children(node2, (prev) => {
-    if (prev.type === "Declaration") {
-      this.token(Semicolon, ";");
-    }
-  });
-}
-var AMPERSAND4, name14, structure14;
-var init_DeclarationList = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/DeclarationList.js"() {
-    init_tokenizer();
-    AMPERSAND4 = 38;
-    name14 = "DeclarationList";
-    structure14 = {
-      children: [[
-        "Declaration",
-        "Atrule",
-        "Rule"
-      ]]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Dimension.js
-var Dimension_exports = {};
-__export(Dimension_exports, {
-  generate: () => generate16,
-  name: () => name15,
-  parse: () => parse17,
-  structure: () => structure15
-});
-function parse17() {
-  const start = this.tokenStart;
-  const value = this.consumeNumber(Dimension);
-  return {
-    type: "Dimension",
-    loc: this.getLocation(start, this.tokenStart),
-    value,
-    unit: this.substring(start + value.length, this.tokenStart)
-  };
-}
-function generate16(node2) {
-  this.token(Dimension, node2.value + node2.unit);
-}
-var name15, structure15;
-var init_Dimension = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Dimension.js"() {
-    init_tokenizer();
-    name15 = "Dimension";
-    structure15 = {
-      value: String,
-      unit: String
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Feature.js
-var Feature_exports = {};
-__export(Feature_exports, {
-  generate: () => generate17,
-  name: () => name16,
-  parse: () => parse18,
-  structure: () => structure16
-});
-function parse18(kind2) {
-  const start = this.tokenStart;
-  let name50;
-  let value = null;
-  this.eat(LeftParenthesis);
-  this.skipSC();
-  name50 = this.consume(Ident);
-  this.skipSC();
-  if (this.tokenType !== RightParenthesis) {
-    this.eat(Colon);
-    this.skipSC();
-    switch (this.tokenType) {
-      case Number2:
-        if (this.lookupNonWSType(1) === Delim) {
-          value = this.Ratio();
-        } else {
-          value = this.Number();
-        }
-        break;
-      case Dimension:
-        value = this.Dimension();
-        break;
-      case Ident:
-        value = this.Identifier();
-        break;
-      case Function:
-        value = this.parseWithFallback(
-          () => {
-            const res = this.Function(this.readSequence, this.scope.Value);
-            this.skipSC();
-            if (this.isDelim(SOLIDUS4)) {
-              this.error();
-            }
-            return res;
-          },
-          () => {
-            return this.Ratio();
-          }
-        );
-        break;
-      default:
-        this.error("Number, dimension, ratio or identifier is expected");
-    }
-    this.skipSC();
-  }
-  if (!this.eof) {
-    this.eat(RightParenthesis);
-  }
-  return {
-    type: "Feature",
-    loc: this.getLocation(start, this.tokenStart),
-    kind: kind2,
-    name: name50,
-    value
-  };
-}
-function generate17(node2) {
-  this.token(LeftParenthesis, "(");
-  this.token(Ident, node2.name);
-  if (node2.value !== null) {
-    this.token(Colon, ":");
-    this.node(node2.value);
-  }
-  this.token(RightParenthesis, ")");
-}
-var SOLIDUS4, name16, structure16;
-var init_Feature = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Feature.js"() {
-    init_tokenizer();
-    SOLIDUS4 = 47;
-    name16 = "Feature";
-    structure16 = {
-      kind: String,
-      name: String,
-      value: ["Identifier", "Number", "Dimension", "Ratio", "Function", null]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/FeatureFunction.js
-var FeatureFunction_exports = {};
-__export(FeatureFunction_exports, {
-  generate: () => generate18,
-  name: () => name17,
-  parse: () => parse19,
-  structure: () => structure17
-});
-function getFeatureParser(kind2, name50) {
-  const featuresOfKind = this.features[kind2] || {};
-  const parser = featuresOfKind[name50];
-  if (typeof parser !== "function") {
-    this.error(`Unknown feature ${name50}()`);
-  }
-  return parser;
-}
-function parse19(kind2 = "unknown") {
-  const start = this.tokenStart;
-  const functionName = this.consumeFunctionName();
-  const valueParser = getFeatureParser.call(this, kind2, functionName.toLowerCase());
-  this.skipSC();
-  const value = this.parseWithFallback(
-    () => {
-      const startValueToken = this.tokenIndex;
-      const value2 = valueParser.call(this);
-      if (this.eof === false && this.isBalanceEdge(startValueToken) === false) {
-        this.error();
-      }
-      return value2;
-    },
-    () => this.Raw(null, false)
-  );
-  if (!this.eof) {
-    this.eat(RightParenthesis);
-  }
-  return {
-    type: "FeatureFunction",
-    loc: this.getLocation(start, this.tokenStart),
-    kind: kind2,
-    feature: functionName,
-    value
-  };
-}
-function generate18(node2) {
-  this.token(Function, node2.feature + "(");
-  this.node(node2.value);
-  this.token(RightParenthesis, ")");
-}
-var name17, structure17;
-var init_FeatureFunction = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/FeatureFunction.js"() {
-    init_tokenizer();
-    name17 = "FeatureFunction";
-    structure17 = {
-      kind: String,
-      feature: String,
-      value: ["Declaration", "Selector"]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/FeatureRange.js
-var FeatureRange_exports = {};
-__export(FeatureRange_exports, {
-  generate: () => generate19,
-  name: () => name18,
-  parse: () => parse20,
-  structure: () => structure18
-});
-function readTerm() {
-  this.skipSC();
-  switch (this.tokenType) {
-    case Number2:
-      if (this.isDelim(SOLIDUS5, this.lookupOffsetNonSC(1))) {
-        return this.Ratio();
-      } else {
-        return this.Number();
-      }
-    case Dimension:
-      return this.Dimension();
-    case Ident:
-      return this.Identifier();
-    case Function:
-      return this.parseWithFallback(
-        () => {
-          const res = this.Function(this.readSequence, this.scope.Value);
-          this.skipSC();
-          if (this.isDelim(SOLIDUS5)) {
-            this.error();
-          }
-          return res;
-        },
-        () => {
-          return this.Ratio();
-        }
-      );
-    default:
-      this.error("Number, dimension, ratio or identifier is expected");
-  }
-}
-function readComparison(expectColon) {
-  this.skipSC();
-  if (this.isDelim(LESSTHANSIGN2) || this.isDelim(GREATERTHANSIGN3)) {
-    const value = this.source[this.tokenStart];
-    this.next();
-    if (this.isDelim(EQUALSSIGN2)) {
-      this.next();
-      return value + "=";
-    }
-    return value;
-  }
-  if (this.isDelim(EQUALSSIGN2)) {
-    return "=";
-  }
-  this.error(`Expected ${expectColon ? '":", ' : ""}"<", ">", "=" or ")"`);
-}
-function parse20(kind2 = "unknown") {
-  const start = this.tokenStart;
-  this.skipSC();
-  this.eat(LeftParenthesis);
-  const left = readTerm.call(this);
-  const leftComparison = readComparison.call(this, left.type === "Identifier");
-  const middle = readTerm.call(this);
-  let rightComparison = null;
-  let right = null;
-  if (this.lookupNonWSType(0) !== RightParenthesis) {
-    rightComparison = readComparison.call(this);
-    right = readTerm.call(this);
-  }
-  this.skipSC();
-  this.eat(RightParenthesis);
-  return {
-    type: "FeatureRange",
-    loc: this.getLocation(start, this.tokenStart),
-    kind: kind2,
-    left,
-    leftComparison,
-    middle,
-    rightComparison,
-    right
-  };
-}
-function generate19(node2) {
-  this.token(LeftParenthesis, "(");
-  this.node(node2.left);
-  this.tokenize(node2.leftComparison);
-  this.node(node2.middle);
-  if (node2.right) {
-    this.tokenize(node2.rightComparison);
-    this.node(node2.right);
-  }
-  this.token(RightParenthesis, ")");
-}
-var SOLIDUS5, LESSTHANSIGN2, EQUALSSIGN2, GREATERTHANSIGN3, name18, structure18;
-var init_FeatureRange = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/FeatureRange.js"() {
-    init_tokenizer();
-    SOLIDUS5 = 47;
-    LESSTHANSIGN2 = 60;
-    EQUALSSIGN2 = 61;
-    GREATERTHANSIGN3 = 62;
-    name18 = "FeatureRange";
-    structure18 = {
-      kind: String,
-      left: ["Identifier", "Number", "Dimension", "Ratio", "Function"],
-      leftComparison: String,
-      middle: ["Identifier", "Number", "Dimension", "Ratio", "Function"],
-      rightComparison: [String, null],
-      right: ["Identifier", "Number", "Dimension", "Ratio", "Function", null]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Function.js
-var Function_exports = {};
-__export(Function_exports, {
-  generate: () => generate20,
-  name: () => name19,
-  parse: () => parse21,
-  structure: () => structure19,
-  walkContext: () => walkContext5
-});
-function parse21(readSequence2, recognizer) {
-  const start = this.tokenStart;
-  const name50 = this.consumeFunctionName();
-  const nameLowerCase = name50.toLowerCase();
-  let children;
-  children = recognizer.hasOwnProperty(nameLowerCase) ? recognizer[nameLowerCase].call(this, recognizer) : readSequence2.call(this, recognizer);
-  if (!this.eof) {
-    this.eat(RightParenthesis);
-  }
-  return {
-    type: "Function",
-    loc: this.getLocation(start, this.tokenStart),
-    name: name50,
-    children
-  };
-}
-function generate20(node2) {
-  this.token(Function, node2.name + "(");
-  this.children(node2);
-  this.token(RightParenthesis, ")");
-}
-var name19, walkContext5, structure19;
-var init_Function = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Function.js"() {
-    init_tokenizer();
-    name19 = "Function";
-    walkContext5 = "function";
-    structure19 = {
-      name: String,
-      children: [[]]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/GeneralEnclosed.js
-var GeneralEnclosed_exports = {};
-__export(GeneralEnclosed_exports, {
-  generate: () => generate21,
-  name: () => name20,
-  parse: () => parse22,
-  structure: () => structure20
-});
-function parse22(kind2) {
-  const start = this.tokenStart;
-  let functionName = null;
-  if (this.tokenType === Function) {
-    functionName = this.consumeFunctionName();
-  } else {
-    this.eat(LeftParenthesis);
-  }
-  const children = this.parseWithFallback(
-    () => {
-      const startValueToken = this.tokenIndex;
-      const children2 = this.readSequence(this.scope.Value);
-      if (this.eof === false && this.isBalanceEdge(startValueToken) === false) {
-        this.error();
-      }
-      return children2;
-    },
-    () => this.createSingleNodeList(
-      this.Raw(null, false)
-    )
-  );
-  if (!this.eof) {
-    this.eat(RightParenthesis);
-  }
-  return {
-    type: "GeneralEnclosed",
-    loc: this.getLocation(start, this.tokenStart),
-    kind: kind2,
-    function: functionName,
-    children
-  };
-}
-function generate21(node2) {
-  if (node2.function) {
-    this.token(Function, node2.function + "(");
-  } else {
-    this.token(LeftParenthesis, "(");
-  }
-  this.children(node2);
-  this.token(RightParenthesis, ")");
-}
-var name20, structure20;
-var init_GeneralEnclosed = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/GeneralEnclosed.js"() {
-    init_tokenizer();
-    name20 = "GeneralEnclosed";
-    structure20 = {
-      kind: String,
-      function: [String, null],
-      children: [[]]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Hash.js
-var Hash_exports = {};
-__export(Hash_exports, {
-  generate: () => generate22,
-  name: () => name21,
-  parse: () => parse23,
-  structure: () => structure21,
-  xxx: () => xxx
-});
-function parse23() {
-  const start = this.tokenStart;
-  this.eat(Hash);
-  return {
-    type: "Hash",
-    loc: this.getLocation(start, this.tokenStart),
-    value: this.substrToCursor(start + 1)
-  };
-}
-function generate22(node2) {
-  this.token(Hash, "#" + node2.value);
-}
-var xxx, name21, structure21;
-var init_Hash = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Hash.js"() {
-    init_tokenizer();
-    xxx = "XXX";
-    name21 = "Hash";
-    structure21 = {
-      value: String
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Identifier.js
-var Identifier_exports = {};
-__export(Identifier_exports, {
-  generate: () => generate23,
-  name: () => name22,
-  parse: () => parse24,
-  structure: () => structure22
-});
-function parse24() {
-  return {
-    type: "Identifier",
-    loc: this.getLocation(this.tokenStart, this.tokenEnd),
-    name: this.consume(Ident)
-  };
-}
-function generate23(node2) {
-  this.token(Ident, node2.name);
-}
-var name22, structure22;
-var init_Identifier = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Identifier.js"() {
-    init_tokenizer();
-    name22 = "Identifier";
-    structure22 = {
-      name: String
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/IdSelector.js
-var IdSelector_exports = {};
-__export(IdSelector_exports, {
-  generate: () => generate24,
-  name: () => name23,
-  parse: () => parse25,
-  structure: () => structure23
-});
-function parse25() {
-  const start = this.tokenStart;
-  this.eat(Hash);
-  return {
-    type: "IdSelector",
-    loc: this.getLocation(start, this.tokenStart),
-    name: this.substrToCursor(start + 1)
-  };
-}
-function generate24(node2) {
-  this.token(Delim, "#" + node2.name);
-}
-var name23, structure23;
-var init_IdSelector = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/IdSelector.js"() {
-    init_tokenizer();
-    name23 = "IdSelector";
-    structure23 = {
-      name: String
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Layer.js
-var Layer_exports = {};
-__export(Layer_exports, {
-  generate: () => generate25,
-  name: () => name24,
-  parse: () => parse26,
-  structure: () => structure24
-});
-function parse26() {
-  let tokenStart = this.tokenStart;
-  let name50 = this.consume(Ident);
-  while (this.isDelim(FULLSTOP2)) {
-    this.eat(Delim);
-    name50 += "." + this.consume(Ident);
-  }
-  return {
-    type: "Layer",
-    loc: this.getLocation(tokenStart, this.tokenStart),
-    name: name50
-  };
-}
-function generate25(node2) {
-  this.tokenize(node2.name);
-}
-var FULLSTOP2, name24, structure24;
-var init_Layer = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Layer.js"() {
-    init_tokenizer();
-    FULLSTOP2 = 46;
-    name24 = "Layer";
-    structure24 = {
-      name: String
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/LayerList.js
-var LayerList_exports = {};
-__export(LayerList_exports, {
-  generate: () => generate26,
-  name: () => name25,
-  parse: () => parse27,
-  structure: () => structure25
-});
-function parse27() {
-  const children = this.createList();
-  this.skipSC();
-  while (!this.eof) {
-    children.push(this.Layer());
-    if (this.lookupTypeNonSC(0) !== Comma) {
-      break;
-    }
-    this.skipSC();
-    this.next();
-    this.skipSC();
-  }
-  return {
-    type: "LayerList",
-    loc: this.getLocationFromList(children),
-    children
-  };
-}
-function generate26(node2) {
-  this.children(node2, () => this.token(Comma, ","));
-}
-var name25, structure25;
-var init_LayerList = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/LayerList.js"() {
-    init_tokenizer();
-    name25 = "LayerList";
-    structure25 = {
-      children: [[
-        "Layer"
-      ]]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/MediaQuery.js
-var MediaQuery_exports = {};
-__export(MediaQuery_exports, {
-  generate: () => generate27,
-  name: () => name26,
-  parse: () => parse28,
-  structure: () => structure26
-});
-function parse28() {
-  const start = this.tokenStart;
-  let modifier = null;
-  let mediaType = null;
-  let condition = null;
-  this.skipSC();
-  if (this.tokenType === Ident && this.lookupTypeNonSC(1) !== LeftParenthesis) {
-    const ident = this.consume(Ident);
-    const identLowerCase = ident.toLowerCase();
-    if (identLowerCase === "not" || identLowerCase === "only") {
-      this.skipSC();
-      modifier = identLowerCase;
-      mediaType = this.consume(Ident);
-    } else {
-      mediaType = ident;
-    }
-    switch (this.lookupTypeNonSC(0)) {
-      case Ident: {
-        this.skipSC();
-        this.eatIdent("and");
-        condition = this.Condition("media");
-        break;
-      }
-      case LeftCurlyBracket:
-      case Semicolon:
-      case Comma:
-      case EOF:
-        break;
-      default:
-        this.error("Identifier or parenthesis is expected");
-    }
-  } else {
-    switch (this.tokenType) {
-      case Ident:
-      case LeftParenthesis:
-      case Function: {
-        condition = this.Condition("media");
-        break;
-      }
-      case LeftCurlyBracket:
-      case Semicolon:
-      case EOF:
-        break;
-      default:
-        this.error("Identifier or parenthesis is expected");
-    }
-  }
-  return {
-    type: "MediaQuery",
-    loc: this.getLocation(start, this.tokenStart),
-    modifier,
-    mediaType,
-    condition
-  };
-}
-function generate27(node2) {
-  if (node2.mediaType) {
-    if (node2.modifier) {
-      this.token(Ident, node2.modifier);
-    }
-    this.token(Ident, node2.mediaType);
-    if (node2.condition) {
-      this.token(Ident, "and");
-      this.node(node2.condition);
-    }
-  } else if (node2.condition) {
-    this.node(node2.condition);
-  }
-}
-var name26, structure26;
-var init_MediaQuery = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/MediaQuery.js"() {
-    init_tokenizer();
-    name26 = "MediaQuery";
-    structure26 = {
-      modifier: [String, null],
-      mediaType: [String, null],
-      condition: ["Condition", null]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/MediaQueryList.js
-var MediaQueryList_exports = {};
-__export(MediaQueryList_exports, {
-  generate: () => generate28,
-  name: () => name27,
-  parse: () => parse29,
-  structure: () => structure27
-});
-function parse29() {
-  const children = this.createList();
-  this.skipSC();
-  while (!this.eof) {
-    children.push(this.MediaQuery());
-    if (this.tokenType !== Comma) {
-      break;
-    }
-    this.next();
-  }
-  return {
-    type: "MediaQueryList",
-    loc: this.getLocationFromList(children),
-    children
-  };
-}
-function generate28(node2) {
-  this.children(node2, () => this.token(Comma, ","));
-}
-var name27, structure27;
-var init_MediaQueryList = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/MediaQueryList.js"() {
-    init_tokenizer();
-    name27 = "MediaQueryList";
-    structure27 = {
-      children: [[
-        "MediaQuery"
-      ]]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/NestingSelector.js
-var NestingSelector_exports = {};
-__export(NestingSelector_exports, {
-  generate: () => generate29,
-  name: () => name28,
-  parse: () => parse30,
-  structure: () => structure28
-});
-function parse30() {
-  const start = this.tokenStart;
-  this.eatDelim(AMPERSAND5);
-  return {
-    type: "NestingSelector",
-    loc: this.getLocation(start, this.tokenStart)
-  };
-}
-function generate29() {
-  this.token(Delim, "&");
-}
-var AMPERSAND5, name28, structure28;
-var init_NestingSelector = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/NestingSelector.js"() {
-    init_tokenizer();
-    AMPERSAND5 = 38;
-    name28 = "NestingSelector";
-    structure28 = {};
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Nth.js
-var Nth_exports = {};
-__export(Nth_exports, {
-  generate: () => generate30,
-  name: () => name29,
-  parse: () => parse31,
-  structure: () => structure29
-});
-function parse31() {
-  this.skipSC();
-  const start = this.tokenStart;
-  let end = start;
-  let selector2 = null;
-  let nth2;
-  if (this.lookupValue(0, "odd") || this.lookupValue(0, "even")) {
-    nth2 = this.Identifier();
-  } else {
-    nth2 = this.AnPlusB();
-  }
-  end = this.tokenStart;
-  this.skipSC();
-  if (this.lookupValue(0, "of")) {
-    this.next();
-    selector2 = this.SelectorList();
-    end = this.tokenStart;
-  }
-  return {
-    type: "Nth",
-    loc: this.getLocation(start, end),
-    nth: nth2,
-    selector: selector2
-  };
-}
-function generate30(node2) {
-  this.node(node2.nth);
-  if (node2.selector !== null) {
-    this.token(Ident, "of");
-    this.node(node2.selector);
-  }
-}
-var name29, structure29;
-var init_Nth = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Nth.js"() {
-    init_tokenizer();
-    name29 = "Nth";
-    structure29 = {
-      nth: ["AnPlusB", "Identifier"],
-      selector: ["SelectorList", null]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Number.js
-var Number_exports = {};
-__export(Number_exports, {
-  generate: () => generate31,
-  name: () => name30,
-  parse: () => parse32,
-  structure: () => structure30
-});
-function parse32() {
-  return {
-    type: "Number",
-    loc: this.getLocation(this.tokenStart, this.tokenEnd),
-    value: this.consume(Number2)
-  };
-}
-function generate31(node2) {
-  this.token(Number2, node2.value);
-}
-var name30, structure30;
-var init_Number = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Number.js"() {
-    init_tokenizer();
-    name30 = "Number";
-    structure30 = {
-      value: String
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Operator.js
-var Operator_exports = {};
-__export(Operator_exports, {
-  generate: () => generate32,
-  name: () => name31,
-  parse: () => parse33,
-  structure: () => structure31
-});
-function parse33() {
-  const start = this.tokenStart;
-  this.next();
-  return {
-    type: "Operator",
-    loc: this.getLocation(start, this.tokenStart),
-    value: this.substrToCursor(start)
-  };
-}
-function generate32(node2) {
-  this.tokenize(node2.value);
-}
-var name31, structure31;
-var init_Operator = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Operator.js"() {
-    name31 = "Operator";
-    structure31 = {
-      value: String
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Parentheses.js
-var Parentheses_exports = {};
-__export(Parentheses_exports, {
-  generate: () => generate33,
-  name: () => name32,
-  parse: () => parse34,
-  structure: () => structure32
-});
-function parse34(readSequence2, recognizer) {
-  const start = this.tokenStart;
-  let children = null;
-  this.eat(LeftParenthesis);
-  children = readSequence2.call(this, recognizer);
-  if (!this.eof) {
-    this.eat(RightParenthesis);
-  }
-  return {
-    type: "Parentheses",
-    loc: this.getLocation(start, this.tokenStart),
-    children
-  };
-}
-function generate33(node2) {
-  this.token(LeftParenthesis, "(");
-  this.children(node2);
-  this.token(RightParenthesis, ")");
-}
-var name32, structure32;
-var init_Parentheses = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Parentheses.js"() {
-    init_tokenizer();
-    name32 = "Parentheses";
-    structure32 = {
-      children: [[]]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Percentage.js
-var Percentage_exports = {};
-__export(Percentage_exports, {
-  generate: () => generate34,
-  name: () => name33,
-  parse: () => parse35,
-  structure: () => structure33
-});
-function parse35() {
-  return {
-    type: "Percentage",
-    loc: this.getLocation(this.tokenStart, this.tokenEnd),
-    value: this.consumeNumber(Percentage)
-  };
-}
-function generate34(node2) {
-  this.token(Percentage, node2.value + "%");
-}
-var name33, structure33;
-var init_Percentage = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Percentage.js"() {
-    init_tokenizer();
-    name33 = "Percentage";
-    structure33 = {
-      value: String
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/PseudoClassSelector.js
-var PseudoClassSelector_exports = {};
-__export(PseudoClassSelector_exports, {
-  generate: () => generate35,
-  name: () => name34,
-  parse: () => parse36,
-  structure: () => structure34,
-  walkContext: () => walkContext6
-});
-function parse36() {
-  const start = this.tokenStart;
-  let children = null;
-  let name50;
-  let nameLowerCase;
-  this.eat(Colon);
-  if (this.tokenType === Function) {
-    name50 = this.consumeFunctionName();
-    nameLowerCase = name50.toLowerCase();
-    if (this.lookupNonWSType(0) == RightParenthesis) {
-      children = this.createList();
-    } else if (hasOwnProperty.call(this.pseudo, nameLowerCase)) {
-      this.skipSC();
-      children = this.pseudo[nameLowerCase].call(this);
-      this.skipSC();
-    } else {
-      children = this.createList();
-      children.push(
-        this.Raw(null, false)
-      );
-    }
-    this.eat(RightParenthesis);
-  } else {
-    name50 = this.consume(Ident);
-  }
-  return {
-    type: "PseudoClassSelector",
-    loc: this.getLocation(start, this.tokenStart),
-    name: name50,
-    children
-  };
-}
-function generate35(node2) {
-  this.token(Colon, ":");
-  if (node2.children === null) {
-    this.token(Ident, node2.name);
-  } else {
-    this.token(Function, node2.name + "(");
-    this.children(node2);
-    this.token(RightParenthesis, ")");
-  }
-}
-var name34, walkContext6, structure34;
-var init_PseudoClassSelector = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/PseudoClassSelector.js"() {
-    init_tokenizer();
-    name34 = "PseudoClassSelector";
-    walkContext6 = "function";
-    structure34 = {
-      name: String,
-      children: [["Raw"], null]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/PseudoElementSelector.js
-var PseudoElementSelector_exports = {};
-__export(PseudoElementSelector_exports, {
-  generate: () => generate36,
-  name: () => name35,
-  parse: () => parse37,
-  structure: () => structure35,
-  walkContext: () => walkContext7
-});
-function parse37() {
-  const start = this.tokenStart;
-  let children = null;
-  let name50;
-  let nameLowerCase;
-  this.eat(Colon);
-  this.eat(Colon);
-  if (this.tokenType === Function) {
-    name50 = this.consumeFunctionName();
-    nameLowerCase = name50.toLowerCase();
-    if (this.lookupNonWSType(0) == RightParenthesis) {
-      children = this.createList();
-    } else if (hasOwnProperty.call(this.pseudo, nameLowerCase)) {
-      this.skipSC();
-      children = this.pseudo[nameLowerCase].call(this);
-      this.skipSC();
-    } else {
-      children = this.createList();
-      children.push(
-        this.Raw(null, false)
-      );
-    }
-    this.eat(RightParenthesis);
-  } else {
-    name50 = this.consume(Ident);
-  }
-  return {
-    type: "PseudoElementSelector",
-    loc: this.getLocation(start, this.tokenStart),
-    name: name50,
-    children
-  };
-}
-function generate36(node2) {
-  this.token(Colon, ":");
-  this.token(Colon, ":");
-  if (node2.children === null) {
-    this.token(Ident, node2.name);
-  } else {
-    this.token(Function, node2.name + "(");
-    this.children(node2);
-    this.token(RightParenthesis, ")");
-  }
-}
-var name35, walkContext7, structure35;
-var init_PseudoElementSelector = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/PseudoElementSelector.js"() {
-    init_tokenizer();
-    name35 = "PseudoElementSelector";
-    walkContext7 = "function";
-    structure35 = {
-      name: String,
-      children: [["Raw"], null]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Ratio.js
-var Ratio_exports = {};
-__export(Ratio_exports, {
-  generate: () => generate37,
-  name: () => name36,
-  parse: () => parse38,
-  structure: () => structure36
-});
-function consumeTerm() {
-  this.skipSC();
-  switch (this.tokenType) {
-    case Number2:
-      return this.Number();
-    case Function:
-      return this.Function(this.readSequence, this.scope.Value);
-    default:
-      this.error("Number of function is expected");
-  }
-}
-function parse38() {
-  const start = this.tokenStart;
-  const left = consumeTerm.call(this);
-  let right = null;
-  this.skipSC();
-  if (this.isDelim(SOLIDUS6)) {
-    this.eatDelim(SOLIDUS6);
-    right = consumeTerm.call(this);
-  }
-  return {
-    type: "Ratio",
-    loc: this.getLocation(start, this.tokenStart),
-    left,
-    right
-  };
-}
-function generate37(node2) {
-  this.node(node2.left);
-  this.token(Delim, "/");
-  if (node2.right) {
-    this.node(node2.right);
-  } else {
-    this.node(Number2, 1);
-  }
-}
-var SOLIDUS6, name36, structure36;
-var init_Ratio = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Ratio.js"() {
-    init_tokenizer();
-    SOLIDUS6 = 47;
-    name36 = "Ratio";
-    structure36 = {
-      left: ["Number", "Function"],
-      right: ["Number", "Function", null]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Raw.js
-var Raw_exports = {};
-__export(Raw_exports, {
-  generate: () => generate38,
-  name: () => name37,
-  parse: () => parse39,
-  structure: () => structure37
-});
-function getOffsetExcludeWS() {
-  if (this.tokenIndex > 0) {
-    if (this.lookupType(-1) === WhiteSpace) {
-      return this.tokenIndex > 1 ? this.getTokenStart(this.tokenIndex - 1) : this.firstCharOffset;
-    }
-  }
-  return this.tokenStart;
-}
-function parse39(consumeUntil, excludeWhiteSpace) {
-  const startOffset = this.getTokenStart(this.tokenIndex);
-  let endOffset;
-  this.skipUntilBalanced(this.tokenIndex, consumeUntil || this.consumeUntilBalanceEnd);
-  if (excludeWhiteSpace && this.tokenStart > startOffset) {
-    endOffset = getOffsetExcludeWS.call(this);
-  } else {
-    endOffset = this.tokenStart;
-  }
-  return {
-    type: "Raw",
-    loc: this.getLocation(startOffset, endOffset),
-    value: this.substring(startOffset, endOffset)
-  };
-}
-function generate38(node2) {
-  this.tokenize(node2.value);
-}
-var name37, structure37;
-var init_Raw = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Raw.js"() {
-    init_tokenizer();
-    name37 = "Raw";
-    structure37 = {
-      value: String
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Rule.js
-var Rule_exports = {};
-__export(Rule_exports, {
-  generate: () => generate39,
-  name: () => name38,
-  parse: () => parse40,
-  structure: () => structure38,
-  walkContext: () => walkContext8
-});
-function consumeRaw4() {
-  return this.Raw(this.consumeUntilLeftCurlyBracket, true);
-}
-function consumePrelude() {
-  const prelude = this.SelectorList();
-  if (prelude.type !== "Raw" && this.eof === false && this.tokenType !== LeftCurlyBracket) {
-    this.error();
-  }
-  return prelude;
-}
-function parse40() {
-  const startToken = this.tokenIndex;
-  const startOffset = this.tokenStart;
-  let prelude;
-  let block;
-  if (this.parseRulePrelude) {
-    prelude = this.parseWithFallback(consumePrelude, consumeRaw4);
-  } else {
-    prelude = consumeRaw4.call(this, startToken);
-  }
-  block = this.Block(true);
-  return {
-    type: "Rule",
-    loc: this.getLocation(startOffset, this.tokenStart),
-    prelude,
-    block
-  };
-}
-function generate39(node2) {
-  this.node(node2.prelude);
-  this.node(node2.block);
-}
-var name38, walkContext8, structure38;
-var init_Rule = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Rule.js"() {
-    init_tokenizer();
-    name38 = "Rule";
-    walkContext8 = "rule";
-    structure38 = {
-      prelude: ["SelectorList", "Raw"],
-      block: ["Block"]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Scope.js
-var Scope_exports = {};
-__export(Scope_exports, {
-  generate: () => generate40,
-  name: () => name39,
-  parse: () => parse41,
-  structure: () => structure39
-});
-function parse41() {
-  let root2 = null;
-  let limit = null;
-  this.skipSC();
-  const startOffset = this.tokenStart;
-  if (this.tokenType === LeftParenthesis) {
-    this.next();
-    this.skipSC();
-    root2 = this.parseWithFallback(
-      this.SelectorList,
-      () => this.Raw(false, true)
-    );
-    this.skipSC();
-    this.eat(RightParenthesis);
-  }
-  if (this.lookupNonWSType(0) === Ident) {
-    this.skipSC();
-    this.eatIdent("to");
-    this.skipSC();
-    this.eat(LeftParenthesis);
-    this.skipSC();
-    limit = this.parseWithFallback(
-      this.SelectorList,
-      () => this.Raw(false, true)
-    );
-    this.skipSC();
-    this.eat(RightParenthesis);
-  }
-  return {
-    type: "Scope",
-    loc: this.getLocation(startOffset, this.tokenStart),
-    root: root2,
-    limit
-  };
-}
-function generate40(node2) {
-  if (node2.root) {
-    this.token(LeftParenthesis, "(");
-    this.node(node2.root);
-    this.token(RightParenthesis, ")");
-  }
-  if (node2.limit) {
-    this.token(Ident, "to");
-    this.token(LeftParenthesis, "(");
-    this.node(node2.limit);
-    this.token(RightParenthesis, ")");
-  }
-}
-var name39, structure39;
-var init_Scope = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Scope.js"() {
-    init_tokenizer();
-    name39 = "Scope";
-    structure39 = {
-      root: ["SelectorList", "Raw", null],
-      limit: ["SelectorList", "Raw", null]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Selector.js
-var Selector_exports = {};
-__export(Selector_exports, {
-  generate: () => generate41,
-  name: () => name40,
-  parse: () => parse42,
-  structure: () => structure40
-});
-function parse42() {
-  const children = this.readSequence(this.scope.Selector);
-  if (this.getFirstListNode(children) === null) {
-    this.error("Selector is expected");
-  }
-  return {
-    type: "Selector",
-    loc: this.getLocationFromList(children),
-    children
-  };
-}
-function generate41(node2) {
-  this.children(node2);
-}
-var name40, structure40;
-var init_Selector = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Selector.js"() {
-    name40 = "Selector";
-    structure40 = {
-      children: [[
-        "TypeSelector",
-        "IdSelector",
-        "ClassSelector",
-        "AttributeSelector",
-        "PseudoClassSelector",
-        "PseudoElementSelector",
-        "Combinator"
-      ]]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/SelectorList.js
-var SelectorList_exports = {};
-__export(SelectorList_exports, {
-  generate: () => generate42,
-  name: () => name41,
-  parse: () => parse43,
-  structure: () => structure41,
-  walkContext: () => walkContext9
-});
-function parse43() {
-  const children = this.createList();
-  while (!this.eof) {
-    children.push(this.Selector());
-    if (this.tokenType === Comma) {
-      this.next();
-      continue;
-    }
-    break;
-  }
-  return {
-    type: "SelectorList",
-    loc: this.getLocationFromList(children),
-    children
-  };
-}
-function generate42(node2) {
-  this.children(node2, () => this.token(Comma, ","));
-}
-var name41, walkContext9, structure41;
-var init_SelectorList = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/SelectorList.js"() {
-    init_tokenizer();
-    name41 = "SelectorList";
-    walkContext9 = "selector";
-    structure41 = {
-      children: [[
-        "Selector",
-        "Raw"
-      ]]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/utils/string.js
-function decode(str) {
-  const len = str.length;
-  const firstChar = str.charCodeAt(0);
-  const start = firstChar === QUOTATION_MARK || firstChar === APOSTROPHE2 ? 1 : 0;
-  const end = start === 1 && len > 1 && str.charCodeAt(len - 1) === firstChar ? len - 2 : len - 1;
-  let decoded = "";
-  for (let i = start; i <= end; i++) {
-    let code4 = str.charCodeAt(i);
-    if (code4 === REVERSE_SOLIDUS) {
-      if (i === end) {
-        if (i !== len - 1) {
-          decoded = str.substr(i + 1);
-        }
-        break;
-      }
-      code4 = str.charCodeAt(++i);
-      if (isValidEscape(REVERSE_SOLIDUS, code4)) {
-        const escapeStart = i - 1;
-        const escapeEnd = consumeEscaped(str, escapeStart);
-        i = escapeEnd - 1;
-        decoded += decodeEscaped(str.substring(escapeStart + 1, escapeEnd));
-      } else {
-        if (code4 === 13 && str.charCodeAt(i + 1) === 10) {
-          i++;
-        }
-      }
-    } else {
-      decoded += str[i];
-    }
-  }
-  return decoded;
-}
-function encode(str, apostrophe) {
-  const quote = apostrophe ? "'" : '"';
-  const quoteCode = apostrophe ? APOSTROPHE2 : QUOTATION_MARK;
-  let encoded = "";
-  let wsBeforeHexIsNeeded = false;
-  for (let i = 0; i < str.length; i++) {
-    const code4 = str.charCodeAt(i);
-    if (code4 === 0) {
-      encoded += "\uFFFD";
-      continue;
-    }
-    if (code4 <= 31 || code4 === 127) {
-      encoded += "\\" + code4.toString(16);
-      wsBeforeHexIsNeeded = true;
-      continue;
-    }
-    if (code4 === quoteCode || code4 === REVERSE_SOLIDUS) {
-      encoded += "\\" + str.charAt(i);
-      wsBeforeHexIsNeeded = false;
-    } else {
-      if (wsBeforeHexIsNeeded && (isHexDigit(code4) || isWhiteSpace(code4))) {
-        encoded += " ";
-      }
-      encoded += str.charAt(i);
-      wsBeforeHexIsNeeded = false;
-    }
-  }
-  return quote + encoded + quote;
-}
-var REVERSE_SOLIDUS, QUOTATION_MARK, APOSTROPHE2;
-var init_string = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/utils/string.js"() {
-    init_tokenizer();
-    REVERSE_SOLIDUS = 92;
-    QUOTATION_MARK = 34;
-    APOSTROPHE2 = 39;
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/String.js
-var String_exports = {};
-__export(String_exports, {
-  generate: () => generate43,
-  name: () => name42,
-  parse: () => parse44,
-  structure: () => structure42
-});
-function parse44() {
-  return {
-    type: "String",
-    loc: this.getLocation(this.tokenStart, this.tokenEnd),
-    value: decode(this.consume(String2))
-  };
-}
-function generate43(node2) {
-  this.token(String2, encode(node2.value));
-}
-var name42, structure42;
-var init_String = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/String.js"() {
-    init_tokenizer();
-    init_string();
-    name42 = "String";
-    structure42 = {
-      value: String
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/StyleSheet.js
-var StyleSheet_exports = {};
-__export(StyleSheet_exports, {
-  generate: () => generate44,
-  name: () => name43,
-  parse: () => parse45,
-  structure: () => structure43,
-  walkContext: () => walkContext10
-});
-function consumeRaw5() {
-  return this.Raw(null, false);
-}
-function parse45() {
-  const start = this.tokenStart;
-  const children = this.createList();
-  let child;
-  scan:
-    while (!this.eof) {
-      switch (this.tokenType) {
-        case WhiteSpace:
-          this.next();
-          continue;
-        case Comment:
-          if (this.charCodeAt(this.tokenStart + 2) !== EXCLAMATIONMARK4) {
-            this.next();
-            continue;
-          }
-          child = this.Comment();
-          break;
-        case CDO:
-          child = this.CDO();
-          break;
-        case CDC:
-          child = this.CDC();
-          break;
-        // CSS Syntax Module Level 3
-        // §2.2 Error handling
-        // At the "top level" of a stylesheet, an <at-keyword-token> starts an at-rule.
-        case AtKeyword:
-          child = this.parseWithFallback(this.Atrule, consumeRaw5);
-          break;
-        // Anything else starts a qualified rule ...
-        default:
-          child = this.parseWithFallback(this.Rule, consumeRaw5);
-      }
-      children.push(child);
-    }
-  return {
-    type: "StyleSheet",
-    loc: this.getLocation(start, this.tokenStart),
-    children
-  };
-}
-function generate44(node2) {
-  this.children(node2);
-}
-var EXCLAMATIONMARK4, name43, walkContext10, structure43;
-var init_StyleSheet = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/StyleSheet.js"() {
-    init_tokenizer();
-    EXCLAMATIONMARK4 = 33;
-    name43 = "StyleSheet";
-    walkContext10 = "stylesheet";
-    structure43 = {
-      children: [[
-        "Comment",
-        "CDO",
-        "CDC",
-        "Atrule",
-        "Rule",
-        "Raw"
-      ]]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/SupportsDeclaration.js
-var SupportsDeclaration_exports = {};
-__export(SupportsDeclaration_exports, {
-  generate: () => generate45,
-  name: () => name44,
-  parse: () => parse46,
-  structure: () => structure44
-});
-function parse46() {
-  const start = this.tokenStart;
-  this.eat(LeftParenthesis);
-  this.skipSC();
-  const declaration = this.Declaration();
-  if (!this.eof) {
-    this.eat(RightParenthesis);
-  }
-  return {
-    type: "SupportsDeclaration",
-    loc: this.getLocation(start, this.tokenStart),
-    declaration
-  };
-}
-function generate45(node2) {
-  this.token(LeftParenthesis, "(");
-  this.node(node2.declaration);
-  this.token(RightParenthesis, ")");
-}
-var name44, structure44;
-var init_SupportsDeclaration = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/SupportsDeclaration.js"() {
-    init_tokenizer();
-    name44 = "SupportsDeclaration";
-    structure44 = {
-      declaration: "Declaration"
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/TypeSelector.js
-var TypeSelector_exports = {};
-__export(TypeSelector_exports, {
-  generate: () => generate46,
-  name: () => name45,
-  parse: () => parse47,
-  structure: () => structure45
-});
-function eatIdentifierOrAsterisk() {
-  if (this.tokenType !== Ident && this.isDelim(ASTERISK5) === false) {
-    this.error("Identifier or asterisk is expected");
-  }
-  this.next();
-}
-function parse47() {
-  const start = this.tokenStart;
-  if (this.isDelim(VERTICALLINE3)) {
-    this.next();
-    eatIdentifierOrAsterisk.call(this);
-  } else {
-    eatIdentifierOrAsterisk.call(this);
-    if (this.isDelim(VERTICALLINE3)) {
-      this.next();
-      eatIdentifierOrAsterisk.call(this);
-    }
-  }
-  return {
-    type: "TypeSelector",
-    loc: this.getLocation(start, this.tokenStart),
-    name: this.substrToCursor(start)
-  };
-}
-function generate46(node2) {
-  this.tokenize(node2.name);
-}
-var ASTERISK5, VERTICALLINE3, name45, structure45;
-var init_TypeSelector = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/TypeSelector.js"() {
-    init_tokenizer();
-    ASTERISK5 = 42;
-    VERTICALLINE3 = 124;
-    name45 = "TypeSelector";
-    structure45 = {
-      name: String
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/UnicodeRange.js
-var UnicodeRange_exports = {};
-__export(UnicodeRange_exports, {
-  generate: () => generate47,
-  name: () => name46,
-  parse: () => parse48,
-  structure: () => structure46
-});
-function eatHexSequence(offset, allowDash) {
-  let len = 0;
-  for (let pos = this.tokenStart + offset; pos < this.tokenEnd; pos++) {
-    const code4 = this.charCodeAt(pos);
-    if (code4 === HYPHENMINUS6 && allowDash && len !== 0) {
-      eatHexSequence.call(this, offset + len + 1, false);
-      return -1;
-    }
-    if (!isHexDigit(code4)) {
-      this.error(
-        allowDash && len !== 0 ? "Hyphen minus" + (len < 6 ? " or hex digit" : "") + " is expected" : len < 6 ? "Hex digit is expected" : "Unexpected input",
-        pos
-      );
-    }
-    if (++len > 6) {
-      this.error("Too many hex digits", pos);
-    }
-    ;
-  }
-  this.next();
-  return len;
-}
-function eatQuestionMarkSequence(max) {
-  let count = 0;
-  while (this.isDelim(QUESTIONMARK3)) {
-    if (++count > max) {
-      this.error("Too many question marks");
-    }
-    this.next();
-  }
-}
-function startsWith2(code4) {
-  if (this.charCodeAt(this.tokenStart) !== code4) {
-    this.error((code4 === PLUSSIGN8 ? "Plus sign" : "Hyphen minus") + " is expected");
-  }
-}
-function scanUnicodeRange() {
-  let hexLength = 0;
-  switch (this.tokenType) {
-    case Number2:
-      hexLength = eatHexSequence.call(this, 1, true);
-      if (this.isDelim(QUESTIONMARK3)) {
-        eatQuestionMarkSequence.call(this, 6 - hexLength);
-        break;
-      }
-      if (this.tokenType === Dimension || this.tokenType === Number2) {
-        startsWith2.call(this, HYPHENMINUS6);
-        eatHexSequence.call(this, 1, false);
-        break;
-      }
-      break;
-    case Dimension:
-      hexLength = eatHexSequence.call(this, 1, true);
-      if (hexLength > 0) {
-        eatQuestionMarkSequence.call(this, 6 - hexLength);
-      }
-      break;
-    default:
-      this.eatDelim(PLUSSIGN8);
-      if (this.tokenType === Ident) {
-        hexLength = eatHexSequence.call(this, 0, true);
-        if (hexLength > 0) {
-          eatQuestionMarkSequence.call(this, 6 - hexLength);
-        }
-        break;
-      }
-      if (this.isDelim(QUESTIONMARK3)) {
-        this.next();
-        eatQuestionMarkSequence.call(this, 5);
-        break;
-      }
-      this.error("Hex digit or question mark is expected");
-  }
-}
-function parse48() {
-  const start = this.tokenStart;
-  this.eatIdent("u");
-  scanUnicodeRange.call(this);
-  return {
-    type: "UnicodeRange",
-    loc: this.getLocation(start, this.tokenStart),
-    value: this.substrToCursor(start)
-  };
-}
-function generate47(node2) {
-  this.tokenize(node2.value);
-}
-var PLUSSIGN8, HYPHENMINUS6, QUESTIONMARK3, name46, structure46;
-var init_UnicodeRange = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/UnicodeRange.js"() {
-    init_tokenizer();
-    PLUSSIGN8 = 43;
-    HYPHENMINUS6 = 45;
-    QUESTIONMARK3 = 63;
-    name46 = "UnicodeRange";
-    structure46 = {
-      value: String
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/utils/url.js
-function decode2(str) {
-  const len = str.length;
-  let start = 4;
-  let end = str.charCodeAt(len - 1) === RIGHTPARENTHESIS3 ? len - 2 : len - 1;
-  let decoded = "";
-  while (start < end && isWhiteSpace(str.charCodeAt(start))) {
-    start++;
-  }
-  while (start < end && isWhiteSpace(str.charCodeAt(end))) {
-    end--;
-  }
-  for (let i = start; i <= end; i++) {
-    let code4 = str.charCodeAt(i);
-    if (code4 === REVERSE_SOLIDUS2) {
-      if (i === end) {
-        if (i !== len - 1) {
-          decoded = str.substr(i + 1);
-        }
-        break;
-      }
-      code4 = str.charCodeAt(++i);
-      if (isValidEscape(REVERSE_SOLIDUS2, code4)) {
-        const escapeStart = i - 1;
-        const escapeEnd = consumeEscaped(str, escapeStart);
-        i = escapeEnd - 1;
-        decoded += decodeEscaped(str.substring(escapeStart + 1, escapeEnd));
-      } else {
-        if (code4 === 13 && str.charCodeAt(i + 1) === 10) {
-          i++;
-        }
-      }
-    } else {
-      decoded += str[i];
-    }
-  }
-  return decoded;
-}
-function encode2(str) {
-  let encoded = "";
-  let wsBeforeHexIsNeeded = false;
-  for (let i = 0; i < str.length; i++) {
-    const code4 = str.charCodeAt(i);
-    if (code4 === 0) {
-      encoded += "\uFFFD";
-      continue;
-    }
-    if (code4 <= 31 || code4 === 127) {
-      encoded += "\\" + code4.toString(16);
-      wsBeforeHexIsNeeded = true;
-      continue;
-    }
-    if (code4 === SPACE3 || code4 === REVERSE_SOLIDUS2 || code4 === QUOTATION_MARK2 || code4 === APOSTROPHE3 || code4 === LEFTPARENTHESIS3 || code4 === RIGHTPARENTHESIS3) {
-      encoded += "\\" + str.charAt(i);
-      wsBeforeHexIsNeeded = false;
-    } else {
-      if (wsBeforeHexIsNeeded && isHexDigit(code4)) {
-        encoded += " ";
-      }
-      encoded += str.charAt(i);
-      wsBeforeHexIsNeeded = false;
-    }
-  }
-  return "url(" + encoded + ")";
-}
-var SPACE3, REVERSE_SOLIDUS2, QUOTATION_MARK2, APOSTROPHE3, LEFTPARENTHESIS3, RIGHTPARENTHESIS3;
-var init_url = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/utils/url.js"() {
-    init_tokenizer();
-    SPACE3 = 32;
-    REVERSE_SOLIDUS2 = 92;
-    QUOTATION_MARK2 = 34;
-    APOSTROPHE3 = 39;
-    LEFTPARENTHESIS3 = 40;
-    RIGHTPARENTHESIS3 = 41;
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Url.js
-var Url_exports = {};
-__export(Url_exports, {
-  generate: () => generate48,
-  name: () => name47,
-  parse: () => parse49,
-  structure: () => structure47
-});
-function parse49() {
-  const start = this.tokenStart;
-  let value;
-  switch (this.tokenType) {
-    case Url:
-      value = decode2(this.consume(Url));
-      break;
-    case Function:
-      if (!this.cmpStr(this.tokenStart, this.tokenEnd, "url(")) {
-        this.error("Function name must be `url`");
-      }
-      this.eat(Function);
-      this.skipSC();
-      value = decode(this.consume(String2));
-      this.skipSC();
-      if (!this.eof) {
-        this.eat(RightParenthesis);
-      }
-      break;
-    default:
-      this.error("Url or Function is expected");
-  }
-  return {
-    type: "Url",
-    loc: this.getLocation(start, this.tokenStart),
-    value
-  };
-}
-function generate48(node2) {
-  this.token(Url, encode2(node2.value));
-}
-var name47, structure47;
-var init_Url = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Url.js"() {
-    init_url();
-    init_string();
-    init_tokenizer();
-    name47 = "Url";
-    structure47 = {
-      value: String
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Value.js
-var Value_exports = {};
-__export(Value_exports, {
-  generate: () => generate49,
-  name: () => name48,
-  parse: () => parse50,
-  structure: () => structure48
-});
-function parse50() {
-  const start = this.tokenStart;
-  const children = this.readSequence(this.scope.Value);
-  return {
-    type: "Value",
-    loc: this.getLocation(start, this.tokenStart),
-    children
-  };
-}
-function generate49(node2) {
-  this.children(node2);
-}
-var name48, structure48;
-var init_Value = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/Value.js"() {
-    name48 = "Value";
-    structure48 = {
-      children: [[]]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/WhiteSpace.js
-var WhiteSpace_exports = {};
-__export(WhiteSpace_exports, {
-  generate: () => generate50,
-  name: () => name49,
-  parse: () => parse51,
-  structure: () => structure49
-});
-function parse51() {
-  this.eat(WhiteSpace);
-  return SPACE4;
-}
-function generate50(node2) {
-  this.token(WhiteSpace, node2.value);
-}
-var SPACE4, name49, structure49;
-var init_WhiteSpace = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/WhiteSpace.js"() {
-    init_tokenizer();
-    SPACE4 = Object.freeze({
-      type: "WhiteSpace",
-      loc: null,
-      value: " "
-    });
-    name49 = "WhiteSpace";
-    structure49 = {
-      value: String
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/index.js
-var node_exports = {};
-__export(node_exports, {
-  AnPlusB: () => AnPlusB_exports,
-  Atrule: () => Atrule_exports,
-  AtrulePrelude: () => AtrulePrelude_exports,
-  AttributeSelector: () => AttributeSelector_exports,
-  Block: () => Block_exports,
-  Brackets: () => Brackets_exports,
-  CDC: () => CDC_exports,
-  CDO: () => CDO_exports,
-  ClassSelector: () => ClassSelector_exports,
-  Combinator: () => Combinator_exports,
-  Comment: () => Comment_exports,
-  Condition: () => Condition_exports,
-  Declaration: () => Declaration_exports,
-  DeclarationList: () => DeclarationList_exports,
-  Dimension: () => Dimension_exports,
-  Feature: () => Feature_exports,
-  FeatureFunction: () => FeatureFunction_exports,
-  FeatureRange: () => FeatureRange_exports,
-  Function: () => Function_exports,
-  GeneralEnclosed: () => GeneralEnclosed_exports,
-  Hash: () => Hash_exports,
-  IdSelector: () => IdSelector_exports,
-  Identifier: () => Identifier_exports,
-  Layer: () => Layer_exports,
-  LayerList: () => LayerList_exports,
-  MediaQuery: () => MediaQuery_exports,
-  MediaQueryList: () => MediaQueryList_exports,
-  NestingSelector: () => NestingSelector_exports,
-  Nth: () => Nth_exports,
-  Number: () => Number_exports,
-  Operator: () => Operator_exports,
-  Parentheses: () => Parentheses_exports,
-  Percentage: () => Percentage_exports,
-  PseudoClassSelector: () => PseudoClassSelector_exports,
-  PseudoElementSelector: () => PseudoElementSelector_exports,
-  Ratio: () => Ratio_exports,
-  Raw: () => Raw_exports,
-  Rule: () => Rule_exports,
-  Scope: () => Scope_exports,
-  Selector: () => Selector_exports,
-  SelectorList: () => SelectorList_exports,
-  String: () => String_exports,
-  StyleSheet: () => StyleSheet_exports,
-  SupportsDeclaration: () => SupportsDeclaration_exports,
-  TypeSelector: () => TypeSelector_exports,
-  UnicodeRange: () => UnicodeRange_exports,
-  Url: () => Url_exports,
-  Value: () => Value_exports,
-  WhiteSpace: () => WhiteSpace_exports
-});
-var init_node = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/index.js"() {
-    init_AnPlusB();
-    init_Atrule();
-    init_AtrulePrelude();
-    init_AttributeSelector();
-    init_Block();
-    init_Brackets();
-    init_CDC();
-    init_CDO();
-    init_ClassSelector();
-    init_Combinator();
-    init_Comment();
-    init_Condition();
-    init_Declaration();
-    init_DeclarationList();
-    init_Dimension();
-    init_Feature();
-    init_FeatureFunction();
-    init_FeatureRange();
-    init_Function();
-    init_GeneralEnclosed();
-    init_Hash();
-    init_Identifier();
-    init_IdSelector();
-    init_Layer();
-    init_LayerList();
-    init_MediaQuery();
-    init_MediaQueryList();
-    init_NestingSelector();
-    init_Nth();
-    init_Number();
-    init_Operator();
-    init_Parentheses();
-    init_Percentage();
-    init_PseudoClassSelector();
-    init_PseudoElementSelector();
-    init_Ratio();
-    init_Raw();
-    init_Rule();
-    init_Scope();
-    init_Selector();
-    init_SelectorList();
-    init_String();
-    init_StyleSheet();
-    init_SupportsDeclaration();
-    init_TypeSelector();
-    init_UnicodeRange();
-    init_Url();
-    init_Value();
-    init_WhiteSpace();
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/config/lexer.js
-var lexer_default;
-var init_lexer = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/config/lexer.js"() {
-    init_generic_const();
-    init_data();
-    init_node();
-    lexer_default = {
-      generic: true,
-      cssWideKeywords,
-      ...data_default,
-      node: node_exports
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/scope/default.js
-function defaultRecognizer(context) {
-  switch (this.tokenType) {
-    case Hash:
-      return this.Hash();
-    case Comma:
-      return this.Operator();
-    case LeftParenthesis:
-      return this.Parentheses(this.readSequence, context.recognizer);
-    case LeftSquareBracket:
-      return this.Brackets(this.readSequence, context.recognizer);
-    case String2:
-      return this.String();
-    case Dimension:
-      return this.Dimension();
-    case Percentage:
-      return this.Percentage();
-    case Number2:
-      return this.Number();
-    case Function:
-      return this.cmpStr(this.tokenStart, this.tokenEnd, "url(") ? this.Url() : this.Function(this.readSequence, context.recognizer);
-    case Url:
-      return this.Url();
-    case Ident:
-      if (this.cmpChar(this.tokenStart, U2) && this.cmpChar(this.tokenStart + 1, PLUSSIGN9)) {
-        return this.UnicodeRange();
-      } else {
-        return this.Identifier();
-      }
-    case Delim: {
-      const code4 = this.charCodeAt(this.tokenStart);
-      if (code4 === SOLIDUS7 || code4 === ASTERISK6 || code4 === PLUSSIGN9 || code4 === HYPHENMINUS7) {
-        return this.Operator();
-      }
-      if (code4 === NUMBERSIGN4) {
-        this.error("Hex or identifier is expected", this.tokenStart + 1);
-      }
-      break;
-    }
-  }
-}
-var NUMBERSIGN4, ASTERISK6, PLUSSIGN9, HYPHENMINUS7, SOLIDUS7, U2;
-var init_default = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/scope/default.js"() {
-    init_tokenizer();
-    NUMBERSIGN4 = 35;
-    ASTERISK6 = 42;
-    PLUSSIGN9 = 43;
-    HYPHENMINUS7 = 45;
-    SOLIDUS7 = 47;
-    U2 = 117;
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/scope/atrulePrelude.js
-var atrulePrelude_default;
-var init_atrulePrelude = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/scope/atrulePrelude.js"() {
-    init_default();
-    atrulePrelude_default = {
-      getNode: defaultRecognizer
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/scope/selector.js
-function onWhiteSpace(next2, children) {
-  if (children.last !== null && children.last.type !== "Combinator" && next2 !== null && next2.type !== "Combinator") {
-    children.push({
-      // FIXME: this.Combinator() should be used instead
-      type: "Combinator",
-      loc: null,
-      name: " "
-    });
-  }
-}
-function getNode() {
-  switch (this.tokenType) {
-    case LeftSquareBracket:
-      return this.AttributeSelector();
-    case Hash:
-      return this.IdSelector();
-    case Colon:
-      if (this.lookupType(1) === Colon) {
-        return this.PseudoElementSelector();
-      } else {
-        return this.PseudoClassSelector();
-      }
-    case Ident:
-      return this.TypeSelector();
-    case Number2:
-    case Percentage:
-      return this.Percentage();
-    case Dimension:
-      if (this.charCodeAt(this.tokenStart) === FULLSTOP3) {
-        this.error("Identifier is expected", this.tokenStart + 1);
-      }
-      break;
-    case Delim: {
-      const code4 = this.charCodeAt(this.tokenStart);
-      switch (code4) {
-        case PLUSSIGN10:
-        case GREATERTHANSIGN4:
-        case TILDE3:
-        case SOLIDUS8:
-          return this.Combinator();
-        case FULLSTOP3:
-          return this.ClassSelector();
-        case ASTERISK7:
-        case VERTICALLINE4:
-          return this.TypeSelector();
-        case NUMBERSIGN5:
-          return this.IdSelector();
-        case AMPERSAND6:
-          return this.NestingSelector();
-      }
-      break;
-    }
-  }
-}
-var NUMBERSIGN5, AMPERSAND6, ASTERISK7, PLUSSIGN10, SOLIDUS8, FULLSTOP3, GREATERTHANSIGN4, VERTICALLINE4, TILDE3, selector_default;
-var init_selector = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/scope/selector.js"() {
-    init_tokenizer();
-    NUMBERSIGN5 = 35;
-    AMPERSAND6 = 38;
-    ASTERISK7 = 42;
-    PLUSSIGN10 = 43;
-    SOLIDUS8 = 47;
-    FULLSTOP3 = 46;
-    GREATERTHANSIGN4 = 62;
-    VERTICALLINE4 = 124;
-    TILDE3 = 126;
-    selector_default = {
-      onWhiteSpace,
-      getNode
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/function/expression.js
-function expression_default() {
-  return this.createSingleNodeList(
-    this.Raw(null, false)
-  );
-}
-var init_expression = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/function/expression.js"() {
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/function/var.js
-function var_default() {
-  const children = this.createList();
-  this.skipSC();
-  children.push(this.Identifier());
-  this.skipSC();
-  if (this.tokenType === Comma) {
-    children.push(this.Operator());
-    const startIndex = this.tokenIndex;
-    const value = this.parseCustomProperty ? this.Value(null) : this.Raw(this.consumeUntilExclamationMarkOrSemicolon, false);
-    if (value.type === "Value" && value.children.isEmpty) {
-      for (let offset = startIndex - this.tokenIndex; offset <= 0; offset++) {
-        if (this.lookupType(offset) === WhiteSpace) {
-          value.children.appendData({
-            type: "WhiteSpace",
-            loc: null,
-            value: " "
-          });
-          break;
-        }
-      }
-    }
-    children.push(value);
-  }
-  return children;
-}
-var init_var = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/function/var.js"() {
-    init_tokenizer();
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/scope/value.js
-function isPlusMinusOperator(node2) {
-  return node2 !== null && node2.type === "Operator" && (node2.value[node2.value.length - 1] === "-" || node2.value[node2.value.length - 1] === "+");
-}
-var value_default;
-var init_value = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/scope/value.js"() {
-    init_default();
-    init_expression();
-    init_var();
-    value_default = {
-      getNode: defaultRecognizer,
-      onWhiteSpace(next2, children) {
-        if (isPlusMinusOperator(next2)) {
-          next2.value = " " + next2.value;
-        }
-        if (isPlusMinusOperator(children.last)) {
-          children.last.value += " ";
-        }
-      },
-      "expression": expression_default,
-      "var": var_default
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/scope/index.js
-var scope_exports = {};
-__export(scope_exports, {
-  AtrulePrelude: () => atrulePrelude_default,
-  Selector: () => selector_default,
-  Value: () => value_default
-});
-var init_scope = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/scope/index.js"() {
-    init_atrulePrelude();
-    init_selector();
-    init_value();
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/container.js
-var nonContainerNameKeywords, container_default;
-var init_container = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/container.js"() {
-    init_tokenizer();
-    nonContainerNameKeywords = /* @__PURE__ */ new Set(["none", "and", "not", "or"]);
-    container_default = {
-      parse: {
-        prelude() {
-          const children = this.createList();
-          if (this.tokenType === Ident) {
-            const name50 = this.substring(this.tokenStart, this.tokenEnd);
-            if (!nonContainerNameKeywords.has(name50.toLowerCase())) {
-              children.push(this.Identifier());
-            }
-          }
-          children.push(this.Condition("container"));
-          return children;
-        },
-        block(nested = false) {
-          return this.Block(nested);
-        }
-      }
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/font-face.js
-var font_face_default;
-var init_font_face = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/font-face.js"() {
-    font_face_default = {
-      parse: {
-        prelude: null,
-        block() {
-          return this.Block(true);
-        }
-      }
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/import.js
-function parseWithFallback(parse57, fallback) {
-  return this.parseWithFallback(
-    () => {
-      try {
-        return parse57.call(this);
-      } finally {
-        this.skipSC();
-        if (this.lookupNonWSType(0) !== RightParenthesis) {
-          this.error();
-        }
-      }
-    },
-    fallback || (() => this.Raw(null, true))
-  );
-}
-var parseFunctions, import_default3;
-var init_import = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/import.js"() {
-    init_tokenizer();
-    parseFunctions = {
-      layer() {
-        this.skipSC();
-        const children = this.createList();
-        const node2 = parseWithFallback.call(this, this.Layer);
-        if (node2.type !== "Raw" || node2.value !== "") {
-          children.push(node2);
-        }
-        return children;
-      },
-      supports() {
-        this.skipSC();
-        const children = this.createList();
-        const node2 = parseWithFallback.call(
-          this,
-          this.Declaration,
-          () => parseWithFallback.call(this, () => this.Condition("supports"))
-        );
-        if (node2.type !== "Raw" || node2.value !== "") {
-          children.push(node2);
-        }
-        return children;
-      }
-    };
-    import_default3 = {
-      parse: {
-        prelude() {
-          const children = this.createList();
-          switch (this.tokenType) {
-            case String2:
-              children.push(this.String());
-              break;
-            case Url:
-            case Function:
-              children.push(this.Url());
-              break;
-            default:
-              this.error("String or url() is expected");
-          }
-          this.skipSC();
-          if (this.tokenType === Ident && this.cmpStr(this.tokenStart, this.tokenEnd, "layer")) {
-            children.push(this.Identifier());
-          } else if (this.tokenType === Function && this.cmpStr(this.tokenStart, this.tokenEnd, "layer(")) {
-            children.push(this.Function(null, parseFunctions));
-          }
-          this.skipSC();
-          if (this.tokenType === Function && this.cmpStr(this.tokenStart, this.tokenEnd, "supports(")) {
-            children.push(this.Function(null, parseFunctions));
-          }
-          if (this.lookupNonWSType(0) === Ident || this.lookupNonWSType(0) === LeftParenthesis) {
-            children.push(this.MediaQueryList());
-          }
-          return children;
-        },
-        block: null
-      }
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/layer.js
-var layer_default;
-var init_layer = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/layer.js"() {
-    layer_default = {
-      parse: {
-        prelude() {
-          return this.createSingleNodeList(
-            this.LayerList()
-          );
-        },
-        block() {
-          return this.Block(false);
-        }
-      }
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/media.js
-var media_default;
-var init_media = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/media.js"() {
-    media_default = {
-      parse: {
-        prelude() {
-          return this.createSingleNodeList(
-            this.MediaQueryList()
-          );
-        },
-        block(nested = false) {
-          return this.Block(nested);
-        }
-      }
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/nest.js
-var nest_default;
-var init_nest = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/nest.js"() {
-    nest_default = {
-      parse: {
-        prelude() {
-          return this.createSingleNodeList(
-            this.SelectorList()
-          );
-        },
-        block() {
-          return this.Block(true);
-        }
-      }
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/page.js
-var page_default;
-var init_page = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/page.js"() {
-    page_default = {
-      parse: {
-        prelude() {
-          return this.createSingleNodeList(
-            this.SelectorList()
-          );
-        },
-        block() {
-          return this.Block(true);
-        }
-      }
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/scope.js
-var scope_default;
-var init_scope2 = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/scope.js"() {
-    scope_default = {
-      parse: {
-        prelude() {
-          return this.createSingleNodeList(
-            this.Scope()
-          );
-        },
-        block(nested = false) {
-          return this.Block(nested);
-        }
-      }
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/starting-style.js
-var starting_style_default;
-var init_starting_style = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/starting-style.js"() {
-    starting_style_default = {
-      parse: {
-        prelude: null,
-        block(nested = false) {
-          return this.Block(nested);
-        }
-      }
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/supports.js
-var supports_default;
-var init_supports = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/supports.js"() {
-    supports_default = {
-      parse: {
-        prelude() {
-          return this.createSingleNodeList(
-            this.Condition("supports")
-          );
-        },
-        block(nested = false) {
-          return this.Block(nested);
-        }
-      }
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/index.js
-var atrule_default;
-var init_atrule = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/atrule/index.js"() {
-    init_container();
-    init_font_face();
-    init_import();
-    init_layer();
-    init_media();
-    init_nest();
-    init_page();
-    init_scope2();
-    init_starting_style();
-    init_supports();
-    atrule_default = {
-      container: container_default,
-      "font-face": font_face_default,
-      import: import_default3,
-      layer: layer_default,
-      media: media_default,
-      nest: nest_default,
-      page: page_default,
-      scope: scope_default,
-      "starting-style": starting_style_default,
-      supports: supports_default
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/pseudo/lang.js
-function parseLanguageRangeList() {
-  const children = this.createList();
-  this.skipSC();
-  loop: while (!this.eof) {
-    switch (this.tokenType) {
-      case Ident:
-        children.push(this.Identifier());
-        break;
-      case String2:
-        children.push(this.String());
-        break;
-      case Comma:
-        children.push(this.Operator());
-        break;
-      case RightParenthesis:
-        break loop;
-      default:
-        this.error("Identifier, string or comma is expected");
-    }
-    this.skipSC();
-  }
-  return children;
-}
-var init_lang = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/pseudo/lang.js"() {
-    init_tokenizer();
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/pseudo/index.js
-var selectorList, selector, identList, langList, nth, pseudo_default;
-var init_pseudo = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/pseudo/index.js"() {
-    init_lang();
-    selectorList = {
-      parse() {
-        return this.createSingleNodeList(
-          this.SelectorList()
-        );
-      }
-    };
-    selector = {
-      parse() {
-        return this.createSingleNodeList(
-          this.Selector()
-        );
-      }
-    };
-    identList = {
-      parse() {
-        return this.createSingleNodeList(
-          this.Identifier()
-        );
-      }
-    };
-    langList = {
-      parse: parseLanguageRangeList
-    };
-    nth = {
-      parse() {
-        return this.createSingleNodeList(
-          this.Nth()
-        );
-      }
-    };
-    pseudo_default = {
-      "dir": identList,
-      "has": selectorList,
-      "lang": langList,
-      "matches": selectorList,
-      "is": selectorList,
-      "-moz-any": selectorList,
-      "-webkit-any": selectorList,
-      "where": selectorList,
-      "not": selectorList,
-      "nth-child": nth,
-      "nth-last-child": nth,
-      "nth-last-of-type": nth,
-      "nth-of-type": nth,
-      "slotted": selector,
-      "host": selector,
-      "host-context": selector
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/index-parse.js
-var index_parse_exports = {};
-__export(index_parse_exports, {
-  AnPlusB: () => parse3,
-  Atrule: () => parse4,
-  AtrulePrelude: () => parse5,
-  AttributeSelector: () => parse6,
-  Block: () => parse7,
-  Brackets: () => parse8,
-  CDC: () => parse9,
-  CDO: () => parse10,
-  ClassSelector: () => parse11,
-  Combinator: () => parse12,
-  Comment: () => parse13,
-  Condition: () => parse14,
-  Declaration: () => parse15,
-  DeclarationList: () => parse16,
-  Dimension: () => parse17,
-  Feature: () => parse18,
-  FeatureFunction: () => parse19,
-  FeatureRange: () => parse20,
-  Function: () => parse21,
-  GeneralEnclosed: () => parse22,
-  Hash: () => parse23,
-  IdSelector: () => parse25,
-  Identifier: () => parse24,
-  Layer: () => parse26,
-  LayerList: () => parse27,
-  MediaQuery: () => parse28,
-  MediaQueryList: () => parse29,
-  NestingSelector: () => parse30,
-  Nth: () => parse31,
-  Number: () => parse32,
-  Operator: () => parse33,
-  Parentheses: () => parse34,
-  Percentage: () => parse35,
-  PseudoClassSelector: () => parse36,
-  PseudoElementSelector: () => parse37,
-  Ratio: () => parse38,
-  Raw: () => parse39,
-  Rule: () => parse40,
-  Scope: () => parse41,
-  Selector: () => parse42,
-  SelectorList: () => parse43,
-  String: () => parse44,
-  StyleSheet: () => parse45,
-  SupportsDeclaration: () => parse46,
-  TypeSelector: () => parse47,
-  UnicodeRange: () => parse48,
-  Url: () => parse49,
-  Value: () => parse50,
-  WhiteSpace: () => parse51
-});
-var init_index_parse = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/node/index-parse.js"() {
-    init_AnPlusB();
-    init_Atrule();
-    init_AtrulePrelude();
-    init_AttributeSelector();
-    init_Block();
-    init_Brackets();
-    init_CDC();
-    init_CDO();
-    init_ClassSelector();
-    init_Combinator();
-    init_Comment();
-    init_Condition();
-    init_Declaration();
-    init_DeclarationList();
-    init_Dimension();
-    init_Feature();
-    init_FeatureFunction();
-    init_FeatureRange();
-    init_Function();
-    init_GeneralEnclosed();
-    init_Hash();
-    init_Identifier();
-    init_IdSelector();
-    init_Layer();
-    init_LayerList();
-    init_MediaQuery();
-    init_MediaQueryList();
-    init_NestingSelector();
-    init_Nth();
-    init_Number();
-    init_Operator();
-    init_Parentheses();
-    init_Percentage();
-    init_PseudoClassSelector();
-    init_PseudoElementSelector();
-    init_Ratio();
-    init_Raw();
-    init_Rule();
-    init_Scope();
-    init_Selector();
-    init_SelectorList();
-    init_String();
-    init_StyleSheet();
-    init_SupportsDeclaration();
-    init_TypeSelector();
-    init_UnicodeRange();
-    init_Url();
-    init_Value();
-    init_WhiteSpace();
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/config/parser.js
-var parser_default;
-var init_parser = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/config/parser.js"() {
-    init_scope();
-    init_atrule();
-    init_pseudo();
-    init_index_parse();
-    parser_default = {
-      parseContext: {
-        default: "StyleSheet",
-        stylesheet: "StyleSheet",
-        atrule: "Atrule",
-        atrulePrelude(options) {
-          return this.AtrulePrelude(options.atrule ? String(options.atrule) : null);
-        },
-        mediaQueryList: "MediaQueryList",
-        mediaQuery: "MediaQuery",
-        condition(options) {
-          return this.Condition(options.kind);
-        },
-        rule: "Rule",
-        selectorList: "SelectorList",
-        selector: "Selector",
-        block() {
-          return this.Block(true);
-        },
-        declarationList: "DeclarationList",
-        declaration: "Declaration",
-        value: "Value"
-      },
-      features: {
-        supports: {
-          selector() {
-            return this.Selector();
-          }
-        },
-        container: {
-          style() {
-            return this.Declaration();
-          }
-        }
-      },
-      scope: scope_exports,
-      atrule: atrule_default,
-      pseudo: pseudo_default,
-      node: index_parse_exports
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/config/walker.js
-var walker_default;
-var init_walker = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/config/walker.js"() {
-    init_node();
-    walker_default = {
-      node: node_exports
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/index.js
-var syntax_default;
-var init_syntax = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/syntax/index.js"() {
-    init_create5();
-    init_lexer();
-    init_parser();
-    init_walker();
-    syntax_default = create_default({
-      ...lexer_default,
-      ...parser_default,
-      ...walker_default
-    });
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/package.json
-var package_default;
-var init_package = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/package.json"() {
-    package_default = {
-      name: "css-tree",
-      version: "3.2.1",
-      description: "A tool set for CSS: fast detailed parser (CSS \u2192 AST), walker (AST traversal), generator (AST \u2192 CSS) and lexer (validation and matching) based on specs and browser implementations",
-      author: "Roman Dvornov <rdvornov@gmail.com> (https://github.com/lahmatiy)",
-      license: "MIT",
-      repository: "csstree/csstree",
-      keywords: [
-        "css",
-        "ast",
-        "tokenizer",
-        "parser",
-        "walker",
-        "lexer",
-        "generator",
-        "utils",
-        "syntax",
-        "validation"
-      ],
-      type: "module",
-      module: "./lib/index.js",
-      sideEffects: false,
-      main: "./cjs/index.cjs",
-      exports: {
-        ".": {
-          import: "./lib/index.js",
-          require: "./cjs/index.cjs"
-        },
-        "./dist/*": "./dist/*.js",
-        "./package.json": "./package.json",
-        "./tokenizer": {
-          import: "./lib/tokenizer/index.js",
-          require: "./cjs/tokenizer/index.cjs"
-        },
-        "./parser": {
-          import: "./lib/parser/index.js",
-          require: "./cjs/parser/index.cjs"
-        },
-        "./selector-parser": {
-          import: "./lib/parser/parse-selector.js",
-          require: "./cjs/parser/parse-selector.cjs"
-        },
-        "./generator": {
-          import: "./lib/generator/index.js",
-          require: "./cjs/generator/index.cjs"
-        },
-        "./walker": {
-          import: "./lib/walker/index.js",
-          require: "./cjs/walker/index.cjs"
-        },
-        "./convertor": {
-          import: "./lib/convertor/index.js",
-          require: "./cjs/convertor/index.cjs"
-        },
-        "./lexer": {
-          import: "./lib/lexer/index.js",
-          require: "./cjs/lexer/index.cjs"
-        },
-        "./definition-syntax": {
-          import: "./lib/definition-syntax/index.js",
-          require: "./cjs/definition-syntax/index.cjs"
-        },
-        "./definition-syntax-data": {
-          import: "./lib/data.js",
-          require: "./cjs/data.cjs"
-        },
-        "./definition-syntax-data-patch": {
-          import: "./lib/data-patch.js",
-          require: "./cjs/data-patch.cjs"
-        },
-        "./utils": {
-          import: "./lib/utils/index.js",
-          require: "./cjs/utils/index.cjs"
-        }
-      },
-      browser: {
-        "./cjs/data.cjs": "./dist/data.cjs",
-        "./cjs/version.cjs": "./dist/version.cjs",
-        "./lib/data.js": "./dist/data.js",
-        "./lib/version.js": "./dist/version.js"
-      },
-      unpkg: "dist/csstree.esm.js",
-      jsdelivr: "dist/csstree.esm.js",
-      scripts: {
-        watch: "npm run build -- --watch",
-        build: "npm run bundle && npm run esm-to-cjs --",
-        "build-and-test": "npm run build && npm run test:dist && npm run test:cjs",
-        bundle: "node scripts/bundle",
-        "bundle-and-test": "npm run bundle && npm run test:dist",
-        "esm-to-cjs": "node scripts/esm-to-cjs.cjs",
-        "esm-to-cjs-and-test": "npm run esm-to-cjs && npm run test:cjs",
-        lint: "eslint lib scripts && node scripts/review-syntax-patch --lint && node scripts/update-docs --lint",
-        "lint-and-test": "npm run lint && npm test",
-        "update:docs": "node scripts/update-docs",
-        "review:syntax-patch": "node scripts/review-syntax-patch",
-        test: "mocha lib/__tests --require lib/__tests/helpers/setup.js --reporter progress",
-        "test:cjs": "mocha cjs/__tests --require lib/__tests/helpers/setup.js --reporter progress",
-        "test:dist": "mocha dist/__tests --reporter progress",
-        coverage: "c8 --exclude lib/__tests --reporter=lcovonly npm test",
-        prepublishOnly: "npm run lint-and-test && npm run build-and-test"
-      },
-      dependencies: {
-        "mdn-data": "2.27.1",
-        "source-map-js": "^1.2.1"
-      },
-      devDependencies: {
-        c8: "^11.0.0",
-        clap: "^2.0.1",
-        esbuild: "^0.27.3",
-        eslint: "^8.50.0",
-        "json-to-ast": "^2.1.0",
-        mocha: "^9.2.2",
-        rollup: "^2.80.0"
-      },
-      engines: {
-        node: "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      },
-      files: [
-        "data",
-        "dist",
-        "cjs",
-        "!cjs/__tests",
-        "lib",
-        "!lib/__tests"
-      ]
-    };
-  }
-});
-
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/version.js
-import { createRequire as createRequire3 } from "module";
-var require4, version;
-var init_version = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/version.js"() {
-    init_package();
-    require4 = createRequire3(import.meta.url);
-    ({ version } = package_default);
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/utils/clone.js
+var init_clone = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/utils/clone.js"() {
   }
 });
 
@@ -29691,31 +11672,15 @@ var init_ident = __esm({
   }
 });
 
-// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/index.js
-var tokenize2, parse52, generate51, lexer, createLexer, walk2, find, findLast, findAll, toPlainObject, fromPlainObject, fork;
-var init_lib = __esm({
-  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/index.js"() {
-    init_syntax();
-    init_version();
-    init_definition_syntax();
-    init_names2();
+// node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/utils/index.js
+var init_utils2 = __esm({
+  "node_modules/.pnpm/css-tree@3.2.1/node_modules/css-tree/lib/utils/index.js"() {
+    init_clone();
     init_ident();
+    init_List();
+    init_names2();
     init_string();
     init_url();
-    ({
-      tokenize: tokenize2,
-      parse: parse52,
-      generate: generate51,
-      lexer,
-      createLexer,
-      walk: walk2,
-      find,
-      findLast,
-      findAll,
-      toPlainObject,
-      fromPlainObject,
-      fork
-    } = syntax_default);
   }
 });
 
@@ -29734,7 +11699,7 @@ var init_bail = __esm({
 var require_extend = __commonJS({
   "node_modules/.pnpm/extend@3.0.2/node_modules/extend/index.js"(exports, module) {
     "use strict";
-    var hasOwn2 = Object.prototype.hasOwnProperty;
+    var hasOwn = Object.prototype.hasOwnProperty;
     var toStr = Object.prototype.toString;
     var defineProperty = Object.defineProperty;
     var gOPD = Object.getOwnPropertyDescriptor;
@@ -29748,15 +11713,15 @@ var require_extend = __commonJS({
       if (!obj || toStr.call(obj) !== "[object Object]") {
         return false;
       }
-      var hasOwnConstructor = hasOwn2.call(obj, "constructor");
-      var hasIsPrototypeOf = obj.constructor && obj.constructor.prototype && hasOwn2.call(obj.constructor.prototype, "isPrototypeOf");
+      var hasOwnConstructor = hasOwn.call(obj, "constructor");
+      var hasIsPrototypeOf = obj.constructor && obj.constructor.prototype && hasOwn.call(obj.constructor.prototype, "isPrototypeOf");
       if (obj.constructor && !hasOwnConstructor && !hasIsPrototypeOf) {
         return false;
       }
       var key;
       for (key in obj) {
       }
-      return typeof key === "undefined" || hasOwn2.call(obj, key);
+      return typeof key === "undefined" || hasOwn.call(obj, key);
     };
     var setProperty = function setProperty2(target, options) {
       if (defineProperty && options.name === "__proto__") {
@@ -29772,7 +11737,7 @@ var require_extend = __commonJS({
     };
     var getProperty = function getProperty2(obj, name50) {
       if (name50 === "__proto__") {
-        if (!hasOwn2.call(obj, name50)) {
+        if (!hasOwn.call(obj, name50)) {
           return void 0;
         } else if (gOPD) {
           return gOPD(obj, name50).value;
@@ -29784,7 +11749,7 @@ var require_extend = __commonJS({
       var options, name50, src, copy, copyIsArray, clone;
       var target = arguments[0];
       var i = 1;
-      var length2 = arguments.length;
+      var length = arguments.length;
       var deep = false;
       if (typeof target === "boolean") {
         deep = target;
@@ -29794,7 +11759,7 @@ var require_extend = __commonJS({
       if (target == null || typeof target !== "object" && typeof target !== "function") {
         target = {};
       }
-      for (; i < length2; ++i) {
+      for (; i < length; ++i) {
         options = arguments[i];
         if (options != null) {
           for (name50 in options) {
@@ -29925,7 +11890,7 @@ function wrap(middleware, callback) {
     done(null, value);
   }
 }
-var init_lib2 = __esm({
+var init_lib = __esm({
   "node_modules/.pnpm/trough@2.2.0/node_modules/trough/lib/index.js"() {
   }
 });
@@ -29933,7 +11898,7 @@ var init_lib2 = __esm({
 // node_modules/.pnpm/trough@2.2.0/node_modules/trough/index.js
 var init_trough = __esm({
   "node_modules/.pnpm/trough@2.2.0/node_modules/trough/index.js"() {
-    init_lib2();
+    init_lib();
   }
 });
 
@@ -29962,7 +11927,7 @@ function position(pos) {
 function index(value) {
   return value && typeof value === "number" ? value : 1;
 }
-var init_lib3 = __esm({
+var init_lib2 = __esm({
   "node_modules/.pnpm/unist-util-stringify-position@4.0.0/node_modules/unist-util-stringify-position/lib/index.js"() {
   }
 });
@@ -29970,13 +11935,13 @@ var init_lib3 = __esm({
 // node_modules/.pnpm/unist-util-stringify-position@4.0.0/node_modules/unist-util-stringify-position/index.js
 var init_unist_util_stringify_position = __esm({
   "node_modules/.pnpm/unist-util-stringify-position@4.0.0/node_modules/unist-util-stringify-position/index.js"() {
-    init_lib3();
+    init_lib2();
   }
 });
 
 // node_modules/.pnpm/vfile-message@4.0.3/node_modules/vfile-message/lib/index.js
 var VFileMessage;
-var init_lib4 = __esm({
+var init_lib3 = __esm({
   "node_modules/.pnpm/vfile-message@4.0.3/node_modules/vfile-message/lib/index.js"() {
     init_unist_util_stringify_position();
     VFileMessage = class extends Error {
@@ -30119,7 +12084,7 @@ var init_lib4 = __esm({
 // node_modules/.pnpm/vfile-message@4.0.3/node_modules/vfile-message/index.js
 var init_vfile_message = __esm({
   "node_modules/.pnpm/vfile-message@4.0.3/node_modules/vfile-message/index.js"() {
-    init_lib4();
+    init_lib3();
   }
 });
 
@@ -30181,7 +12146,7 @@ function isUint8Array(value) {
   );
 }
 var order, VFile;
-var init_lib5 = __esm({
+var init_lib4 = __esm({
   "node_modules/.pnpm/vfile@6.0.3/node_modules/vfile/lib/index.js"() {
     init_vfile_message();
     init_minpath();
@@ -30623,7 +12588,7 @@ var init_lib5 = __esm({
 // node_modules/.pnpm/vfile@6.0.3/node_modules/vfile/index.js
 var init_vfile = __esm({
   "node_modules/.pnpm/vfile@6.0.3/node_modules/vfile/index.js"() {
-    init_lib5();
+    init_lib4();
   }
 });
 
@@ -30640,7 +12605,7 @@ var init_callable_instance = __esm({
      * @param {string | symbol} property
      * @returns {(...parameters: Array<unknown>) => unknown}
      */
-    (function(property2) {
+    (function(property) {
       const self = this;
       const constr = self.constructor;
       const proto2 = (
@@ -30649,7 +12614,7 @@ var init_callable_instance = __esm({
         // type-coverage:ignore-next-line
         constr.prototype
       );
-      const value = proto2[property2];
+      const value = proto2[property];
       const apply = function() {
         return value.apply(apply, arguments);
       };
@@ -30706,7 +12671,7 @@ function isUint8Array2(value) {
   );
 }
 var import_extend, own, Processor, unified;
-var init_lib6 = __esm({
+var init_lib5 = __esm({
   "node_modules/.pnpm/unified@11.0.5/node_modules/unified/lib/index.js"() {
     init_bail();
     import_extend = __toESM(require_extend(), 1);
@@ -31310,7 +13275,7 @@ var init_lib6 = __esm({
 // node_modules/.pnpm/unified@11.0.5/node_modules/unified/index.js
 var init_unified = __esm({
   "node_modules/.pnpm/unified@11.0.5/node_modules/unified/index.js"() {
-    init_lib6();
+    init_lib5();
   }
 });
 
@@ -31350,7 +13315,7 @@ function node(value) {
   return Boolean(value && typeof value === "object");
 }
 var emptyOptions;
-var init_lib7 = __esm({
+var init_lib6 = __esm({
   "node_modules/.pnpm/mdast-util-to-string@4.0.0/node_modules/mdast-util-to-string/lib/index.js"() {
     emptyOptions = {};
   }
@@ -31359,7 +13324,7 @@ var init_lib7 = __esm({
 // node_modules/.pnpm/mdast-util-to-string@4.0.0/node_modules/mdast-util-to-string/index.js
 var init_mdast_util_to_string = __esm({
   "node_modules/.pnpm/mdast-util-to-string@4.0.0/node_modules/mdast-util-to-string/index.js"() {
-    init_lib7();
+    init_lib6();
   }
 });
 
@@ -33559,13 +15524,13 @@ function combineExtensions(extensions) {
 function syntaxExtension(all3, extension2) {
   let hook;
   for (hook in extension2) {
-    const maybe = hasOwnProperty5.call(all3, hook) ? all3[hook] : void 0;
+    const maybe = hasOwnProperty3.call(all3, hook) ? all3[hook] : void 0;
     const left = maybe || (all3[hook] = {});
     const right = extension2[hook];
     let code4;
     if (right) {
       for (code4 in right) {
-        if (!hasOwnProperty5.call(left, code4)) left[code4] = [];
+        if (!hasOwnProperty3.call(left, code4)) left[code4] = [];
         const value = right[code4];
         constructs(
           // @ts-expect-error Looks like a list.
@@ -33585,11 +15550,11 @@ function constructs(existing, list3) {
   }
   splice(existing, 0, 0, before);
 }
-var hasOwnProperty5;
+var hasOwnProperty3;
 var init_micromark_util_combine_extensions = __esm({
   "node_modules/.pnpm/micromark-util-combine-extensions@2.0.1/node_modules/micromark-util-combine-extensions/index.js"() {
     init_micromark_util_chunked();
-    hasOwnProperty5 = {}.hasOwnProperty;
+    hasOwnProperty3 = {}.hasOwnProperty;
   }
 });
 
@@ -37714,7 +19679,7 @@ var init_create_tokenizer = __esm({
 });
 
 // node_modules/.pnpm/micromark@4.0.2/node_modules/micromark/lib/parse.js
-function parse53(options) {
+function parse51(options) {
   const settings = options || {};
   const constructs2 = (
     /** @type {FullNormalizedExtension} */
@@ -37738,7 +19703,7 @@ function parse53(options) {
     }
   }
 }
-var init_parse2 = __esm({
+var init_parse = __esm({
   "node_modules/.pnpm/micromark@4.0.2/node_modules/micromark/lib/parse.js"() {
     init_micromark_util_combine_extensions();
     init_content();
@@ -37849,7 +19814,7 @@ var init_preprocess = __esm({
 // node_modules/.pnpm/micromark@4.0.2/node_modules/micromark/index.js
 var init_micromark = __esm({
   "node_modules/.pnpm/micromark@4.0.2/node_modules/micromark/index.js"() {
-    init_parse2();
+    init_parse();
     init_postprocess();
     init_preprocess();
   }
@@ -37886,7 +19851,7 @@ function fromMarkdown(value, encoding, options) {
     options = encoding;
     encoding = void 0;
   }
-  return compiler(options)(postprocess(parse53(options).document().write(preprocess()(value, encoding, true))));
+  return compiler(options)(postprocess(parse51(options).document().write(preprocess()(value, encoding, true))));
 }
 function compiler(options) {
   const config = {
@@ -38049,7 +20014,7 @@ function compiler(options) {
     }
     return tree;
   }
-  function prepareList(events, start, length2) {
+  function prepareList(events, start, length) {
     let index2 = start - 1;
     let containerBalance = -1;
     let listSpread = false;
@@ -38057,7 +20022,7 @@ function compiler(options) {
     let lineIndex;
     let firstBlankLineIndex;
     let atMarker;
-    while (++index2 <= length2) {
+    while (++index2 <= length) {
       const event = events[index2];
       switch (event[1].type) {
         case "listUnordered":
@@ -38116,7 +20081,7 @@ function compiler(options) {
           listItem3.end = Object.assign({}, lineIndex ? events[lineIndex][1].start : event[1].end);
           events.splice(lineIndex || index2, 0, ["exit", listItem3, event[2]]);
           index2++;
-          length2++;
+          length++;
         }
         if (event[1].type === "listItemPrefix") {
           const item = {
@@ -38129,14 +20094,14 @@ function compiler(options) {
           listItem3 = item;
           events.splice(index2, 0, ["enter", item, event[2]]);
           index2++;
-          length2++;
+          length++;
           firstBlankLineIndex = void 0;
           atMarker = true;
         }
       }
     }
     events[start][1]._spread = listSpread;
-    return length2;
+    return length;
   }
   function opener(create2, and) {
     return open;
@@ -38588,7 +20553,7 @@ function defaultOnError(left, right) {
   }
 }
 var own3;
-var init_lib8 = __esm({
+var init_lib7 = __esm({
   "node_modules/.pnpm/mdast-util-from-markdown@2.0.3/node_modules/mdast-util-from-markdown/lib/index.js"() {
     init_mdast_util_to_string();
     init_micromark();
@@ -38604,7 +20569,7 @@ var init_lib8 = __esm({
 // node_modules/.pnpm/mdast-util-from-markdown@2.0.3/node_modules/mdast-util-from-markdown/index.js
 var init_mdast_util_from_markdown = __esm({
   "node_modules/.pnpm/mdast-util-from-markdown@2.0.3/node_modules/mdast-util-from-markdown/index.js"() {
-    init_lib8();
+    init_lib7();
   }
 });
 
@@ -38624,7 +20589,7 @@ function remarkParse(options) {
     });
   }
 }
-var init_lib9 = __esm({
+var init_lib8 = __esm({
   "node_modules/.pnpm/remark-parse@11.0.0/node_modules/remark-parse/lib/index.js"() {
     init_mdast_util_from_markdown();
   }
@@ -38633,7 +20598,7 @@ var init_lib9 = __esm({
 // node_modules/.pnpm/remark-parse@11.0.0/node_modules/remark-parse/index.js
 var init_remark_parse = __esm({
   "node_modules/.pnpm/remark-parse@11.0.0/node_modules/remark-parse/index.js"() {
-    init_lib9();
+    init_lib8();
   }
 });
 
@@ -38729,7 +20694,7 @@ function looksLikeANode(value) {
   return value !== null && typeof value === "object" && "type" in value;
 }
 var convert;
-var init_lib10 = __esm({
+var init_lib9 = __esm({
   "node_modules/.pnpm/unist-util-is@6.0.1/node_modules/unist-util-is/lib/index.js"() {
     convert = // Note: overloads in JSDoc can’t yet use different `@template`s.
     /**
@@ -38773,7 +20738,7 @@ var init_lib10 = __esm({
 // node_modules/.pnpm/unist-util-is@6.0.1/node_modules/unist-util-is/index.js
 var init_unist_util_is = __esm({
   "node_modules/.pnpm/unist-util-is@6.0.1/node_modules/unist-util-is/index.js"() {
-    init_lib10();
+    init_lib9();
   }
 });
 
@@ -38859,7 +20824,7 @@ function toResult(value) {
   return value === null || value === void 0 ? empty : [value];
 }
 var empty, CONTINUE, EXIT, SKIP;
-var init_lib11 = __esm({
+var init_lib10 = __esm({
   "node_modules/.pnpm/unist-util-visit-parents@6.0.2/node_modules/unist-util-visit-parents/lib/index.js"() {
     init_unist_util_is();
     init_color_node();
@@ -38873,7 +20838,7 @@ var init_lib11 = __esm({
 // node_modules/.pnpm/unist-util-visit-parents@6.0.2/node_modules/unist-util-visit-parents/index.js
 var init_unist_util_visit_parents = __esm({
   "node_modules/.pnpm/unist-util-visit-parents@6.0.2/node_modules/unist-util-visit-parents/index.js"() {
-    init_lib11();
+    init_lib10();
   }
 });
 
@@ -38907,15 +20872,15 @@ function findAndReplace(tree, list3, options) {
   }
   function handler(node2, parents) {
     const parent = parents[parents.length - 1];
-    const find3 = pairs[pairIndex][0];
+    const find2 = pairs[pairIndex][0];
     const replace2 = pairs[pairIndex][1];
     let start = 0;
     const siblings = parent.children;
     const index2 = siblings.indexOf(node2);
     let change = false;
     let nodes = [];
-    find3.lastIndex = 0;
-    let match = find3.exec(node2.value);
+    find2.lastIndex = 0;
+    let match = find2.exec(node2.value);
     while (match) {
       const position3 = match.index;
       const matchObject = {
@@ -38928,7 +20893,7 @@ function findAndReplace(tree, list3, options) {
         value = value.length > 0 ? { type: "text", value } : void 0;
       }
       if (value === false) {
-        find3.lastIndex = position3 + 1;
+        find2.lastIndex = position3 + 1;
       } else {
         if (start !== position3) {
           nodes.push({
@@ -38944,10 +20909,10 @@ function findAndReplace(tree, list3, options) {
         start = position3 + match[0].length;
         change = true;
       }
-      if (!find3.global) {
+      if (!find2.global) {
         break;
       }
-      match = find3.exec(node2.value);
+      match = find2.exec(node2.value);
     }
     if (change) {
       if (start < node2.value.length) {
@@ -38973,15 +20938,15 @@ function toPairs(tupleOrList) {
   }
   return result;
 }
-function toExpression(find3) {
-  return typeof find3 === "string" ? new RegExp(escapeStringRegexp(find3), "g") : find3;
+function toExpression(find2) {
+  return typeof find2 === "string" ? new RegExp(escapeStringRegexp(find2), "g") : find2;
 }
 function toFunction(replace2) {
   return typeof replace2 === "function" ? replace2 : function() {
     return replace2;
   };
 }
-var init_lib12 = __esm({
+var init_lib11 = __esm({
   "node_modules/.pnpm/mdast-util-find-and-replace@3.0.2/node_modules/mdast-util-find-and-replace/lib/index.js"() {
     init_escape_string_regexp();
     init_unist_util_visit_parents();
@@ -38992,7 +20957,7 @@ var init_lib12 = __esm({
 // node_modules/.pnpm/mdast-util-find-and-replace@3.0.2/node_modules/mdast-util-find-and-replace/index.js
 var init_mdast_util_find_and_replace = __esm({
   "node_modules/.pnpm/mdast-util-find-and-replace@3.0.2/node_modules/mdast-util-find-and-replace/index.js"() {
-    init_lib12();
+    init_lib11();
   }
 });
 
@@ -39144,7 +21109,7 @@ function previous2(match, email) {
   (!email || code4 !== 47);
 }
 var inConstruct, notInConstruct;
-var init_lib13 = __esm({
+var init_lib12 = __esm({
   "node_modules/.pnpm/mdast-util-gfm-autolink-literal@2.0.1/node_modules/mdast-util-gfm-autolink-literal/lib/index.js"() {
     init_ccount();
     init_default2();
@@ -39158,7 +21123,7 @@ var init_lib13 = __esm({
 // node_modules/.pnpm/mdast-util-gfm-autolink-literal@2.0.1/node_modules/mdast-util-gfm-autolink-literal/index.js
 var init_mdast_util_gfm_autolink_literal = __esm({
   "node_modules/.pnpm/mdast-util-gfm-autolink-literal@2.0.1/node_modules/mdast-util-gfm-autolink-literal/index.js"() {
-    init_lib13();
+    init_lib12();
   }
 });
 
@@ -39273,7 +21238,7 @@ function mapExceptFirst(line, index2, blank) {
 function mapAll(line, index2, blank) {
   return (blank ? "" : "    ") + line;
 }
-var init_lib14 = __esm({
+var init_lib13 = __esm({
   "node_modules/.pnpm/mdast-util-gfm-footnote@2.1.0/node_modules/mdast-util-gfm-footnote/lib/index.js"() {
     init_default2();
     init_micromark_util_normalize_identifier();
@@ -39284,7 +21249,7 @@ var init_lib14 = __esm({
 // node_modules/.pnpm/mdast-util-gfm-footnote@2.1.0/node_modules/mdast-util-gfm-footnote/index.js
 var init_mdast_util_gfm_footnote = __esm({
   "node_modules/.pnpm/mdast-util-gfm-footnote@2.1.0/node_modules/mdast-util-gfm-footnote/index.js"() {
-    init_lib14();
+    init_lib13();
   }
 });
 
@@ -39331,7 +21296,7 @@ function peekDelete() {
   return "~";
 }
 var constructsWithoutStrikethrough;
-var init_lib15 = __esm({
+var init_lib14 = __esm({
   "node_modules/.pnpm/mdast-util-gfm-strikethrough@2.0.0/node_modules/mdast-util-gfm-strikethrough/lib/index.js"() {
     constructsWithoutStrikethrough = [
       "autolink",
@@ -39348,7 +21313,7 @@ var init_lib15 = __esm({
 // node_modules/.pnpm/mdast-util-gfm-strikethrough@2.0.0/node_modules/mdast-util-gfm-strikethrough/index.js
 var init_mdast_util_gfm_strikethrough = __esm({
   "node_modules/.pnpm/mdast-util-gfm-strikethrough@2.0.0/node_modules/mdast-util-gfm-strikethrough/index.js"() {
-    init_lib15();
+    init_lib14();
   }
 });
 
@@ -39889,7 +21854,7 @@ function visit(tree, testOrVisitor, visitorOrReverse, maybeReverse) {
     return visitor(node2, index2, parent);
   }
 }
-var init_lib16 = __esm({
+var init_lib15 = __esm({
   "node_modules/.pnpm/unist-util-visit@5.1.0/node_modules/unist-util-visit/lib/index.js"() {
     init_unist_util_visit_parents();
     init_unist_util_visit_parents();
@@ -39899,7 +21864,7 @@ var init_lib16 = __esm({
 // node_modules/.pnpm/unist-util-visit@5.1.0/node_modules/unist-util-visit/index.js
 var init_unist_util_visit = __esm({
   "node_modules/.pnpm/unist-util-visit@5.1.0/node_modules/unist-util-visit/index.js"() {
-    init_lib16();
+    init_lib15();
   }
 });
 
@@ -40457,7 +22422,7 @@ var init_paragraph = __esm({
 
 // node_modules/.pnpm/mdast-util-phrasing@4.1.0/node_modules/mdast-util-phrasing/lib/index.js
 var phrasing;
-var init_lib17 = __esm({
+var init_lib16 = __esm({
   "node_modules/.pnpm/mdast-util-phrasing@4.1.0/node_modules/mdast-util-phrasing/lib/index.js"() {
     init_unist_util_is();
     phrasing = /** @type {(node?: unknown) => node is Exclude<PhrasingContent, Html>} */
@@ -40490,7 +22455,7 @@ var init_lib17 = __esm({
 // node_modules/.pnpm/mdast-util-phrasing@4.1.0/node_modules/mdast-util-phrasing/index.js
 var init_mdast_util_phrasing = __esm({
   "node_modules/.pnpm/mdast-util-phrasing@4.1.0/node_modules/mdast-util-phrasing/index.js"() {
-    init_lib17();
+    init_lib16();
   }
 });
 
@@ -40813,7 +22778,7 @@ function gfmTableToMarkdown(options) {
     return value;
   }
 }
-var init_lib18 = __esm({
+var init_lib17 = __esm({
   "node_modules/.pnpm/mdast-util-gfm-table@2.0.0/node_modules/mdast-util-gfm-table/lib/index.js"() {
     init_default2();
     init_markdown_table();
@@ -40824,7 +22789,7 @@ var init_lib18 = __esm({
 // node_modules/.pnpm/mdast-util-gfm-table@2.0.0/node_modules/mdast-util-gfm-table/index.js
 var init_mdast_util_gfm_table = __esm({
   "node_modules/.pnpm/mdast-util-gfm-table@2.0.0/node_modules/mdast-util-gfm-table/index.js"() {
-    init_lib18();
+    init_lib17();
   }
 });
 
@@ -40900,7 +22865,7 @@ function listItemWithTaskListItem(node2, parent, state, info) {
     return $0 + checkbox;
   }
 }
-var init_lib19 = __esm({
+var init_lib18 = __esm({
   "node_modules/.pnpm/mdast-util-gfm-task-list-item@2.0.0/node_modules/mdast-util-gfm-task-list-item/lib/index.js"() {
     init_default2();
     init_mdast_util_to_markdown();
@@ -40910,7 +22875,7 @@ var init_lib19 = __esm({
 // node_modules/.pnpm/mdast-util-gfm-task-list-item@2.0.0/node_modules/mdast-util-gfm-task-list-item/index.js
 var init_mdast_util_gfm_task_list_item = __esm({
   "node_modules/.pnpm/mdast-util-gfm-task-list-item@2.0.0/node_modules/mdast-util-gfm-task-list-item/index.js"() {
-    init_lib19();
+    init_lib18();
   }
 });
 
@@ -40935,7 +22900,7 @@ function gfmToMarkdown(options) {
     ]
   };
 }
-var init_lib20 = __esm({
+var init_lib19 = __esm({
   "node_modules/.pnpm/mdast-util-gfm@3.1.0/node_modules/mdast-util-gfm/lib/index.js"() {
     init_mdast_util_gfm_autolink_literal();
     init_mdast_util_gfm_footnote();
@@ -40948,7 +22913,7 @@ var init_lib20 = __esm({
 // node_modules/.pnpm/mdast-util-gfm@3.1.0/node_modules/mdast-util-gfm/index.js
 var init_mdast_util_gfm = __esm({
   "node_modules/.pnpm/mdast-util-gfm@3.1.0/node_modules/mdast-util-gfm/index.js"() {
-    init_lib20();
+    init_lib19();
   }
 });
 
@@ -41243,7 +23208,7 @@ function previousUnbalanced(events) {
   return result;
 }
 var wwwPrefix, domain, path, trail, emailDomainDotTrail, wwwAutolink, protocolAutolink, emailAutolink, text4, code3;
-var init_syntax2 = __esm({
+var init_syntax = __esm({
   "node_modules/.pnpm/micromark-extension-gfm-autolink-literal@2.1.0/node_modules/micromark-extension-gfm-autolink-literal/lib/syntax.js"() {
     init_micromark_util_character();
     wwwPrefix = {
@@ -41303,7 +23268,7 @@ var init_syntax2 = __esm({
 // node_modules/.pnpm/micromark-extension-gfm-autolink-literal@2.1.0/node_modules/micromark-extension-gfm-autolink-literal/index.js
 var init_micromark_extension_gfm_autolink_literal = __esm({
   "node_modules/.pnpm/micromark-extension-gfm-autolink-literal@2.1.0/node_modules/micromark-extension-gfm-autolink-literal/index.js"() {
-    init_syntax2();
+    init_syntax();
   }
 });
 
@@ -41578,7 +23543,7 @@ function tokenizeIndent2(effects, ok3, nok) {
   }
 }
 var indent;
-var init_syntax3 = __esm({
+var init_syntax2 = __esm({
   "node_modules/.pnpm/micromark-extension-gfm-footnote@2.1.0/node_modules/micromark-extension-gfm-footnote/lib/syntax.js"() {
     init_micromark_core_commonmark();
     init_micromark_factory_space();
@@ -41594,7 +23559,7 @@ var init_syntax3 = __esm({
 // node_modules/.pnpm/micromark-extension-gfm-footnote@2.1.0/node_modules/micromark-extension-gfm-footnote/index.js
 var init_micromark_extension_gfm_footnote = __esm({
   "node_modules/.pnpm/micromark-extension-gfm-footnote@2.1.0/node_modules/micromark-extension-gfm-footnote/index.js"() {
-    init_syntax3();
+    init_syntax2();
   }
 });
 
@@ -41691,7 +23656,7 @@ function gfmStrikethrough(options) {
     }
   }
 }
-var init_syntax4 = __esm({
+var init_syntax3 = __esm({
   "node_modules/.pnpm/micromark-extension-gfm-strikethrough@2.1.0/node_modules/micromark-extension-gfm-strikethrough/lib/syntax.js"() {
     init_micromark_util_chunked();
     init_micromark_util_classify_character();
@@ -41702,7 +23667,7 @@ var init_syntax4 = __esm({
 // node_modules/.pnpm/micromark-extension-gfm-strikethrough@2.1.0/node_modules/micromark-extension-gfm-strikethrough/index.js
 var init_micromark_extension_gfm_strikethrough = __esm({
   "node_modules/.pnpm/micromark-extension-gfm-strikethrough@2.1.0/node_modules/micromark-extension-gfm-strikethrough/index.js"() {
-    init_syntax4();
+    init_syntax3();
   }
 });
 
@@ -42206,7 +24171,7 @@ function getPoint(events, index2) {
   const side = event[0] === "enter" ? "start" : "end";
   return event[1][side];
 }
-var init_syntax5 = __esm({
+var init_syntax4 = __esm({
   "node_modules/.pnpm/micromark-extension-gfm-table@2.1.1/node_modules/micromark-extension-gfm-table/lib/syntax.js"() {
     init_micromark_factory_space();
     init_micromark_util_character();
@@ -42218,7 +24183,7 @@ var init_syntax5 = __esm({
 // node_modules/.pnpm/micromark-extension-gfm-table@2.1.1/node_modules/micromark-extension-gfm-table/index.js
 var init_micromark_extension_gfm_table = __esm({
   "node_modules/.pnpm/micromark-extension-gfm-table@2.1.1/node_modules/micromark-extension-gfm-table/index.js"() {
-    init_syntax5();
+    init_syntax4();
   }
 });
 
@@ -42292,7 +24257,7 @@ function spaceThenNonSpace(effects, ok3, nok) {
   }
 }
 var tasklistCheck;
-var init_syntax6 = __esm({
+var init_syntax5 = __esm({
   "node_modules/.pnpm/micromark-extension-gfm-task-list-item@2.1.0/node_modules/micromark-extension-gfm-task-list-item/lib/syntax.js"() {
     init_micromark_factory_space();
     init_micromark_util_character();
@@ -42306,7 +24271,7 @@ var init_syntax6 = __esm({
 // node_modules/.pnpm/micromark-extension-gfm-task-list-item@2.1.0/node_modules/micromark-extension-gfm-task-list-item/index.js
 var init_micromark_extension_gfm_task_list_item = __esm({
   "node_modules/.pnpm/micromark-extension-gfm-task-list-item@2.1.0/node_modules/micromark-extension-gfm-task-list-item/index.js"() {
-    init_syntax6();
+    init_syntax5();
   }
 });
 
@@ -42347,7 +24312,7 @@ function remarkGfm(options) {
   toMarkdownExtensions.push(gfmToMarkdown(settings));
 }
 var emptyOptions2;
-var init_lib21 = __esm({
+var init_lib20 = __esm({
   "node_modules/.pnpm/remark-gfm@4.0.1/node_modules/remark-gfm/lib/index.js"() {
     init_mdast_util_gfm();
     init_micromark_extension_gfm();
@@ -42358,7 +24323,7 @@ var init_lib21 = __esm({
 // node_modules/.pnpm/remark-gfm@4.0.1/node_modules/remark-gfm/index.js
 var init_remark_gfm = __esm({
   "node_modules/.pnpm/remark-gfm@4.0.1/node_modules/remark-gfm/index.js"() {
-    init_lib21();
+    init_lib20();
   }
 });
 
@@ -42377,9 +24342,9 @@ var init_schema = __esm({
        * @returns
        *   Schema.
        */
-      constructor(property2, normal, space) {
+      constructor(property, normal, space) {
         this.normal = normal;
-        this.property = property2;
+        this.property = property;
         if (space) {
           this.space = space;
         }
@@ -42393,13 +24358,13 @@ var init_schema = __esm({
 
 // node_modules/.pnpm/property-information@7.2.0/node_modules/property-information/lib/util/merge.js
 function merge(definitions, space) {
-  const property2 = {};
+  const property = {};
   const normal = {};
   for (const definition3 of definitions) {
-    Object.assign(property2, definition3.property);
+    Object.assign(property, definition3.property);
     Object.assign(normal, definition3.normal);
   }
-  return new Schema(property2, normal, space);
+  return new Schema(property, normal, space);
 }
 var init_merge = __esm({
   "node_modules/.pnpm/property-information@7.2.0/node_modules/property-information/lib/util/merge.js"() {
@@ -42429,9 +24394,9 @@ var init_info = __esm({
        * @returns
        *   Info.
        */
-      constructor(property2, attribute) {
+      constructor(property, attribute) {
         this.attribute = attribute;
-        this.property = property2;
+        this.property = property;
       }
     };
     Info.prototype.attribute = "";
@@ -42456,21 +24421,21 @@ __export(types_exports2, {
   booleanish: () => booleanish,
   commaOrSpaceSeparated: () => commaOrSpaceSeparated,
   commaSeparated: () => commaSeparated,
-  number: () => number2,
+  number: () => number,
   overloadedBoolean: () => overloadedBoolean,
   spaceSeparated: () => spaceSeparated
 });
 function increment() {
   return 2 ** ++powers;
 }
-var powers, boolean, booleanish, overloadedBoolean, number2, spaceSeparated, commaSeparated, commaOrSpaceSeparated;
+var powers, boolean, booleanish, overloadedBoolean, number, spaceSeparated, commaSeparated, commaOrSpaceSeparated;
 var init_types2 = __esm({
   "node_modules/.pnpm/property-information@7.2.0/node_modules/property-information/lib/util/types.js"() {
     powers = 0;
     boolean = increment();
     booleanish = increment();
     overloadedBoolean = increment();
-    number2 = increment();
+    number = increment();
     spaceSeparated = increment();
     commaSeparated = increment();
     commaOrSpaceSeparated = increment();
@@ -42504,9 +24469,9 @@ var init_defined_info = __esm({
        * @returns
        *   Info.
        */
-      constructor(property2, attribute, mask, space) {
+      constructor(property, attribute, mask, space) {
         let index2 = -1;
-        super(property2, attribute);
+        super(property, attribute);
         mark(this, "space", space);
         if (typeof mask === "number") {
           while (++index2 < checks.length) {
@@ -42522,25 +24487,25 @@ var init_defined_info = __esm({
 
 // node_modules/.pnpm/property-information@7.2.0/node_modules/property-information/lib/util/create.js
 function create(definition3) {
-  const properties2 = {};
+  const properties = {};
   const normals = {};
-  for (const [property2, value] of Object.entries(definition3.properties)) {
+  for (const [property, value] of Object.entries(definition3.properties)) {
     const info = new DefinedInfo(
-      property2,
-      definition3.transform(definition3.attributes || {}, property2),
+      property,
+      definition3.transform(definition3.attributes || {}, property),
       value,
       definition3.space
     );
-    if (definition3.mustUseProperty && definition3.mustUseProperty.includes(property2)) {
+    if (definition3.mustUseProperty && definition3.mustUseProperty.includes(property)) {
       info.mustUseProperty = true;
     }
-    properties2[property2] = info;
-    normals[normalize(property2)] = property2;
-    normals[normalize(info.attribute)] = property2;
+    properties[property] = info;
+    normals[normalize(property)] = property;
+    normals[normalize(info.attribute)] = property;
   }
-  return new Schema(properties2, normals, definition3.space);
+  return new Schema(properties, normals, definition3.space);
 }
-var init_create6 = __esm({
+var init_create4 = __esm({
   "node_modules/.pnpm/property-information@7.2.0/node_modules/property-information/lib/util/create.js"() {
     init_normalize();
     init_defined_info();
@@ -42552,7 +24517,7 @@ var init_create6 = __esm({
 var aria;
 var init_aria = __esm({
   "node_modules/.pnpm/property-information@7.2.0/node_modules/property-information/lib/aria.js"() {
-    init_create6();
+    init_create4();
     init_types2();
     aria = create({
       properties: {
@@ -42561,9 +24526,9 @@ var init_aria = __esm({
         ariaAutoComplete: null,
         ariaBusy: booleanish,
         ariaChecked: booleanish,
-        ariaColCount: number2,
-        ariaColIndex: number2,
-        ariaColSpan: number2,
+        ariaColCount: number,
+        ariaColIndex: number,
+        ariaColSpan: number,
         ariaControls: spaceSeparated,
         ariaCurrent: null,
         ariaDescribedBy: spaceSeparated,
@@ -42580,7 +24545,7 @@ var init_aria = __esm({
         ariaKeyShortcuts: null,
         ariaLabel: null,
         ariaLabelledBy: spaceSeparated,
-        ariaLevel: number2,
+        ariaLevel: number,
         ariaLive: null,
         ariaModal: booleanish,
         ariaMultiLine: booleanish,
@@ -42588,26 +24553,26 @@ var init_aria = __esm({
         ariaOrientation: null,
         ariaOwns: spaceSeparated,
         ariaPlaceholder: null,
-        ariaPosInSet: number2,
+        ariaPosInSet: number,
         ariaPressed: booleanish,
         ariaReadOnly: booleanish,
         ariaRelevant: null,
         ariaRequired: booleanish,
         ariaRoleDescription: spaceSeparated,
-        ariaRowCount: number2,
-        ariaRowIndex: number2,
-        ariaRowSpan: number2,
+        ariaRowCount: number,
+        ariaRowIndex: number,
+        ariaRowSpan: number,
         ariaSelected: booleanish,
-        ariaSetSize: number2,
+        ariaSetSize: number,
         ariaSort: null,
-        ariaValueMax: number2,
-        ariaValueMin: number2,
-        ariaValueNow: number2,
+        ariaValueMax: number,
+        ariaValueMin: number,
+        ariaValueNow: number,
         ariaValueText: null,
         role: null
       },
-      transform(_, property2) {
-        return property2 === "role" ? property2 : "aria-" + property2.slice(4).toLowerCase();
+      transform(_, property) {
+        return property === "role" ? property : "aria-" + property.slice(4).toLowerCase();
       }
     });
   }
@@ -42623,8 +24588,8 @@ var init_case_sensitive_transform = __esm({
 });
 
 // node_modules/.pnpm/property-information@7.2.0/node_modules/property-information/lib/util/case-insensitive-transform.js
-function caseInsensitiveTransform(attributes, property2) {
-  return caseSensitiveTransform(attributes, property2.toLowerCase());
+function caseInsensitiveTransform(attributes, property) {
+  return caseSensitiveTransform(attributes, property.toLowerCase());
 }
 var init_case_insensitive_transform = __esm({
   "node_modules/.pnpm/property-information@7.2.0/node_modules/property-information/lib/util/case-insensitive-transform.js"() {
@@ -42637,7 +24602,7 @@ var html2;
 var init_html2 = __esm({
   "node_modules/.pnpm/property-information@7.2.0/node_modules/property-information/lib/html.js"() {
     init_case_insensitive_transform();
-    init_create6();
+    init_create4();
     init_types2();
     html2 = create({
       attributes: {
@@ -42674,15 +24639,15 @@ var init_html2 = __esm({
         className: spaceSeparated,
         closedBy: null,
         colorSpace: null,
-        cols: number2,
-        colSpan: number2,
+        cols: number,
+        colSpan: number,
         command: null,
         commandFor: null,
         content: null,
         contentEditable: booleanish,
         controls: boolean,
         controlsList: spaceSeparated,
-        coords: number2 | commaSeparated,
+        coords: number | commaSeparated,
         crossOrigin: null,
         data: null,
         dateTime: null,
@@ -42704,9 +24669,9 @@ var init_html2 = __esm({
         formNoValidate: boolean,
         formTarget: null,
         headers: spaceSeparated,
-        height: number2,
+        height: number,
         hidden: overloadedBoolean,
-        high: number2,
+        high: number,
         href: null,
         hrefLang: null,
         htmlFor: spaceSeparated,
@@ -42731,14 +24696,14 @@ var init_html2 = __esm({
         list: null,
         loading: null,
         loop: boolean,
-        low: number2,
+        low: number,
         manifest: null,
         max: null,
-        maxLength: number2,
+        maxLength: number,
         media: null,
         method: null,
         min: null,
-        minLength: number2,
+        minLength: number,
         multiple: boolean,
         muted: boolean,
         name: null,
@@ -42834,7 +24799,7 @@ var init_html2 = __esm({
         onWaiting: null,
         onWheel: null,
         open: boolean,
-        optimum: number2,
+        optimum: number,
         pattern: null,
         ping: spaceSeparated,
         placeholder: null,
@@ -42849,8 +24814,8 @@ var init_html2 = __esm({
         rel: spaceSeparated,
         required: boolean,
         reversed: boolean,
-        rows: number2,
-        rowSpan: number2,
+        rows: number,
+        rowSpan: number,
         sandbox: spaceSeparated,
         scope: null,
         scoped: boolean,
@@ -42862,19 +24827,19 @@ var init_html2 = __esm({
         shadowRootMode: null,
         shadowRootSerializable: boolean,
         shape: null,
-        size: number2,
+        size: number,
         sizes: null,
         slot: null,
-        span: number2,
+        span: number,
         spellCheck: booleanish,
         src: null,
         srcDoc: null,
         srcLang: null,
         srcSet: null,
-        start: number2,
+        start: number,
         step: null,
         style: null,
-        tabIndex: number2,
+        tabIndex: number,
         target: null,
         title: null,
         translate: null,
@@ -42882,7 +24847,7 @@ var init_html2 = __esm({
         typeMustMatch: boolean,
         useMap: null,
         value: booleanish,
-        width: number2,
+        width: number,
         wrap: null,
         writingSuggestions: null,
         // Legacy.
@@ -42899,11 +24864,11 @@ var init_html2 = __esm({
         // `<body>`. Use CSS `background-image` instead
         bgColor: null,
         // `<body>` and table elements. Use CSS `background-color` instead
-        border: number2,
+        border: number,
         // `<table>`. Use CSS `border-width` instead,
         borderColor: null,
         // `<table>`. Use CSS `border-color` instead,
-        bottomMargin: number2,
+        bottomMargin: number,
         // `<body>`
         cellPadding: null,
         // `<table>`
@@ -42937,9 +24902,9 @@ var init_html2 = __esm({
         // `<table>`
         frameBorder: null,
         // `<iframe>`. Use CSS `border` instead
-        hSpace: number2,
+        hSpace: number,
         // `<img>` and `<object>`
-        leftMargin: number2,
+        leftMargin: number,
         // `<body>`
         link: null,
         // `<body>`. Use CSS `a:link {color: *}` instead
@@ -42947,9 +24912,9 @@ var init_html2 = __esm({
         // `<frame>`, `<iframe>`, and `<img>`. Use an `<a>`
         lowSrc: null,
         // `<img>`. Use a `<picture>`
-        marginHeight: number2,
+        marginHeight: number,
         // `<body>`
-        marginWidth: number2,
+        marginWidth: number,
         // `<body>`
         noResize: boolean,
         // `<frame>`
@@ -42967,7 +24932,7 @@ var init_html2 = __esm({
         // `<isindex>`
         rev: null,
         // `<link>`
-        rightMargin: number2,
+        rightMargin: number,
         // `<body>`
         rules: null,
         // `<table>`
@@ -42981,7 +24946,7 @@ var init_html2 = __esm({
         // `<table>`
         text: null,
         // `<body>`. Use CSS `color` instead
-        topMargin: number2,
+        topMargin: number,
         // `<body>`
         valueType: null,
         // `<param>`
@@ -42991,7 +24956,7 @@ var init_html2 = __esm({
         // Several. Use CSS `vertical-align` instead
         vLink: null,
         // `<body>`. Use CSS `a:visited {color}` instead
-        vSpace: number2,
+        vSpace: number,
         // `<img>` and `<object>`
         // Non-standard Properties.
         allowTransparency: null,
@@ -43004,7 +24969,7 @@ var init_html2 = __esm({
         part: spaceSeparated,
         prefix: null,
         property: null,
-        results: number2,
+        results: number,
         security: null,
         unselectable: null
       },
@@ -43019,7 +24984,7 @@ var svg;
 var init_svg = __esm({
   "node_modules/.pnpm/property-information@7.2.0/node_modules/property-information/lib/svg.js"() {
     init_case_sensitive_transform();
-    init_create6();
+    init_create4();
     init_types2();
     svg = create({
       attributes: {
@@ -43200,27 +25165,27 @@ var init_svg = __esm({
       },
       properties: {
         about: commaOrSpaceSeparated,
-        accentHeight: number2,
+        accentHeight: number,
         accumulate: null,
         additive: null,
         alignmentBaseline: null,
-        alphabetic: number2,
-        amplitude: number2,
+        alphabetic: number,
+        amplitude: number,
         arabicForm: null,
-        ascent: number2,
+        ascent: number,
         attributeName: null,
         attributeType: null,
-        azimuth: number2,
+        azimuth: number,
         bandwidth: null,
         baselineShift: null,
         baseFrequency: null,
         baseProfile: null,
         bbox: null,
         begin: null,
-        bias: number2,
+        bias: number,
         by: null,
         calcMode: null,
-        capHeight: number2,
+        capHeight: number,
         className: spaceSeparated,
         clip: null,
         clipPath: null,
@@ -43241,26 +25206,26 @@ var init_svg = __esm({
         d: null,
         dataType: null,
         defaultAction: null,
-        descent: number2,
-        diffuseConstant: number2,
+        descent: number,
+        diffuseConstant: number,
         direction: null,
         display: null,
         dur: null,
-        divisor: number2,
+        divisor: number,
         dominantBaseline: null,
         download: boolean,
         dx: null,
         dy: null,
         edgeMode: null,
         editable: null,
-        elevation: number2,
+        elevation: number,
         enableBackground: null,
         end: null,
         event: null,
-        exponent: number2,
+        exponent: number,
         externalResourcesRequired: null,
         fill: null,
-        fillOpacity: number2,
+        fillOpacity: number,
         fillRule: null,
         filter: null,
         filterRes: null,
@@ -43290,27 +25255,27 @@ var init_svg = __esm({
         gradientTransform: null,
         gradientUnits: null,
         handler: null,
-        hanging: number2,
+        hanging: number,
         hatchContentUnits: null,
         hatchUnits: null,
         height: null,
         href: null,
         hrefLang: null,
-        horizAdvX: number2,
-        horizOriginX: number2,
-        horizOriginY: number2,
+        horizAdvX: number,
+        horizOriginX: number,
+        horizOriginY: number,
         id: null,
-        ideographic: number2,
+        ideographic: number,
         imageRendering: null,
         initialVisibility: null,
         in: null,
         in2: null,
-        intercept: number2,
-        k: number2,
-        k1: number2,
-        k2: number2,
-        k3: number2,
-        k4: number2,
+        intercept: number,
+        k: number,
+        k1: number,
+        k2: number,
+        k3: number,
+        k4: number,
         kernelMatrix: commaOrSpaceSeparated,
         kernelUnitLength: null,
         keyPoints: null,
@@ -43324,7 +25289,7 @@ var init_svg = __esm({
         lengthAdjust: null,
         letterSpacing: null,
         lightingColor: null,
-        limitingConeAngle: number2,
+        limitingConeAngle: number,
         local: null,
         markerEnd: null,
         markerMid: null,
@@ -43341,7 +25306,7 @@ var init_svg = __esm({
         media: null,
         mediaCharacterEncoding: null,
         mediaContentEncodings: null,
-        mediaSize: number2,
+        mediaSize: number,
         mediaTime: null,
         method: null,
         min: null,
@@ -43447,12 +25412,12 @@ var init_svg = __esm({
         origin: null,
         overflow: null,
         overlay: null,
-        overlinePosition: number2,
-        overlineThickness: number2,
+        overlinePosition: number,
+        overlineThickness: number,
         paintOrder: null,
         panose1: null,
         path: null,
-        pathLength: number2,
+        pathLength: number,
         patternContentUnits: null,
         patternTransform: null,
         patternUnits: null,
@@ -43462,9 +25427,9 @@ var init_svg = __esm({
         playbackOrder: null,
         pointerEvents: null,
         points: null,
-        pointsAtX: number2,
-        pointsAtY: number2,
-        pointsAtZ: number2,
+        pointsAtX: number,
+        pointsAtY: number,
+        pointsAtZ: number,
         preserveAlpha: null,
         preserveAspectRatio: null,
         primitiveUnits: null,
@@ -43496,8 +25461,8 @@ var init_svg = __esm({
         side: null,
         slope: null,
         snapshotTime: null,
-        specularConstant: number2,
-        specularExponent: number2,
+        specularConstant: number,
+        specularExponent: number,
         spreadMethod: null,
         spacing: null,
         startOffset: null,
@@ -43507,30 +25472,30 @@ var init_svg = __esm({
         stitchTiles: null,
         stopColor: null,
         stopOpacity: null,
-        strikethroughPosition: number2,
-        strikethroughThickness: number2,
+        strikethroughPosition: number,
+        strikethroughThickness: number,
         string: null,
         stroke: null,
         strokeDashArray: commaOrSpaceSeparated,
         strokeDashOffset: null,
         strokeLineCap: null,
         strokeLineJoin: null,
-        strokeMiterLimit: number2,
-        strokeOpacity: number2,
+        strokeMiterLimit: number,
+        strokeOpacity: number,
         strokeWidth: null,
         style: null,
-        surfaceScale: number2,
+        surfaceScale: number,
         syncBehavior: null,
         syncBehaviorDefault: null,
         syncMaster: null,
         syncTolerance: null,
         syncToleranceDefault: null,
         systemLanguage: commaOrSpaceSeparated,
-        tabIndex: number2,
+        tabIndex: number,
         tableValues: null,
         target: null,
-        targetX: number2,
-        targetY: number2,
+        targetX: number,
+        targetY: number,
         textAnchor: null,
         textDecoration: null,
         textRendering: null,
@@ -43545,22 +25510,22 @@ var init_svg = __esm({
         transformOrigin: null,
         u1: null,
         u2: null,
-        underlinePosition: number2,
-        underlineThickness: number2,
+        underlinePosition: number,
+        underlineThickness: number,
         unicode: null,
         unicodeBidi: null,
         unicodeRange: null,
-        unitsPerEm: number2,
+        unitsPerEm: number,
         values: null,
-        vAlphabetic: number2,
-        vMathematical: number2,
+        vAlphabetic: number,
+        vMathematical: number,
         vectorEffect: null,
-        vHanging: number2,
-        vIdeographic: number2,
+        vHanging: number,
+        vIdeographic: number,
         version: null,
-        vertAdvY: number2,
-        vertOriginX: number2,
-        vertOriginY: number2,
+        vertAdvY: number,
+        vertOriginX: number,
+        vertOriginY: number,
         viewBox: null,
         viewTarget: null,
         visibility: null,
@@ -43572,7 +25537,7 @@ var init_svg = __esm({
         x1: null,
         x2: null,
         xChannelSelector: null,
-        xHeight: number2,
+        xHeight: number,
         y: null,
         y1: null,
         y2: null,
@@ -43590,7 +25555,7 @@ var init_svg = __esm({
 var xlink;
 var init_xlink = __esm({
   "node_modules/.pnpm/property-information@7.2.0/node_modules/property-information/lib/xlink.js"() {
-    init_create6();
+    init_create4();
     xlink = create({
       properties: {
         xLinkActuate: null,
@@ -43602,8 +25567,8 @@ var init_xlink = __esm({
         xLinkType: null
       },
       space: "xlink",
-      transform(_, property2) {
-        return "xlink:" + property2.slice(5).toLowerCase();
+      transform(_, property) {
+        return "xlink:" + property.slice(5).toLowerCase();
       }
     });
   }
@@ -43613,7 +25578,7 @@ var init_xlink = __esm({
 var xmlns;
 var init_xmlns = __esm({
   "node_modules/.pnpm/property-information@7.2.0/node_modules/property-information/lib/xmlns.js"() {
-    init_create6();
+    init_create4();
     init_case_insensitive_transform();
     xmlns = create({
       attributes: { xmlnsxlink: "xmlns:xlink" },
@@ -43628,21 +25593,21 @@ var init_xmlns = __esm({
 var xml;
 var init_xml = __esm({
   "node_modules/.pnpm/property-information@7.2.0/node_modules/property-information/lib/xml.js"() {
-    init_create6();
+    init_create4();
     xml = create({
       properties: { xmlBase: null, xmlLang: null, xmlSpace: null },
       space: "xml",
-      transform(_, property2) {
-        return "xml:" + property2.slice(3).toLowerCase();
+      transform(_, property) {
+        return "xml:" + property.slice(3).toLowerCase();
       }
     });
   }
 });
 
 // node_modules/.pnpm/property-information@7.2.0/node_modules/property-information/lib/find.js
-function find2(schema, value) {
+function find(schema, value) {
   const normal = normalize(value);
-  let property2 = value;
+  let property = value;
   let Type = Info;
   if (normal in schema.normal) {
     return schema.property[schema.normal[normal]];
@@ -43650,7 +25615,7 @@ function find2(schema, value) {
   if (normal.length > 4 && normal.slice(0, 4) === "data" && valid.test(value)) {
     if (value.charAt(4) === "-") {
       const rest = value.slice(5).replace(dash, camelcase);
-      property2 = "data" + rest.charAt(0).toUpperCase() + rest.slice(1);
+      property = "data" + rest.charAt(0).toUpperCase() + rest.slice(1);
     } else {
       const rest = value.slice(4);
       if (!dash.test(rest)) {
@@ -43663,7 +25628,7 @@ function find2(schema, value) {
     }
     Type = DefinedInfo;
   }
-  return new Type(property2, value);
+  return new Type(property, value);
 }
 function kebab($0) {
   return "-" + $0.toLowerCase();
@@ -43702,7 +25667,7 @@ var init_property_information = __esm({
 });
 
 // node_modules/.pnpm/comma-separated-tokens@2.0.3/node_modules/comma-separated-tokens/index.js
-function parse54(value) {
+function parse52(value) {
   const tokens = [];
   const input = String(value || "");
   let index2 = input.indexOf(",");
@@ -43764,7 +25729,7 @@ function parseSelector(selector2, defaultTagName) {
   };
 }
 var search2;
-var init_lib22 = __esm({
+var init_lib21 = __esm({
   "node_modules/.pnpm/hast-util-parse-selector@4.0.0/node_modules/hast-util-parse-selector/lib/index.js"() {
     search2 = /[#.]/g;
   }
@@ -43773,12 +25738,12 @@ var init_lib22 = __esm({
 // node_modules/.pnpm/hast-util-parse-selector@4.0.0/node_modules/hast-util-parse-selector/index.js
 var init_hast_util_parse_selector = __esm({
   "node_modules/.pnpm/hast-util-parse-selector@4.0.0/node_modules/hast-util-parse-selector/index.js"() {
-    init_lib22();
+    init_lib21();
   }
 });
 
 // node_modules/.pnpm/space-separated-tokens@2.0.2/node_modules/space-separated-tokens/index.js
-function parse55(value) {
+function parse53(value) {
   const input = String(value || "").trim();
   return input ? input.split(/[ \t\n\r\f]+/g) : [];
 }
@@ -43790,13 +25755,13 @@ var init_space_separated_tokens = __esm({
 // node_modules/.pnpm/hastscript@9.0.1/node_modules/hastscript/lib/create-h.js
 function createH(schema, defaultTagName, caseSensitive) {
   const adjust = caseSensitive ? createAdjustMap(caseSensitive) : void 0;
-  function h2(selector2, properties2, ...children) {
+  function h2(selector2, properties, ...children) {
     let node2;
     if (selector2 === null || selector2 === void 0) {
       node2 = { type: "root", children: [] };
       const child = (
         /** @type {Child} */
-        properties2
+        properties
       );
       children.unshift(child);
     } else {
@@ -43804,10 +25769,10 @@ function createH(schema, defaultTagName, caseSensitive) {
       const lower = node2.tagName.toLowerCase();
       const adjusted = adjust ? adjust.get(lower) : void 0;
       node2.tagName = adjusted || lower;
-      if (isChild(properties2)) {
-        children.unshift(properties2);
+      if (isChild(properties)) {
+        children.unshift(properties);
       } else {
-        for (const [key, value] of Object.entries(properties2)) {
+        for (const [key, value] of Object.entries(properties)) {
           addProperty(schema, node2.properties, key, value);
         }
       }
@@ -43853,8 +25818,8 @@ function isChild(value) {
   }
   return false;
 }
-function addProperty(schema, properties2, key, value) {
-  const info = find2(schema, key);
+function addProperty(schema, properties, key, value) {
+  const info = find(schema, key);
   let result;
   if (value === null || value === void 0) return;
   if (typeof value === "number") {
@@ -43864,11 +25829,11 @@ function addProperty(schema, properties2, key, value) {
     result = value;
   } else if (typeof value === "string") {
     if (info.spaceSeparated) {
-      result = parse55(value);
+      result = parse53(value);
     } else if (info.commaSeparated) {
-      result = parse54(value);
+      result = parse52(value);
     } else if (info.commaOrSpaceSeparated) {
-      result = parse55(parse54(value).join(" "));
+      result = parse53(parse52(value).join(" "));
     } else {
       result = parsePrimitive(info, info.property, value);
     }
@@ -43887,13 +25852,13 @@ function addProperty(schema, properties2, key, value) {
     }
     result = finalResult;
   }
-  if (info.property === "className" && Array.isArray(properties2.className)) {
-    result = properties2.className.concat(
+  if (info.property === "className" && Array.isArray(properties.className)) {
+    result = properties.className.concat(
       /** @type {Array<number | string> | number | string} */
       result
     );
   }
-  properties2[info.property] = result;
+  properties[info.property] = result;
 }
 function addChild(nodes, value) {
   if (value === null || value === void 0) {
@@ -43997,7 +25962,7 @@ var init_svg_case_sensitive_tag_names = __esm({
 
 // node_modules/.pnpm/hastscript@9.0.1/node_modules/hastscript/lib/index.js
 var h, s;
-var init_lib23 = __esm({
+var init_lib22 = __esm({
   "node_modules/.pnpm/hastscript@9.0.1/node_modules/hastscript/lib/index.js"() {
     init_property_information();
     init_create_h();
@@ -44010,7 +25975,7 @@ var init_lib23 = __esm({
 // node_modules/.pnpm/hastscript@9.0.1/node_modules/hastscript/index.js
 var init_hastscript = __esm({
   "node_modules/.pnpm/hastscript@9.0.1/node_modules/hastscript/index.js"() {
-    init_lib23();
+    init_lib22();
   }
 });
 
@@ -44061,7 +26026,7 @@ function next(value, from) {
   if (cr === -1 || cr + 1 === lf) return lf;
   return cr < lf ? cr : lf;
 }
-var init_lib24 = __esm({
+var init_lib23 = __esm({
   "node_modules/.pnpm/vfile-location@5.0.3/node_modules/vfile-location/lib/index.js"() {
   }
 });
@@ -44069,7 +26034,7 @@ var init_lib24 = __esm({
 // node_modules/.pnpm/vfile-location@5.0.3/node_modules/vfile-location/index.js
 var init_vfile_location = __esm({
   "node_modules/.pnpm/vfile-location@5.0.3/node_modules/vfile-location/index.js"() {
-    init_lib24();
+    init_lib23();
   }
 });
 
@@ -44110,7 +26075,7 @@ function one2(state, node2) {
         node2
       );
       result = { type: "comment", value: reference.data };
-      patch2(state, reference, result);
+      patch(state, reference, result);
       return result;
     }
     case "#document":
@@ -44142,7 +26107,7 @@ function one2(state, node2) {
         node2
       );
       result = { type: "doctype" };
-      patch2(state, reference, result);
+      patch(state, reference, result);
       return result;
     }
     case "#text": {
@@ -44151,7 +26116,7 @@ function one2(state, node2) {
         node2
       );
       result = { type: "text", value: reference.value };
-      patch2(state, reference, result);
+      patch(state, reference, result);
       return result;
     }
     // Element.
@@ -44181,17 +26146,17 @@ function element(state, node2) {
   const schema = state.schema;
   state.schema = node2.namespaceURI === webNamespaces.svg ? svg2 : html3;
   let index2 = -1;
-  const properties2 = {};
+  const properties = {};
   while (++index2 < node2.attrs.length) {
     const attribute = node2.attrs[index2];
     const name50 = (attribute.prefix ? attribute.prefix + ":" : "") + attribute.name;
     if (!own4.call(proto, name50)) {
-      properties2[name50] = attribute.value;
+      properties[name50] = attribute.value;
     }
   }
   const x = state.schema.space === "svg" ? s : h;
-  const result = x(node2.tagName, properties2, all2(state, node2.childNodes));
-  patch2(state, node2, result);
+  const result = x(node2.tagName, properties, all2(state, node2.childNodes));
+  patch(state, node2, result);
   if (result.tagName === "template") {
     const reference = (
       /** @type {DefaultTreeAdapterMap['template']} */
@@ -44212,7 +26177,7 @@ function element(state, node2) {
   state.schema = schema;
   return result;
 }
-function patch2(state, from, to) {
+function patch(state, from, to) {
   if ("sourceCodeLocation" in from && from.sourceCodeLocation && state.file) {
     const position3 = createLocation(state, to, from.sourceCodeLocation);
     if (position3) {
@@ -44229,12 +26194,12 @@ function createLocation(state, node2, location2) {
       result.end = Object.assign({}, tail.position.end);
     }
     if (state.verbose) {
-      const properties2 = {};
+      const properties = {};
       let key;
       if (location2.attrs) {
         for (key in location2.attrs) {
           if (own4.call(location2.attrs, key)) {
-            properties2[find2(state.schema, key).property] = position2(
+            properties[find(state.schema, key).property] = position2(
               location2.attrs[key]
             );
           }
@@ -44245,7 +26210,7 @@ function createLocation(state, node2, location2) {
       const closing = location2.endTag ? position2(location2.endTag) : void 0;
       const data = { opening };
       if (closing) data.closing = closing;
-      data.properties = properties2;
+      data.properties = properties;
       node2.data = { position: data };
     }
   }
@@ -44268,7 +26233,7 @@ function point3(point4) {
   return point4.line && point4.column ? point4 : void 0;
 }
 var own4, proto;
-var init_lib25 = __esm({
+var init_lib24 = __esm({
   "node_modules/.pnpm/hast-util-from-parse5@8.0.3/node_modules/hast-util-from-parse5/lib/index.js"() {
     init_default2();
     init_hastscript();
@@ -44283,7 +26248,7 @@ var init_lib25 = __esm({
 // node_modules/.pnpm/hast-util-from-parse5@8.0.3/node_modules/hast-util-from-parse5/index.js
 var init_hast_util_from_parse5 = __esm({
   "node_modules/.pnpm/hast-util-from-parse5@8.0.3/node_modules/hast-util-from-parse5/index.js"() {
-    init_lib25();
+    init_lib24();
   }
 });
 
@@ -48169,10 +30134,10 @@ var init_tokenizer2 = __esm({
       // Character reference state
       //------------------------------------------------------------------
       _stateCharacterReference() {
-        let length2 = this.entityDecoder.write(this.preprocessor.html, this.preprocessor.pos);
-        if (length2 < 0) {
+        let length = this.entityDecoder.write(this.preprocessor.html, this.preprocessor.pos);
+        if (length < 0) {
           if (this.preprocessor.lastChunkWritten) {
-            length2 = this.entityDecoder.end();
+            length = this.entityDecoder.end();
           } else {
             this.active = false;
             this.preprocessor.pos = this.preprocessor.html.length - 1;
@@ -48181,7 +30146,7 @@ var init_tokenizer2 = __esm({
             return;
           }
         }
-        if (length2 === 0) {
+        if (length === 0) {
           this.preprocessor.pos = this.entityStartPos;
           this._flushCodePointConsumedAsCharacterReference(CODE_POINTS.AMPERSAND);
           this.state = !this._isCharacterReferenceInAttribute() && isAsciiAlphaNumeric2(this.preprocessor.peek(1)) ? State.AMBIGUOUS_AMPERSAND : this.returnState;
@@ -51078,7 +33043,7 @@ function endTagInForeignContent(p, token) {
   }
 }
 var HIDDEN_INPUT_TYPE, AA_OUTER_LOOP_ITER, AA_INNER_LOOP_ITER, InsertionMode, BASE_LOC, TABLE_STRUCTURE_TAGS, defaultParserOptions, Parser, TABLE_VOID_ELEMENTS;
-var init_parser2 = __esm({
+var init_parser3 = __esm({
   "node_modules/.pnpm/parse5@7.3.0/node_modules/parse5/dist/parser/index.js"() {
     init_tokenizer2();
     init_open_element_stack();
@@ -52239,7 +34204,7 @@ var init_serializer = __esm({
 });
 
 // node_modules/.pnpm/parse5@7.3.0/node_modules/parse5/dist/index.js
-function parse56(html4, options) {
+function parse54(html4, options) {
   return Parser.parse(html4, options);
 }
 function parseFragment(fragmentContext, html4, options) {
@@ -52254,9 +34219,9 @@ function parseFragment(fragmentContext, html4, options) {
 }
 var init_dist = __esm({
   "node_modules/.pnpm/parse5@7.3.0/node_modules/parse5/dist/index.js"() {
-    init_parser2();
+    init_parser3();
     init_default3();
-    init_parser2();
+    init_parser3();
     init_serializer();
     init_error_codes();
     init_foreign_content();
@@ -52591,7 +34556,7 @@ function fromHtml(value, options) {
   const settings = options || emptyOptions3;
   const onerror = settings.onerror;
   const file = value instanceof VFile ? value : new VFile(value);
-  const parseFunction = settings.fragment ? parseFragment : parse56;
+  const parseFunction = settings.fragment ? parseFragment : parse54;
   const document3 = String(file);
   const p5Document = parseFunction(document3, {
     sourceCodeLocationInfo: true,
@@ -52671,7 +34636,7 @@ function visualizeCharacterCode(charCode) {
   return "0x" + charCode.toString(16).toUpperCase();
 }
 var base, dashToCamelRe, formatCRe, formatXRe, fatalities, emptyOptions3;
-var init_lib26 = __esm({
+var init_lib25 = __esm({
   "node_modules/.pnpm/hast-util-from-html@2.0.3/node_modules/hast-util-from-html/lib/index.js"() {
     init_default2();
     init_hast_util_from_parse5();
@@ -52691,7 +34656,7 @@ var init_lib26 = __esm({
 // node_modules/.pnpm/hast-util-from-html@2.0.3/node_modules/hast-util-from-html/index.js
 var init_hast_util_from_html = __esm({
   "node_modules/.pnpm/hast-util-from-html@2.0.3/node_modules/hast-util-from-html/index.js"() {
-    init_lib26();
+    init_lib25();
   }
 });
 
@@ -52713,7 +34678,7 @@ function rehypeParse(options) {
     });
   }
 }
-var init_lib27 = __esm({
+var init_lib26 = __esm({
   "node_modules/.pnpm/rehype-parse@9.0.1/node_modules/rehype-parse/lib/index.js"() {
     init_hast_util_from_html();
   }
@@ -52722,7 +34687,7 @@ var init_lib27 = __esm({
 // node_modules/.pnpm/rehype-parse@9.0.1/node_modules/rehype-parse/index.js
 var init_rehype_parse = __esm({
   "node_modules/.pnpm/rehype-parse@9.0.1/node_modules/rehype-parse/index.js"() {
-    init_lib27();
+    init_lib26();
   }
 });
 
@@ -54037,9 +36002,9 @@ function createNamespaceGuard(config, adapter) {
         source: collision
       };
       if (config.suggest && !options?.skipSuggestions) {
-        const generate52 = resolveGenerator(config.suggest, pattern);
+        const generate50 = resolveGenerator(config.suggest, pattern);
         const max = config.suggest.max ?? 3;
-        const candidates = generate52(normalized);
+        const candidates = generate50(normalized);
         const suggestions = [];
         const passedSync = candidates.filter(
           (c) => pattern.test(c) && !reservedMap.has(c) && (allowPurelyNumeric || !/^\d+(-\d+)*$/.test(c))
@@ -63093,7 +45058,7 @@ __export(confusables_exports, {
   scopeFor: () => scopeFor,
   selectFoldableFindings: () => selectFoldableFindings
 });
-import { createRequire as createRequire4 } from "node:module";
+import { createRequire } from "node:module";
 function scopeFor(tool, fields = DEFAULT_FIELDS) {
   if (Object.hasOwn(fields, tool))
     return { kind: "covered", fields: fields[tool] };
@@ -63104,7 +45069,7 @@ function scopeFor(tool, fields = DEFAULT_FIELDS) {
   return { kind: "undeclared" };
 }
 function resolveScan() {
-  defaultScan ??= createRequire4(import.meta.url)("namespace-guard").scan;
+  defaultScan ??= createRequire(import.meta.url)("namespace-guard").scan;
   return (
     /** @type {any} */
     defaultScan
@@ -63552,7 +45517,7 @@ function canonicalizeColor(raw) {
 function paintsImageLayer(node2) {
   if (!node2) return false;
   let found = false;
-  walk2(node2, {
+  walker_default2(node2, {
     enter(child) {
       if (child.type === "Url" || child.type === "Raw") found = true;
       if (child.type === "Function" && (child.name === "url" || child.name.endsWith("gradient") || child.name.endsWith("image-set")))
@@ -63676,7 +45641,7 @@ function isFontShorthandHidden(node2) {
   return false;
 }
 function tokenText(token) {
-  return token.type === "Identifier" ? token.name : generate51(token);
+  return token.type === "Identifier" ? token.name : generator_default2(token);
 }
 function declText(valueNode) {
   if (!valueNode) return "";
@@ -63689,7 +45654,7 @@ function declText(valueNode) {
   return parts2.join(" ");
 }
 function canonicalizeValue(valueNode) {
-  walk2(valueNode, {
+  walker_default2(valueNode, {
     enter(node2) {
       if (node2.type === "Identifier" || node2.type === "Function")
         node2.name = ident_exports.decode(node2.name).toLowerCase();
@@ -63702,7 +45667,7 @@ function parseDeclarations(styleStr) {
   const decls = /* @__PURE__ */ new Map();
   let ast;
   try {
-    ast = parse52(styleStr, {
+    ast = parser_default2(styleStr, {
       context: "declarationList",
       parseValue: true,
       parseCustomProperty: false,
@@ -63712,13 +45677,13 @@ function parseDeclarations(styleStr) {
   } catch {
     return decls;
   }
-  walk2(ast, {
+  walker_default2(ast, {
     visit: "Declaration",
     enter(node2) {
-      const property2 = ident_exports.decode(node2.property).trim().toLowerCase();
-      if (!CSS_PROPERTY_IDENT_RE.test(property2)) return;
+      const property = ident_exports.decode(node2.property).trim().toLowerCase();
+      if (!CSS_PROPERTY_IDENT_RE.test(property)) return;
       canonicalizeValue(node2.value);
-      decls.set(property2, node2.value);
+      decls.set(property, node2.value);
     }
   });
   return decls;
@@ -63762,16 +45727,16 @@ function isSelfClosedForeign(tagName, value) {
 }
 function isHiddenElement(node2) {
   if (node2.type !== "element") return false;
-  const { properties: properties2 = {} } = node2;
-  if (properties2.hidden !== void 0 && properties2.hidden !== null)
+  const { properties = {} } = node2;
+  if (properties.hidden !== void 0 && properties.hidden !== null)
     return true;
-  if (properties2.style && isHiddenStyle(properties2.style)) return true;
+  if (properties.style && isHiddenStyle(properties.style)) return true;
   return false;
 }
 function hasDataSrc(el) {
   return typeof el.properties?.src === "string" && el.properties.src.startsWith("data:");
 }
-function walk3(tree, test, visitor) {
+function walk(tree, test, visitor) {
   const nodes = [tree];
   const indices = [void 0];
   const parents = [void 0];
@@ -63791,12 +45756,12 @@ function walk3(tree, test, visitor) {
     }
   }
 }
-function lastParseCached(parse57) {
+function lastParseCached(parse55) {
   let cachedText = null;
   let cachedTree = null;
   return (text5) => {
     if (cachedText === text5) return cachedTree;
-    const tree = parse57(text5);
+    const tree = parse55(text5);
     cachedText = text5;
     cachedTree = tree;
     return tree;
@@ -63805,7 +45770,7 @@ function lastParseCached(parse57) {
 function parseHtmlTag(htmlValue) {
   const tree = parseFragment2(htmlValue);
   let firstElement = null;
-  walk3(tree, "element", (node2) => {
+  walk(tree, "element", (node2) => {
     firstElement = node2;
     return EXIT;
   });
@@ -63878,7 +45843,7 @@ function scanHtmlFragment(html4) {
 function scanFragmentTree(html4, tree) {
   const ranges = [];
   const warned = newWarned();
-  walk3(tree, null, (node2) => {
+  walk(tree, null, (node2) => {
     const isComment = node2.type === "comment";
     if (isComment || isHiddenElement(node2)) {
       if (!node2.position) {
@@ -63906,7 +45871,7 @@ function foldAbsorb(absorbing, raw) {
 function commentSpans(value) {
   const tree = parseFragment2(value);
   const spans = /* @__PURE__ */ new Map();
-  walk3(tree, "comment", (node2) => {
+  walk(tree, "comment", (node2) => {
     if (node2.position)
       spans.set(node2.position.start.offset, node2.position.end.offset);
   });
@@ -64022,7 +45987,7 @@ function scanMarkdown(text5) {
   const tree = parseMarkdown(text5);
   const ranges = [];
   const warned = newWarned();
-  walk3(tree, "html", (node2, _index, parent) => {
+  walk(tree, "html", (node2, _index, parent) => {
     if (!FLOW_HTML_PARENTS.has(parent?.type)) return;
     const base2 = node2.position.start.offset;
     const sub = scanHtmlFragment(text5.slice(base2, node2.position.end.offset));
@@ -64035,7 +46000,7 @@ function scanMarkdown(text5) {
     }
     mergeWarned(warned, sub.warned);
   });
-  walk3(tree, null, (node2) => {
+  walk(tree, null, (node2) => {
     if (!PHRASING_ROOTS.has(node2.type)) return;
     if (!hasHtmlLeaf(node2)) return;
     scanInlineChildren(node2, text5, ranges, warned);
@@ -64045,7 +46010,7 @@ function scanMarkdown(text5) {
 function hasMarkdownCode(text5) {
   if (!MARKDOWN_CODE_HINT.test(text5)) return false;
   let found = false;
-  walk3(parseMarkdown(text5), "code", () => {
+  walk(parseMarkdown(text5), "code", () => {
     found = true;
     return EXIT;
   });
@@ -64310,7 +46275,7 @@ function multiUrlAttr(value) {
 function extractHtmlUrls(text5) {
   const tree = parseFragment2(text5);
   const urls = [];
-  walk3(tree, "element", (node2) => {
+  walk(tree, "element", (node2) => {
     const props = node2.properties;
     const isImage = node2.tagName === "img";
     const isAnchor = node2.tagName === "a";
@@ -64349,7 +46314,7 @@ function extractHtmlUrls(text5) {
 }
 function collectUrls(text5) {
   const urls = [];
-  walk3(parseMarkdown(text5), null, (node2) => {
+  walk(parseMarkdown(text5), null, (node2) => {
     if (node2.type !== "link" && node2.type !== "image" && node2.type !== "definition")
       return;
     urls.push({
@@ -64415,7 +46380,10 @@ var NEAR_ZERO_EPSILON, OFFSCREEN_ABSOLUTE_THRESHOLD, OFFSCREEN_VIEWPORT_THRESHOL
 var init_html4 = __esm({
   "src/html.mjs"() {
     "use strict";
-    init_lib();
+    init_parser2();
+    init_walker2();
+    init_generator2();
+    init_utils2();
     init_unified();
     init_remark_parse();
     init_remark_gfm();
@@ -67380,7 +49348,7 @@ function containsPlaceholder(value, depth = 0) {
 function collectPlaceholders(value) {
   const secret = /* @__PURE__ */ new Map();
   const layer2 = /* @__PURE__ */ new Map();
-  const walk4 = (node2, path2, depth) => {
+  const walk2 = (node2, path2, depth) => {
     if (depth > 32) return;
     if (typeof node2 === "string") {
       for (const match of node2.matchAll(PLACEHOLDER_RE_G))
@@ -67392,14 +49360,14 @@ function collectPlaceholders(value) {
       return;
     }
     if (Array.isArray(node2)) {
-      node2.forEach((item, index2) => walk4(item, `${path2}[${index2}]`, depth + 1));
+      node2.forEach((item, index2) => walk2(item, `${path2}[${index2}]`, depth + 1));
       return;
     }
     if (node2 !== null && typeof node2 === "object")
       for (const [key, item] of Object.entries(node2))
-        walk4(item, path2 === "" ? key : `${path2}.${key}`, depth + 1);
+        walk2(item, path2 === "" ? key : `${path2}.${key}`, depth + 1);
   };
-  walk4(value, "", 0);
+  walk2(value, "", 0);
   const entries = (map3) => [...map3].map(([token, path2]) => ({ token, path: path2 }));
   return { secret: entries(secret), layer2: entries(layer2) };
 }
@@ -67484,7 +49452,7 @@ function bestEffortTrace(sink) {
   };
 }
 var TraceEvent, LEVELS;
-var init_trace2 = __esm({
+var init_trace = __esm({
   "claude-hooks/lib/trace.mjs"() {
     "use strict";
     TraceEvent = Object.freeze({
@@ -67512,7 +49480,7 @@ __export(pretooluse_sanitize_exports, {
   preToolUseLayers: () => preToolUseLayers,
   rehydrateLayer2: () => rehydrateLayer2
 });
-import { createRequire as createRequire5 } from "node:module";
+import { createRequire as createRequire2 } from "node:module";
 import { readFileSync as readFileSync6 } from "node:fs";
 function substituteLayer2(text5, field) {
   const matches = [...text5.matchAll(LAYER2_PLACEHOLDER_RE2)].map((match) => ({
@@ -67813,7 +49781,7 @@ async function cliMain(opts = {}) {
     }
   );
 }
-var HOOK_NAME, PRE_TOOL_USE_MESSAGES, normalizeConfusables2, normalizeContext2, rehydrateRedacted2, spliceOrdered2, require5, confusableScan, redactorIo, guardedRehydrate, defaultRehydrate, REDACTION_HINT, WRITE_SHAPED_TOOLS;
+var HOOK_NAME, PRE_TOOL_USE_MESSAGES, normalizeConfusables2, normalizeContext2, rehydrateRedacted2, spliceOrdered2, require2, confusableScan, redactorIo, guardedRehydrate, defaultRehydrate, REDACTION_HINT, WRITE_SHAPED_TOOLS;
 var init_pretooluse_sanitize = __esm({
   async "claude-hooks/pretooluse-sanitize.mjs"() {
     "use strict";
@@ -67828,7 +49796,7 @@ var init_pretooluse_sanitize = __esm({
     await init_secret_drop_guard();
     init_placeholder_grammar();
     init_reveal();
-    init_trace2();
+    init_trace();
     HOOK_NAME = "pretooluse-sanitize";
     PRE_TOOL_USE_MESSAGES = Object.freeze({
       unknownEvent: "PreToolUse sanitization blocked (fail-closed): unrecognized hook payload.",
@@ -67846,8 +49814,8 @@ var init_pretooluse_sanitize = __esm({
     await lazyImport("agent-sanitizer/rehydrate"));
     ({ spliceOrdered: spliceOrdered2 } = /** @type {typeof import("agent-sanitizer/view-map")} */
     await lazyImport("agent-sanitizer/view-map"));
-    require5 = createRequire5(import.meta.url);
-    confusableScan = (text5) => (registeredLazyModule("namespace-guard") ?? require5("namespace-guard")).scan(
+    require2 = createRequire2(import.meta.url);
+    confusableScan = (text5) => (registeredLazyModule("namespace-guard") ?? require2("namespace-guard")).scan(
       text5
     );
     redactorIo = {
@@ -68818,7 +50786,7 @@ var init_sanitize_output = __esm({
     init_hook_io();
     init_hook_fault();
     await init_control_plane2();
-    init_trace2();
+    init_trace();
     init_secret_annotate();
     init_env_config();
     init_reveal();
@@ -68931,7 +50899,7 @@ var init_sanitize_user_prompt = __esm({
     init_hook_io();
     init_hook_fault();
     await init_control_plane2();
-    init_trace2();
+    init_trace();
     USER_PROMPT_MESSAGES = Object.freeze({
       unknownEvent: "User prompt blocked (fail-closed): unrecognized hook payload.",
       blockContext: "User prompt blocked: payload-capable invisible/ANSI characters detected.",
@@ -69250,7 +51218,7 @@ var init_scan_invisible_chars = __esm({
     init_invisible_report();
     init_reveal();
     await init_secret_drop_guard();
-    init_trace2();
+    init_trace();
     init_hook_timing();
     init_claude_context();
     ({
@@ -69422,7 +51390,7 @@ var init_scan_loaded_instructions = __esm({
     init_hook_io();
     init_hook_fault();
     await init_invisible_alert();
-    init_trace2();
+    init_trace();
     init_hook_timing();
     init_invisible_report();
     init_claude_context();

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -29,9 +29,23 @@
  * entry `await import()`s this module only when its cheap regex gates match.
  */
 import { createHash } from "node:crypto";
+// Subpath specifiers, never the `css-tree` root: the root builds the default
+// syntax at module scope, that construction reaches the lexer's `lib/data.js`,
+// and `lib/data.js` pulls the whole `mdn-data` CSS table set in through
+// `createRequire`. esbuild cannot tree-shake a side-effectful module-level
+// construction, so the root put ~18k lines of at-rule/property/syntax tables
+// into every shipped bundle for four functions that never consult them. Each
+// subpath's closure stops at `syntax/config/*`, and the functions are the same
+// ones the root re-exports, built by the same factories from the same config.
 // @ts-ignore -- css-tree ships no bundled types and @types/css-tree lags the 3.x
 // API (e.g. `ident.decode`); the value AST is walked with local `any` types.
-import * as csstree from "css-tree";
+import cssParse from "css-tree/parser";
+// @ts-ignore -- see above. Aliased: `walk` is this module's own unist walker.
+import cssWalk from "css-tree/walker";
+// @ts-ignore -- see above.
+import cssGenerate from "css-tree/generator";
+// @ts-ignore -- see above.
+import { ident as cssIdent } from "css-tree/utils";
 import { unified } from "unified";
 import remarkParse from "remark-parse";
 import remarkGfm from "remark-gfm";
@@ -752,7 +766,7 @@ function canonicalizeColor(raw) {
 function paintsImageLayer(node) {
   if (!node) return false;
   let found = false;
-  csstree.walk(node, {
+  cssWalk(node, {
     enter(/** @type {any} */ child) {
       if (child.type === "Url" || child.type === "Raw") found = true;
       // Names are canonicalized at the parse boundary, so a suffix test covers
@@ -1111,7 +1125,7 @@ const CSS_PROPERTY_IDENT_RE = /^-{0,2}[A-Za-z_][A-Za-z0-9_-]*$/;
  * @returns {string}
  */
 function tokenText(token) {
-  return token.type === "Identifier" ? token.name : csstree.generate(token);
+  return token.type === "Identifier" ? token.name : cssGenerate(token);
 }
 
 /**
@@ -1151,14 +1165,14 @@ function declText(valueNode) {
  * @returns {void}
  */
 function canonicalizeValue(valueNode) {
-  csstree.walk(valueNode, {
+  cssWalk(valueNode, {
     enter(/** @type {any} */ node) {
-      // ident.decode is pure string iteration and cannot throw on a token the
+      // cssIdent.decode is pure string iteration and cannot throw on a token the
       // tokenizer already produced.
       if (node.type === "Identifier" || node.type === "Function")
-        node.name = csstree.ident.decode(node.name).toLowerCase();
+        node.name = cssIdent.decode(node.name).toLowerCase();
       else if (node.type === "Dimension")
-        node.unit = csstree.ident.decode(node.unit).toLowerCase();
+        node.unit = cssIdent.decode(node.unit).toLowerCase();
     },
   });
 }
@@ -1182,7 +1196,7 @@ function parseDeclarations(styleStr) {
   const decls = new Map();
   let ast;
   try {
-    ast = csstree.parse(styleStr, {
+    ast = cssParse(styleStr, {
       context: "declarationList",
       parseValue: true,
       parseCustomProperty: false,
@@ -1195,12 +1209,12 @@ function parseDeclarations(styleStr) {
     return decls;
   }
   /* c8 ignore stop */
-  csstree.walk(ast, {
+  cssWalk(ast, {
     visit: "Declaration",
     enter(/** @type {any} */ node) {
-      // ident.decode is pure string iteration and cannot throw on a real ident
+      // cssIdent.decode is pure string iteration and cannot throw on a real ident
       // token; property is escape-decoded then gated to a clean CSS ident.
-      const property = csstree.ident.decode(node.property).trim().toLowerCase();
+      const property = cssIdent.decode(node.property).trim().toLowerCase();
       if (!CSS_PROPERTY_IDENT_RE.test(property)) return;
       canonicalizeValue(node.value);
       decls.set(property, node.value);


### PR DESCRIPTION
`src/html.mjs` imported the whole `css-tree` package. That entry point builds CSS-Tree's default syntax object while the module loads, and the build reaches the CSS lexer, which reads MDN's CSS reference tables (the `mdn-data` package) through `createRequire`. A bundler cannot drop work a module performs at load time, so esbuild copied every table into both artifacts we ship. The module calls four css-tree functions — `parse`, `walk`, `generate`, `ident` — and never the lexer. Each has its own entry point in css-tree's exports map, and none of them reaches the tables.

The four imports are aliased `cssParse`/`cssWalk`/`cssGenerate`/`cssIdent`, because this module already defines its own unist `walk`. Same functions, same factories, same config the root re-exports. `plugin/dist/hooks/plugin-hooks.bundle.mjs` and `hook-binaries.sha256` are regenerated.

A fresh `bundleHardened` build of each target, before and after:

```
plugin-hooks  69,575 -> 51,543 lines (-25.9%)   2,415,931 -> 1,826,275 bytes
python-cli    62,314 -> 44,282 lines (-28.9%)   2,162,771 -> 1,573,125 bytes
```

`mdn-data` appears in neither artifact now.

## What is blocking this PR

`Review findings resolved` is pending because no automated review has ever posted here. The `opened` run skipped for size — 31,204 diff lines against a 20,000-line cap, of which 31,095 are the rebuilt hook bundle — and a later push is a `synchronize`, which by design is not a re-read. Every other check on the head is green or skipped.

[#368](https://github.com/AlexanderMattTurner/agent-sanitizer/pull/368) fixes that cap by dropping generated files from the reviewer's diff, which takes this PR to 98 reviewable lines. It has to land first: `claude-pr-review.yaml` is `pull_request_target` and checks out `base.ref`, so the reviewer always runs `main`'s copy of the script. Once #368 is on `main`, the `needs-auto-review` label buys this PR its read.

## Decisions made

- **The `.github/scripts/` commit stays on this branch as well as on [#368](https://github.com/AlexanderMattTurner/agent-sanitizer/pull/368).** It is the same commit content in both, so whichever merges first makes the other a no-op; removing it here would need a force-push over an auto-merge-armed branch for no gain. An earlier revision of this body claimed that commit made this PR reviewable — that was wrong, for the base-checkout reason above, and splitting it out is the correction.
- **`test/html.mjs` still imports the css-tree root** for `tokenTypes`/`tokenize`. That is a test-only import no bundle reaches, so it is left alone.
- **`inlineRuntimeJsonRequires` in `scripts/lib/bundle-esbuild.mjs` stays.** It exists because of this same `createRequire` shape, but it is written against the pattern rather than against css-tree, `assertNoRuntimeRequires` is the actual guard, and every test covering both drives synthetic source, so none goes vacuous.

## Tests / verification

- `node --test test/html.test.mjs` — 838 pass.
- `node --test scripts/lib/bundle-hardening.test.mjs` — 18 pass.
- `node --test plugin/test/plugin-bundle.test.mjs` — 106 pass.
- `node --test .github/scripts/strip-generated-diff.test.mjs` — 7 pass.
- `pnpm check`, `npx eslint src/html.mjs`, and the pre-commit battery on both pushes (1811 pass).
- No whole-suite local run; CI owns that. All 117 check runs on `7ba2168` are success or skipped.

## Review focus

`src/html.mjs` imports first. The invariant to check is that no bare `walk`/`parse`/`generate` call site was rebound: `walk` names this module's own unist walker at eight sites, and only the four CSS-AST calls became `cssWalk`.

## Evidence

The closure claim, checked against the published tarball rather than inferred:

```
$ npm pack css-tree@3.2.1 && tar xzf css-tree-3.2.1.tgz
# transitive relative-import closure per entry:
lib/parser/index.js     88 files; reaches lib/data.js? false
lib/walker/index.js     64 files; reaches lib/data.js? false
lib/generator/index.js  66 files; reaches lib/data.js? false
lib/utils/index.js      15 files; reaches lib/data.js? false
lib/index.js           123 files; reaches lib/data.js? true
```

`lib/index.js` destructures `parse`/`generate`/`walk` off `createSyntax({...lexerConfig, ...parserConfig, ...walkerConfig})`; `lib/parser/index.js` is `createParser(parserConfig)`, and the parser/walker/generator factories read only their own config keys, which is why the subpath functions behave identically.