### PR TITLE
fix(hooks): silence the InstructionsLoaded gap notice during a cold start

### DIFF
--- a/claude-hooks/lib/invisible-alert.mjs
+++ b/claude-hooks/lib/invisible-alert.mjs
@@ -27,6 +27,7 @@ import {
   hookgateMarkerPath,
   lazyImport,
   markerIsTrusted,
+  probeSetupAlive,
   PROJECT_DIR,
   PROJECT_HASH,
   scrubUntrustedText,
@@ -478,8 +479,11 @@ export function instructionsLoadedGapNotice(
   // may not have been able to run yet: a launch event fires within a second of
   // SessionStart, and a hook whose file or dependency setup has not written yet
   // never reached the marker. Every cause below would be wrong, so say nothing
-  // until the host is provisioned.
-  if (markerIsTrusted(hookgateMarkerPath())) return null;
+  // while setup RUNS. Liveness, not the marker alone: a setup killed mid-install
+  // leaves its marker behind, and a marker test alone would then silence this
+  // notice for every later session on the host.
+  const marker = hookgateMarkerPath();
+  if (markerIsTrusted(marker) && probeSetupAlive(marker)) return null;
   const launchCached = markerIsTrusted(launchEmptyFile(sessionId));
   const launchHasBytes =
     !launchCached &&

--- a/claude-hooks/lib/invisible-alert.mjs
+++ b/claude-hooks/lib/invisible-alert.mjs
@@ -24,6 +24,7 @@ import { randomBytes } from "node:crypto";
 import { basename, join } from "node:path";
 import { homedir, tmpdir, userInfo } from "node:os";
 import {
+  hookgateMarkerPath,
   lazyImport,
   markerIsTrusted,
   PROJECT_DIR,
@@ -442,8 +443,9 @@ function userGlobalLaunchHasContent(env = process.env) {
 
 /**
  * The one-time context line for a session where no InstructionsLoaded scan ran,
- * or null when the scan has been seen, the notice already ran this session, or
- * neither launch nor `touchedDir` could have fired the event.
+ * or null when the scan has been seen, the notice already ran this session, the
+ * host's cold-start marker says setup is still running, or neither launch nor
+ * `touchedDir` could have fired the event.
  *
  * PURE for the notice: nothing is recorded until the caller confirms it landed
  * in a returned response. Launch-emptiness is cached once found — fixed for the
@@ -472,6 +474,12 @@ export function instructionsLoadedGapNotice(
 ) {
   if (instructionsLoadedSeen(sessionId)) return null;
   if (markerIsTrusted(instructionsLoadedNoticeFile(sessionId))) return null;
+  // The host's setup script is still provisioning this session, so the scanner
+  // may not have been able to run yet: a launch event fires within a second of
+  // SessionStart, and a hook whose file or dependency setup has not written yet
+  // never reached the marker. Every cause below would be wrong, so say nothing
+  // until the host is provisioned.
+  if (markerIsTrusted(hookgateMarkerPath())) return null;
   const launchCached = markerIsTrusted(launchEmptyFile(sessionId));
   const launchHasBytes =
     !launchCached &&

--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=cc4406eb963983442e4d2fec36c226fbb3eac41412aa8c8f2f4b3f6cb510f46a
-6c563ec796d433a05513263e35157c0ed5549b741b86be608e8970fd0589151e  agent-sanitizer-hooks-darwin-arm64
-a1236874048878c633476eb6d924e48a626766ea6affbf4e7ad695f7bf059e58  agent-sanitizer-hooks-darwin-x64
-01d0d315c45f814bf8d11862cff6fd4366642a0e8bdd7fcec212c16ce1227190  agent-sanitizer-hooks-linux-arm64
-622d35e10c659ebbd9b4566b4b2e77591e31d1881247084c0f4ac778c2b86d94  agent-sanitizer-hooks-linux-x64
+# bundle=d2a4e5108e8aeacf9599c388fc503a5778ce2b44aa5e1c0b05fbdbd71da3513e
+9e25448e1f4b6af9a35924c28de7837d6bd70244bd1e153fbe0b5a6073786531  agent-sanitizer-hooks-darwin-arm64
+fdb5c5a95bcbf67298f53c6456c6fa8b7ff30026708c4862bda895281076139d  agent-sanitizer-hooks-darwin-x64
+9f7df8c6f04cdae8bc0fcbb579f231235542ce0a04a08676f2c8de9db95a50e0  agent-sanitizer-hooks-linux-arm64
+ca8a143c1ba9c90bccd2ae82ef4ac014d9f5e0ff695ec9bade7e36c90b0fbf62  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=1c21cbf0a1431cf05afe95b035106deb5e12f7951ac12d2e194f9597efc4c482
-11879b810204cdeffd7d6b231999af6a3fbe1406915b42ab7bc71f9eb290ece8  agent-sanitizer-hooks-darwin-arm64
-cfd5722426a46bb93f45d331c3631bf557907a8bdcbb23f54ca1bb58648c1325  agent-sanitizer-hooks-darwin-x64
-fdfcf1b546afc9cfead50b92b3a896a963d19b65b6f451142917facbc9d919b4  agent-sanitizer-hooks-linux-arm64
-5c5bb8c031dbf7cd630d2751f9d307a3b903735f0986770eee078bae2c46c8b7  agent-sanitizer-hooks-linux-x64
+# bundle=cc4406eb963983442e4d2fec36c226fbb3eac41412aa8c8f2f4b3f6cb510f46a
+6c563ec796d433a05513263e35157c0ed5549b741b86be608e8970fd0589151e  agent-sanitizer-hooks-darwin-arm64
+a1236874048878c633476eb6d924e48a626766ea6affbf4e7ad695f7bf059e58  agent-sanitizer-hooks-darwin-x64
+01d0d315c45f814bf8d11862cff6fd4366642a0e8bdd7fcec212c16ce1227190  agent-sanitizer-hooks-linux-arm64
+622d35e10c659ebbd9b4566b4b2e77591e31d1881247084c0f4ac778c2b86d94  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -47997,6 +47997,7 @@ function userGlobalLaunchHasContent(env = process.env) {
 function instructionsLoadedGapNotice(sessionId, dir = PROJECT_DIR, touchedDir) {
   if (instructionsLoadedSeen(sessionId)) return null;
   if (markerIsTrusted(instructionsLoadedNoticeFile(sessionId))) return null;
+  if (markerIsTrusted(hookgateMarkerPath())) return null;
   const launchCached = markerIsTrusted(launchEmptyFile(sessionId));
   const launchHasBytes = !launchCached && (anyFileHasBytes(announcedLaunchFiles(dir)) || userGlobalLaunchHasContent());
   if (!launchCached && !launchHasBytes)

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -47997,6 +47997,8 @@ function userGlobalLaunchHasContent(env = process.env) {
 function instructionsLoadedGapNotice(sessionId, dir = PROJECT_DIR, touchedDir) {
   if (instructionsLoadedSeen(sessionId)) return null;
   if (markerIsTrusted(instructionsLoadedNoticeFile(sessionId))) return null;
+  const marker2 = hookgateMarkerPath();
+  if (markerIsTrusted(marker2) && probeSetupAlive(marker2)) return null;
   const launchCached = markerIsTrusted(launchEmptyFile(sessionId));
   const launchHasBytes = !launchCached && (anyFileHasBytes(announcedLaunchFiles(dir)) || userGlobalLaunchHasContent());
   if (!launchCached && !launchHasBytes)

--- a/test/claude-hooks-loaded-instructions.test.mjs
+++ b/test/claude-hooks-loaded-instructions.test.mjs
@@ -47,6 +47,7 @@ process.env.CLAUDE_CONFIG_DIR = emptyConfigDir;
 const { readLoadedFile, scanLoadedFile, loadedFileMessage, scopeNotice } =
   await import("../claude-hooks/scan-loaded-instructions.mjs");
 const { LONG_RUN_THRESHOLD } = await import("../src/invisible.mjs");
+const { hookgateMarkerPath } = await import("../claude-hooks/lib/hook-io.mjs");
 const {
   alertDir,
   appendAlert,
@@ -553,6 +554,41 @@ describe("a session with no InstructionsLoaded scan is named, once", () => {
     } finally {
       rmSync(withContentDir, { recursive: true, force: true });
       rmSync(instructionsLoadedNoticeFile(contentSession), { force: true });
+    }
+  });
+
+  it("stays silent while the host's cold-start marker is present", () => {
+    // A launch event fires about a second after SessionStart, so a host that is
+    // still installing has not necessarily wired anything wrong: the three
+    // causes the notice names would all be false. This is the Claude Code web
+    // case, where the hook files are build output a fresh container lacks.
+    const coldDir = mkdtempSync(join(tmpdir(), "sanitizer-cold-start-"));
+    const runtimeDir = mkdtempSync(join(tmpdir(), "sanitizer-runtime-"));
+    const coldSession = "sess-cold-start";
+    const priorProject = process.env.CLAUDE_PROJECT_DIR;
+    const priorRuntime = process.env.XDG_RUNTIME_DIR;
+    try {
+      writeFileSync(join(coldDir, "CLAUDE.md"), PROSE);
+      process.env.CLAUDE_PROJECT_DIR = coldDir;
+      process.env.XDG_RUNTIME_DIR = runtimeDir;
+      const marker = /** @type {string} */ (hookgateMarkerPath());
+      writeFileSync(marker, String(process.pid));
+      assert.equal(instructionsLoadedGapNotice(coldSession, coldDir), null);
+      // The same launch set warns once setup is done, so the silence above is
+      // the marker's doing and not an empty-launch answer.
+      rmSync(marker, { force: true });
+      assert.match(
+        instructionsLoadedGapNotice(coldSession, coldDir),
+        /unscanned/u,
+      );
+    } finally {
+      process.env.CLAUDE_PROJECT_DIR = /** @type {string} */ (priorProject);
+      if (priorRuntime === undefined) delete process.env.XDG_RUNTIME_DIR;
+      else process.env.XDG_RUNTIME_DIR = priorRuntime;
+      rmSync(coldDir, { recursive: true, force: true });
+      rmSync(runtimeDir, { recursive: true, force: true });
+      rmSync(launchEmptyFile(coldSession), { force: true });
+      rmSync(instructionsLoadedNoticeFile(coldSession), { force: true });
     }
   });
 

--- a/test/claude-hooks-loaded-instructions.test.mjs
+++ b/test/claude-hooks-loaded-instructions.test.mjs
@@ -68,6 +68,9 @@ const SESSION = "sess-loaded-1";
 const PAYLOAD = "\u{e0001}".repeat(LONG_RUN_THRESHOLD + 2);
 const PROSE = "real prose the strip must keep\n";
 
+/** A pid above Linux's default pid_max, so no live process can carry it. */
+const DEAD_PID = 2 ** 31 - 1;
+
 const markers = [
   instructionsLoadedFile(),
   instructionsLoadedNoticeFile(),
@@ -574,6 +577,15 @@ describe("a session with no InstructionsLoaded scan is named, once", () => {
       const marker = /** @type {string} */ (hookgateMarkerPath());
       writeFileSync(marker, String(process.pid));
       assert.equal(instructionsLoadedGapNotice(coldSession, coldDir), null);
+      // A setup killed mid-install leaves its marker behind. The pid in it is
+      // then dead, and suppressing on the marker alone would silence this
+      // notice for every later session on the host.
+      writeFileSync(marker, String(DEAD_PID));
+      assert.match(
+        instructionsLoadedGapNotice(coldSession, coldDir),
+        /unscanned/u,
+      );
+      rmSync(instructionsLoadedNoticeFile(coldSession), { force: true });
       // The same launch set warns once setup is done, so the silence above is
       // the marker's doing and not an empty-launch answer.
       rmSync(marker, { force: true });


### PR DESCRIPTION
## What & why

The PreToolUse gate reports that no `InstructionsLoaded` scan has run this session, and names three causes: the host never wired the event, Claude Code is older than 2.1.69, or the hook is switched off. On a host whose setup script is still installing, all three are false. Claude Code fires the launch event about a second after the session starts, before a hook file or its dependencies can exist, so the scanner never reached the marker that says it ran.

The notice now returns null while the host's cold-start marker is present AND the setup process that wrote it is still alive — `probeSetupAlive` reads that marker's own lock or pid, so a setup killed mid-install does not silence the notice for every later session. It fires as before once setup finishes.

The diff also rebuilds `plugin/dist/hooks/plugin-hooks.bundle.mjs`, the artifact the installed plugin actually runs; `hook-binaries.sha256` still pins the previous bundle, which `plugin-dist-autofix.yaml` regenerates on push.

```js
process.env.XDG_RUNTIME_DIR = runtimeDir;
writeFileSync(hookgateMarkerPath(), String(process.pid));
instructionsLoadedGapNotice(session, dir); // null, was the three-cause notice
```

## Decisions made

- Suppress while setup runs, rather than adding a fourth cause to the message. A cause the reader cannot act on is the same interruption at more words, and the marker already says setup is the reason.
