### PR TITLE
feat(claude-hooks): let a host choose the clean-parse fail-closed verdict

### DIFF
--- a/claude-hooks/pretooluse-sanitize.mjs
+++ b/claude-hooks/pretooluse-sanitize.mjs
@@ -713,6 +713,11 @@ export function depLoadHint(
  * — redactor daemon down, package not loaded) is the sanitizer being UNAVAILABLE,
  * so it ASKS to keep a human in the loop rather than hard-block on infrastructure.
  *
+ * An UNATTENDED host has no human for that ask to reach, so the ask stops the
+ * call and buys no review. Such a host passes `unavailableDecision: DENY` and
+ * gets a hard refusal on the clean-parse arm too, with the same reason text.
+ * The default stays ASK, so a host that wires nothing keeps today's behavior.
+ *
  * Deliberately knob-blind: this is the fail-CLOSED posture itself, so it ignores
  * AGENT_SANITIZER_FAIL_OPEN — a host that wires it directly keeps strictness by
  * construction, with no env var to remember. A host that instead wants the
@@ -720,19 +725,27 @@ export function depLoadHint(
  * which delegates here when the posture is closed.
  * @param {boolean} parsedOk whether the input parsed before the failure
  * @param {unknown} err
- * @param {{ messages?: Partial<typeof PRE_TOOL_USE_MESSAGES>, hint?: string }} [opts]
+ * @param {{
+ *   messages?: Partial<typeof PRE_TOOL_USE_MESSAGES>,
+ *   hint?: string,
+ *   unavailableDecision?: (typeof PermissionDecision)[keyof typeof PermissionDecision],
+ * }} [opts]
  * @returns {Record<string, unknown>}
  */
 export function failClosedFields(parsedOk, err, opts = {}) {
-  const { hint = depLoadHint(err) } = opts;
+  const { hint = depLoadHint(err), unavailableDecision } = opts;
   // Merged, not substituted — see judgePreToolUseSanitize. This is the call site
   // where a missing field would throw out of the catch and fail OPEN.
   const messages = { ...PRE_TOOL_USE_MESSAGES, ...opts.messages };
   const cause = `${safeErrMessage(err)}${hint}`;
+  // An unknown or absent override falls back to ASK rather than being trusted:
+  // a typo must not silently widen this arm past the two closed verdicts.
+  const unavailable =
+    unavailableDecision === PermissionDecision.DENY
+      ? PermissionDecision.DENY
+      : PermissionDecision.ASK;
   return {
-    permissionDecision: parsedOk
-      ? PermissionDecision.ASK
-      : PermissionDecision.DENY,
+    permissionDecision: parsedOk ? unavailable : PermissionDecision.DENY,
     permissionDecisionReason: parsedOk
       ? messages.failed(cause)
       : messages.unparsable(cause),

--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=2136a25521ba67b43b57d7589a578893053b8b39714add09a9e51cc41f9f17f7
-b569ca45ec6b53100b159e7028670e0e21e15690f915f33012745f8b2c246eac  agent-sanitizer-hooks-darwin-arm64
-a41ede21cff0d4fc8f748f98c523f582eacd8d43bfd62223828a3e320a83f9ed  agent-sanitizer-hooks-darwin-x64
-a6279dbc018eb17807d17484c8ad84a83b2dfc28ca3e0df19a77d638381c8ad6  agent-sanitizer-hooks-linux-arm64
-c89ac4cbb66dd1a29a295b1b2804b3723c58f6b6d7101b597de819d7d797d884  agent-sanitizer-hooks-linux-x64
+# bundle=a055e6b9152d69aecbbf80d454baf55be7ad980aaea01e9eb732266ad90f8b1b
+7af24b931c21999054a3e51b9932b639fd93d934cbebede3862fc247444b3781  agent-sanitizer-hooks-darwin-arm64
+40a1a4813255f4b4220c0e82ddbe70410ccd5fb8944b7db858aa4462360abec1  agent-sanitizer-hooks-darwin-x64
+a4b56c5e3edd5d8bd8b17a215be09a3ea40a800e7137286a44c2c233f4c2e26e  agent-sanitizer-hooks-linux-arm64
+eb7ff2434502d182c499136f44a4180a2c80f206a991db69ba961ce97ce80341  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -49625,11 +49625,12 @@ function depLoadHint(err, remedy = DEFAULT_MISSING_PACKAGE_REMEDY, failedPackage
   return pkg === void 0 ? "" : ` ${missingPackageMessage(pkg, loadErrorFor(pkg), remedy)}`;
 }
 function failClosedFields(parsedOk, err, opts = {}) {
-  const { hint = depLoadHint(err) } = opts;
+  const { hint = depLoadHint(err), unavailableDecision } = opts;
   const messages = { ...PRE_TOOL_USE_MESSAGES, ...opts.messages };
   const cause = `${safeErrMessage(err)}${hint}`;
+  const unavailable = unavailableDecision === PermissionDecision.DENY ? PermissionDecision.DENY : PermissionDecision.ASK;
   return {
-    permissionDecision: parsedOk ? PermissionDecision.ASK : PermissionDecision.DENY,
+    permissionDecision: parsedOk ? unavailable : PermissionDecision.DENY,
     permissionDecisionReason: parsedOk ? messages.failed(cause) : messages.unparsable(cause)
   };
 }

--- a/test/claude-hooks-host-seams.test.mjs
+++ b/test/claude-hooks-host-seams.test.mjs
@@ -688,6 +688,31 @@ describe("PreToolUse fail-closed fields", () => {
     assert.equal(failClosedFields(false, err).permissionDecision, "deny");
   });
 
+  it("denies the clean-parse arm for a host that set unavailableDecision", () => {
+    // An unattended host has nobody to answer the ask, so it opts into a refusal.
+    // The reason text is the same one the ask carried, so the session still reads
+    // the cause and the remedy.
+    const err = new Error("boom");
+    const denied = failClosedFields(true, err, { unavailableDecision: "deny" });
+    assert.equal(denied.permissionDecision, "deny");
+    assert.equal(
+      denied.permissionDecisionReason,
+      failClosedFields(true, err).permissionDecisionReason,
+    );
+  });
+
+  it("falls back to ask for an unavailableDecision it does not recognize", () => {
+    // A typo must not widen this arm past the two closed verdicts, so anything
+    // other than "deny" keeps the default rather than being passed through.
+    for (const bogus of ["allow", "", "DENY", undefined, null, 1])
+      assert.equal(
+        failClosedFields(true, new Error("boom"), {
+          unavailableDecision: /** @type {any} */ (bogus),
+        }).permissionDecision,
+        "ask",
+      );
+  });
+
   it("routes both reasons through the host's table and hint", () => {
     const opts = {
       messages: {


### PR DESCRIPTION
## What & why

`failClosedFields` in `claude-hooks/pretooluse-sanitize.mjs` builds the answer a PreToolUse hook gives when the hook itself broke. It picks by which failure happened: input that would not parse is a state an attacker can create, so it refuses outright, while a layer that threw after a clean parse means the sanitizer is merely unavailable, so it asks and a person decides. That second choice assumes a person is watching. A host that runs the agent with nobody at the keyboard has none, so the ask stops the call and buys no review — the same block as a refusal, under a name that says the opposite. Such a host has to reach in and rewrite the decision after the fact, which is how a downstream tree ends up carrying a patch over a function it does not own.

This adds an opt-in `unavailableDecision`. A host passing `DENY` gets a refusal on the clean-parse arm, carrying the reason text the ask already carried, so the session still reads the cause and the remedy. The default stays `ASK`, so a host that wires nothing sees no change. A value the function does not recognize falls back to `ASK` rather than being passed through, so a typo cannot widen the arm past the two closed verdicts.

```js
const err = new Error("redactor daemon down");
failClosedFields(true, err).permissionDecision;                          // "ask"  (unchanged)
failClosedFields(true, err, { unavailableDecision: "deny" }).permissionDecision;  // "deny"
failClosedFields(true, err, { unavailableDecision: "allow" }).permissionDecision; // "ask"
```

## Review focus

Read `failClosedFields` first. The invariant one screen cannot show is that this function runs inside `runJudgeCli`'s catch, so anything that throws here escapes the handler and the hook emits nothing — which Claude Code reads as non-blocking. The new branch is a comparison against a frozen constant and cannot throw, but that is the property to check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UbaxxSSjjxcLLihRfrUNgP

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbaxxSSjjxcLLihRfrUNgP)_