### PR TITLE
fix(template-sync): run the sync's own scripts from a staged copy

### DIFF
--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -179,6 +179,23 @@ jobs:
           filter: blob:none
           persist-credentials: false
 
+      # The sync writes conflict markers into .github/ itself — SYNC_PATHS
+      # covers .github/scripts — and the resolve step then checks out the
+      # template-sync branch, so every later `bash .github/scripts/...` would
+      # read a marker-bearing copy of its own tooling. Stage the default
+      # branch's .github/ once, before anything writes to the tree, and run
+      # every script of this workflow from there. Staging the whole directory
+      # keeps each script's own relative sources (lib/, ../tool-versions.sh)
+      # resolving next to it.
+      - name: Stage this workflow's tooling from the default branch
+        id: tools
+        run: |
+          dest="${RUNNER_TEMP}/template-sync-tools"
+          rm -rf "$dest"
+          mkdir -p "$dest"
+          cp -R .github "$dest/.github"
+          echo "scripts=${dest}/.github/scripts" >>"$GITHUB_OUTPUT"
+
       - name: Check token workflow scope
         env:
           # Mirrors the checkout step above — validates whichever token is
@@ -189,7 +206,7 @@ jobs:
         # Run the child repo's own copy — never execute scripts directly from
         # the template checkout. Template script updates arrive via sync PRs
         # and go through human review before they can execute.
-        run: bash .github/scripts/check-token-scope.sh
+        run: bash ${{ steps.tools.outputs.scripts }}/check-token-scope.sh
 
       - name: Sync template files with conflict detection
         id: sync
@@ -197,7 +214,7 @@ jobs:
           SYNC_PATHS: ${{ env.SYNC_PATHS }}
           EXCLUDE_PATHS: ${{ env.EXCLUDE_PATHS }}
           OPT_IN_PATHS: ${{ env.OPT_IN_PATHS }}
-        run: bash .github/scripts/template-sync.sh
+        run: bash ${{ steps.tools.outputs.scripts }}/template-sync.sh
 
       - name: Show diff (dry run)
         if: inputs.dry-run == true && steps.sync.outputs.has_changes == 'true'
@@ -206,7 +223,7 @@ jobs:
           HAS_DELETIONS: ${{ steps.sync.outputs.has_deletions }}
           CONFLICT_FILES: ${{ steps.sync.outputs.conflict_files }}
           DELETED_FILES: ${{ steps.sync.outputs.deleted_files }}
-        run: bash .github/scripts/show-sync-diff.sh
+        run: bash ${{ steps.tools.outputs.scripts }}/show-sync-diff.sh
 
       - name: Create Pull Request
         if: inputs.dry-run != true && (steps.sync.outputs.has_changes == 'true' || steps.sync.outputs.has_conflicts == 'true' || steps.sync.outputs.has_deletions == 'true')
@@ -292,7 +309,7 @@ jobs:
       # markers live on the sync branch, so switch to it before resolving.
       - name: Install mergiraf (pinned, digest-verified)
         if: inputs.dry-run != true && steps.sync.outputs.has_conflicts == 'true' && steps.create-pr.outputs.pull-request-number
-        run: bash .github/scripts/install-mergiraf.sh
+        run: bash ${{ steps.tools.outputs.scripts }}/install-mergiraf.sh
 
       # template-sync-resolve.sh's tier 2 hands unresolved conflicts to the
       # resolver's own auto-resolve/fanout.py, which no longer ships in this
@@ -328,7 +345,7 @@ jobs:
         run: |
           git fetch --no-tags origin "+refs/heads/template-sync:refs/remotes/origin/template-sync"
           git checkout -B template-sync origin/template-sync
-          bash .github/scripts/template-sync-resolve.sh
+          bash ${{ steps.tools.outputs.scripts }}/template-sync-resolve.sh
 
       - name: Push the resolutions
         if: steps.resolve.outcome == 'success' && (steps.resolve.outputs.deterministic != '' || steps.resolve.outputs.by_model != '')
@@ -337,7 +354,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.GITHUB_TOKEN }}
           DETERMINISTIC: ${{ steps.resolve.outputs.deterministic }}
           BY_MODEL: ${{ steps.resolve.outputs.by_model }}
-        run: bash .github/scripts/template-sync-push.sh
+        run: bash ${{ steps.tools.outputs.scripts }}/template-sync-push.sh
 
       # A sync merges itself only when NOTHING needed judgement. See the script
       # for the full predicate; the two carve-outs are that a model-resolved file
@@ -353,4 +370,4 @@ jobs:
           HAS_DOWNGRADES: ${{ steps.sync.outputs.has_downgrades }}
           ALL_DETERMINISTIC: ${{ steps.resolve.outputs.all_deterministic }}
           CHANGED_PATHS: ${{ steps.sync.outputs.changed_paths }}
-        run: bash .github/scripts/template-sync-automerge.sh
+        run: bash ${{ steps.tools.outputs.scripts }}/template-sync-automerge.sh

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -203,27 +203,30 @@ jobs:
           # scope this sync needs to push .github/workflows/ changes.
           # token-fallback-ok: designed graceful degradation, not an accident.
           TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.GITHUB_TOKEN }}
+          SYNC_TOOLS: ${{ steps.tools.outputs.scripts }}
         # Run the child repo's own copy — never execute scripts directly from
         # the template checkout. Template script updates arrive via sync PRs
         # and go through human review before they can execute.
-        run: bash ${{ steps.tools.outputs.scripts }}/check-token-scope.sh
+        run: bash "$SYNC_TOOLS/check-token-scope.sh"
 
       - name: Sync template files with conflict detection
         id: sync
         env:
+          SYNC_TOOLS: ${{ steps.tools.outputs.scripts }}
           SYNC_PATHS: ${{ env.SYNC_PATHS }}
           EXCLUDE_PATHS: ${{ env.EXCLUDE_PATHS }}
           OPT_IN_PATHS: ${{ env.OPT_IN_PATHS }}
-        run: bash ${{ steps.tools.outputs.scripts }}/template-sync.sh
+        run: bash "$SYNC_TOOLS/template-sync.sh"
 
       - name: Show diff (dry run)
         if: inputs.dry-run == true && steps.sync.outputs.has_changes == 'true'
         env:
+          SYNC_TOOLS: ${{ steps.tools.outputs.scripts }}
           HAS_CONFLICTS: ${{ steps.sync.outputs.has_conflicts }}
           HAS_DELETIONS: ${{ steps.sync.outputs.has_deletions }}
           CONFLICT_FILES: ${{ steps.sync.outputs.conflict_files }}
           DELETED_FILES: ${{ steps.sync.outputs.deleted_files }}
-        run: bash ${{ steps.tools.outputs.scripts }}/show-sync-diff.sh
+        run: bash "$SYNC_TOOLS/show-sync-diff.sh"
 
       - name: Create Pull Request
         if: inputs.dry-run != true && (steps.sync.outputs.has_changes == 'true' || steps.sync.outputs.has_conflicts == 'true' || steps.sync.outputs.has_deletions == 'true')
@@ -309,7 +312,9 @@ jobs:
       # markers live on the sync branch, so switch to it before resolving.
       - name: Install mergiraf (pinned, digest-verified)
         if: inputs.dry-run != true && steps.sync.outputs.has_conflicts == 'true' && steps.create-pr.outputs.pull-request-number
-        run: bash ${{ steps.tools.outputs.scripts }}/install-mergiraf.sh
+        env:
+          SYNC_TOOLS: ${{ steps.tools.outputs.scripts }}
+        run: bash "$SYNC_TOOLS/install-mergiraf.sh"
 
       # template-sync-resolve.sh's tier 2 hands unresolved conflicts to the
       # resolver's own auto-resolve/fanout.py, which no longer ships in this
@@ -332,6 +337,7 @@ jobs:
         id: resolve
         if: inputs.dry-run != true && steps.sync.outputs.has_conflicts == 'true' && steps.create-pr.outputs.pull-request-number
         env:
+          SYNC_TOOLS: ${{ steps.tools.outputs.scripts }}
           CONFLICT_FILES: ${{ steps.sync.outputs.conflict_files }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
           RESOLVER_DIR: ${{ steps.resolver.outputs.dir }}
@@ -345,16 +351,17 @@ jobs:
         run: |
           git fetch --no-tags origin "+refs/heads/template-sync:refs/remotes/origin/template-sync"
           git checkout -B template-sync origin/template-sync
-          bash ${{ steps.tools.outputs.scripts }}/template-sync-resolve.sh
+          bash "$SYNC_TOOLS/template-sync-resolve.sh"
 
       - name: Push the resolutions
         if: steps.resolve.outcome == 'success' && (steps.resolve.outputs.deterministic != '' || steps.resolve.outputs.by_model != '')
         env:
+          SYNC_TOOLS: ${{ steps.tools.outputs.scripts }}
           # token-fallback-ok: designed graceful degradation, not an accident.
           GITHUB_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.GITHUB_TOKEN }}
           DETERMINISTIC: ${{ steps.resolve.outputs.deterministic }}
           BY_MODEL: ${{ steps.resolve.outputs.by_model }}
-        run: bash ${{ steps.tools.outputs.scripts }}/template-sync-push.sh
+        run: bash "$SYNC_TOOLS/template-sync-push.sh"
 
       # A sync merges itself only when NOTHING needed judgement. See the script
       # for the full predicate; the two carve-outs are that a model-resolved file
@@ -362,6 +369,7 @@ jobs:
       - name: Enable auto-merge on a fully deterministic sync
         if: inputs.dry-run != true && steps.create-pr.outputs.pull-request-number && vars.TEMPLATE_SYNC_AUTOMERGE != 'false'
         env:
+          SYNC_TOOLS: ${{ steps.tools.outputs.scripts }}
           GH_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || github.token }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
@@ -370,4 +378,4 @@ jobs:
           HAS_DOWNGRADES: ${{ steps.sync.outputs.has_downgrades }}
           ALL_DETERMINISTIC: ${{ steps.resolve.outputs.all_deterministic }}
           CHANGED_PATHS: ${{ steps.sync.outputs.changed_paths }}
-        run: bash ${{ steps.tools.outputs.scripts }}/template-sync-automerge.sh
+        run: bash "$SYNC_TOOLS/template-sync-automerge.sh"


### PR DESCRIPTION
Claims: `.github/workflows/template-sync.yaml`, the sync job's script invocations.

The sync job ran its own tooling out of the working tree. `SYNC_PATHS` covers `.github/scripts`, so `template-sync.sh` writes conflict markers into those very scripts, and the resolve step then checks out the `template-sync` branch, which carries them. Every script the job ran after that point read a marker-bearing copy of itself.

The fix stages the default branch's whole `.github/` to `${RUNNER_TEMP}/template-sync-tools` in one new step, placed before anything writes to the tree, and runs all seven of the job's scripts from there. Staging the whole directory keeps each script's relative sources resolving (`lib/merge-conflict.bash`, `../tool-versions.sh`). One step covers the class, so no call site opts out on its own.

Worked example — run 33209471506, job 98978887263:

```
.github/scripts/template-sync-resolve.sh: line 38: syntax error near unexpected token `<<<'
```

Line 38 on `origin/template-sync` is `<<<<<<< local`, and 42 files on that branch carry markers. With this change the resolver read at that moment comes from `${RUNNER_TEMP}`, which no sync ever writes.

## Decisions made

- Staged the whole `.github/` rather than an enumerated script list. An enumeration goes stale the moment a step gains a script, or a script gains a sibling source; the directory copy cannot. Cost: a few hundred KB copied per run.
- Routed `check-token-scope.sh` too, though it runs before the tree is dirtied. Uniformity means a step added later inherits the safe form. Under the alternative it keeps the old spelling and reads as the exception nobody remembers.

## Proposed guards

A check that every `run:` in the sync job invokes its scripts through `$SYNC_TOOLS`, never `.github/scripts/`. Benefit: catches the reintroduction, which is one line and looks correct in review. Cost: one more workflow-parsing assertion, guarding a single file. Not shipped here — the whole-directory staging already removes the per-script decision.

<details>
<summary>Detail</summary>

The exposed steps were: check token scope, sync, show diff, install mergiraf, resolve, push, auto-merge. `install-mergiraf` and the resolver checkout run before the branch checkout but after `template-sync.sh` has rewritten the tree, so they are the same class.

The staged path travels as a step-level `SYNC_TOOLS` env var rather than inline `${{ }}` in `run:` — zizmor's `template-injection` audit flags the inline form (7 findings on the first draft, 0 now).

The 42 marker-bearing files on `template-sync` are untouched: the next sync run regenerates that branch.

Verified: `yaml.safe_load` on the workflow plus `bash -n` over the changed run blocks, exit 0. The `pre-push` hook then ran the repo's own workflow guards — `script-reachability`, `workflow-step-refs`, `synced-deps`, zizmor — all passed.
</details>