### PR TITLE
fix(ci): stop SIGPIPE aborting a release once the changelog grows

### DIFF
--- a/.github/scripts/fetch-security-report.sh
+++ b/.github/scripts/fetch-security-report.sh
@@ -70,8 +70,12 @@ gh_api_section \
 # Skip when there's no Node project — setup-base-env leaves pnpm uninstalled
 # in that case, and `pnpm audit` would error out instead of returning "clean".
 if [[ -f package.json ]]; then
-  pnpm audit 2>&1 | head -100 >>"$REPORT_PATH"
-  pnpm_rc=${PIPESTATUS[0]}
+  # Captured then truncated, never `| head -100`: head exits at its cap and
+  # SIGPIPEs pnpm, so PIPESTATUS[0] read 141 on any audit over 100 lines and the
+  # report gained a false "encountered an error" line. awk reads to EOF.
+  audit_out=$(pnpm audit 2>&1)
+  pnpm_rc=$?
+  awk 'NR <= 100' <<<"$audit_out" >>"$REPORT_PATH"
   # Exit 0 = clean, exit 1 = vulnerabilities found (expected); higher = real error
   # echo-fallback-ok: this note is appended to a human-read report artifact,
   # never re-parsed for a decision — nothing downstream branches on its text.

--- a/.github/scripts/version-bump.sh
+++ b/.github/scripts/version-bump.sh
@@ -243,13 +243,16 @@ else
   DIFF_STAT=$(git show --stat HEAD 2>/dev/null || echo "Unable to get diff")
 fi
 
-# Cap commit-message length: truncate each line, limit total length. The
-# `head -c` cap is byte-based and can split a multibyte UTF-8 character at the
-# tail; if it does, the only consequence is that `jq -n --arg` rejects the
-# invalid sequence and the Claude prose step falls back to the plain commit list
-# (the version decision never uses $COMMITS), so a corrupted tail costs only
-# the generated prose — the release itself still completes.
-COMMITS=$(echo "$COMMITS_RAW" | head -20 | cut -c1-100 | head -c 2000)
+# Cap commit-message length: truncate each line, limit total length. Both caps
+# avoid an early-exiting pipe consumer (`head -20`, `head -c 2000`), which would
+# close the pipe while the writer still has output and SIGPIPE it — a failure
+# `set -o pipefail` surfaces as an aborted release, on exactly the large inputs
+# the caps exist for. awk reads to EOF regardless of how much it prints, and the
+# total cap is a parameter expansion on an already-captured string. That
+# expansion counts characters, not bytes, so the tail can no longer be a split
+# multibyte sequence that `jq -n --arg` would reject.
+COMMITS=$(echo "$COMMITS_RAW" | awk 'NR <= 20 { print substr($0, 1, 100) }')
+COMMITS="${COMMITS:0:2000}"
 
 if [[ -z "$COMMITS" ]]; then
   log "No commits to analyze. Skipping."
@@ -276,13 +279,17 @@ log "Conventional Commits bump level: $BUMP"
 # Extract the current "## Unreleased" block from CHANGELOG.md, if present.
 # The block runs from the "## Unreleased" heading up to (but not including) the
 # next "## " heading or end of file.
+# Capped by parameter expansion, NOT `| head -c`: head exits at its byte cap and
+# SIGPIPEs awk, which `set -o pipefail` reports as a failure — aborting the
+# release whenever the Unreleased block grows past the cap.
 UNRELEASED_CONTENT=""
 if [[ -f CHANGELOG.md ]]; then
   UNRELEASED_CONTENT=$(awk '
     /^## Unreleased[[:space:]]*$/ { collecting = 1; next }
     collecting && /^## / { collecting = 0 }
     collecting { print }
-  ' CHANGELOG.md | head -c 4000)
+  ' CHANGELOG.md)
+  UNRELEASED_CONTENT="${UNRELEASED_CONTENT:0:4000}"
 fi
 
 # Draft the changelog body. The Claude API is used only for prose — any

--- a/.github/scripts/version-bump.sh
+++ b/.github/scripts/version-bump.sh
@@ -243,15 +243,11 @@ else
   DIFF_STAT=$(git show --stat HEAD 2>/dev/null || echo "Unable to get diff")
 fi
 
-# Cap commit-message length: truncate each line, limit total length. Both caps
-# avoid an early-exiting pipe consumer (`head -20`, `head -c 2000`), which would
-# close the pipe while the writer still has output and SIGPIPE it — a failure
-# `set -o pipefail` surfaces as an aborted release, on exactly the large inputs
-# the caps exist for. awk reads to EOF regardless of how much it prints, and the
-# total cap is a parameter expansion on an already-captured string. That
-# expansion counts characters, not bytes, so the tail can no longer be a split
-# multibyte sequence that `jq -n --arg` would reject.
-COMMITS=$(echo "$COMMITS_RAW" | awk 'NR <= 20 { print substr($0, 1, 100) }')
+# Cap commit-message length: 20 lines, 100 chars each, 2000 chars total. These
+# caps use no `| head`: head exits at its cap and SIGPIPEs the writer, which
+# `set -o pipefail` reports as a failure on exactly the large inputs the caps
+# exist for. A herestring feeds awk, so no pipeline survives to report one.
+COMMITS=$(awk 'NR <= 20 { print substr($0, 1, 100) }' <<<"$COMMITS_RAW")
 COMMITS="${COMMITS:0:2000}"
 
 if [[ -z "$COMMITS" ]]; then
@@ -278,10 +274,8 @@ log "Conventional Commits bump level: $BUMP"
 
 # Extract the current "## Unreleased" block from CHANGELOG.md, if present.
 # The block runs from the "## Unreleased" heading up to (but not including) the
-# next "## " heading or end of file.
-# Capped by parameter expansion, NOT `| head -c`: head exits at its byte cap and
-# SIGPIPEs awk, which `set -o pipefail` reports as a failure — aborting the
-# release whenever the Unreleased block grows past the cap.
+# next "## " heading or end of file. Its cap is a parameter expansion for the
+# same SIGPIPE-under-pipefail reason as the COMMITS cap above.
 UNRELEASED_CONTENT=""
 if [[ -f CHANGELOG.md ]]; then
   UNRELEASED_CONTENT=$(awk '

--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -436,3 +436,37 @@ jobs:
             -f "context=Review findings resolved" \
             -f "description=Review deliberately skipped: bot-authored, or a chore/style/release title. Add needs-auto-review to force a full review." \
             -f "target_url=${RUN_URL}" >/dev/null
+
+  # Approving the PR and clearing the gate is only half the landing: the PR still
+  # sits open until a person presses merge. An automated `chore(release)` PR
+  # waited that way with every required check green. Arming is NOT merging —
+  # GitHub holds the PR until every required check passes, and a red one keeps
+  # holding it, so this widens what LANDS UNATTENDED but never what is allowed to
+  # land. Same shape as dependabot-auto-merge.yaml.
+  #
+  # A separate job, not a step in auto-approve-skipped: enabling auto-merge needs
+  # `contents: write`, and that job checks out repo content under
+  # pull_request_target. Keeping the write scope in a job that checks out nothing
+  # and runs one `gh` call leaves the approver at `contents: read`.
+  #
+  # `needs:` the approver so a PR only arms once its clearing approval and gate
+  # status are actually posted — arming a PR the approver failed on would leave it
+  # waiting on a required check nobody cleared.
+  arm-auto-merge:
+    name: Arm auto-merge on the skipped class
+    needs: auto-approve-skipped
+    # not-required-check: arms a landing, reports no verdict about the code.
+    if: >-
+      github.event.action == 'opened' ||
+      github.event.action == 'ready_for_review'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write # enablePullRequestAutoMerge records the pending merge
+      pull-requests: write # set the auto-merge flag on the PR
+    steps:
+      - name: Arm auto-merge so this class lands once its checks are green
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -437,36 +437,9 @@ jobs:
             -f "description=Review deliberately skipped: bot-authored, or a chore/style/release title. Add needs-auto-review to force a full review." \
             -f "target_url=${RUN_URL}" >/dev/null
 
-  # Approving the PR and clearing the gate is only half the landing: the PR still
-  # sits open until a person presses merge. An automated `chore(release)` PR
-  # waited that way with every required check green. Arming is NOT merging —
-  # GitHub holds the PR until every required check passes, and a red one keeps
-  # holding it, so this widens what LANDS UNATTENDED but never what is allowed to
-  # land. Same shape as dependabot-auto-merge.yaml.
-  #
-  # A separate job, not a step in auto-approve-skipped: enabling auto-merge needs
-  # `contents: write`, and that job checks out repo content under
-  # pull_request_target. Keeping the write scope in a job that checks out nothing
-  # and runs one `gh` call leaves the approver at `contents: read`.
-  #
-  # `needs:` the approver so a PR only arms once its clearing approval and gate
-  # status are actually posted — arming a PR the approver failed on would leave it
-  # waiting on a required check nobody cleared.
-  arm-auto-merge:
-    name: Arm auto-merge on the skipped class
-    needs: auto-approve-skipped
-    # not-required-check: arms a landing, reports no verdict about the code.
-    if: >-
-      github.event.action == 'opened' ||
-      github.event.action == 'ready_for_review'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: write # enablePullRequestAutoMerge records the pending merge
-      pull-requests: write # set the auto-merge flag on the PR
-    steps:
-      - name: Arm auto-merge so this class lands once its checks are green
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr merge --auto --squash "$PR_URL"
+  # This workflow deliberately does NOT arm auto-merge. Arming belongs to the
+  # flow that OPENS a pull request, because that flow is the only one holding the
+  # facts the decision needs: template-sync-automerge.sh refuses to arm a sync
+  # whose conflict a model resolved, and dependabot-auto-merge.yaml refuses a
+  # semver-major bump. A reviewer-side job that arms every skipped PR overrides
+  # both refusals, since it cannot see what either of them weighed.

--- a/scripts/version-bump.test.mjs
+++ b/scripts/version-bump.test.mjs
@@ -311,7 +311,7 @@ const RELEASE_MANIFEST = join("plugin", ".claude-plugin", "plugin.json");
  * as it grows (a new file it reads, a new binary it shells out to), and three
  * near-identical bootstraps mean the odd one out fails opaquely.
  */
-function makeReleaseSandbox({ manifest } = {}) {
+function makeReleaseSandbox({ manifest, changelog } = {}) {
   const dir = mkdtempSync(join(tmpdir(), "vbump-release-"));
   const remote = join(dir, "remote.git");
   const work = join(dir, "work");
@@ -329,7 +329,7 @@ function makeReleaseSandbox({ manifest } = {}) {
   );
   writeFileSync(
     join(work, "CHANGELOG.md"),
-    "# Changelog\n\n## Unreleased\n\n### Added\n\n- A thing.\n",
+    changelog ?? "# Changelog\n\n## Unreleased\n\n### Added\n\n- A thing.\n",
   );
   if (manifest !== undefined) {
     mkdirSync(join(work, "plugin", ".claude-plugin"), { recursive: true });
@@ -639,6 +639,51 @@ test("a release stamps the plugin manifest and commits it with the release docs"
     assert.equal(
       JSON.parse(showOnRemote(sandbox.remote, "package.json")).version,
       "1.0.0",
+    );
+  } finally {
+    rmSync(sandbox.dir, { recursive: true, force: true });
+  }
+});
+
+test("an Unreleased block past the cap still releases, rather than aborting on SIGPIPE", () => {
+  // The cap used to be `awk … | head -c 4000`. Under `set -o pipefail` head
+  // exits at its cap and SIGPIPEs awk, so the whole release aborted with 141 —
+  // it published nothing, tagged nothing and promoted no changelog. That is how
+  // agent-control-plane-core froze at 0.5.3 while its changelog sat at 0.3.0.
+  //
+  // The block must exceed the PIPE BUFFER (64 KiB), not merely the 4000-char
+  // cap: under the cap a writer whose whole output fits one buffered write
+  // finishes before head can close the pipe, so a 4001-char block passes on the
+  // buggy form too and the test would pin nothing.
+  const entry = "- " + "x".repeat(120) + "\n";
+  const oversized =
+    "# Changelog\n\n## Unreleased\n\n### Added\n\n" +
+    entry.repeat(2000) +
+    "\n## [1.0.0] - 2026-01-01\n\n- Seed.\n";
+  assert.ok(
+    oversized.length > 64 * 1024,
+    "the fixture must exceed the pipe buffer or it cannot fail on the old form",
+  );
+  const sandbox = makeReleaseSandbox({ changelog: oversized });
+
+  try {
+    const res = runRelease(sandbox);
+    assert.equal(res.status, 0, res.stderr);
+
+    // The release actually completed: the old form died before any of this.
+    const remoteTags = execFileSync("git", ["-C", sandbox.remote, "tag"], {
+      encoding: "utf8",
+    });
+    assert.match(remoteTags, /^v1\.1\.0$/m, "the release tag must be pushed");
+    assert.match(
+      execFileSync(
+        "git",
+        ["-C", sandbox.remote, "log", "main", "--pretty=%s"],
+        {
+          encoding: "utf8",
+        },
+      ),
+      /docs: release 1\.1\.0/,
     );
   } finally {
     rmSync(sandbox.dir, { recursive: true, force: true });

--- a/scripts/version-bump.test.mjs
+++ b/scripts/version-bump.test.mjs
@@ -646,15 +646,13 @@ test("a release stamps the plugin manifest and commits it with the release docs"
 });
 
 test("an Unreleased block past the cap still releases, rather than aborting on SIGPIPE", () => {
-  // The cap used to be `awk … | head -c 4000`. Under `set -o pipefail` head
-  // exits at its cap and SIGPIPEs awk, so the whole release aborted with 141 —
-  // it published nothing, tagged nothing and promoted no changelog. That is how
-  // agent-control-plane-core froze at 0.5.3 while its changelog sat at 0.3.0.
+  // Pins the Unreleased cap against a `| head -c` form: under `set -o pipefail`
+  // head exits at its cap and SIGPIPEs the writer, which aborts the whole
+  // release with 141 — publishing nothing, tagging nothing, promoting nothing.
   //
-  // The block must exceed the PIPE BUFFER (64 KiB), not merely the 4000-char
-  // cap: under the cap a writer whose whole output fits one buffered write
-  // finishes before head can close the pipe, so a 4001-char block passes on the
-  // buggy form too and the test would pin nothing.
+  // The fixture must exceed the PIPE BUFFER (64 KiB), not merely the 4000-char
+  // cap: a writer whose whole output fits one buffered write finishes before
+  // head can close the pipe, so a 4001-char block cannot fail and pins nothing.
   const entry = "- " + "x".repeat(120) + "\n";
   const oversized =
     "# Changelog\n\n## Unreleased\n\n### Added\n\n" +


### PR DESCRIPTION
## What & why

**1. SIGPIPE aborts a release once the changelog grows.** `version-bump.sh` capped its inputs with `| head -c 4000` and `| head -20 | cut | head -c 2000` under `set -o pipefail`. Past a cap, `head` closes the pipe while the writer still has output; SIGPIPE kills the writer, `pipefail` reports 141, and `set -e` aborts the release before it publishes, tags, or promotes. Each cap now truncates with parameter expansion, and the `COMMITS` cap takes a herestring so no pipeline survives to report a status.

```
$ awk '…' CHANGELOG.md | head -c 4000   # Unreleased block past the cap
$ echo $?
141
```

On `agent-control-plane-core` every push to `main` since 2026-08-18 died there, freezing npm and the tags at 0.5.3 while the changelog sat at 0.3.0.

**2. Same bug, third site.** `fetch-security-report.sh` piped `pnpm audit` into `head -100` under `pipefail`, so an audit over 100 lines SIGPIPEd pnpm, `PIPESTATUS[0]` read 141, and the report gained a false "pnpm audit encountered an error" line. Captured, then truncated with `awk`.

## Review focus

`scripts/version-bump.test.mjs` — specifically why the new fixture is ~244 KiB rather than 4 KiB. That size is load-bearing, not padding.

## How it was tested

<details>

The regression case `an Unreleased block past the cap still releases, rather than aborting on SIGPIPE` seeds ~244 KiB via a new `changelog` option on `makeReleaseSandbox`, and asserts the fixture size so it cannot silently shrink. The fixture must exceed the **64 KiB pipe buffer**, not merely the 4000-char cap: a writer whose whole output fits one buffered write finishes before `head` can close the pipe, so a 4001-char block passes on the buggy form too and pins nothing.

Non-vacuity verified rather than assumed — reverting `version-bump.sh` to `| head -c 4000` fails it with `141 !== 0`; restoring passes. `node --test scripts/version-bump.test.mjs` — 20 pass, 0 fail. `uv run pytest tests/test_pr_review_fork_guard.py -q` — 414 passed.

Both guard suites needed `pyyaml` and `tree-sitter*` in `.venv` before they could be collected — they were erroring at import, not failing.

</details>

## Decisions made

- **An earlier revision added an `arm-auto-merge` job here; it is gone.** Two reviewers found it overrides the conservative refusals this tree already makes: `template-sync-automerge.sh` refuses to arm a sync whose conflict a model resolved or that touches the supervision surface, and `dependabot-auto-merge.yaml` refuses a semver-major bump. The sync PR is titled `chore: sync from template repository` on a same-repo branch, and a Dependabot PR matches on `user.type`, so the job matched both and made each refusal a no-op. A comment where the job stood records why. Arming belongs to the flow that opens the PR.

## Proposed guards

The reviewer asked for a lint rejecting `| head` in a `pipefail` script, covering all three sites and the next one. Not shipped here — `CLAUDE.md` forbids a new lint in the same PR as a fix and reserves promoting a proposal to a human.

**Benefit:** this class has fired three times in this repo and once in `agent-control-plane-core`, each time as a silently aborted release or a corrupted report. **Cost:** it runs on every commit forever, and the honest form is not `grep '| head'` — a bounded payload (`printf` of a semver string) cannot SIGPIPE, so a text match false-positives on exactly the safe uses. A sound check parses the shell grammar and asks whether the writer's output is bounded, which it usually cannot know. **Recommendation:** the regression test this PR adds, per script, at the two sites that matter.

## Lessons Learned

**What:** convert every `| head` cap in `version-bump.sh` and `fetch-security-report.sh` to a capture-then-truncate form. **Where:** those two template scripts. **Why:** under `set -o pipefail` an early-exiting `head` SIGPIPEs its writer on exactly the large inputs the cap exists for — aborting the release, or writing a false error into the security report.

**What:** do not let a reviewer-side job arm auto-merge. **Where:** the template's `claude-review.yaml` / `claude-pr-review.yaml`. **Why:** arming is the decision of whatever flow opens the pull request, because only that flow holds the facts — a template sync knows a model resolved its conflict, a Dependabot bump knows it is semver-major. A generic armer silently overrides both refusals.