### PR TITLE
fix(ci): omit only the generated files a required check re-derives

### DIFF
--- a/.github/scripts/prepare-pr-review-input.sh
+++ b/.github/scripts/prepare-pr-review-input.sh
@@ -80,7 +80,7 @@ printf '%s\n' "$raw_diff_content" >"$raw_diff"
 # resolve-generated.mjs owns the decision; nothing classifies a path here. The
 # filter must run BEFORE the line count and before sanitize, so both see the
 # diff a reviewer will actually read.
-node .github/scripts/resolve-generated.mjs --review-omit >"$omit_list"
+node .github/scripts/resolve-generated.mjs --owned --rederived-only >"$omit_list"
 node .github/scripts/strip-generated-diff.mjs "$omit_list" \
   <"$raw_diff" >"$review_diff"
 

--- a/.github/scripts/prepare-pr-review-input.sh
+++ b/.github/scripts/prepare-pr-review-input.sh
@@ -5,11 +5,14 @@
 # diff — so an injection payload hidden in it (zero-width control text, ANSI
 # escapes, exfil beacons) cannot reach the agent intact.
 #
-# Generated-file filter: every path config/auto-resolve-regen-rules.json declares
-# as GENERATED is stripped from the diff before it is counted or sanitized. CI
-# rebuilds those artifacts and fails on any difference, so reviewing them adds no
-# signal, and this repo commits a ~29k-line hook bundle that pushed ordinary
-# source edits over the size guard below.
+# Generated-file filter: a path whose regen rule sets `reviewOmit` is stripped
+# from the diff before it is counted or sanitized. That flag asserts a REQUIRED
+# check re-derives the artifact and reds on any difference, so its bytes cannot
+# disagree with their sources and a reviewer reading them learns nothing. Being
+# generated is NOT enough on its own — a lockfile has a generator but no such
+# check, so nothing regenerates it and the reviewer is the only reader it has.
+# This repo commits a ~29k-line hook bundle, which pushed ordinary source edits
+# over the size guard below.
 #
 # Oversized-diff guard: the base-only checkout means diff.txt is the ONLY source
 # of the PR's changes — the agent cannot reconstruct them from the trusted base
@@ -53,8 +56,8 @@ emit_output() {
 # diff.txt ever reaches the reviewer.
 raw_diff="$(mktemp)"
 review_diff="$(mktemp)"
-owned_list="$(mktemp)"
-trap 'rm -f "$raw_diff" "$review_diff" "$owned_list"' EXIT
+omit_list="$(mktemp)"
+trap 'rm -f "$raw_diff" "$review_diff" "$omit_list"' EXIT
 # curl for the diff media type, not `gh api`/`gh pr diff`: gh's own
 # client-side safety guard (pkg/iostreams content sanitization) refuses to
 # print ANY response holding a raw terminal escape sequence unless
@@ -74,14 +77,13 @@ raw_diff_content="$(retry_stdout curl -fsS \
   "${api_url}/repos/${GH_REPO}/pulls/${PR}")"
 printf '%s\n' "$raw_diff_content" >"$raw_diff"
 
-# Drop the generated files before counting or reviewing. CI rebuilds each one
-# and fails on any difference, so its diff cannot disagree with the sources — and
-# this repo commits a ~29k-line hook bundle, so leaving them in pushed an
-# ordinary source edit past MAX_DIFF_LINES and skipped the review of the very
-# lines a human wrote. resolve-generated.mjs is the same ownership oracle the
-# auto-resolver partitions on; nothing classifies a path here.
-node .github/scripts/resolve-generated.mjs --owned >"$owned_list"
-node .github/scripts/strip-generated-diff.mjs "$owned_list" \
+# Drop the vouched-for artifacts before counting or reviewing: leaving them in
+# pushed an ordinary source edit past MAX_DIFF_LINES and skipped the review of
+# the very lines a human wrote. resolve-generated.mjs owns the decision — no path
+# is classified here — and `--review-omit` is narrower than `--owned`, listing
+# only rules whose output a required check re-derives and compares.
+node .github/scripts/resolve-generated.mjs --review-omit >"$omit_list"
+node .github/scripts/strip-generated-diff.mjs "$omit_list" \
   <"$raw_diff" >"$review_diff"
 
 diff_lines="$(wc -l <"$review_diff" | tr -d '[:space:]')"

--- a/.github/scripts/prepare-pr-review-input.sh
+++ b/.github/scripts/prepare-pr-review-input.sh
@@ -5,10 +5,16 @@
 # diff — so an injection payload hidden in it (zero-width control text, ANSI
 # escapes, exfil beacons) cannot reach the agent intact.
 #
+# Generated-file filter: every path config/auto-resolve-regen-rules.json declares
+# as GENERATED is stripped from the diff before it is counted or sanitized. CI
+# rebuilds those artifacts and fails on any difference, so reviewing them adds no
+# signal, and this repo commits a ~29k-line hook bundle that pushed ordinary
+# source edits over the size guard below.
+#
 # Oversized-diff guard: the base-only checkout means diff.txt is the ONLY source
 # of the PR's changes — the agent cannot reconstruct them from the trusted base
-# tree, so an enormous diff (a mega-merge, a vendored/generated dump) would be
-# ingested whole into an Opus read that is slow, costly, and low-signal. Above
+# tree, so an enormous diff (a mega-merge, a vendored dump) would be ingested
+# whole into an Opus read that is slow, costly, and low-signal. Above
 # MAX_DIFF_LINES lines this skips the review, emitting oversized=true so the
 # caller posts a "please review manually" notice instead of spending the read.
 #
@@ -46,7 +52,9 @@ emit_output() {
 # grants the agent read over PR_INPUT_DIR via --add-dir), so only the SANITIZED
 # diff.txt ever reaches the reviewer.
 raw_diff="$(mktemp)"
-trap 'rm -f "$raw_diff"' EXIT
+review_diff="$(mktemp)"
+owned_list="$(mktemp)"
+trap 'rm -f "$raw_diff" "$review_diff" "$owned_list"' EXIT
 # curl for the diff media type, not `gh api`/`gh pr diff`: gh's own
 # client-side safety guard (pkg/iostreams content sanitization) refuses to
 # print ANY response holding a raw terminal escape sequence unless
@@ -66,7 +74,17 @@ raw_diff_content="$(retry_stdout curl -fsS \
   "${api_url}/repos/${GH_REPO}/pulls/${PR}")"
 printf '%s\n' "$raw_diff_content" >"$raw_diff"
 
-diff_lines="$(wc -l <"$raw_diff" | tr -d '[:space:]')"
+# Drop the generated files before counting or reviewing. CI rebuilds each one
+# and fails on any difference, so its diff cannot disagree with the sources — and
+# this repo commits a ~29k-line hook bundle, so leaving them in pushed an
+# ordinary source edit past MAX_DIFF_LINES and skipped the review of the very
+# lines a human wrote. resolve-generated.mjs is the same ownership oracle the
+# auto-resolver partitions on; nothing classifies a path here.
+node .github/scripts/resolve-generated.mjs --owned >"$owned_list"
+node .github/scripts/strip-generated-diff.mjs "$owned_list" \
+  <"$raw_diff" >"$review_diff"
+
+diff_lines="$(wc -l <"$review_diff" | tr -d '[:space:]')"
 if ((diff_lines > MAX_DIFF_LINES)); then
   emit_output "oversized=true"
   emit_output "diff_lines=$diff_lines"
@@ -80,7 +98,7 @@ emit_output "oversized=false"
 
 sanitize() { node .github/scripts/sanitize-pr-input.mjs; }
 
-sanitize <"$raw_diff" >"${PR_INPUT_DIR}/diff.txt" 2>"${PR_INPUT_DIR}/diff.report.txt"
+sanitize <"$review_diff" >"${PR_INPUT_DIR}/diff.txt" 2>"${PR_INPUT_DIR}/diff.report.txt"
 # Capture the metadata JSON with retry_stdout, THEN pipe the clean result into
 # the sanitizer — retrying gh directly inside the `| sanitize` pipe is unsafe (a
 # failing attempt would stream partial JSON into the sanitizer, and a SIGPIPE if

--- a/.github/scripts/prepare-pr-review-input.sh
+++ b/.github/scripts/prepare-pr-review-input.sh
@@ -77,11 +77,9 @@ raw_diff_content="$(retry_stdout curl -fsS \
   "${api_url}/repos/${GH_REPO}/pulls/${PR}")"
 printf '%s\n' "$raw_diff_content" >"$raw_diff"
 
-# Drop the vouched-for artifacts before counting or reviewing: leaving them in
-# pushed an ordinary source edit past MAX_DIFF_LINES and skipped the review of
-# the very lines a human wrote. resolve-generated.mjs owns the decision — no path
-# is classified here — and `--review-omit` is narrower than `--owned`, listing
-# only rules whose output a required check re-derives and compares.
+# resolve-generated.mjs owns the decision; nothing classifies a path here. The
+# filter must run BEFORE the line count and before sanitize, so both see the
+# diff a reviewer will actually read.
 node .github/scripts/resolve-generated.mjs --review-omit >"$omit_list"
 node .github/scripts/strip-generated-diff.mjs "$omit_list" \
   <"$raw_diff" >"$review_diff"

--- a/.github/scripts/resolve-generated.mjs
+++ b/.github/scripts/resolve-generated.mjs
@@ -92,6 +92,11 @@ function loadRules() {
     }
     if (rule.reviewOmit !== undefined && typeof rule.reviewOmit !== "boolean")
       die(`${at}: "reviewOmit" must be a boolean`);
+    // A check that regenerates its outputs and diffs them says nothing about an
+    // EXTRA file in the subtree, while the reader acting on the flag stops
+    // reading the WHOLE directory.
+    if (rule.reviewOmit === true && rule.ownsPrefix !== undefined)
+      die(`${at}: "reviewOmit" cannot cover an "ownsPrefix" — list the paths in "owns"`);
     if (rule.sourcesPattern !== undefined) {
       try {
         RegExp(rule.sourcesPattern);

--- a/.github/scripts/resolve-generated.mjs
+++ b/.github/scripts/resolve-generated.mjs
@@ -96,7 +96,9 @@ function loadRules() {
     // EXTRA file in the subtree, while the reader acting on the flag stops
     // reading the WHOLE directory.
     if (rule.reviewOmit === true && rule.ownsPrefix !== undefined)
-      die(`${at}: "reviewOmit" cannot cover an "ownsPrefix" — list the paths in "owns"`);
+      die(
+        `${at}: "reviewOmit" cannot cover an "ownsPrefix" — list the paths in "owns"`,
+      );
     if (rule.sourcesPattern !== undefined) {
       try {
         RegExp(rule.sourcesPattern);

--- a/.github/scripts/resolve-generated.mjs
+++ b/.github/scripts/resolve-generated.mjs
@@ -11,6 +11,11 @@
 // Two modes:
 //   --owned            print every path the rules generate, one per line. This is
 //                      the ownership oracle auto-resolve/prepare.sh partitions on.
+//   --review-omit      print only the paths of rules flagged `reviewOmit`, which
+//                      asserts a required check re-derives them and fails on any
+//                      difference. strip-generated-diff.mjs hides exactly these
+//                      from the automated reviewer, so a generated path with no
+//                      such check (a lockfile) is deliberately NOT listed.
 //   (no flag)          run every rule whose sources changed, re-deriving its outputs.
 //   --changed <paths>  restrict the run to rules matching these changed paths.
 //
@@ -81,6 +86,8 @@ function loadRules() {
         die(`${at}: "ownsPrefix" must be a string ending in "/"`);
       }
     }
+    if (rule.reviewOmit !== undefined && typeof rule.reviewOmit !== "boolean")
+      die(`${at}: "reviewOmit" must be a boolean`);
     if (rule.sourcesPattern !== undefined) {
       try {
         RegExp(rule.sourcesPattern);
@@ -104,6 +111,13 @@ const ownedPaths = (rules) => {
   }
   return [...new Set(out)];
 };
+
+/** The paths a rule vouches for with `reviewOmit`. Narrower than {@link
+ * ownedPaths} on purpose: being generated says a path has a generator, while
+ * this says a required check re-derives it and reds on a difference, which is
+ * the only thing that makes hiding it from a reviewer safe. */
+const reviewOmitPaths = (rules) =>
+  ownedPaths(rules.filter((r) => r.reviewOmit));
 
 const ruleMatches = (rule, changed) => {
   if (changed === null) return true;
@@ -166,6 +180,11 @@ function main(argv) {
 
   if (argv.includes("--owned")) {
     for (const p of ownedPaths(rules)) process.stdout.write(`${p}\n`);
+    return;
+  }
+
+  if (argv.includes("--review-omit")) {
+    for (const p of reviewOmitPaths(rules)) process.stdout.write(`${p}\n`);
     return;
   }
 

--- a/.github/scripts/resolve-generated.mjs
+++ b/.github/scripts/resolve-generated.mjs
@@ -11,11 +11,15 @@
 // Two modes:
 //   --owned            print every path the rules generate, one per line. This is
 //                      the ownership oracle auto-resolve/prepare.sh partitions on.
-//   --review-omit      print only the paths of rules flagged `reviewOmit`, which
-//                      asserts a required check re-derives them and fails on any
-//                      difference. strip-generated-diff.mjs hides exactly these
-//                      from the automated reviewer, so a generated path with no
-//                      such check (a lockfile) is deliberately NOT listed.
+//   --rederived-only   with --owned, print only the paths of rules flagged
+//                      `reviewOmit`, which asserts a required check re-derives
+//                      them and fails on any difference. Two readers hide
+//                      exactly these from a reviewer: strip-generated-diff.mjs
+//                      here, and the resolver's own remerge-diff-report.py,
+//                      which runs `--owned --rederived-only` against this file
+//                      from the pinned agent-resolve-merge-conflicts checkout.
+//                      A generated path with no such check (a lockfile) is
+//                      deliberately NOT listed, so both reviewers read it.
 //   (no flag)          run every rule whose sources changed, re-deriving its outputs.
 //   --changed <paths>  restrict the run to rules matching these changed paths.
 //
@@ -115,7 +119,8 @@ const ownedPaths = (rules) => {
 /** The paths a rule vouches for with `reviewOmit`. Narrower than {@link
  * ownedPaths} on purpose: being generated says a path has a generator, while
  * this says a required check re-derives it and reds on a difference, which is
- * the only thing that makes hiding it from a reviewer safe. */
+ * the only thing that makes hiding it from a reviewer safe. This repo runs no
+ * pre-commit regeneration hook, so no rule kind earns the claim by default. */
 const reviewOmitPaths = (rules) =>
   ownedPaths(rules.filter((r) => r.reviewOmit));
 
@@ -178,13 +183,17 @@ function runRule(rule) {
 function main(argv) {
   const rules = loadRules();
 
-  if (argv.includes("--owned")) {
-    for (const p of ownedPaths(rules)) process.stdout.write(`${p}\n`);
-    return;
-  }
+  // Guard the modifier, because the fallthrough is not inert: a mistyped or
+  // lone --rederived-only would drop into the run path below and rewrite every
+  // generated file in the tree.
+  if (argv.includes("--rederived-only") && !argv.includes("--owned"))
+    die("--rederived-only is a modifier of --owned, not a mode of its own");
 
-  if (argv.includes("--review-omit")) {
-    for (const p of reviewOmitPaths(rules)) process.stdout.write(`${p}\n`);
+  if (argv.includes("--owned")) {
+    const paths = argv.includes("--rederived-only")
+      ? reviewOmitPaths(rules)
+      : ownedPaths(rules);
+    for (const p of paths) process.stdout.write(`${p}\n`);
     return;
   }
 

--- a/.github/scripts/resolve-generated.test.mjs
+++ b/.github/scripts/resolve-generated.test.mjs
@@ -216,7 +216,7 @@ test("a failing rule command fails the run", () => {
   rmSync(root, { recursive: true, force: true });
 });
 
-// --review-omit is what strip-generated-diff.mjs hides from the automated
+// --owned --rederived-only is what strip-generated-diff.mjs hides from the
 // reviewer, so it must be strictly narrower than --owned. A path that is merely
 // generated (a lockfile) has no check re-deriving it in CI, and hiding it would
 // tell the reviewer a guarantee nobody provides.
@@ -232,9 +232,9 @@ const OMIT_RULES = JSON.stringify({
   ],
 });
 
-test("--review-omit lists only the rules that set the flag", () => {
+test("--owned --rederived-only lists only the rules that set the flag", () => {
   const root = repoWith(OMIT_RULES);
-  const omit = run(root, ["--review-omit"]);
+  const omit = run(root, ["--owned", "--rederived-only"]);
   assert.equal(omit.status, 0);
   assert.deepEqual(omit.stdout.split("\n").filter(Boolean), [
     "dist/bundle.mjs",
@@ -255,8 +255,18 @@ test("a non-boolean reviewOmit fails loud", () => {
   const root = repoWith(
     '{"rules":[{"command":["true"],"sources":["a"],"owns":["b"],"reviewOmit":"yes"}]}',
   );
-  const r = run(root, ["--review-omit"]);
+  const r = run(root, ["--owned", "--rederived-only"]);
   assert.equal(r.status, 1);
   assert.match(r.stderr, /"reviewOmit" must be a boolean/);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("--rederived-only without --owned is refused, never a run", () => {
+  // The fallthrough would re-derive every generated file in the tree, so the
+  // modifier must not be silently ignored when its mode is missing.
+  const root = repoWith(OMIT_RULES);
+  const r = run(root, ["--rederived-only"]);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /modifier of --owned/);
   rmSync(root, { recursive: true, force: true });
 });

--- a/.github/scripts/resolve-generated.test.mjs
+++ b/.github/scripts/resolve-generated.test.mjs
@@ -270,3 +270,16 @@ test("--rederived-only without --owned is refused, never a run", () => {
   assert.match(r.stderr, /modifier of --owned/);
   rmSync(root, { recursive: true, force: true });
 });
+
+test("reviewOmit cannot cover an ownsPrefix", () => {
+  // The check the flag names regenerates its outputs and diffs them, which says
+  // nothing about an EXTRA file in the subtree — while the reader acting on it
+  // stops reading the whole directory. Refused rather than documented.
+  const root = repoWith(
+    '{"rules":[{"command":["true"],"sources":["a"],"ownsPrefix":"dist/","reviewOmit":true}]}',
+  );
+  const r = run(root, ["--owned", "--rederived-only"]);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /cannot cover an "ownsPrefix"/);
+  rmSync(root, { recursive: true, force: true });
+});

--- a/.github/scripts/resolve-generated.test.mjs
+++ b/.github/scripts/resolve-generated.test.mjs
@@ -215,3 +215,48 @@ test("a failing rule command fails the run", () => {
   assert.match(r.stderr, /exited 1/);
   rmSync(root, { recursive: true, force: true });
 });
+
+// --review-omit is what strip-generated-diff.mjs hides from the automated
+// reviewer, so it must be strictly narrower than --owned. A path that is merely
+// generated (a lockfile) has no check re-deriving it in CI, and hiding it would
+// tell the reviewer a guarantee nobody provides.
+const OMIT_RULES = JSON.stringify({
+  rules: [
+    {
+      command: ["true"],
+      sources: ["package.json"],
+      owns: ["dist/bundle.mjs"],
+      reviewOmit: true,
+    },
+    { command: ["true"], sources: ["package.json"], owns: ["pnpm-lock.yaml"] },
+  ],
+});
+
+test("--review-omit lists only the rules that set the flag", () => {
+  const root = repoWith(OMIT_RULES);
+  const omit = run(root, ["--review-omit"]);
+  assert.equal(omit.status, 0);
+  assert.deepEqual(omit.stdout.split("\n").filter(Boolean), [
+    "dist/bundle.mjs",
+  ]);
+  // Paired positive marker: --owned must still carry BOTH, so a flag that
+  // silently stopped being read would show up here as the two modes agreeing.
+  const owned = run(root, ["--owned"]);
+  assert.deepEqual(owned.stdout.split("\n").filter(Boolean), [
+    "dist/bundle.mjs",
+    "pnpm-lock.yaml",
+  ]);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("a non-boolean reviewOmit fails loud", () => {
+  // The flag asserts a required check exists. A truthy string would enable the
+  // omission by accident, which is the one direction that loses review coverage.
+  const root = repoWith(
+    '{"rules":[{"command":["true"],"sources":["a"],"owns":["b"],"reviewOmit":"yes"}]}',
+  );
+  const r = run(root, ["--review-omit"]);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /"reviewOmit" must be a boolean/);
+  rmSync(root, { recursive: true, force: true });
+});

--- a/.github/scripts/strip-generated-diff.mjs
+++ b/.github/scripts/strip-generated-diff.mjs
@@ -24,7 +24,7 @@
 // change.
 //
 // Usage: node .github/scripts/strip-generated-diff.mjs <omit-list-file> <diff
-// where <omit-list-file> holds one path (or `ownsPrefix` subtree) per line.
+// where <omit-list-file> holds one exact path per line.
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
@@ -39,13 +39,10 @@ const SECTION_START = /^diff --git /u;
 // section is kept — see the fail-open note above.
 const HEADER = /^diff --git a\/(\S+) b\/(\S+)$/u;
 
-/** True when `path` is one the omit list vouches for: an exact `owns` entry, or
- * under an `ownsPrefix` (which the oracle prints with its trailing slash). */
-function isOmitted(path, omit) {
-  return omit.some((entry) =>
-    entry.endsWith("/") ? path.startsWith(entry) : path === entry,
-  );
-}
+/** True when `path` is one the omit list vouches for. EXACT match only: a
+ * directory would hide a file its generator never emits, which no check the
+ * flag names has to catch. resolve-generated.mjs refuses that rule too. */
+const isOmitted = (path, omit) => omit.includes(path);
 
 /** Split a unified diff into sections, each starting at a `diff --git` line.
  * A leading chunk before the first one (git emits none, but a caller may
@@ -110,6 +107,13 @@ export function omissionNote(dropped) {
 
 function main(omitListFile) {
   const omit = readFileSync(omitListFile, "utf8").split("\n").filter(Boolean);
+  const prefix = omit.find((entry) => entry.endsWith("/"));
+  if (prefix) {
+    process.stderr.write(
+      `strip-generated-diff: ${prefix} is a directory; the omit list takes exact paths only\n`,
+    );
+    process.exit(1);
+  }
   const diff = readFileSync(0, "utf8");
   const { kept, dropped } = stripGenerated(diff, omit);
   process.stdout.write(

--- a/.github/scripts/strip-generated-diff.mjs
+++ b/.github/scripts/strip-generated-diff.mjs
@@ -11,9 +11,11 @@
 // each one and fails on any difference, so the diff cannot disagree with its
 // sources.
 //
-// Ownership comes from `resolve-generated.mjs --owned`, the same oracle the
-// auto-resolver partitions on, passed in on argv. A path is never classified
-// here.
+// The omit list comes from `resolve-generated.mjs --review-omit`, passed in as a
+// file. A path is never classified here, and that mode is narrower than
+// `--owned`: it lists only rules whose output a required check re-derives and
+// compares. A lockfile is generated but nothing regenerates it in CI, so it
+// stays visible — a reviewer is the only reader it has.
 //
 // Reads the diff on stdin, writes the filtered diff on stdout, and reports what
 // it dropped on stderr. Fails OPEN: a section whose header this cannot parse
@@ -21,35 +23,45 @@
 // wasted review budget and the cost of dropping a hand-written one is an unread
 // change.
 //
-// Usage: node .github/scripts/strip-generated-diff.mjs <owned-list-file> <diff
-// where <owned-list-file> holds one owned path per line.
+// Usage: node .github/scripts/strip-generated-diff.mjs <omit-list-file> <diff
+// where <omit-list-file> holds one path (or `ownsPrefix` subtree) per line.
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-// A section header git wrote for a path with no whitespace, which every owned
-// path in this repo is. A quoted or space-bearing path does not match, and its
+// Where a section STARTS. Every `diff --git` line begins one, whatever its
+// paths look like, so splitting never depends on parsing them.
+const SECTION_START = /^diff --git /u;
+
+// A section header git wrote for a path with no whitespace, which every omitted
+// path in this repo is. A quoted or space-bearing path does not match, so its
 // section is kept — see the fail-open note above.
 const HEADER = /^diff --git a\/(\S+) b\/(\S+)$/u;
 
-/** True when `path` is generated: an exact `owns` entry, or under an
- * `ownsPrefix` (which the oracle prints with its trailing slash). */
-function isOwned(path, owned) {
-  return owned.some((entry) =>
+/** True when `path` is one the omit list vouches for: an exact `owns` entry, or
+ * under an `ownsPrefix` (which the oracle prints with its trailing slash). */
+function isOmitted(path, omit) {
+  return omit.some((entry) =>
     entry.endsWith("/") ? path.startsWith(entry) : path === entry,
   );
 }
 
 /** Split a unified diff into sections, each starting at a `diff --git` line.
- * A leading chunk before the first header (git emits none, but a caller may
- * prepend text) becomes its own always-kept section. */
+ * A leading chunk before the first one (git emits none, but a caller may
+ * prepend text) becomes its own always-kept section.
+ *
+ * Splits on SECTION_START, never on HEADER: a file whose header HEADER cannot
+ * read must become its OWN section, or it is appended to the section above it
+ * and shares that section\'s fate. A space-bearing source file listed after an
+ * omitted artifact would then be dropped with it — the fail-CLOSED outcome this
+ * script exists to avoid. */
 function splitSections(diff) {
   const lines = diff.split("\n");
   /** @type {string[][]} */
   const sections = [];
   for (const line of lines) {
-    if (HEADER.test(line) || sections.length === 0) sections.push([]);
+    if (SECTION_START.test(line) || sections.length === 0) sections.push([]);
     sections[sections.length - 1].push(line);
   }
   return sections.map((s) => s.join("\n"));
@@ -57,9 +69,9 @@ function splitSections(diff) {
 
 /** The filtered diff and the paths dropped from it.
  * @param {string} diff a unified diff
- * @param {string[]} owned paths and path prefixes that are generated
+ * @param {string[]} omit paths and path prefixes a required check re-derives
  * @returns {{ kept: string, dropped: {path: string, lines: number}[] }} */
-export function stripGenerated(diff, owned) {
+export function stripGenerated(diff, omit) {
   /** @type {{path: string, lines: number}[]} */
   const dropped = [];
   const kept = [];
@@ -67,7 +79,7 @@ export function stripGenerated(diff, owned) {
     const header = HEADER.exec(section.split("\n", 1)[0]);
     // Both sides must be generated, so a rename that moves a hand-written file
     // onto a generated path (or the reverse) stays in the review.
-    if (header && isOwned(header[1], owned) && isOwned(header[2], owned)) {
+    if (header && isOmitted(header[1], omit) && isOmitted(header[2], omit)) {
       dropped.push({ path: header[2], lines: section.split("\n").length });
       continue;
     }
@@ -86,19 +98,20 @@ export function omissionNote(dropped) {
   );
   return [
     `# NOTE: ${dropped.length} generated file(s) are omitted from the diff below.`,
-    "# They are build outputs listed in config/auto-resolve-regen-rules.json.",
-    "# CI rebuilds each one and fails on any difference, so they cannot disagree",
-    "# with the sources shown here. Review the sources.",
+    "# Each is a build output whose rule in config/auto-resolve-regen-rules.json",
+    "# sets reviewOmit, asserting a required check re-derives it and fails on any",
+    "# difference — so it cannot disagree with the sources shown here. A generated",
+    "# file with no such check (a lockfile) is NOT omitted. Review the sources.",
     ...rows,
     "",
     "",
   ].join("\n");
 }
 
-function main(ownedListFile) {
-  const owned = readFileSync(ownedListFile, "utf8").split("\n").filter(Boolean);
+function main(omitListFile) {
+  const omit = readFileSync(omitListFile, "utf8").split("\n").filter(Boolean);
   const diff = readFileSync(0, "utf8");
-  const { kept, dropped } = stripGenerated(diff, owned);
+  const { kept, dropped } = stripGenerated(diff, omit);
   process.stdout.write(
     dropped.length === 0 ? diff : omissionNote(dropped) + kept,
   );

--- a/.github/scripts/strip-generated-diff.mjs
+++ b/.github/scripts/strip-generated-diff.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// Drop GENERATED files' sections from a unified diff, so the automated reviewer
+// reads the hand-written change instead of a rebuilt artifact.
+//
+// PROBLEM CLASS — a review budget spent on bytes nobody wrote. This repo commits
+// its build outputs (plugin/dist/hooks/plugin-hooks.bundle.mjs and friends), so a
+// 25-line source edit arrives as a ~30k-line diff. That is over
+// prepare-pr-review-input.sh's MAX_DIFF_LINES, so the review is skipped
+// entirely and the source edit gets no automated read at all — the opposite of
+// what the size guard is for. The artifacts need no review anyway: CI rebuilds
+// each one and fails on any difference, so the diff cannot disagree with its
+// sources.
+//
+// Ownership comes from `resolve-generated.mjs --owned`, the same oracle the
+// auto-resolver partitions on, passed in on argv. A path is never classified
+// here.
+//
+// Reads the diff on stdin, writes the filtered diff on stdout, and reports what
+// it dropped on stderr. Fails OPEN: a section whose header this cannot parse
+// unambiguously is KEPT, because the cost of keeping a generated file is some
+// wasted review budget and the cost of dropping a hand-written one is an unread
+// change.
+//
+// Usage: node .github/scripts/strip-generated-diff.mjs <owned-list-file> <diff
+// where <owned-list-file> holds one owned path per line.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// A section header git wrote for a path with no whitespace, which every owned
+// path in this repo is. A quoted or space-bearing path does not match, and its
+// section is kept — see the fail-open note above.
+const HEADER = /^diff --git a\/(\S+) b\/(\S+)$/u;
+
+/** True when `path` is generated: an exact `owns` entry, or under an
+ * `ownsPrefix` (which the oracle prints with its trailing slash). */
+function isOwned(path, owned) {
+  return owned.some((entry) =>
+    entry.endsWith("/") ? path.startsWith(entry) : path === entry,
+  );
+}
+
+/** Split a unified diff into sections, each starting at a `diff --git` line.
+ * A leading chunk before the first header (git emits none, but a caller may
+ * prepend text) becomes its own always-kept section. */
+function splitSections(diff) {
+  const lines = diff.split("\n");
+  /** @type {string[][]} */
+  const sections = [];
+  for (const line of lines) {
+    if (HEADER.test(line) || sections.length === 0) sections.push([]);
+    sections[sections.length - 1].push(line);
+  }
+  return sections.map((s) => s.join("\n"));
+}
+
+/** The filtered diff and the paths dropped from it.
+ * @param {string} diff a unified diff
+ * @param {string[]} owned paths and path prefixes that are generated
+ * @returns {{ kept: string, dropped: {path: string, lines: number}[] }} */
+export function stripGenerated(diff, owned) {
+  /** @type {{path: string, lines: number}[]} */
+  const dropped = [];
+  const kept = [];
+  for (const section of splitSections(diff)) {
+    const header = HEADER.exec(section.split("\n", 1)[0]);
+    // Both sides must be generated, so a rename that moves a hand-written file
+    // onto a generated path (or the reverse) stays in the review.
+    if (header && isOwned(header[1], owned) && isOwned(header[2], owned)) {
+      dropped.push({ path: header[2], lines: section.split("\n").length });
+      continue;
+    }
+    kept.push(section);
+  }
+  return { kept: kept.join("\n"), dropped };
+}
+
+/** The note prepended to a filtered diff, so the reviewer knows the artifacts
+ * changed and why it is not being shown them. Empty when nothing was dropped —
+ * an unfiltered diff must pass through byte for byte. */
+export function omissionNote(dropped) {
+  if (dropped.length === 0) return "";
+  const rows = dropped.map(
+    (d) => `#   ${d.path} (${d.lines} diff lines, omitted)`,
+  );
+  return [
+    `# NOTE: ${dropped.length} generated file(s) are omitted from the diff below.`,
+    "# They are build outputs listed in config/auto-resolve-regen-rules.json.",
+    "# CI rebuilds each one and fails on any difference, so they cannot disagree",
+    "# with the sources shown here. Review the sources.",
+    ...rows,
+    "",
+    "",
+  ].join("\n");
+}
+
+function main(ownedListFile) {
+  const owned = readFileSync(ownedListFile, "utf8").split("\n").filter(Boolean);
+  const diff = readFileSync(0, "utf8");
+  const { kept, dropped } = stripGenerated(diff, owned);
+  process.stdout.write(
+    dropped.length === 0 ? diff : omissionNote(dropped) + kept,
+  );
+  for (const d of dropped)
+    process.stderr.write(
+      `strip-generated-diff: omitted ${d.path} (${d.lines} lines)\n`,
+    );
+}
+
+// Only when RUN, not when the test suite imports the pure functions above.
+if (
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === resolve(process.argv[1])
+)
+  main(process.argv[2]);

--- a/.github/scripts/strip-generated-diff.mjs
+++ b/.github/scripts/strip-generated-diff.mjs
@@ -11,7 +11,7 @@
 // each one and fails on any difference, so the diff cannot disagree with its
 // sources.
 //
-// The omit list comes from `resolve-generated.mjs --review-omit`, passed in as a
+// The omit list comes from `resolve-generated.mjs --owned --rederived-only`, passed in as a
 // file. A path is never classified here, and that mode is narrower than
 // `--owned`: it lists only rules whose output a required check re-derives and
 // compares. A lockfile is generated but nothing regenerates it in CI, so it

--- a/.github/scripts/strip-generated-diff.test.mjs
+++ b/.github/scripts/strip-generated-diff.test.mjs
@@ -126,3 +126,21 @@ test("the note names every omitted path and is empty when none were", () => {
   for (const line of note.split("\n").filter(Boolean))
     assert.match(line, /^#/u);
 });
+
+test("a content line that looks like a header does not start a section", () => {
+  // Section splitting is safe only because diff content lines always carry a
+  // +/-/space prefix, so `^diff --git ` can never match inside a hunk. That is
+  // what stops a fixture file from smuggling a hand-written change into a
+  // dropped section, and it is load-bearing enough to pin: a later relaxation of
+  // the anchor would break it with every other case still green.
+  const diff = [
+    "diff --git a/src/fixture.txt b/src/fixture.txt",
+    "@@ -0,0 +1,2 @@",
+    "+diff --git a/plugin/dist/hooks/plugin-hooks.bundle.mjs b/plugin/dist/hooks/plugin-hooks.bundle.mjs",
+    "+payload",
+    "",
+  ].join("\n");
+  const { kept, dropped } = stripGenerated(diff, OMIT);
+  assert.deepEqual(dropped, []);
+  assert.equal(kept, diff);
+});

--- a/.github/scripts/strip-generated-diff.test.mjs
+++ b/.github/scripts/strip-generated-diff.test.mjs
@@ -1,0 +1,103 @@
+// strip-generated-diff decides what the automated reviewer never sees, so the
+// asymmetry is the whole test: dropping a hand-written file is an unread change,
+// while keeping a generated one costs only review budget. Every case below is a
+// header shape that could be misread in one of those two directions.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { omissionNote, stripGenerated } from "./strip-generated-diff.mjs";
+
+/** A minimal but real two-file diff: one generated, one hand-written. */
+const DIFF = [
+  "diff --git a/plugin/dist/hooks/plugin-hooks.bundle.mjs b/plugin/dist/hooks/plugin-hooks.bundle.mjs",
+  "index 1111111..2222222 100644",
+  "--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs",
+  "+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs",
+  "@@ -1 +1 @@",
+  "-var a = 1;",
+  "+var a = 2;",
+  "diff --git a/src/html.mjs b/src/html.mjs",
+  "index 3333333..4444444 100644",
+  "--- a/src/html.mjs",
+  "+++ b/src/html.mjs",
+  "@@ -1 +1 @@",
+  '-import * as csstree from "css-tree";',
+  '+import cssParse from "css-tree/parser";',
+  "",
+].join("\n");
+
+const OWNED = ["plugin/dist/hooks/plugin-hooks.bundle.mjs", "types/"];
+
+test("drops a generated file's section and keeps the hand-written one", () => {
+  const { kept, dropped } = stripGenerated(DIFF, OWNED);
+  assert.deepEqual(
+    dropped.map((d) => d.path),
+    ["plugin/dist/hooks/plugin-hooks.bundle.mjs"],
+  );
+  assert.ok(kept.includes("diff --git a/src/html.mjs b/src/html.mjs"));
+  assert.ok(!kept.includes("plugin-hooks.bundle.mjs"));
+  // The kept section must survive intact, not merely be present: a splitter that
+  // ate the first or last line of a section would still pass a substring check.
+  assert.ok(kept.includes('+import cssParse from "css-tree/parser";'));
+});
+
+test("a diff with nothing generated passes through byte for byte", () => {
+  const { kept, dropped } = stripGenerated(DIFF, ["types/"]);
+  assert.deepEqual(dropped, []);
+  assert.equal(kept, DIFF);
+});
+
+test("an ownsPrefix entry covers its whole subtree", () => {
+  const diff = [
+    "diff --git a/types/index.d.ts b/types/index.d.ts",
+    "@@ -1 +1 @@",
+    "-declare const a: 1;",
+    "+declare const a: 2;",
+    "",
+  ].join("\n");
+  assert.deepEqual(
+    stripGenerated(diff, OWNED).dropped.map((d) => d.path),
+    ["types/index.d.ts"],
+  );
+  // The prefix must not match a sibling that merely starts with the same letters.
+  assert.deepEqual(
+    stripGenerated(diff.replaceAll("types/", "types-doc/"), OWNED).dropped,
+    [],
+  );
+});
+
+test("a rename with only one generated side is kept", () => {
+  const diff = [
+    "diff --git a/src/html.mjs b/plugin/dist/hooks/plugin-hooks.bundle.mjs",
+    "similarity index 100%",
+    "",
+  ].join("\n");
+  assert.deepEqual(stripGenerated(diff, OWNED).dropped, []);
+});
+
+test("an unparsable header is kept, never dropped", () => {
+  // git leaves a space-bearing path unquoted, so the header is ambiguous. Keeping
+  // it costs review budget; dropping it would hide a change nobody reviewed.
+  const diff = [
+    'diff --git "a/plugin/dist/hooks/plugin-hooks.bundle.mjs" "b/plugin/dist/hooks/plugin-hooks.bundle.mjs"',
+    "@@ -1 +1 @@",
+    "-a",
+    "+b",
+    "",
+  ].join("\n");
+  assert.deepEqual(stripGenerated(diff, OWNED).dropped, []);
+});
+
+test("an empty owned list drops nothing", () => {
+  assert.deepEqual(stripGenerated(DIFF, []).dropped, []);
+});
+
+test("the note names every omitted path and is empty when none were", () => {
+  assert.equal(omissionNote([]), "");
+  const note = omissionNote([{ path: "a/b.json", lines: 42 }]);
+  assert.match(note, /1 generated file\(s\)/u);
+  assert.match(note, /a\/b\.json \(42 diff lines, omitted\)/u);
+  // Every line must be a comment, so the note cannot be read as diff content.
+  for (const line of note.split("\n").filter(Boolean))
+    assert.match(line, /^#/u);
+});

--- a/.github/scripts/strip-generated-diff.test.mjs
+++ b/.github/scripts/strip-generated-diff.test.mjs
@@ -47,7 +47,11 @@ test("a diff with nothing generated passes through byte for byte", () => {
   assert.equal(kept, DIFF);
 });
 
-test("an ownsPrefix entry covers its whole subtree", () => {
+test("a directory entry hides nothing under it", () => {
+  // A check that regenerates its outputs and diffs them says nothing about an
+  // EXTRA file in the subtree, so a prefix cannot carry the flag's claim.
+  // resolve-generated.mjs refuses such a rule and main() refuses such a list;
+  // this pins the matcher itself, which is what would hide the file.
   const diff = [
     "diff --git a/types/index.d.ts b/types/index.d.ts",
     "@@ -1 +1 @@",
@@ -55,14 +59,11 @@ test("an ownsPrefix entry covers its whole subtree", () => {
     "+declare const a: 2;",
     "",
   ].join("\n");
+  assert.deepEqual(stripGenerated(diff, OMIT).dropped, []);
+  // ...while the exact path it names still goes.
   assert.deepEqual(
-    stripGenerated(diff, OMIT).dropped.map((d) => d.path),
+    stripGenerated(diff, ["types/index.d.ts"]).dropped.map((d) => d.path),
     ["types/index.d.ts"],
-  );
-  // The prefix must not match a sibling that merely starts with the same letters.
-  assert.deepEqual(
-    stripGenerated(diff.replaceAll("types/", "types-doc/"), OMIT).dropped,
-    [],
   );
 });
 

--- a/.github/scripts/strip-generated-diff.test.mjs
+++ b/.github/scripts/strip-generated-diff.test.mjs
@@ -26,10 +26,10 @@ const DIFF = [
   "",
 ].join("\n");
 
-const OWNED = ["plugin/dist/hooks/plugin-hooks.bundle.mjs", "types/"];
+const OMIT = ["plugin/dist/hooks/plugin-hooks.bundle.mjs", "types/"];
 
 test("drops a generated file's section and keeps the hand-written one", () => {
-  const { kept, dropped } = stripGenerated(DIFF, OWNED);
+  const { kept, dropped } = stripGenerated(DIFF, OMIT);
   assert.deepEqual(
     dropped.map((d) => d.path),
     ["plugin/dist/hooks/plugin-hooks.bundle.mjs"],
@@ -56,12 +56,12 @@ test("an ownsPrefix entry covers its whole subtree", () => {
     "",
   ].join("\n");
   assert.deepEqual(
-    stripGenerated(diff, OWNED).dropped.map((d) => d.path),
+    stripGenerated(diff, OMIT).dropped.map((d) => d.path),
     ["types/index.d.ts"],
   );
   // The prefix must not match a sibling that merely starts with the same letters.
   assert.deepEqual(
-    stripGenerated(diff.replaceAll("types/", "types-doc/"), OWNED).dropped,
+    stripGenerated(diff.replaceAll("types/", "types-doc/"), OMIT).dropped,
     [],
   );
 });
@@ -72,7 +72,32 @@ test("a rename with only one generated side is kept", () => {
     "similarity index 100%",
     "",
   ].join("\n");
-  assert.deepEqual(stripGenerated(diff, OWNED).dropped, []);
+  assert.deepEqual(stripGenerated(diff, OMIT).dropped, []);
+});
+
+test("a space-bearing path AFTER an omitted file survives", () => {
+  // The section split must not depend on parsing paths. When it did, this
+  // header failed to start a new section, so the hand-written file was appended
+  // to the omitted artifact above it and vanished from the review with it —
+  // fail-CLOSED, the one outcome this script must never produce.
+  const diff = [
+    "diff --git a/plugin/dist/hooks/plugin-hooks.bundle.mjs b/plugin/dist/hooks/plugin-hooks.bundle.mjs",
+    "@@ -1 +1 @@",
+    "-var a = 1;",
+    "+var a = 2;",
+    "diff --git a/src/file name.mjs b/src/file name.mjs",
+    "@@ -1 +1 @@",
+    "-const hand = 1;",
+    "+const written = 2;",
+    "",
+  ].join("\n");
+  const { kept, dropped } = stripGenerated(diff, OMIT);
+  assert.deepEqual(
+    dropped.map((d) => d.path),
+    ["plugin/dist/hooks/plugin-hooks.bundle.mjs"],
+  );
+  assert.ok(kept.includes("+const written = 2;"), kept);
+  assert.ok(kept.includes("diff --git a/src/file name.mjs"), kept);
 });
 
 test("an unparsable header is kept, never dropped", () => {
@@ -85,7 +110,7 @@ test("an unparsable header is kept, never dropped", () => {
     "+b",
     "",
   ].join("\n");
-  assert.deepEqual(stripGenerated(diff, OWNED).dropped, []);
+  assert.deepEqual(stripGenerated(diff, OMIT).dropped, []);
 });
 
 test("an empty owned list drops nothing", () => {

--- a/config/auto-resolve-regen-rules.json
+++ b/config/auto-resolve-regen-rules.json
@@ -7,7 +7,8 @@
     "sources": "exact paths whose change requires re-running this rule.",
     "sourcesPattern": "optional regex (string) matched against changed paths, in addition to `sources`.",
     "owns": "exact paths this rule GENERATES. A conflict in one of these is resolved by regenerating, never by editing.",
-    "ownsPrefix": "optional path prefix, ending in '/', whose whole subtree this rule generates."
+    "ownsPrefix": "optional path prefix, ending in '/', whose whole subtree this rule generates.",
+    "reviewOmit": "optional boolean, default false. TRUE asserts that a REQUIRED check re-derives every path this rule owns and fails on any difference, so the committed bytes cannot disagree with their sources. .github/scripts/strip-generated-diff.mjs omits only these paths from the automated reviewer's diff. Set it only beside the name of the check that proves it: a path that is merely machine-written (a lockfile) but that no check regenerates and compares stays VISIBLE, because a reviewer is then the only thing reading it."
   },
 
   "notOwned": {
@@ -50,7 +51,8 @@
       "owns": [
         "plugin/dist/hooks/plugin-hooks.bundle.mjs",
         "plugin/requirements.in"
-      ]
+      ],
+      "reviewOmit": true
     },
     {
       "command": [
@@ -60,7 +62,8 @@
       ],
       "sources": ["plugin/dist/hooks/plugin-hooks.bundle.mjs", "package.json"],
       "sourcesPattern": "^(claude-hooks|src)/.*\\.mjs$",
-      "owns": ["plugin/dist/hooks/hook-binaries.sha256"]
+      "owns": ["plugin/dist/hooks/hook-binaries.sha256"],
+      "reviewOmit": true
     },
     {
       "generator": "plugin/scripts/build-redactor-pyz.mjs",

--- a/config/auto-resolve-regen-rules.json
+++ b/config/auto-resolve-regen-rules.json
@@ -8,7 +8,7 @@
     "sourcesPattern": "optional regex (string) matched against changed paths, in addition to `sources`.",
     "owns": "exact paths this rule GENERATES. A conflict in one of these is resolved by regenerating, never by editing.",
     "ownsPrefix": "optional path prefix, ending in '/', whose whole subtree this rule generates.",
-    "reviewOmit": "optional boolean, default false. TRUE asserts that a REQUIRED check re-derives every path this rule owns and fails on any difference, so the committed bytes cannot disagree with their sources. .github/scripts/strip-generated-diff.mjs omits only these paths from the automated reviewer's diff. Set it only beside the name of the check that proves it: a path that is merely machine-written (a lockfile) but that no check regenerates and compares stays VISIBLE, because a reviewer is then the only thing reading it."
+    "reviewOmit": "optional boolean, default false. TRUE asserts that a REQUIRED check re-derives every path this rule owns and fails on any difference, so the committed bytes cannot disagree with their sources. .github/scripts/strip-generated-diff.mjs omits only these paths from the PR reviewer's diff, and the resolver's remerge-diff-report.py reads the same flag through `resolve-generated.mjs --owned --rederived-only` to decide which merge deltas it stops reading. Set it only beside the name of the check that proves it: a path that is merely machine-written (a lockfile) but that no check regenerates and compares stays VISIBLE, because a reviewer is then the only thing reading it."
   },
 
   "notOwned": {


### PR DESCRIPTION
## Summary

**`main` already carries this filter's first revision, and it has two defects.** [#367](https://github.com/AlexanderMattTurner/agent-sanitizer/pull/367) merged carrying `7ba2168`, so `prepare-pr-review-input.sh` on `main` hides every path `resolve-generated.mjs --owned` names — `pnpm-lock.yaml`, `uv.lock` and `python/uv.lock` included — and splits the diff on a parsed header, which drops a space-bearing path listed after a generated one. This PR is the corrected version of those same files.

The filter exists because the automated reviewer never reads a change that also rebuilds a committed build output. `prepare-pr-review-input.sh` skips the review past 20,000 diff lines, and this repo commits `plugin/dist/hooks/plugin-hooks.bundle.mjs` — about 29,000 lines of it. A small source edit arrives as an enormous diff, the size guard fires, and the hand-written lines get no read at all.

## Changes

A rule in `config/auto-resolve-regen-rules.json` opts in with `reviewOmit`, which asserts that a **required check re-derives the artifact and fails on any difference**, and `resolve-generated.mjs --owned --rederived-only` prints only those. Two rules set it, covering the three paths with such a check — `plugin/test/plugin-bundle.test.mjs`'s `committed bundle matches a fresh build from this tree`, `committed hook-binary manifest is fresh for this tree` and `committed requirements.in matches the secrets extra`, plus `build-hook-binaries.mjs --check` in `node-tests.yaml`.

`strip-generated-diff.mjs` now splits sections on the bare `diff --git ` marker and parses paths only per section, so a header it cannot read keeps its own section instead of joining the one above it.

`--owned --rederived-only` is the merge-conflict resolver's existing CLI for this question, not a new one. `remerge-diff-report.py` has been calling it against this repo's copy of `resolve-generated.mjs` since the pinned sha in `auto-resolve-conflicts.yaml`, and this copy never implemented the modifier — `argv.includes("--owned")` answered and the flag fell on the floor. So the merge-delta reviewer was skipping **every** owned path, the three lockfiles included, on exactly the guarantee this PR argues nothing provides.

```
$ node .github/scripts/resolve-generated.mjs --owned --rederived-only > omit.txt
$ node .github/scripts/strip-generated-diff.mjs omit.txt < pr367.diff | wc -l
strip-generated-diff: omitted plugin/dist/hooks/hook-binaries.sha256 (18 lines)
strip-generated-diff: omitted plugin/dist/hooks/plugin-hooks.bundle.mjs (31095 lines)
99
```

The reviewer still learns the artifacts changed: the filtered diff opens with a comment block naming each omitted path, and `meta.txt`'s file list is untouched.

## Decisions made

- **Generated is not enough to hide a file — a check that re-derives it is.** `--owned` includes `pnpm-lock.yaml`, `uv.lock` and `python/uv.lock`. Nothing in CI regenerates or byte-compares a lockfile (`setup-base-env` runs `uv sync --frozen`, which installs from the lock rather than checking it against a fresh resolution), so hiding one asserts a guarantee nobody provides, on the repo's most sensitive supply-chain surface — and replaces a *loud* skip with a *silent* removal. Both reviewers caught this independently.
- **One predicate, one flag, two readers.** The resolver already owns this question upstream as `rederivedByCheck` / `--owned --rederived-only`, and its `remerge-diff-report.py` runs that command here. A separate `--review-omit` would leave two names that can disagree, while the ignored modifier kept the merge-delta hole open. Upstream's per-kind default (`generator` implies checked) is deliberately **not** adopted: it assumes pre-commit regeneration hooks, and this repo has none, so the flag stays opt-in.
- **The flag cannot cover an `ownsPrefix`, and such a rule is REFUSED.** A check that regenerates a rule's outputs and diffs them says nothing about an extra file in the subtree, so a prefix cannot carry the claim while the reader acting on it stops reading the whole directory. `isOmitted` is exact-match, `resolve-generated.mjs` dies on the pairing, and the stripper refuses a directory in its omit list. No rule here sets `ownsPrefix`, so nothing that ships today changes. Found by the upstream reviewer on [agent-resolve-merge-conflicts#68](https://github.com/AlexanderMattTurner/agent-resolve-merge-conflicts/pull/68) and ported back so the two copies stay identical.
- **A lone `--rederived-only` is refused rather than ignored.** The fallthrough is not inert — it re-derives every generated file in the tree.
- **The filter fails open, and splitting never depends on parsing.** Only the per-section path parse can fail, and a header it cannot read keeps its section. Fail-closed is the one outcome this must never produce.
- **Both sides of a rename must be on the omit list** for the section to go, so a rename onto a generated path stays visible.
- **`main` was merged in, not rebased onto.** `adbd0d6` takes this branch's side for all three conflicted files, because `main`'s copies are the pre-review revision this PR corrects. Nothing of `#367`'s own change is dropped: the conflict is confined to the three files `7ba2168` touched.

## Tests / verification

`node --test .github/scripts/resolve-generated.test.mjs .github/scripts/strip-generated-diff.test.mjs` — 26 pass, re-run on the merged tree. The regression cases are non-vacuous: `a space-bearing path AFTER an omitted file survives` is red on `main`'s split and green here, and `--owned --rederived-only lists only the rules that set the flag` is paired with a positive `--owned` assertion so a flag that stopped being read shows up as the two modes agreeing — which is precisely the failure the ignored modifier was. A non-boolean `reviewOmit` exits 1, a lone `--rederived-only` exits 1 rather than running the generators, and `reviewOmit` on an `ownsPrefix` rule exits 1.

## Review focus

`stripGenerated`'s both-sides-on-the-list condition and the `SECTION_START` / `HEADER` split of responsibilities — those decide what a reviewer never sees, so a bug there is silent by construction. Then whether every path carrying `reviewOmit` really does have a required check behind it; that flag is a claim about CI, and only a reader can check it. It gates two reviewers, not one.

## Lessons Learned

- **What:** add a generated-file filter to the PR-review input script, so a committed build artifact cannot push a small source change past the reviewer's size cap. Drive it from the omit oracle the merge-conflict resolver already calls.
- **Where:** `.github/scripts/prepare-pr-review-input.sh` (or the template's equivalent reviewer-input step), plus a `strip-generated-diff.mjs` beside it and a `reviewOmit` marker in whatever config already declares the repo's generated paths.
- **Why:** any downstream repo that commits a build output — a bundle, a lockfile, a generated client — hits this the first time one is rebuilt. The size guard then spends its whole budget on bytes nobody wrote and skips the review of the lines a human did write, silently.
- **The constraint that makes it safe:** hide a path only when a *required check re-derives it and fails on a difference*, and only for an EXACT path. "It is generated" is not that guarantee — a lockfile is generated, nothing regenerates it in CI, and hiding it turns the highest-value supply-chain edit into the one nobody reads. A directory is not that guarantee either: regenerating a rule's outputs and diffing them cannot see an extra file in the subtree.
- **Check the copied script against the caller before adding a flag to it.** `resolve-generated.mjs` is copied from `agent-resolve-merge-conflicts`, which calls it with `--owned --rederived-only`. This copy had drifted and ignored the modifier, so a second flag for the same predicate would have shipped the duplication and left the original hole open. A copied script's unknown-flag handling is where drift hides: `argv.includes()` answers a stale question silently instead of failing.
