### PR TITLE
test(secrets): take the copy gate's denominator as the best of five samples

### DIFF
--- a/tests/secrets/test_algorithmic_complexity.py
+++ b/tests/secrets/test_algorithmic_complexity.py
@@ -226,12 +226,16 @@ def test_entry_point_is_sub_quadratic_on_one_line(name):
 
 # The copy-volume gate's sizes and threshold. An 8x step, so linear is ~8x and
 # quadratic ~64x; the per-call fixed cost pulls the linear curve slightly under
-# 8. Both curves are MEASURED on the payload below — 7.85x when each line is
-# spliced in one pass, 30.27x when it is rebuilt per span — and 15.0 sits
-# between them with ~2x margin on each side.
+# 8. Both curves are MEASURED on the payload below — 8.18x at worst when each
+# line is spliced in one pass, 96.57x when it is rebuilt per span — and 15.0
+# sits between them with ~1.8x margin below and ~6x above.
 _COPY_SMALL_BYTES = 64 * 1024
 _COPY_LARGE_BYTES = 512 * 1024
 _COPY_GROWTH_LIMIT = 15.0
+# Samples of the SMALL side, whose best one is the denominator. Five, not more:
+# the small case is ~1/100th of the large one, so the repeats are free, and the
+# estimator only needs one sample that no collection or arena growth landed in.
+_COPY_SMALL_REPEATS = 5
 
 # `password="<next unit's `password=`>"` redacts once per TWO units, so the span
 # count grows with the line and a per-span whole-line rebuild shows as the
@@ -256,9 +260,21 @@ def _cpu_seconds(call) -> float:
 def _cpu_growth_ratio(thunk_for) -> float:
     """CPU-time growth from :data:`_COPY_SMALL_BYTES` to :data:`_COPY_LARGE_BYTES`
     on ONE line, with the engine's lazy one-time setup warmed out first (same
-    reason :func:`_growth_ratio` warms up)."""
-    thunk_for(_long_field_line(1024))()
-    small = _cpu_seconds(thunk_for(_long_field_line(_COPY_SMALL_BYTES)))
+    reason :func:`_growth_ratio` warms up).
+
+    The warm-up runs at the SMALL size, and the small side is the best of
+    :data:`_COPY_SMALL_REPEATS` samples. Noise can only ADD CPU time, so an
+    anomalously LOW ratio can only come from an inflated denominator: one 64 KiB
+    sample that absorbed a garbage collection or the allocator's first arena
+    growth at this size reads as the quadratic having gone away. That is what a
+    CI runner measured, putting the quadratic control at 11.26x against a 30.27x
+    baseline. The large side needs no repeat — inflating it only ever raises the
+    ratio, and no assertion here reads a raised ratio as a pass."""
+    thunk_for(_long_field_line(_COPY_SMALL_BYTES))()
+    small = min(
+        _cpu_seconds(thunk_for(_long_field_line(_COPY_SMALL_BYTES)))
+        for _ in range(_COPY_SMALL_REPEATS)
+    )
     large = _cpu_seconds(thunk_for(_long_field_line(_COPY_LARGE_BYTES)))
     # allow-wall-clock: a zero measurement means the entry point never ran at
     # all, not that a loaded runner was fast — and the caller's real

--- a/tests/secrets/test_algorithmic_complexity.py
+++ b/tests/secrets/test_algorithmic_complexity.py
@@ -233,8 +233,9 @@ _COPY_SMALL_BYTES = 64 * 1024
 _COPY_LARGE_BYTES = 512 * 1024
 _COPY_GROWTH_LIMIT = 15.0
 # Samples of the SMALL side, whose best one is the denominator. Five, not more:
-# the small case is ~1/100th of the large one, so the repeats are free, and the
-# estimator only needs one sample that no collection or arena growth landed in.
+# the small case costs ~1/8th of the large one on the linear entry points (far
+# less on the quadratic control), so the repeats are cheap, and the estimator
+# only needs one sample that no collection or arena growth landed in.
 _COPY_SMALL_REPEATS = 5
 
 # `password="<next unit's `password=`>"` redacts once per TWO units, so the span
@@ -266,10 +267,10 @@ def _cpu_growth_ratio(thunk_for) -> float:
     :data:`_COPY_SMALL_REPEATS` samples. Noise can only ADD CPU time, so an
     anomalously LOW ratio can only come from an inflated denominator: one 64 KiB
     sample that absorbed a garbage collection or the allocator's first arena
-    growth at this size reads as the quadratic having gone away. That is what a
-    CI runner measured, putting the quadratic control at 11.26x against a 30.27x
-    baseline. The large side needs no repeat — inflating it only ever raises the
-    ratio, and no assertion here reads a raised ratio as a pass."""
+    growth at this size reads as the quadratic having gone away. The large side
+    needs no repeat — it burns far more CPU, so the same fixed pause is a much
+    smaller share of it, and inflating it only ever raises the ratio, which no
+    assertion here reads as a pass."""
     thunk_for(_long_field_line(_COPY_SMALL_BYTES))()
     small = min(
         _cpu_seconds(thunk_for(_long_field_line(_COPY_SMALL_BYTES)))


### PR DESCRIPTION
## Summary

`_cpu_growth_ratio` took one CPU sample per size, so the copy-volume gate's `large / small` ratio rested on a single unreplicated 64 KiB measurement. Noise only ever ADDS time, so an anomalously LOW ratio can only come from an inflated denominator — one small sample that absorbed a garbage collection, or the allocator's first arena growth at that size, reads as the quadratic having gone away.

That fired: a CI runner measured the non-vacuity control `_rebuild_per_span` at 11.26x against the 15.0 floor, failing `validate` on a pull request whose diff was one workflow file and a lockfile.

## Changes

- The warm-up runs at `_COPY_SMALL_BYTES` instead of 1024 bytes, so no first-touch cost at the measured size lands in the first sample.
- The small side is the best of `_COPY_SMALL_REPEATS` (5) samples. On the six linear entry points the small case costs ~1/8th of the large one, so four extra samples add ~50% of one large sample per test — cheap, not free; on the quadratic control it is ~1/100th.
- The large side is unchanged: it burns far more CPU, so the same fixed pause is a much smaller share of it, and inflating it only raises the ratio, which no assertion here reads as a pass.
- The constants comment carried the figures measured before this change (7.85x / 30.27x); it now carries the ones measured after.

## Tests / verification

`uv run pytest tests/secrets/test_algorithmic_complexity.py -q -p no:randomly` — 20 passed.

Both sides of the gate, measured through the module's own `_cpu_growth_ratio` after the change:

```
linear    detected_secret_values      7.86x   (limit < 15.0)
linear    is_bare_pem_header          1.02x
linear    redact                      7.84x
linear    redact_configured           7.77x
linear    redact_map                  7.95x
linear    secret_previews             8.18x
quadratic _rebuild_per_span          96.57x   (limit >= 15.0)
```

The threshold keeps ~1.8x margin below and ~6.4x above. The smaller denominator moves the linear side up by ~0.3x at most, which is the strict direction for the gate that catches a real regression.

## Checklist

- [x] Commits follow Conventional Commits.
- [ ] `pnpm test`, `pnpm lint`, `pnpm check` — left to CI; the changed file is Python and was run directly above.
- [x] No detector behaviour changes, so no new negative tests are owed.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` untouched.