### PR TITLE
fix(claude-hooks): suppress InstructionsLoaded gap notice with nothing to load

### DIFF
--- a/claude-hooks/lib/invisible-alert.mjs
+++ b/claude-hooks/lib/invisible-alert.mjs
@@ -11,11 +11,13 @@
  * have one definition.
  */
 import {
+  globSync,
   lstatSync,
   mkdirSync,
   readdirSync,
   readFileSync,
   rmSync,
+  statSync,
 } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { basename, join } from "node:path";
@@ -23,11 +25,21 @@ import { tmpdir, userInfo } from "node:os";
 import {
   lazyImport,
   markerIsTrusted,
+  PROJECT_DIR,
   PROJECT_HASH,
   scrubUntrustedText,
   writeFileNoFollow,
   writeSentinelFile,
 } from "./hook-io.mjs";
+// Relative, like scan-invisible-chars.mjs's own import of this module: the
+// launch scope is hook POLICY (see src/claude-context.mjs), and this table is
+// pure data with no fs access of its own — the fs calls below are this
+// module's, not a copy of the SessionStart hook's target-discovery glue.
+import {
+  ancestorInstructionFiles,
+  CLAUDE_LAUNCH_GLOBS,
+  excludeFromContextScan,
+} from "../../src/claude-context.mjs";
 
 // Layer-1 scrubber for the untrusted alert-store contents the gate splices into a
 // permissionDecisionReason. The WELL-FORMED composition, not the bare applyLayer1:
@@ -281,7 +293,11 @@ function sweepStaleFallback(sessionId) {
   };
   for (const path of [alertAckFile(), ...entries])
     if (!withinFallbackTtl(path)) drop(path);
-  for (const path of [instructionsLoadedFile(), instructionsLoadedNoticeFile()])
+  for (const path of [
+    instructionsLoadedFile(),
+    instructionsLoadedNoticeFile(),
+    launchEmptyFile(),
+  ])
     if (!withinTtl(path, MARKER_TTL_MS)) drop(path);
 }
 
@@ -311,32 +327,81 @@ export function recordInstructionsLoaded(sessionId) {
 const EVENT_MIN_CLI_VERSION = "2.1.69";
 
 /**
+ * Companion marker: this session already found nothing at launch — the launch
+ * set is fixed at session start, so a second glob can never change the answer.
+ * @param {string} [sessionId]
+ * @returns {string}
+ */
+function launchEmptyFile(sessionId) {
+  return `${instructionsLoadedFile(sessionId)}.launch-empty`;
+}
+
+/**
+ * Whether anything Claude Code loads at launch from `dir` — its own
+ * instruction files, its `.claude/` context tree, or the CLAUDE.md /
+ * CLAUDE.local.md chain above it — actually has bytes. An existing but EMPTY
+ * file (a freshly `touch`ed `~/.claude/CLAUDE.md`) is nothing to load: Claude
+ * Code 2.1.246 fires no InstructionsLoaded event when a launch has nothing in
+ * it, so the missing event is expected there, not a sign the scanner is
+ * unwired. Same candidate set the SessionStart scan reads (see
+ * scan-invisible-chars.mjs's findInstructionFiles), built from the same
+ * src/claude-context.mjs table so the two enumerations of "what loads at
+ * launch" cannot drift apart.
+ * @param {string} dir
+ * @returns {boolean}
+ */
+function launchHasContent(dir) {
+  const candidates = [
+    ...globSync([...CLAUDE_LAUNCH_GLOBS], {
+      cwd: dir,
+      exclude: excludeFromContextScan,
+    }).map((name) => join(dir, name)),
+    ...ancestorInstructionFiles(dir),
+  ];
+  for (const file of candidates) {
+    try {
+      if (statSync(file).size > 0) return true;
+    } catch {
+      // ENOENT: most candidates — the ancestor chain above all — name a file
+      // that does not exist. Nothing there either way.
+    }
+  }
+  return false;
+}
+
+/**
  * The one-time context line for a session where no InstructionsLoaded scan ran,
- * or null when the scan has been seen or the notice was already surfaced this
- * session.
+ * or null when the scan has been seen, the notice already ran this session, or
+ * nothing at launch could have fired the event ({@link launchHasContent}).
  *
- * PURE: it does not record that the notice was handed out. The caller records
- * separately, once the notice has actually landed in a response — a deny
- * assembled after this call discards the notice, and a marker written here would
- * have burned the session's one chance to report the loss.
+ * PURE for the notice itself: nothing is recorded until the caller confirms it
+ * landed in a returned response, so a discarded deny leaves the report to come.
+ * The launch-emptiness answer is cached as found instead — a fact about the
+ * filesystem at launch, fixed for the session, so caching it early loses nothing.
  *
- * The loss it names is real and otherwise invisible: SessionStart scans the
- * instruction files that load at launch, and everything a subdirectory loads
- * later is scanned by the event. No scan, and nothing says so.
+ * The loss it names is real: SessionStart scans what loads at launch, a
+ * subdirectory's file is scanned by the event, and no scan means nothing says
+ * so — unless launch had nothing to scan either, where silence is correct.
  *
- * The notice names the OBSERVABLE — no scan ran — and all three causes, because
- * the marker cannot tell them apart: a host that never wired the event to
- * scan-loaded-instructions, a Claude Code older than EVENT_MIN_CLI_VERSION, and
- * the hook switched off in AGENT_SANITIZER_DISABLED_HOOKS; asserting one sends a
- * reader who is in another to the wrong fix. The wiring cause leads because it is
- * the only one the reader can repair in this session, and nothing else reports it.
+ * The notice names the OBSERVABLE and all three remaining causes, since the
+ * marker cannot tell them apart: an unwired event, a Claude Code older than
+ * EVENT_MIN_CLI_VERSION, or the hook disabled via AGENT_SANITIZER_DISABLED_HOOKS.
+ * Naming one sends a reader who is in another to the wrong fix; wiring leads
+ * because it is the only cause this session can repair.
  * @param {string} [sessionId]  the harness's session identity, so the answer
  *   belongs to THIS session (see instructionsLoadedFile)
+ * @param {string} [dir]  the project root to check for launch content
+ *   (injectable for tests; defaults to the real project)
  * @returns {string | null}
  */
-export function instructionsLoadedGapNotice(sessionId) {
+export function instructionsLoadedGapNotice(sessionId, dir = PROJECT_DIR) {
   if (instructionsLoadedSeen(sessionId)) return null;
   if (markerIsTrusted(instructionsLoadedNoticeFile(sessionId))) return null;
+  if (markerIsTrusted(launchEmptyFile(sessionId))) return null;
+  if (!launchHasContent(dir)) {
+    writeSentinelFile(launchEmptyFile(sessionId));
+    return null;
+  }
   return (
     "agent-sanitizer: no InstructionsLoaded scan has run this session, so " +
     "instruction files loaded from SUBDIRECTORIES (a nested CLAUDE.md, a " +

--- a/claude-hooks/lib/invisible-alert.mjs
+++ b/claude-hooks/lib/invisible-alert.mjs
@@ -22,7 +22,7 @@ import {
 } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { basename, join } from "node:path";
-import { tmpdir, userInfo } from "node:os";
+import { homedir, tmpdir, userInfo } from "node:os";
 import {
   lazyImport,
   markerIsTrusted,
@@ -38,6 +38,7 @@ import {
 // module's, not a copy of the SessionStart hook's target-discovery glue.
 import {
   ancestorInstructionFiles,
+  CLAUDE_CONTEXT_SUBDIRS,
   CLAUDE_LAUNCH_GLOBS,
   excludeFromContextScan,
 } from "../../src/claude-context.mjs";
@@ -397,6 +398,37 @@ function launchHasContent(dir) {
 }
 
 /**
+ * Whether the USER-GLOBAL `~/.claude` memory and rules — a second root Claude
+ * Code loads at launch regardless of the project directory (see
+ * scan-loaded-instructions.mjs's header) — has any bytes. `launchHasContent`
+ * cannot see this root on its own: it is `dir`-relative, and `~/.claude` is
+ * outside `dir`'s own tree whenever the project is not `$HOME` itself, exactly
+ * the case a project opened anywhere but home is in.
+ *
+ * Honours `CLAUDE_CONFIG_DIR` the way plugin/scripts/enable-auto-update.mjs's
+ * own resolution does, since that root — not always `~/.claude` — is where
+ * Claude Code actually reads this content from.
+ * @param {Record<string, string | undefined>} [env]
+ * @returns {boolean}
+ */
+function userGlobalLaunchHasContent(env = process.env) {
+  const configDir = env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+  const candidates = globSync(
+    ["*.md", ...CLAUDE_CONTEXT_SUBDIRS.map((sub) => `${sub}/**/*.md`)],
+    { cwd: configDir, exclude: excludeFromContextScan },
+  ).map((name) => join(configDir, name));
+  for (const file of candidates) {
+    try {
+      if (statSync(file).size > 0) return true;
+    } catch (err) {
+      if (/** @type {NodeJS.ErrnoException} */ (err).code !== "ENOENT")
+        return true;
+    }
+  }
+  return false;
+}
+
+/**
  * The one-time context line for a session where no InstructionsLoaded scan ran,
  * or null when the scan has been seen, the notice already ran this session, or
  * neither launch nor `touchedDir` could have fired the event.
@@ -428,7 +460,8 @@ export function instructionsLoadedGapNotice(
   if (instructionsLoadedSeen(sessionId)) return null;
   if (markerIsTrusted(instructionsLoadedNoticeFile(sessionId))) return null;
   const launchCached = markerIsTrusted(launchEmptyFile(sessionId));
-  const launchHasBytes = !launchCached && launchHasContent(dir);
+  const launchHasBytes =
+    !launchCached && (launchHasContent(dir) || userGlobalLaunchHasContent());
   if (!launchCached && !launchHasBytes)
     writeSentinelFile(launchEmptyFile(sessionId));
   const touchedHasBytes =

--- a/claude-hooks/lib/invisible-alert.mjs
+++ b/claude-hooks/lib/invisible-alert.mjs
@@ -11,6 +11,7 @@
  * have one definition.
  */
 import {
+  existsSync,
   globSync,
   lstatSync,
   mkdirSync,
@@ -268,13 +269,14 @@ export function sweepStaleSessions(sessionId) {
  * The ack always expires; the findings only when this session has its own store
  * and so merely INHERITED these.
  *
- * The two InstructionsLoaded markers under the same prefix answer "did a scan
- * run at all", so FALLBACK_TTL_MS must never reach them: expiring one mid-session
- * would render the gap notice on a session that WAS scanned. They still go, at
- * MARKER_TTL_MS — the same age the loop above ages a real session's prefix out
- * at, and far past any session's life — because the loop skips this prefix and
- * would otherwise leave a session-less host's markers in $TMPDIR forever, with
- * the gap notice suppressed on every later session.
+ * The three InstructionsLoaded markers under the same prefix answer "did a scan
+ * run at all" and "was launch empty", so FALLBACK_TTL_MS must never reach them:
+ * expiring one mid-session would render the gap notice on a session that WAS
+ * scanned, or re-glob a launch this session already found empty. They still go,
+ * at MARKER_TTL_MS — the same age the loop above ages a real session's prefix
+ * out at, and far past any session's life — because the loop skips this prefix
+ * and would otherwise leave a session-less host's markers in $TMPDIR forever,
+ * with the gap notice suppressed on every later session.
  * @param {string} [sessionId]
  * @returns {void}
  */
@@ -327,43 +329,68 @@ export function recordInstructionsLoaded(sessionId) {
 const EVENT_MIN_CLI_VERSION = "2.1.69";
 
 /**
- * Companion marker: this session already found nothing at launch — the launch
- * set is fixed at session start, so a second glob can never change the answer.
+ * Companion marker: this session already found the LAUNCH set empty — that set
+ * (which files load at session start) cannot change mid-session, so a second
+ * glob of `dir` can never change that half of the answer. It says nothing about
+ * a directory touched later; {@link instructionsLoadedGapNotice}'s `touchedDir`
+ * covers that half fresh on every call instead.
  * @param {string} [sessionId]
  * @returns {string}
  */
-function launchEmptyFile(sessionId) {
+export function launchEmptyFile(sessionId) {
   return `${instructionsLoadedFile(sessionId)}.launch-empty`;
 }
 
 /**
- * Whether anything Claude Code loads at launch from `dir` — its own
- * instruction files, its `.claude/` context tree, or the CLAUDE.md /
- * CLAUDE.local.md chain above it — actually has bytes. An existing but EMPTY
- * file (a freshly `touch`ed `~/.claude/CLAUDE.md`) is nothing to load: Claude
- * Code 2.1.246 fires no InstructionsLoaded event when a launch has nothing in
- * it, so the missing event is expected there, not a sign the scanner is
- * unwired. Same candidate set the SessionStart scan reads (see
- * scan-invisible-chars.mjs's findInstructionFiles), built from the same
- * src/claude-context.mjs table so the two enumerations of "what loads at
- * launch" cannot drift apart.
+ * Every file Claude Code loads as model context AT LAUNCH from `dir`: its own
+ * instruction files, its `.claude/` context tree, and the CLAUDE.md /
+ * CLAUDE.local.md of every directory above it. THE SSOT scan-invisible-chars.mjs
+ * reads too (re-exported there as `findInstructionFiles`) — sharing the one
+ * function is what keeps the SessionStart scan's targets and this module's
+ * launch-emptiness check from drifting into two different answers for "what
+ * loads at launch". See src/claude-context.mjs for why this is the shallow
+ * launch scope and not a whole-tree walk.
  * @param {string} dir
- * @returns {boolean}
+ * @returns {string[]}
  */
-function launchHasContent(dir) {
-  const candidates = [
+export function launchInstructionFiles(dir) {
+  return [
     ...globSync([...CLAUDE_LAUNCH_GLOBS], {
       cwd: dir,
       exclude: excludeFromContextScan,
     }).map((name) => join(dir, name)),
-    ...ancestorInstructionFiles(dir),
+    // Filtered, unlike the glob's matches: almost every parent directory holds
+    // neither memory file, so the unfiltered chain would file ~10 phantom
+    // targets per session into scan-invisible-chars.mjs's operator-facing
+    // "absent" bucket. A file that appears after this check was not loaded at
+    // launch either, so nothing is lost by not listing it.
+    ...ancestorInstructionFiles(dir).filter((file) => existsSync(file)),
   ];
-  for (const file of candidates) {
+}
+
+/**
+ * Whether anything Claude Code loads at launch from `dir` actually has bytes.
+ * An existing but EMPTY file (a freshly `touch`ed `~/.claude/CLAUDE.md`) is
+ * nothing to load: Claude Code 2.1.246 fires no InstructionsLoaded event when
+ * a launch has nothing in it, so the missing event is expected there, not a
+ * sign the scanner is unwired.
+ *
+ * A file this uid cannot even STAT (EACCES, EISDIR, ELOOP…) is unvetted
+ * context, not evidence of absence — the same split scan-invisible-chars.mjs's
+ * classifyReadFailure makes between ABSENT and SKIPPED. Reading such a failure
+ * as "no content" would suppress the notice over a file that may carry a real,
+ * unscanned payload, so only ENOENT counts as nothing there; anything else
+ * counts as content and leaves the notice free to fire.
+ * @param {string} dir
+ * @returns {boolean}
+ */
+function launchHasContent(dir) {
+  for (const file of launchInstructionFiles(dir)) {
     try {
       if (statSync(file).size > 0) return true;
-    } catch {
-      // ENOENT: most candidates — the ancestor chain above all — name a file
-      // that does not exist. Nothing there either way.
+    } catch (err) {
+      if (/** @type {NodeJS.ErrnoException} */ (err).code !== "ENOENT")
+        return true;
     }
   }
   return false;
@@ -372,36 +399,41 @@ function launchHasContent(dir) {
 /**
  * The one-time context line for a session where no InstructionsLoaded scan ran,
  * or null when the scan has been seen, the notice already ran this session, or
- * nothing at launch could have fired the event ({@link launchHasContent}).
+ * neither launch nor `touchedDir` could have fired the event.
  *
- * PURE for the notice itself: nothing is recorded until the caller confirms it
- * landed in a returned response, so a discarded deny leaves the report to come.
- * The launch-emptiness answer is cached as found instead — a fact about the
- * filesystem at launch, fixed for the session, so caching it early loses nothing.
+ * PURE for the notice: nothing is recorded until the caller confirms it landed
+ * in a returned response. Launch-emptiness is cached once found — fixed for the
+ * session — but `touchedDir` is re-checked every call: the claim below is about
+ * SUBDIRECTORY files, so an empty launch must not silence a later call whose
+ * tool touched a directory that DOES carry real, unscanned content.
  *
- * The loss it names is real: SessionStart scans what loads at launch, a
- * subdirectory's file is scanned by the event, and no scan means nothing says
- * so — unless launch had nothing to scan either, where silence is correct.
- *
- * The notice names the OBSERVABLE and all three remaining causes, since the
- * marker cannot tell them apart: an unwired event, a Claude Code older than
+ * SessionStart scans what loads at launch; a subdirectory's file is scanned by
+ * the event; no scan means nothing says so — unless nothing touched so far had
+ * anything to scan either. The notice names all three remaining causes, since
+ * the marker cannot tell them apart: an unwired event, a Claude Code older than
  * EVENT_MIN_CLI_VERSION, or the hook disabled via AGENT_SANITIZER_DISABLED_HOOKS.
- * Naming one sends a reader who is in another to the wrong fix; wiring leads
- * because it is the only cause this session can repair.
- * @param {string} [sessionId]  the harness's session identity, so the answer
- *   belongs to THIS session (see instructionsLoadedFile)
- * @param {string} [dir]  the project root to check for launch content
- *   (injectable for tests; defaults to the real project)
+ * @param {string} [sessionId]  the harness's session identity (see
+ *   instructionsLoadedFile)
+ * @param {string} [dir]  the project root to check (injectable; defaults to
+ *   the real project)
+ * @param {string} [touchedDir]  this tool call's own target directory, when
+ *   known — re-checked every call, never cached
  * @returns {string | null}
  */
-export function instructionsLoadedGapNotice(sessionId, dir = PROJECT_DIR) {
+export function instructionsLoadedGapNotice(
+  sessionId,
+  dir = PROJECT_DIR,
+  touchedDir,
+) {
   if (instructionsLoadedSeen(sessionId)) return null;
   if (markerIsTrusted(instructionsLoadedNoticeFile(sessionId))) return null;
-  if (markerIsTrusted(launchEmptyFile(sessionId))) return null;
-  if (!launchHasContent(dir)) {
+  const launchCached = markerIsTrusted(launchEmptyFile(sessionId));
+  const launchHasBytes = !launchCached && launchHasContent(dir);
+  if (!launchCached && !launchHasBytes)
     writeSentinelFile(launchEmptyFile(sessionId));
-    return null;
-  }
+  const touchedHasBytes =
+    touchedDir !== undefined && launchHasContent(touchedDir);
+  if (!launchHasBytes && !touchedHasBytes) return null;
   return (
     "agent-sanitizer: no InstructionsLoaded scan has run this session, so " +
     "instruction files loaded from SUBDIRECTORIES (a nested CLAUDE.md, a " +

--- a/claude-hooks/pretooluse-sanitize.mjs
+++ b/claude-hooks/pretooluse-sanitize.mjs
@@ -29,6 +29,7 @@
  */
 import { createRequire } from "node:module";
 import { readFileSync } from "node:fs";
+import { dirname } from "node:path";
 import {
   isMain,
   lazyImport,
@@ -424,6 +425,40 @@ export function preToolUseLayers(rehydrate, env = process.env) {
     : layers;
 }
 
+// The tools whose path field Claude Code sends as an absolute path by
+// contract, so reading it needs no cwd to resolve against. Bounded to these:
+// Glob/Grep's `path` can be relative or omitted (defaults to a cwd this
+// payload does not carry), and Bash has no reliable target at all — the same
+// carve-out WRITE_SHAPED_TOOLS below takes for Bash writes.
+const PATH_FIELD_BY_TOOL = /** @type {Record<string, string>} */ (
+  Object.freeze({
+    Read: "file_path",
+    Edit: "file_path",
+    Write: "file_path",
+    MultiEdit: "file_path",
+    NotebookEdit: "notebook_path",
+  })
+);
+
+/**
+ * The directory THIS tool call targets, for the InstructionsLoaded gap-notice
+ * check — or undefined when the tool carries no reliable absolute path. An
+ * imprecise guess here only ever WIDENS coverage (see instructionsLoadedGapNotice's
+ * `touchedDir`): missing a real target loses nothing this check did not
+ * already lack, and there is no wrong-directory case that suppresses a real
+ * finding.
+ * @param {string} tool
+ * @param {any} toolInput
+ * @returns {string | undefined}
+ */
+function toolTargetDir(tool, toolInput) {
+  const field = PATH_FIELD_BY_TOOL[tool];
+  const path = field && toolInput?.[field];
+  return typeof path === "string" && path.startsWith("/")
+    ? dirname(path)
+    : undefined;
+}
+
 /**
  * Compose the four protections. Returns the `hookSpecificOutput` fields to
  * emit, or null for a clean no-op. Throws only if a layer's engine throws; the
@@ -468,7 +503,11 @@ export async function buildPreToolUseResponse(
   // the notice was surfaced: a rehydrate deny below returns before the response
   // is assembled, and recording here would burn the session's one report on a
   // call that never carried it.
-  const gapNotice = instructionsLoadedGapNotice(input.session_id);
+  const gapNotice = instructionsLoadedGapNotice(
+    input.session_id,
+    undefined,
+    toolTargetDir(tool, toolInput),
+  );
   if (gapNotice !== null) contexts.push(gapNotice);
 
   // Layers 2-4, run by the declared pipeline: the driver — not this call order —

--- a/claude-hooks/scan-invisible-chars.mjs
+++ b/claude-hooks/scan-invisible-chars.mjs
@@ -21,8 +21,8 @@
  * false positive the SSOT had already fixed, and its clean path was a bare
  * `writeFileSync` with none of cleanFile's symlink/UTF-8/TOCTOU guards.
  */
-import { existsSync, readFileSync, globSync } from "node:fs";
-import { join, relative, resolve } from "node:path";
+import { readFileSync } from "node:fs";
+import { relative, resolve } from "node:path";
 import {
   awaitLazyDependency,
   emitHookResponse,
@@ -45,6 +45,7 @@ import {
   alertAckFile,
   alertDir,
   appendAlert,
+  launchInstructionFiles,
   sweepStaleSessions,
 } from "./lib/invisible-alert.mjs";
 import { formatReport } from "./lib/invisible-report.mjs";
@@ -59,11 +60,9 @@ import { reportSlowHook, startHookTimer } from "./lib/hook-timing.mjs";
 // so importing it statically carries none of the fail-open hazard lazyImport
 // exists to cover.
 import {
-  ancestorInstructionFiles,
   CLAUDE_CONTEXT_SUBDIRS,
   CLAUDE_INSTRUCTION_GLOBS,
   CLAUDE_LAUNCH_GLOBS,
-  excludeFromContextScan,
   isInsideDir,
 } from "../src/claude-context.mjs";
 
@@ -234,26 +233,14 @@ function decodeRun(run) {
  * files load when a tool reads their directory, and scan-loaded-instructions
  * scans each one at that moment.
  *
- * The scope itself — which globs, and which directories the walk must prune — is
- * the library's (see src/claude-context.mjs for why it is imported relatively
- * rather than through the `agent-sanitizer` specifier the plugin bundle pins).
+ * lib/invisible-alert.mjs's `launchInstructionFiles` IS this function — shared
+ * so its InstructionsLoaded gap-notice check reads the identical target set
+ * this scan does, rather than a second enumeration that could drift.
  * @param {string} dir
  * @returns {string[]}
  */
 function findInstructionFiles(dir) {
-  return [
-    ...globSync([...CLAUDE_LAUNCH_GLOBS], {
-      cwd: dir,
-      exclude: excludeFromContextScan,
-    }).map((name) => join(dir, name)),
-    // Filtered, unlike the glob's matches: almost every parent directory holds
-    // neither memory file, so the unfiltered chain would file ~10 phantom
-    // targets per session into the `absent` bucket and bury the one thing that
-    // bucket reports — a target that existed when the scan listed it and was
-    // gone by the read. A file that appears after this check was not loaded at
-    // launch either, so nothing is lost by not listing it.
-    ...ancestorInstructionFiles(dir).filter((file) => existsSync(file)),
-  ];
+  return launchInstructionFiles(dir);
 }
 
 // Scanner

--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=12d2a5c6992a0a653db5726550b8717d32421d93c743199c93c9ed8843ec20bd
-d4983799eae30ca49e4175591e12496095be6beba630c368e512c5bca2492986  agent-sanitizer-hooks-darwin-arm64
-e50a6d86115cbcc701050c73cc4e1a22ab22a047b81d9f8a7ee8204b679f135f  agent-sanitizer-hooks-darwin-x64
-cf4ab6e32ec9133c675abc1625d5fc15d978b3b17306011413506e16e62f4968  agent-sanitizer-hooks-linux-arm64
-5aced1f9359a1acbe5df98d59387b4128df0bd8a063a47cf68bbe4b5739e0e23  agent-sanitizer-hooks-linux-x64
+# bundle=9d2ba9c2e0146b2e1e9b266ef0a0209dcc60c87f115132ff01a3c4f431115738
+f8d067b6a2f46957c5e334e99058b004897c7ca8882df510bbd4677bff6695d5  agent-sanitizer-hooks-darwin-arm64
+45be27aea0cc2b113b7cea7732bd94504010bf89b4f4ec01f8a625bd6e2cb0b1  agent-sanitizer-hooks-darwin-x64
+fd06024dfb5e4d129d4d2993d469c2506b926eba40e9048e6d879cb7043afa6c  agent-sanitizer-hooks-linux-arm64
+ad2a6e4019e2f420c2d09e8dd103b1697b121c283f435f3c1204b98c134aec40  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=9d2ba9c2e0146b2e1e9b266ef0a0209dcc60c87f115132ff01a3c4f431115738
-f8d067b6a2f46957c5e334e99058b004897c7ca8882df510bbd4677bff6695d5  agent-sanitizer-hooks-darwin-arm64
-45be27aea0cc2b113b7cea7732bd94504010bf89b4f4ec01f8a625bd6e2cb0b1  agent-sanitizer-hooks-darwin-x64
-fd06024dfb5e4d129d4d2993d469c2506b926eba40e9048e6d879cb7043afa6c  agent-sanitizer-hooks-linux-arm64
-ad2a6e4019e2f420c2d09e8dd103b1697b121c283f435f3c1204b98c134aec40  agent-sanitizer-hooks-linux-x64
+# bundle=840ee4d409eb4b48abf167019d3ff18ab936bdd390d22d5c7904cd9e5d92253b
+2b833e8e448070f1c51da5395b7477aefbf9f77de42bbdb8bb069c95dd37f139  agent-sanitizer-hooks-darwin-arm64
+ea62d3b0fcb08d7e9c2228e79f03ac92a1f304bfe52a426b0e7bdd52414d5ddd  agent-sanitizer-hooks-darwin-x64
+9ca35a32134bc8f6628bfae63ed5980ee4da412925f5a9f2ed4405bdb2d321f6  agent-sanitizer-hooks-linux-arm64
+f0ecd27ff2f9b29aa36694acfb584cb2f34a798819b2e606c7c981773c3b0a2a  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=9f28bbab2780995f0aae507d3b35e16b2ee51e6e668f6c73d4388f0a917ed0b8
-81035760c5bdbc438b97ac878dd0c19f9759e316f02565ef6410121ffcc8d933  agent-sanitizer-hooks-darwin-arm64
-c9a75765ed8c7eec838cb4023adb2b99569064a6cf08e1e4e91b98f0cf95ef31  agent-sanitizer-hooks-darwin-x64
-e34a776919451b8051dc0b26eef93e4648cda3cddb4b2eab3b6dad88864b9793  agent-sanitizer-hooks-linux-arm64
-c7eee019b79e5aa8811cc42f59ee210153f11b68dd32574d910a54b566e094fe  agent-sanitizer-hooks-linux-x64
+# bundle=12d2a5c6992a0a653db5726550b8717d32421d93c743199c93c9ed8843ec20bd
+d4983799eae30ca49e4175591e12496095be6beba630c368e512c5bca2492986  agent-sanitizer-hooks-darwin-arm64
+e50a6d86115cbcc701050c73cc4e1a22ab22a047b81d9f8a7ee8204b679f135f  agent-sanitizer-hooks-darwin-x64
+cf4ab6e32ec9133c675abc1625d5fc15d978b3b17306011413506e16e62f4968  agent-sanitizer-hooks-linux-arm64
+5aced1f9359a1acbe5df98d59387b4128df0bd8a063a47cf68bbe4b5739e0e23  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -10500,7 +10500,7 @@ var require_util = __commonJS({
       return path2;
     });
     exports.normalize = normalize3;
-    function join9(aRoot, aPath) {
+    function join8(aRoot, aPath) {
       if (aRoot === "") {
         aRoot = ".";
       }
@@ -10532,7 +10532,7 @@ var require_util = __commonJS({
       }
       return joined;
     }
-    exports.join = join9;
+    exports.join = join8;
     exports.isAbsolute = function(aPath) {
       return aPath.charAt(0) === "/" || urlRegexp.test(aPath);
     };
@@ -10746,7 +10746,7 @@ var require_util = __commonJS({
             parsed.path = parsed.path.substring(0, index2 + 1);
           }
         }
-        sourceURL = join9(urlGenerate(parsed), sourceURL);
+        sourceURL = join8(urlGenerate(parsed), sourceURL);
       }
       return normalize3(sourceURL);
     }
@@ -12262,9 +12262,9 @@ var init_lib4 = __esm({
        * @returns {undefined}
        *   Nothing.
        */
-      set dirname(dirname6) {
+      set dirname(dirname7) {
         assertPath(this.basename, "dirname");
-        this.path = default2.join(dirname6 || "", this.basename);
+        this.path = default2.join(dirname7 || "", this.basename);
       }
       /**
        * Get the extname (including dot) (example: `'.js'`).
@@ -47850,6 +47850,7 @@ var init_control_plane2 = __esm({
 
 // claude-hooks/lib/invisible-alert.mjs
 import {
+  existsSync,
   globSync as globSync2,
   lstatSync as lstatSync3,
   mkdirSync,
@@ -47943,30 +47944,43 @@ function recordInstructionsLoaded(sessionId) {
 function launchEmptyFile(sessionId) {
   return `${instructionsLoadedFile(sessionId)}.launch-empty`;
 }
-function launchHasContent(dir) {
-  const candidates = [
+function launchInstructionFiles(dir) {
+  return [
     ...globSync2([...CLAUDE_LAUNCH_GLOBS], {
       cwd: dir,
       exclude: excludeFromContextScan
     }).map((name50) => join3(dir, name50)),
-    ...ancestorInstructionFiles(dir)
+    // Filtered, unlike the glob's matches: almost every parent directory holds
+    // neither memory file, so the unfiltered chain would file ~10 phantom
+    // targets per session into scan-invisible-chars.mjs's operator-facing
+    // "absent" bucket. A file that appears after this check was not loaded at
+    // launch either, so nothing is lost by not listing it.
+    ...ancestorInstructionFiles(dir).filter((file) => existsSync(file))
   ];
-  for (const file of candidates) {
+}
+function launchHasContent(dir) {
+  for (const file of launchInstructionFiles(dir)) {
     try {
       if (statSync(file).size > 0) return true;
-    } catch {
+    } catch (err) {
+      if (
+        /** @type {NodeJS.ErrnoException} */
+        err.code !== "ENOENT"
+      )
+        return true;
     }
   }
   return false;
 }
-function instructionsLoadedGapNotice(sessionId, dir = PROJECT_DIR) {
+function instructionsLoadedGapNotice(sessionId, dir = PROJECT_DIR, touchedDir) {
   if (instructionsLoadedSeen(sessionId)) return null;
   if (markerIsTrusted(instructionsLoadedNoticeFile(sessionId))) return null;
-  if (markerIsTrusted(launchEmptyFile(sessionId))) return null;
-  if (!launchHasContent(dir)) {
+  const launchCached = markerIsTrusted(launchEmptyFile(sessionId));
+  const launchHasBytes = !launchCached && launchHasContent(dir);
+  if (!launchCached && !launchHasBytes)
     writeSentinelFile(launchEmptyFile(sessionId));
-    return null;
-  }
+  const touchedHasBytes = touchedDir !== void 0 && launchHasContent(touchedDir);
+  if (!launchHasBytes && !touchedHasBytes) return null;
   return `agent-sanitizer: no InstructionsLoaded scan has run this session, so instruction files loaded from SUBDIRECTORIES (a nested CLAUDE.md, a directory-scoped rule) are reaching the model unscanned for hidden Unicode \u2014 the session-start scan covers only the files loaded at launch. Tell the user, and name all three causes with the command that decides each: this host never wired the InstructionsLoaded event to scan-loaded-instructions (the \`/hooks\` command lists what this session actually registered, whichever config dir or plugin root the host uses; wiring it restores the coverage), a Claude Code older than ${EVENT_MIN_CLI_VERSION}, the first build that emits the event (\`claude --version\`; upgrading restores it), or scan-loaded-instructions switched off in AGENT_SANITIZER_DISABLED_HOOKS (\`echo $AGENT_SANITIZER_DISABLED_HOOKS\`).`;
 }
 function recordInstructionsLoadedNotice(sessionId) {
@@ -48457,7 +48471,7 @@ var init_env_config = __esm({
 
 // claude-hooks/lib/redactor-client.mjs
 import { spawn } from "node:child_process";
-import { existsSync, lstatSync as lstatSync4 } from "node:fs";
+import { existsSync as existsSync2, lstatSync as lstatSync4 } from "node:fs";
 import { createConnection } from "node:net";
 import { tmpdir as tmpdir2, userInfo as userInfo3 } from "node:os";
 import { dirname as dirname4, join as join5 } from "node:path";
@@ -48470,7 +48484,7 @@ function daemonCommand() {
   const configured = process.env._AGENT_SANITIZER_REDACTOR_DAEMON;
   if (configured) return [configured];
   const pyz = fileURLToPath3(new URL("../redactor/daemon.pyz", import.meta.url));
-  if (existsSync(pyz)) return ["python3", pyz];
+  if (existsSync2(pyz)) return ["python3", pyz];
   return ["agent-secret-redactor-daemon"];
 }
 function requestDeadlineMs() {
@@ -48601,7 +48615,7 @@ function spawnDaemon(socketPath, command = daemonCommand()) {
 async function waitForSocket(socketPath, { deadlineMs = WAIT_DEADLINE_MS, stepMs = 100 } = {}) {
   const deadline = Date.now() + deadlineMs;
   while (Date.now() < deadline) {
-    if (existsSync(socketPath) && await canConnect(socketPath)) return true;
+    if (existsSync2(socketPath) && await canConnect(socketPath)) return true;
     await sleep(stepMs);
   }
   return false;
@@ -48826,7 +48840,7 @@ var init_secret_drop_guard = __esm({
 // claude-hooks/lib/reveal.mjs
 import { createHash as createHash4 } from "node:crypto";
 import {
-  existsSync as existsSync2,
+  existsSync as existsSync3,
   mkdirSync as mkdirSync2,
   lstatSync as lstatSync6,
   readdirSync as readdirSync3,
@@ -48843,7 +48857,7 @@ function revealDir() {
 }
 function sweepStaleReveals() {
   const dir = revealDir();
-  if (!existsSync2(dir) || !revealDirIsSafe(dir)) return;
+  if (!existsSync3(dir) || !revealDirIsSafe(dir)) return;
   const cutoff = Date.now() - REVEAL_TTL_MS;
   for (const name50 of readdirSync3(dir)) {
     const path2 = join7(dir, name50);
@@ -49128,6 +49142,7 @@ __export(pretooluse_sanitize_exports, {
 });
 import { createRequire as createRequire2 } from "node:module";
 import { readFileSync as readFileSync6 } from "node:fs";
+import { dirname as dirname6 } from "node:path";
 function substituteLayer2(text5, field) {
   const matches = [...text5.matchAll(LAYER2_PLACEHOLDER_RE2)].map((match) => ({
     text: match[0],
@@ -49256,6 +49271,11 @@ function preToolUseLayers(rehydrate, env = process.env) {
   ];
   return env.AGENT_SANITIZER_OUTPUT_DISABLED === "1" ? layers.filter((layer) => layer.name !== "authored-content") : layers;
 }
+function toolTargetDir(tool, toolInput) {
+  const field = PATH_FIELD_BY_TOOL[tool];
+  const path2 = field && toolInput?.[field];
+  return typeof path2 === "string" && path2.startsWith("/") ? dirname6(path2) : void 0;
+}
 async function buildPreToolUseResponse(input, rehydrate = defaultRehydrate, sink = trace) {
   const emitTrace = bestEffortTrace(sink);
   const asks = [];
@@ -49271,7 +49291,11 @@ async function buildPreToolUseResponse(input, rehydrate = defaultRehydrate, sink
     }
   }
   const { tool_name: tool, tool_input: toolInput } = input;
-  const gapNotice = instructionsLoadedGapNotice(input.session_id);
+  const gapNotice = instructionsLoadedGapNotice(
+    input.session_id,
+    void 0,
+    toolTargetDir(tool, toolInput)
+  );
   if (gapNotice !== null) contexts.push(gapNotice);
   const {
     updatedInput: current,
@@ -49427,7 +49451,7 @@ async function cliMain(opts = {}) {
     }
   );
 }
-var HOOK_NAME, PRE_TOOL_USE_MESSAGES, normalizeConfusables2, normalizeContext2, rehydrateRedacted2, spliceOrdered2, require2, confusableScan, redactorIo, guardedRehydrate, defaultRehydrate, REDACTION_HINT, WRITE_SHAPED_TOOLS;
+var HOOK_NAME, PRE_TOOL_USE_MESSAGES, normalizeConfusables2, normalizeContext2, rehydrateRedacted2, spliceOrdered2, require2, confusableScan, redactorIo, guardedRehydrate, defaultRehydrate, PATH_FIELD_BY_TOOL, REDACTION_HINT, WRITE_SHAPED_TOOLS;
 var init_pretooluse_sanitize = __esm({
   async "claude-hooks/pretooluse-sanitize.mjs"() {
     "use strict";
@@ -49483,6 +49507,14 @@ var init_pretooluse_sanitize = __esm({
       redactorIo
     );
     defaultRehydrate = async (tool, toolInput) => secretsEnabled() ? guardedRehydrate(tool, toolInput) : null;
+    PATH_FIELD_BY_TOOL = /** @type {Record<string, string>} */
+    Object.freeze({
+      Read: "file_path",
+      Edit: "file_path",
+      Write: "file_path",
+      MultiEdit: "file_path",
+      NotebookEdit: "notebook_path"
+    });
     REDACTION_HINT = "[REDACTED";
     WRITE_SHAPED_TOOLS = /* @__PURE__ */ new Set([
       "Write",
@@ -50635,8 +50667,8 @@ __export(scan_invisible_chars_exports, {
   scanProject: () => scanProject,
   sessionIdFromStdin: () => sessionIdFromStdin
 });
-import { existsSync as existsSync3, readFileSync as readFileSync7, globSync as globSync3 } from "node:fs";
-import { join as join8, relative as relative3, resolve as resolve4 } from "node:path";
+import { readFileSync as readFileSync7 } from "node:fs";
+import { relative as relative3, resolve as resolve4 } from "node:path";
 async function ensureSanitizerLoaded() {
   if (typeof scanText2 === "function" && typeof cleanFile2 === "function")
     return true;
@@ -50684,19 +50716,7 @@ function decodeRun2(run) {
   return instrDecodeRun(run);
 }
 function findInstructionFiles2(dir) {
-  return [
-    ...globSync3([...CLAUDE_LAUNCH_GLOBS], {
-      cwd: dir,
-      exclude: excludeFromContextScan
-    }).map((name50) => join8(dir, name50)),
-    // Filtered, unlike the glob's matches: almost every parent directory holds
-    // neither memory file, so the unfiltered chain would file ~10 phantom
-    // targets per session into the `absent` bucket and bury the one thing that
-    // bucket reports — a target that existed when the scan listed it and was
-    // gone by the read. A file that appears after this check was not loaded at
-    // launch either, so nothing is lost by not listing it.
-    ...ancestorInstructionFiles(dir).filter((file) => existsSync3(file))
-  ];
+  return launchInstructionFiles(dir);
 }
 function scanFile(filePath) {
   return scanText2(readFileSync7(filePath, "utf-8"));

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -47861,7 +47861,7 @@ import {
 } from "node:fs";
 import { randomBytes as randomBytes2 } from "node:crypto";
 import { basename, join as join3 } from "node:path";
-import { tmpdir, userInfo as userInfo2 } from "node:os";
+import { homedir, tmpdir, userInfo as userInfo2 } from "node:os";
 function sessionPrefix(sessionId) {
   const key = (sessionId ?? "").replace(/[^A-Za-z0-9._-]/gu, "_") || "no-session";
   return `${ALERT_BASE}.s-${key}`;
@@ -47972,11 +47972,30 @@ function launchHasContent(dir) {
   }
   return false;
 }
+function userGlobalLaunchHasContent(env = process.env) {
+  const configDir = env.CLAUDE_CONFIG_DIR || join3(homedir(), ".claude");
+  const candidates = globSync2(
+    ["*.md", ...CLAUDE_CONTEXT_SUBDIRS.map((sub) => `${sub}/**/*.md`)],
+    { cwd: configDir, exclude: excludeFromContextScan }
+  ).map((name50) => join3(configDir, name50));
+  for (const file of candidates) {
+    try {
+      if (statSync(file).size > 0) return true;
+    } catch (err) {
+      if (
+        /** @type {NodeJS.ErrnoException} */
+        err.code !== "ENOENT"
+      )
+        return true;
+    }
+  }
+  return false;
+}
 function instructionsLoadedGapNotice(sessionId, dir = PROJECT_DIR, touchedDir) {
   if (instructionsLoadedSeen(sessionId)) return null;
   if (markerIsTrusted(instructionsLoadedNoticeFile(sessionId))) return null;
   const launchCached = markerIsTrusted(launchEmptyFile(sessionId));
-  const launchHasBytes = !launchCached && launchHasContent(dir);
+  const launchHasBytes = !launchCached && (launchHasContent(dir) || userGlobalLaunchHasContent());
   if (!launchCached && !launchHasBytes)
     writeSentinelFile(launchEmptyFile(sessionId));
   const touchedHasBytes = touchedDir !== void 0 && launchHasContent(touchedDir);

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -47850,11 +47850,13 @@ var init_control_plane2 = __esm({
 
 // claude-hooks/lib/invisible-alert.mjs
 import {
+  globSync as globSync2,
   lstatSync as lstatSync3,
   mkdirSync,
   readdirSync,
   readFileSync as readFileSync3,
-  rmSync
+  rmSync,
+  statSync
 } from "node:fs";
 import { randomBytes as randomBytes2 } from "node:crypto";
 import { basename, join as join3 } from "node:path";
@@ -47925,7 +47927,11 @@ function sweepStaleFallback(sessionId) {
   };
   for (const path2 of [alertAckFile(), ...entries])
     if (!withinFallbackTtl(path2)) drop(path2);
-  for (const path2 of [instructionsLoadedFile(), instructionsLoadedNoticeFile()])
+  for (const path2 of [
+    instructionsLoadedFile(),
+    instructionsLoadedNoticeFile(),
+    launchEmptyFile()
+  ])
     if (!withinTtl(path2, MARKER_TTL_MS)) drop(path2);
 }
 function recordInstructionsLoaded(sessionId) {
@@ -47934,9 +47940,33 @@ function recordInstructionsLoaded(sessionId) {
   writeSentinelFile(marker2);
   sweepStaleSessions(sessionId);
 }
-function instructionsLoadedGapNotice(sessionId) {
+function launchEmptyFile(sessionId) {
+  return `${instructionsLoadedFile(sessionId)}.launch-empty`;
+}
+function launchHasContent(dir) {
+  const candidates = [
+    ...globSync2([...CLAUDE_LAUNCH_GLOBS], {
+      cwd: dir,
+      exclude: excludeFromContextScan
+    }).map((name50) => join3(dir, name50)),
+    ...ancestorInstructionFiles(dir)
+  ];
+  for (const file of candidates) {
+    try {
+      if (statSync(file).size > 0) return true;
+    } catch {
+    }
+  }
+  return false;
+}
+function instructionsLoadedGapNotice(sessionId, dir = PROJECT_DIR) {
   if (instructionsLoadedSeen(sessionId)) return null;
   if (markerIsTrusted(instructionsLoadedNoticeFile(sessionId))) return null;
+  if (markerIsTrusted(launchEmptyFile(sessionId))) return null;
+  if (!launchHasContent(dir)) {
+    writeSentinelFile(launchEmptyFile(sessionId));
+    return null;
+  }
   return `agent-sanitizer: no InstructionsLoaded scan has run this session, so instruction files loaded from SUBDIRECTORIES (a nested CLAUDE.md, a directory-scoped rule) are reaching the model unscanned for hidden Unicode \u2014 the session-start scan covers only the files loaded at launch. Tell the user, and name all three causes with the command that decides each: this host never wired the InstructionsLoaded event to scan-loaded-instructions (the \`/hooks\` command lists what this session actually registered, whichever config dir or plugin root the host uses; wiring it restores the coverage), a Claude Code older than ${EVENT_MIN_CLI_VERSION}, the first build that emits the event (\`claude --version\`; upgrading restores it), or scan-loaded-instructions switched off in AGENT_SANITIZER_DISABLED_HOOKS (\`echo $AGENT_SANITIZER_DISABLED_HOOKS\`).`;
 }
 function recordInstructionsLoadedNotice(sessionId) {
@@ -47996,6 +48026,7 @@ var init_invisible_alert = __esm({
   async "claude-hooks/lib/invisible-alert.mjs"() {
     "use strict";
     init_hook_io();
+    init_claude_context();
     ({ applyLayer1WellFormed: applyLayer1WellFormed2 } = /** @type {typeof import("agent-sanitizer")} */
     await lazyImport("agent-sanitizer"));
     ALERT_BASE = join3(
@@ -50604,7 +50635,7 @@ __export(scan_invisible_chars_exports, {
   scanProject: () => scanProject,
   sessionIdFromStdin: () => sessionIdFromStdin
 });
-import { existsSync as existsSync3, readFileSync as readFileSync7, globSync as globSync2 } from "node:fs";
+import { existsSync as existsSync3, readFileSync as readFileSync7, globSync as globSync3 } from "node:fs";
 import { join as join8, relative as relative3, resolve as resolve4 } from "node:path";
 async function ensureSanitizerLoaded() {
   if (typeof scanText2 === "function" && typeof cleanFile2 === "function")
@@ -50654,7 +50685,7 @@ function decodeRun2(run) {
 }
 function findInstructionFiles2(dir) {
   return [
-    ...globSync2([...CLAUDE_LAUNCH_GLOBS], {
+    ...globSync3([...CLAUDE_LAUNCH_GLOBS], {
       cwd: dir,
       exclude: excludeFromContextScan
     }).map((name50) => join8(dir, name50)),

--- a/test/claude-hooks-exports.test.mjs
+++ b/test/claude-hooks-exports.test.mjs
@@ -278,6 +278,8 @@ const PUBLISHED_EXPORTS = {
     "instructionsLoadedNoticeFile",
     "instructionsLoadedSeen",
     "invisibleCharAlert",
+    "launchEmptyFile",
+    "launchInstructionFiles",
     "recordInstructionsLoaded",
     "recordInstructionsLoadedNotice",
     "sessionPrefix",

--- a/test/claude-hooks-loaded-instructions.test.mjs
+++ b/test/claude-hooks-loaded-instructions.test.mjs
@@ -44,6 +44,7 @@ const {
   instructionsLoadedNoticeFile,
   instructionsLoadedSeen,
   invisibleCharAlert,
+  launchEmptyFile,
   recordInstructionsLoaded,
   recordInstructionsLoadedNotice,
 } = await import("../claude-hooks/lib/invisible-alert.mjs");
@@ -62,8 +63,8 @@ const markers = [
   instructionsLoadedNoticeFile(SESSION),
   // The "nothing loads at launch" cache instructionsLoadedGapNotice writes
   // itself — see the "no InstructionsLoaded scan" describe block below.
-  `${instructionsLoadedFile()}.launch-empty`,
-  `${instructionsLoadedFile(SESSION)}.launch-empty`,
+  launchEmptyFile(),
+  launchEmptyFile(SESSION),
 ];
 
 /** Every alert store these cases touch: the shared fallback and SESSION's. */
@@ -514,13 +515,15 @@ describe("a session with no InstructionsLoaded scan is named, once", () => {
       assert.equal(instructionsLoadedSeen(emptySession), false);
       assert.equal(instructionsLoadedGapNotice(emptySession, emptyDir), null);
       // Cached, not just silent this once: the launch set cannot change
-      // mid-session, so a second ask must not re-glob to find the same answer.
+      // mid-session, so the first call must have recorded the answer rather
+      // than merely returning null (a call that never wrote the sentinel
+      // would pass this assertion by accident, by re-globbing the same
+      // empty answer every time).
+      assert.ok(existsSync(launchEmptyFile(emptySession)));
       assert.equal(instructionsLoadedGapNotice(emptySession, emptyDir), null);
     } finally {
       rmSync(emptyDir, { recursive: true, force: true });
-      rmSync(`${instructionsLoadedFile(emptySession)}.launch-empty`, {
-        force: true,
-      });
+      rmSync(launchEmptyFile(emptySession), { force: true });
     }
   });
 
@@ -538,6 +541,80 @@ describe("a session with no InstructionsLoaded scan is named, once", () => {
     } finally {
       rmSync(withContentDir, { recursive: true, force: true });
       rmSync(instructionsLoadedNoticeFile(contentSession), { force: true });
+    }
+  });
+
+  it("counts a non-empty ancestor CLAUDE.md as launch content", () => {
+    // The ancestor-chain arm of the launch check, not the root glob: the
+    // checked directory itself carries nothing, but a PARENT does — matching
+    // a project opened one level below a repo-wide CLAUDE.md.
+    const parentDir = mkdtempSync(join(tmpdir(), "sanitizer-ancestor-"));
+    const childDir = join(parentDir, "child");
+    const ancestorSession = "sess-ancestor-launch";
+    try {
+      mkdirSync(childDir);
+      writeFileSync(join(parentDir, "CLAUDE.md"), PROSE);
+      assert.match(
+        instructionsLoadedGapNotice(ancestorSession, childDir),
+        /unscanned/u,
+      );
+    } finally {
+      rmSync(parentDir, { recursive: true, force: true });
+      rmSync(instructionsLoadedNoticeFile(ancestorSession), { force: true });
+    }
+  });
+
+  it("treats an unstattable launch candidate as content, not absence", () => {
+    // A file this uid cannot even stat (ELOOP here; EACCES/EISDIR in
+    // production) is unvetted context, not proof nothing is there — the
+    // opposite of ENOENT. Silently reading it as "empty" would suppress the
+    // notice over a file that may carry a real, unscanned payload.
+    const loopDir = mkdtempSync(join(tmpdir(), "sanitizer-unstattable-"));
+    const loopSession = "sess-unstattable-launch";
+    const loopPath = join(loopDir, "CLAUDE.md");
+    try {
+      symlinkSync(loopPath, loopPath);
+      assert.match(
+        instructionsLoadedGapNotice(loopSession, loopDir),
+        /unscanned/u,
+      );
+    } finally {
+      rmSync(loopDir, { recursive: true, force: true });
+      rmSync(instructionsLoadedNoticeFile(loopSession), { force: true });
+    }
+  });
+
+  it("fires once a later call touches a directory the empty launch never covered", () => {
+    // The blocker this fix must not reintroduce: an empty LAUNCH must not
+    // silence the whole session. If the scanner is genuinely unwired and a
+    // later tool call reaches into a subdirectory that DOES carry real,
+    // still-unscanned content, the notice must still fire there — the
+    // launch-empty cache only ever answers for the launch half.
+    const emptyDir = mkdtempSync(join(tmpdir(), "sanitizer-empty-then-"));
+    const nestedDir = join(emptyDir, "packages", "foo");
+    const session = "sess-empty-then-nested";
+    try {
+      // Call 1: nothing at launch and no touched directory yet — silent, and
+      // the empty answer gets cached.
+      assert.equal(instructionsLoadedGapNotice(session, emptyDir), null);
+      assert.ok(existsSync(launchEmptyFile(session)));
+      // Call 2: still nothing touched — the cached empty answer alone must
+      // not manufacture a warning.
+      assert.equal(instructionsLoadedGapNotice(session, emptyDir), null);
+      // Call 3: a tool now reads a file in a subdirectory that carries real
+      // content, and the scanner STILL never fired InstructionsLoaded — the
+      // one case that must not stay silent.
+      mkdirSync(nestedDir, { recursive: true });
+      writeFileSync(join(nestedDir, "CLAUDE.md"), PROSE);
+      assert.equal(instructionsLoadedSeen(session), false);
+      assert.match(
+        instructionsLoadedGapNotice(session, emptyDir, nestedDir),
+        /unscanned/u,
+      );
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true });
+      rmSync(launchEmptyFile(session), { force: true });
+      rmSync(instructionsLoadedNoticeFile(session), { force: true });
     }
   });
 

--- a/test/claude-hooks-loaded-instructions.test.mjs
+++ b/test/claude-hooks-loaded-instructions.test.mjs
@@ -60,6 +60,10 @@ const markers = [
   instructionsLoadedNoticeFile(),
   instructionsLoadedFile(SESSION),
   instructionsLoadedNoticeFile(SESSION),
+  // The "nothing loads at launch" cache instructionsLoadedGapNotice writes
+  // itself — see the "no InstructionsLoaded scan" describe block below.
+  `${instructionsLoadedFile()}.launch-empty`,
+  `${instructionsLoadedFile(SESSION)}.launch-empty`,
 ];
 
 /** Every alert store these cases touch: the shared fallback and SESSION's. */
@@ -469,6 +473,13 @@ describe("the hook CLI, driven end to end on a real event", () => {
 });
 
 describe("a session with no InstructionsLoaded scan is named, once", () => {
+  // The notice is only a real gap when something at launch could have fired
+  // the event — see the "stays silent when nothing loads at launch" block
+  // below for the empty case. Written explicitly here rather than relying on
+  // an earlier describe block's fixture: it must survive whichever order the
+  // suite runs in.
+  beforeEach(() => project("CLAUDE.md", PROSE));
+
   it("warns while no scan has been seen, naming every cause", () => {
     const notice = instructionsLoadedGapNotice();
     assert.match(notice, /InstructionsLoaded/u);
@@ -488,6 +499,46 @@ describe("a session with no InstructionsLoaded scan is named, once", () => {
     // ...and the hook switched off by the operator.
     assert.match(notice, /AGENT_SANITIZER_DISABLED_HOOKS/u);
     assert.match(notice, /echo \$AGENT_SANITIZER_DISABLED_HOOKS/u);
+  });
+
+  it("stays silent when nothing loads at launch, even with no scan seen", () => {
+    // Reported bug: launching in a directory whose ancestor chain has no
+    // NON-EMPTY CLAUDE.md/rules file (e.g. an empty ~/.claude/CLAUDE.md) gives
+    // Claude Code nothing to fire InstructionsLoaded over, so the missing
+    // event is expected there, not evidence the scanner is unwired.
+    const emptyDir = mkdtempSync(join(tmpdir(), "sanitizer-empty-launch-"));
+    const emptySession = "sess-empty-launch";
+    try {
+      mkdirSync(join(emptyDir, ".claude"));
+      writeFileSync(join(emptyDir, ".claude", "CLAUDE.md"), "");
+      assert.equal(instructionsLoadedSeen(emptySession), false);
+      assert.equal(instructionsLoadedGapNotice(emptySession, emptyDir), null);
+      // Cached, not just silent this once: the launch set cannot change
+      // mid-session, so a second ask must not re-glob to find the same answer.
+      assert.equal(instructionsLoadedGapNotice(emptySession, emptyDir), null);
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true });
+      rmSync(`${instructionsLoadedFile(emptySession)}.launch-empty`, {
+        force: true,
+      });
+    }
+  });
+
+  it("still warns once the launch set actually has content", () => {
+    const withContentDir = mkdtempSync(
+      join(tmpdir(), "sanitizer-nonempty-launch-"),
+    );
+    const contentSession = "sess-nonempty-launch";
+    try {
+      writeFileSync(join(withContentDir, "CLAUDE.md"), PROSE);
+      assert.match(
+        instructionsLoadedGapNotice(contentSession, withContentDir),
+        /unscanned/u,
+      );
+    } finally {
+      rmSync(withContentDir, { recursive: true, force: true });
+      rmSync(instructionsLoadedNoticeFile(contentSession), { force: true });
+    }
   });
 
   it("does not repeat the warning once it has been surfaced", () => {

--- a/test/claude-hooks-loaded-instructions.test.mjs
+++ b/test/claude-hooks-loaded-instructions.test.mjs
@@ -33,6 +33,17 @@ import { repoRoot } from "./helpers/repo-root.mjs";
 const projectDir = mkdtempSync(join(tmpdir(), "sanitizer-loaded-proj-"));
 process.env.CLAUDE_PROJECT_DIR = projectDir;
 
+// instructionsLoadedGapNotice also checks the user-global `~/.claude` root
+// (CLAUDE_CONFIG_DIR), read fresh from process.env on every call rather than
+// captured at import time. Pointed at an empty directory of our own so a real
+// ~/.claude on the machine running these tests (skills, rules — this very
+// checkout ships some) cannot make an "empty launch" case find content by
+// accident. Tests that need the global root non-empty override this and
+// restore it, never delete it — a later test must not fall back to the host's
+// real ~/.claude either.
+const emptyConfigDir = mkdtempSync(join(tmpdir(), "sanitizer-empty-config-"));
+process.env.CLAUDE_CONFIG_DIR = emptyConfigDir;
+
 const { readLoadedFile, scanLoadedFile, loadedFileMessage, scopeNotice } =
   await import("../claude-hooks/scan-loaded-instructions.mjs");
 const { LONG_RUN_THRESHOLD } = await import("../src/invisible.mjs");
@@ -77,6 +88,7 @@ beforeEach(() => {
 
 after(() => {
   rmSync(projectDir, { recursive: true, force: true });
+  rmSync(emptyConfigDir, { recursive: true, force: true });
   for (const path of markers) rmSync(path, { force: true });
   for (const path of alertDirs) rmSync(path, { recursive: true, force: true });
 });
@@ -561,6 +573,33 @@ describe("a session with no InstructionsLoaded scan is named, once", () => {
     } finally {
       rmSync(parentDir, { recursive: true, force: true });
       rmSync(instructionsLoadedNoticeFile(ancestorSession), { force: true });
+    }
+  });
+
+  it("counts the user-global ~/.claude root as launch content", () => {
+    // A project opened somewhere other than $HOME still has Claude Code load
+    // the user-global `~/.claude` memory and rules at launch (see
+    // scan-loaded-instructions.mjs's header) — a second root the project's own
+    // launch glob and ancestor chain cannot see on their own.
+    const projectEmptyDir = mkdtempSync(
+      join(tmpdir(), "sanitizer-empty-launch2-"),
+    );
+    const globalConfigDir = mkdtempSync(
+      join(tmpdir(), "sanitizer-global-config-"),
+    );
+    const session = "sess-user-global-launch";
+    try {
+      writeFileSync(join(globalConfigDir, "CLAUDE.md"), PROSE);
+      process.env.CLAUDE_CONFIG_DIR = globalConfigDir;
+      assert.match(
+        instructionsLoadedGapNotice(session, projectEmptyDir),
+        /unscanned/u,
+      );
+    } finally {
+      process.env.CLAUDE_CONFIG_DIR = emptyConfigDir;
+      rmSync(projectEmptyDir, { recursive: true, force: true });
+      rmSync(globalConfigDir, { recursive: true, force: true });
+      rmSync(instructionsLoadedNoticeFile(session), { force: true });
     }
   });
 


### PR DESCRIPTION
## Summary

`instructionsLoadedGapNotice` warns once per session that Claude Code's `InstructionsLoaded` event never fired, naming three possible wiring problems. It fired as a false positive whenever a session's launch-time instruction files had nothing non-empty to load (e.g. launching in `~` with an empty `~/.claude/CLAUDE.md`) — Claude Code 2.1.246 fires no event when there is nothing to load, so the missing marker there is not evidence of broken wiring.

The notice now checks the same launch-time file set the SessionStart scan reads (the project's own launch glob, its ancestor `CLAUDE.md`/`CLAUDE.local.md` chain, and the user-global `~/.claude` root Claude Code loads regardless of project directory), and stays silent when none of it is empty; the answer is cached per session since that set is fixed at session start.

That launch-only check alone would silently drop a real gap: if launch is empty but a scanner is genuinely unwired and a later tool call reaches a subdirectory with real content, nothing would ever warn. The notice now also re-checks, fresh on every call, the directory the CURRENT tool call targets (`pretooluse-sanitize.mjs` derives it for Read/Edit/Write/MultiEdit/NotebookEdit), and fires if that carries unscanned content.

A launch file this uid cannot even stat (EACCES/EISDIR/ELOOP) now counts as content, not absence, matching the ABSENT-vs-SKIPPED split the SessionStart scan already makes. The launch-set enumerator is shared between this check and the SessionStart scan (`scan-invisible-chars.mjs`'s `findInstructionFiles` now delegates to `invisible-alert.mjs`'s new `launchInstructionFiles`) instead of duplicated.

## Tests / verification

`test/claude-hooks-loaded-instructions.test.mjs` covers: silent on an empty launch (cached — verified via the sentinel file, not just a second null return); still warns on real launch content; counts a non-empty ancestor `CLAUDE.md`; counts non-empty `CLAUDE_CONFIG_DIR`/user-global content when the project's own launch set is empty; treats an unstattable file as content; and — the regression a follow-up commit on this branch fixes — still fires once a later call touches a subdirectory with real content even though launch was empty. The suite now pins `CLAUDE_CONFIG_DIR` to an empty fixture directory so the "empty launch" cases do not depend on whatever `~/.claude` the machine running the tests happens to have.

`pnpm test`, `pnpm lint`, and `pnpm check` (tsc, both configs) pass locally.

## Decisions made

An imprecise `touchedDir` guess only ever widens coverage (a missed extraction loses nothing this check lacked before; there is no case where a wrong guess suppresses a real finding), so the tool list is deliberately narrow rather than attempting to parse `Bash`/`Glob`/`Grep` targets.

A reviewer also raised the case where a launch file's ENTIRE content is a hidden-Unicode payload the SessionStart scan auto-cleans before this check runs, so it reads as empty. Left as-is: `scan-invisible-chars.mjs`'s own `autoCleanFindings` already reports that case directly (arms the PreToolUse gate, and warns that this session may have read the pre-clean bytes) — a more specific signal than this notice would add, for a scenario this notice's own stated scope (subdirectory files) does not cover anyway.

## Checklist

- [x] Commits follow Conventional Commits; each subject reads as a user-facing release note.
- [x] `pnpm test`, `pnpm lint`, and `pnpm check` pass locally.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version are left untouched (the release workflow owns them).
