### PR TITLE
fix(hooks): charge a host trace sink's wait to the host window

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,8 +357,13 @@ the extension bag's `trace` on
 receives the same `TraceEvent` names the default emits, and it **replaces** the
 default rather than running alongside it — the package channel goes silent, so
 there is one announcement to detect, not two. It may throw freely: each hook
-binds the sink it is given through `bestEffortTrace`, so an announcement can
-never be the thing that breaks a hook.
+binds the sink it is given through `hookTrace`, so an announcement can never be
+the thing that breaks a hook.
+
+That same binding charges whatever a host sink spends — a write to an unanswered
+socket, a subprocess — to the slow-hook notice's host-extension window. A hook
+past its budget then names the sink, instead of leaving the wait in the
+unattributed remainder and the sink's in-process CPU billed to the sanitizer.
 
 **A host's own cold-start marker can replace the derived one.** The hooks wait
 out an in-flight dependency install by polling a marker file whose path they

--- a/claude-hooks/lib/trace.mjs
+++ b/claude-hooks/lib/trace.mjs
@@ -19,6 +19,7 @@
  */
 
 import { appendFileSync } from "node:fs";
+import { chargeHostExtensionSync } from "./hook-timing.mjs";
 
 /**
  * The sink shape a hook emits through: the event name, its metadata fields, and
@@ -104,4 +105,26 @@ export function bestEffortTrace(sink) {
       // See above: an announcement must never be the thing that breaks a hook.
     }
   };
+}
+
+/**
+ * The sink to emit through given a host's, or none: a HOST sink is charged to
+ * the host-extension window, the package's own {@link trace} is not.
+ *
+ * A composer's sink may write over a socket or spawn a subprocess whose cost
+ * this process cannot see, so an uncharged one leaves its wait in the slow-hook
+ * notice's unattributed remainder and its in-process CPU billed to the
+ * sanitizer. The default sink's file write IS the sanitizer's own work, so
+ * charging it would move a real per-call cost out of the figure that names it.
+ *
+ * Wrap the result in {@link bestEffortTrace}, not the other way round: the charge
+ * is booked in a `finally`, so a host sink that THROWS — the one that spent the
+ * most — is still measured before the throw is swallowed.
+ * @param {TraceFn} [sink]  a host's sink; absent asks for the package channel
+ * @returns {TraceFn}
+ */
+export function hostChargedTrace(sink) {
+  if (!sink) return trace;
+  return (event, fields, level) =>
+    chargeHostExtensionSync(() => sink(event, fields, level));
 }

--- a/claude-hooks/lib/trace.mjs
+++ b/claude-hooks/lib/trace.mjs
@@ -27,7 +27,7 @@ import { chargeHostExtensionSync } from "./hook-timing.mjs";
  * default emits, so it can remap them onto its own channel's vocabulary.
  *
  * A sink is NOT required to be total — throw freely. Every hook binds the one it
- * was given through {@link bestEffortTrace}, which is what upholds the channel's
+ * was given through {@link hookTrace}, which is what upholds the channel's
  * never-breaks-a-hook posture on host code that cannot promise it.
  * @typedef {(event: string, fields?: Record<string, unknown>, level?: "info"|"debug") => void} TraceFn
  */
@@ -108,23 +108,26 @@ export function bestEffortTrace(sink) {
 }
 
 /**
- * The sink to emit through given a host's, or none: a HOST sink is charged to
- * the host-extension window, the package's own {@link trace} is not.
+ * The sink a hook emits through, given a host's or none: a HOST sink is made
+ * best-effort and charged to the slow-hook notice's host-extension window; the
+ * package's own {@link trace} is handed back untouched.
  *
  * A composer's sink may write over a socket or spawn a subprocess whose cost
- * this process cannot see, so an uncharged one leaves its wait in the slow-hook
- * notice's unattributed remainder and its in-process CPU billed to the
- * sanitizer. The default sink's file write IS the sanitizer's own work, so
- * charging it would move a real per-call cost out of the figure that names it.
+ * this process cannot see, so an uncharged one leaves its wait in the notice's
+ * unattributed remainder and its in-process CPU billed to the sanitizer. The
+ * default sink's file write IS the sanitizer's own work, so charging it would
+ * move a real per-call cost out of the figure that names it.
  *
- * Wrap the result in {@link bestEffortTrace}, not the other way round: the charge
- * is booked in a `finally`, so a host sink that THROWS — the one that spent the
- * most — is still measured before the throw is swallowed.
+ * The two wrappers compose in one order only, which is why every hook binds
+ * through this and not through the pieces: the charge is booked in a `finally`
+ * INSIDE the best-effort bracket, so a host sink that THROWS — the one that
+ * spent the most — is still measured before the throw is swallowed.
  * @param {TraceFn} [sink]  a host's sink; absent asks for the package channel
  * @returns {TraceFn}
  */
-export function hostChargedTrace(sink) {
+export function hookTrace(sink) {
   if (!sink) return trace;
-  return (event, fields, level) =>
-    chargeHostExtensionSync(() => sink(event, fields, level));
+  return bestEffortTrace((event, fields, level) =>
+    chargeHostExtensionSync(() => sink(event, fields, level)),
+  );
 }

--- a/claude-hooks/lib/trace.mjs
+++ b/claude-hooks/lib/trace.mjs
@@ -118,10 +118,12 @@ export function bestEffortTrace(sink) {
  * default sink's file write IS the sanitizer's own work, so charging it would
  * move a real per-call cost out of the figure that names it.
  *
- * The two wrappers compose in one order only, which is why every hook binds
- * through this and not through the pieces: the charge is booked in a `finally`
- * INSIDE the best-effort bracket, so a host sink that THROWS — the one that
- * spent the most — is still measured before the throw is swallowed.
+ * Both properties are bound HERE, not at each hook, so a sixth caller can
+ * neither drop one nor nest them wrong — and the nesting is load-bearing twice
+ * over. The charge is booked in a `finally` inside the best-effort bracket, so
+ * a sink that spends its wait and THEN throws is measured before the throw is
+ * swallowed. And the exemption above reads the host's own sink, which a
+ * best-effort wrapper applied first would have replaced with a truthy one.
  * @param {TraceFn} [sink]  a host's sink; absent asks for the package channel
  * @returns {TraceFn}
  */

--- a/claude-hooks/pretooluse-sanitize.mjs
+++ b/claude-hooks/pretooluse-sanitize.mjs
@@ -73,7 +73,12 @@ import {
   LAYER2_PLACEHOLDER_RE,
 } from "./lib/placeholder-grammar.mjs";
 import { readSpan, spanPath } from "./lib/reveal.mjs";
-import { bestEffortTrace, trace, TraceEvent } from "./lib/trace.mjs";
+import {
+  bestEffortTrace,
+  hostChargedTrace,
+  trace,
+  TraceEvent,
+} from "./lib/trace.mjs";
 
 const HOOK_NAME = "pretooluse-sanitize";
 
@@ -474,11 +479,12 @@ function toolTargetDir(tool, toolInput) {
 export async function buildPreToolUseResponse(
   input,
   rehydrate = defaultRehydrate,
-  sink = trace,
+  sink,
 ) {
   // Every path into the announcement runs through here, so this is the one place
-  // a host sink has to be made best-effort (see bestEffortTrace).
-  const emitTrace = bestEffortTrace(sink);
+  // a host sink has to be made best-effort (see bestEffortTrace) and charged to
+  // the host window (see hostChargedTrace).
+  const emitTrace = bestEffortTrace(hostChargedTrace(sink));
   const asks = [];
   const contexts = [];
 

--- a/claude-hooks/pretooluse-sanitize.mjs
+++ b/claude-hooks/pretooluse-sanitize.mjs
@@ -73,7 +73,7 @@ import {
   LAYER2_PLACEHOLDER_RE,
 } from "./lib/placeholder-grammar.mjs";
 import { readSpan, spanPath } from "./lib/reveal.mjs";
-import { bestEffortTrace, hostChargedTrace, TraceEvent } from "./lib/trace.mjs";
+import { hookTrace, TraceEvent } from "./lib/trace.mjs";
 
 const HOOK_NAME = "pretooluse-sanitize";
 
@@ -476,10 +476,9 @@ export async function buildPreToolUseResponse(
   rehydrate = defaultRehydrate,
   sink,
 ) {
-  // Every path into the announcement runs through here, so this is the one place
-  // a host sink has to be made best-effort (see bestEffortTrace) and charged to
-  // the host window (see hostChargedTrace).
-  const emitTrace = bestEffortTrace(hostChargedTrace(sink));
+  // Every path into the announcement runs through here, so this is the one
+  // place a host sink has to be bound (see hookTrace).
+  const emitTrace = hookTrace(sink);
   const asks = [];
   const contexts = [];
 
@@ -620,9 +619,9 @@ function assembleResponse({
  */
 export async function judgePreToolUseSanitize(event, rehydrate, opts = {}) {
   // Forwarded UNRESOLVED: substituting the package sink for an absent one here
-  // would hand hostChargedTrace a truthy sink, charging this package's own
-  // trace write to the host window — the misattribution the split exists to
-  // prevent. Only buildPreToolUseResponse's binding may pick the default.
+  // would hand hookTrace a truthy sink, charging this package's own trace write
+  // to the host window — the misattribution the split exists to prevent. Only
+  // buildPreToolUseResponse's binding may pick the default.
   const { gates = [], trace: sink } = opts;
   // MERGED over the defaults, never substituted for them. A host that overrides
   // one field would otherwise leave the rest undefined, and the miss lands in

--- a/claude-hooks/pretooluse-sanitize.mjs
+++ b/claude-hooks/pretooluse-sanitize.mjs
@@ -73,12 +73,7 @@ import {
   LAYER2_PLACEHOLDER_RE,
 } from "./lib/placeholder-grammar.mjs";
 import { readSpan, spanPath } from "./lib/reveal.mjs";
-import {
-  bestEffortTrace,
-  hostChargedTrace,
-  trace,
-  TraceEvent,
-} from "./lib/trace.mjs";
+import { bestEffortTrace, hostChargedTrace, TraceEvent } from "./lib/trace.mjs";
 
 const HOOK_NAME = "pretooluse-sanitize";
 
@@ -624,7 +619,11 @@ function assembleResponse({
  * @returns {Promise<import("agent-control-plane-core").Verdict>}
  */
 export async function judgePreToolUseSanitize(event, rehydrate, opts = {}) {
-  const { gates = [], trace: emitTrace = trace } = opts;
+  // Forwarded UNRESOLVED: substituting the package sink for an absent one here
+  // would hand hostChargedTrace a truthy sink, charging this package's own
+  // trace write to the host window — the misattribution the split exists to
+  // prevent. Only buildPreToolUseResponse's binding may pick the default.
+  const { gates = [], trace: sink } = opts;
   // MERGED over the defaults, never substituted for them. A host that overrides
   // one field would otherwise leave the rest undefined, and the miss lands in
   // the fail-closed path: failClosedFields runs inside runJudgeCli's catch, so a
@@ -659,7 +658,7 @@ export async function judgePreToolUseSanitize(event, rehydrate, opts = {}) {
     const denyReason = gate(input);
     if (denyReason) return { decision: Decision.DENY, reason: denyReason };
   }
-  const fields = await buildPreToolUseResponse(input, rehydrate, emitTrace);
+  const fields = await buildPreToolUseResponse(input, rehydrate, sink);
   if (fields === null) return { decision: Decision.ALLOW };
   /** @type {Record<string, unknown>} */
   const verdict = {
@@ -903,7 +902,8 @@ registerFaultPolicy(HOOK_NAME, {
  * @returns {Promise<void>}
  */
 export async function cliMain(opts = {}) {
-  const { gates = [], trace: emitTrace = trace } = opts;
+  // Unresolved, for the reason judgePreToolUseSanitize states.
+  const { gates = [], trace: sink } = opts;
   const messages = { ...PRE_TOOL_USE_MESSAGES, ...opts.messages };
   await runJudgeCli(
     HOOK_NAME,
@@ -911,7 +911,7 @@ export async function cliMain(opts = {}) {
       judgePreToolUseSanitize(event, undefined, {
         messages,
         gates,
-        trace: emitTrace,
+        trace: sink,
       }),
     {
       // The caller's posture, WITHOUT the package: pass through with a warning

--- a/claude-hooks/sanitize-output.mjs
+++ b/claude-hooks/sanitize-output.mjs
@@ -47,7 +47,7 @@ import {
 } from "./lib/hook-io.mjs";
 import { registerFaultPolicy, hookFaultOutcome } from "./lib/hook-fault.mjs";
 import { controlPlane, runJudgeCli } from "./lib/control-plane.mjs";
-import { bestEffortTrace, hostChargedTrace, TraceEvent } from "./lib/trace.mjs";
+import { hookTrace, TraceEvent } from "./lib/trace.mjs";
 import { hasEnvBoundSecret } from "./lib/secret-annotate.mjs";
 import { digestFlaggingEnabled, secretsEnabled } from "./lib/env-config.mjs";
 import {
@@ -856,9 +856,9 @@ registerFaultPolicy(HOOK_NAME, {
  * @returns {Promise<{ mutated_output?: unknown, additional_context?: string } | null>}
  */
 export async function evaluateToolOutput(input, ext = {}) {
-  // Best-effort, like the default sink: a host callback that throws must not be
-  // the thing that suppresses a tool output (see bestEffortTrace).
-  const emitTrace = bestEffortTrace(hostChargedTrace(ext.trace));
+  // A host callback that throws must not be the thing that suppresses a tool
+  // output (see hookTrace).
+  const emitTrace = hookTrace(ext.trace);
   /**
    * @param {string} outcome  noop | clean | flagged | modified
    * @param {{ mutated_output?: unknown, additional_context?: string } | null} fields

--- a/claude-hooks/sanitize-output.mjs
+++ b/claude-hooks/sanitize-output.mjs
@@ -47,7 +47,7 @@ import {
 } from "./lib/hook-io.mjs";
 import { registerFaultPolicy, hookFaultOutcome } from "./lib/hook-fault.mjs";
 import { controlPlane, runJudgeCli } from "./lib/control-plane.mjs";
-import { bestEffortTrace, trace, TraceEvent } from "./lib/trace.mjs";
+import { bestEffortTrace, hostChargedTrace, TraceEvent } from "./lib/trace.mjs";
 import { hasEnvBoundSecret } from "./lib/secret-annotate.mjs";
 import { digestFlaggingEnabled, secretsEnabled } from "./lib/env-config.mjs";
 import {
@@ -857,17 +857,8 @@ registerFaultPolicy(HOOK_NAME, {
  */
 export async function evaluateToolOutput(input, ext = {}) {
   // Best-effort, like the default sink: a host callback that throws must not be
-  // the thing that suppresses a tool output (see bestEffortTrace). A COMPOSER's
-  // sink is charged to the host window — it may write over a socket this process
-  // cannot see the cost of — while the package's own sink is not, since that
-  // file write is the sanitizer's own work.
-  const hostTrace = ext.trace;
-  const emitTrace = bestEffortTrace(
-    hostTrace
-      ? (event, fields) =>
-          chargeHostExtensionSync(() => hostTrace(event, fields))
-      : trace,
-  );
+  // the thing that suppresses a tool output (see bestEffortTrace).
+  const emitTrace = bestEffortTrace(hostChargedTrace(ext.trace));
   /**
    * @param {string} outcome  noop | clean | flagged | modified
    * @param {{ mutated_output?: unknown, additional_context?: string } | null} fields

--- a/claude-hooks/sanitize-user-prompt.mjs
+++ b/claude-hooks/sanitize-user-prompt.mjs
@@ -32,7 +32,7 @@ import {
   writeFaultOutcome,
 } from "./lib/hook-fault.mjs";
 import { controlPlane, runJudgeCli } from "./lib/control-plane.mjs";
-import { bestEffortTrace, hostChargedTrace, TraceEvent } from "./lib/trace.mjs";
+import { hookTrace, TraceEvent } from "./lib/trace.mjs";
 // classifyPrompt (the user-prompt verdict) and stripAnsiFully (its ANSI stripper)
 // come from the agent-sanitizer package. They are bound by a *caught* dynamic
 // import, never a bare top-level `import … from "…"`: a static npm import
@@ -211,7 +211,7 @@ export async function main(read, write, opts = {}) {
     trace: sink,
     env = process.env,
   } = opts;
-  const emitTrace = bestEffortTrace(hostChargedTrace(sink));
+  const emitTrace = hookTrace(sink);
   // Merged, not substituted — see judgeSanitizeUserPrompt. onError below is the
   // call site where a missing field would throw out of the catch and fail OPEN.
   const messages = { ...USER_PROMPT_MESSAGES, ...overrides };

--- a/claude-hooks/sanitize-user-prompt.mjs
+++ b/claude-hooks/sanitize-user-prompt.mjs
@@ -32,7 +32,7 @@ import {
   writeFaultOutcome,
 } from "./lib/hook-fault.mjs";
 import { controlPlane, runJudgeCli } from "./lib/control-plane.mjs";
-import { bestEffortTrace, trace, TraceEvent } from "./lib/trace.mjs";
+import { bestEffortTrace, hostChargedTrace, TraceEvent } from "./lib/trace.mjs";
 // classifyPrompt (the user-prompt verdict) and stripAnsiFully (its ANSI stripper)
 // come from the agent-sanitizer package. They are bound by a *caught* dynamic
 // import, never a bare top-level `import … from "…"`: a static npm import
@@ -208,10 +208,10 @@ export async function main(read, write, opts = {}) {
   const {
     strip = stripAnsiFully,
     overrides = USER_PROMPT_MESSAGES,
-    trace: sink = trace,
+    trace: sink,
     env = process.env,
   } = opts;
-  const emitTrace = bestEffortTrace(sink);
+  const emitTrace = bestEffortTrace(hostChargedTrace(sink));
   // Merged, not substituted — see judgeSanitizeUserPrompt. onError below is the
   // call site where a missing field would throw out of the catch and fail OPEN.
   const messages = { ...USER_PROMPT_MESSAGES, ...overrides };

--- a/claude-hooks/scan-invisible-chars.mjs
+++ b/claude-hooks/scan-invisible-chars.mjs
@@ -51,7 +51,7 @@ import {
 import { formatReport } from "./lib/invisible-report.mjs";
 import { sweepStaleReveals } from "./lib/reveal.mjs";
 import { sweepStaleConfirms } from "./lib/secret-drop-guard.mjs";
-import { bestEffortTrace, hostChargedTrace, TraceEvent } from "./lib/trace.mjs";
+import { hookTrace, TraceEvent } from "./lib/trace.mjs";
 import { reportSlowHook, startHookTimer } from "./lib/hook-timing.mjs";
 // Relative, not the `agent-sanitizer` specifier every other engine import uses:
 // this is the scan's SCOPE, which is hook policy, and package.json's exports map
@@ -414,8 +414,7 @@ export async function cliMain(opts = {}) {
       undefined,
       // All four windows, including the two this scan normally leaves empty: a
       // measured 0 rules a window OUT, where an omitted one leaves the notice
-      // naming candidates it cannot separate. The host window is a real
-      // measurement because the injected trace sink is charged above.
+      // naming candidates it cannot separate.
       {
         cpuMs: timer.cpuMs(),
         redactorMs: timer.redactorMs(),
@@ -439,8 +438,8 @@ export async function cliMain(opts = {}) {
 async function runScanCli({ trace: sink, scan: runScan, sessionId }) {
   // Bound best-effort: the announcements below run BEFORE the auto-clean and
   // the alert write, with no catch above them, so a throwing host sink would
-  // abort the scan silently (see bestEffortTrace).
-  const emitTrace = bestEffortTrace(hostChargedTrace(sink));
+  // abort the scan silently (see hookTrace).
+  const emitTrace = hookTrace(sink);
   // Everything the PreToolUse gate must surface this session, written once at
   // the end: an incomplete scan and an uncleanable file are independent reasons
   // to arm the gate, and two separate writes would have the second clobber the

--- a/claude-hooks/scan-invisible-chars.mjs
+++ b/claude-hooks/scan-invisible-chars.mjs
@@ -51,7 +51,7 @@ import {
 import { formatReport } from "./lib/invisible-report.mjs";
 import { sweepStaleReveals } from "./lib/reveal.mjs";
 import { sweepStaleConfirms } from "./lib/secret-drop-guard.mjs";
-import { bestEffortTrace, trace, TraceEvent } from "./lib/trace.mjs";
+import { bestEffortTrace, hostChargedTrace, TraceEvent } from "./lib/trace.mjs";
 import { reportSlowHook, startHookTimer } from "./lib/hook-timing.mjs";
 // Relative, not the `agent-sanitizer` specifier every other engine import uses:
 // this is the scan's SCOPE, which is hook policy, and package.json's exports map
@@ -412,7 +412,15 @@ export async function cliMain(opts = {}) {
       HookEvent.SESSION_START,
       emitHookResponse,
       undefined,
-      { cpuMs: timer.cpuMs() },
+      // All four windows, including the two this scan normally leaves empty: a
+      // measured 0 rules a window OUT, where an omitted one leaves the notice
+      // naming candidates it cannot separate. The host window is a real
+      // measurement because the injected trace sink is charged above.
+      {
+        cpuMs: timer.cpuMs(),
+        redactorMs: timer.redactorMs(),
+        hostMs: timer.hostMs(),
+      },
     );
   }
 }
@@ -428,11 +436,11 @@ export async function cliMain(opts = {}) {
  * }} opts  see {@link cliMain}
  * @returns {Promise<void>}
  */
-async function runScanCli({ trace: sink = trace, scan: runScan, sessionId }) {
+async function runScanCli({ trace: sink, scan: runScan, sessionId }) {
   // Bound best-effort: the announcements below run BEFORE the auto-clean and
   // the alert write, with no catch above them, so a throwing host sink would
   // abort the scan silently (see bestEffortTrace).
-  const emitTrace = bestEffortTrace(sink);
+  const emitTrace = bestEffortTrace(hostChargedTrace(sink));
   // Everything the PreToolUse gate must surface this session, written once at
   // the end: an incomplete scan and an uncleanable file are independent reasons
   // to arm the gate, and two separate writes would have the second clobber the

--- a/claude-hooks/scan-loaded-instructions.mjs
+++ b/claude-hooks/scan-loaded-instructions.mjs
@@ -37,7 +37,7 @@ import {
   appendAlert,
   recordInstructionsLoaded,
 } from "./lib/invisible-alert.mjs";
-import { bestEffortTrace, hostChargedTrace, TraceEvent } from "./lib/trace.mjs";
+import { hookTrace, TraceEvent } from "./lib/trace.mjs";
 import { reportSlowHook, startHookTimer } from "./lib/hook-timing.mjs";
 import { formatReport } from "./lib/invisible-report.mjs";
 import {
@@ -258,7 +258,7 @@ export { HOOK_NAME };
  */
 export async function cliMain({ trace: sink } = {}) {
   const timer = startHookTimer();
-  const emitTrace = bestEffortTrace(hostChargedTrace(sink));
+  const emitTrace = hookTrace(sink);
   /** @type {string | undefined} */
   let sessionId;
   try {
@@ -323,8 +323,7 @@ export async function cliMain({ trace: sink } = {}) {
       undefined,
       // All four windows, including the two this scan normally leaves empty: a
       // measured 0 rules a window OUT, where an omitted one leaves the notice
-      // naming candidates it cannot separate. The host window is a real
-      // measurement because the injected trace sink is charged above.
+      // naming candidates it cannot separate.
       {
         cpuMs: timer.cpuMs(),
         redactorMs: timer.redactorMs(),

--- a/claude-hooks/scan-loaded-instructions.mjs
+++ b/claude-hooks/scan-loaded-instructions.mjs
@@ -37,7 +37,7 @@ import {
   appendAlert,
   recordInstructionsLoaded,
 } from "./lib/invisible-alert.mjs";
-import { bestEffortTrace, trace, TraceEvent } from "./lib/trace.mjs";
+import { bestEffortTrace, hostChargedTrace, TraceEvent } from "./lib/trace.mjs";
 import { reportSlowHook, startHookTimer } from "./lib/hook-timing.mjs";
 import { formatReport } from "./lib/invisible-report.mjs";
 import {
@@ -256,9 +256,9 @@ export { HOOK_NAME };
  *   passes its sink (see lib/trace.mjs)
  * @returns {Promise<void>}
  */
-export async function cliMain({ trace: sink = trace } = {}) {
+export async function cliMain({ trace: sink } = {}) {
   const timer = startHookTimer();
-  const emitTrace = bestEffortTrace(sink);
+  const emitTrace = bestEffortTrace(hostChargedTrace(sink));
   /** @type {string | undefined} */
   let sessionId;
   try {
@@ -321,7 +321,15 @@ export async function cliMain({ trace: sink = trace } = {}) {
       HookEvent.INSTRUCTIONS_LOADED,
       emitHookResponse,
       undefined,
-      { cpuMs: timer.cpuMs() },
+      // All four windows, including the two this scan normally leaves empty: a
+      // measured 0 rules a window OUT, where an omitted one leaves the notice
+      // naming candidates it cannot separate. The host window is a real
+      // measurement because the injected trace sink is charged above.
+      {
+        cpuMs: timer.cpuMs(),
+        redactorMs: timer.redactorMs(),
+        hostMs: timer.hostMs(),
+      },
     );
   }
 }

--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=a055e6b9152d69aecbbf80d454baf55be7ad980aaea01e9eb732266ad90f8b1b
-7af24b931c21999054a3e51b9932b639fd93d934cbebede3862fc247444b3781  agent-sanitizer-hooks-darwin-arm64
-40a1a4813255f4b4220c0e82ddbe70410ccd5fb8944b7db858aa4462360abec1  agent-sanitizer-hooks-darwin-x64
-a4b56c5e3edd5d8bd8b17a215be09a3ea40a800e7137286a44c2c233f4c2e26e  agent-sanitizer-hooks-linux-arm64
-eb7ff2434502d182c499136f44a4180a2c80f206a991db69ba961ce97ce80341  agent-sanitizer-hooks-linux-x64
+# bundle=8bc8d63cff434c1016854a1c41ead3be26ffb55a825881a6656c96b42e4a43ae
+b3f1d778abfd9ca05a6d3e7790acb5d08966c0ca942f81e0d7e2db0e127e311e  agent-sanitizer-hooks-darwin-arm64
+4a4289cf476e71f9f492e15fcaa2cdc6416deed048dbbbf7051732de726c9731  agent-sanitizer-hooks-darwin-x64
+dac0d32faf6ef9061d048a196f1162df3b072c9ecce18945b5771d0802eaac48  agent-sanitizer-hooks-linux-arm64
+dc5b7c121058549c83baa9e180e859284b018cf60bee6b03a1500f492f7ac757  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=8bc8d63cff434c1016854a1c41ead3be26ffb55a825881a6656c96b42e4a43ae
-b3f1d778abfd9ca05a6d3e7790acb5d08966c0ca942f81e0d7e2db0e127e311e  agent-sanitizer-hooks-darwin-arm64
-4a4289cf476e71f9f492e15fcaa2cdc6416deed048dbbbf7051732de726c9731  agent-sanitizer-hooks-darwin-x64
-dac0d32faf6ef9061d048a196f1162df3b072c9ecce18945b5771d0802eaac48  agent-sanitizer-hooks-linux-arm64
-dc5b7c121058549c83baa9e180e859284b018cf60bee6b03a1500f492f7ac757  agent-sanitizer-hooks-linux-x64
+# bundle=88ffa3a1cf883d896c0c05e7731a88a3cfa8ecfe0f6c0613ec369c4b73717506
+64b62a6c7794fd1e51ce40ed0d924c06ddb6ec3520ca944c9365f8fd115a11dc  agent-sanitizer-hooks-darwin-arm64
+bd2f384340d28515786234cb6dddbfe9d000139b36c10276c47db67bcec33f6e  agent-sanitizer-hooks-darwin-x64
+a839fbfb9b09f28c2975e6c706448440df24ad1973638b66bafe66eaf3c0e4cf  agent-sanitizer-hooks-linux-arm64
+6f30c6f6d1bdaed22f3df9a064a7216011d90a4dabe7654160507a1123ff26ce  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -49345,9 +49345,11 @@ function bestEffortTrace(sink) {
     }
   };
 }
-function hostChargedTrace(sink) {
+function hookTrace(sink) {
   if (!sink) return trace;
-  return (event, fields, level) => chargeHostExtensionSync(() => sink(event, fields, level));
+  return bestEffortTrace(
+    (event, fields, level) => chargeHostExtensionSync(() => sink(event, fields, level))
+  );
 }
 var TraceEvent, LEVELS;
 var init_trace = __esm({
@@ -49516,7 +49518,7 @@ function toolTargetDir(tool, toolInput) {
   return typeof path2 === "string" && path2.startsWith("/") ? dirname7(path2) : void 0;
 }
 async function buildPreToolUseResponse(input, rehydrate = defaultRehydrate, sink) {
-  const emitTrace = bestEffortTrace(hostChargedTrace(sink));
+  const emitTrace = hookTrace(sink);
   const asks = [];
   const contexts = [];
   const findings = invisibleCharAlert(input.session_id);
@@ -50580,7 +50582,7 @@ function suppressionMessage(cause) {
   return `[SANITIZATION FAILED \u2014 original output suppressed for safety. Hook error: ${cause}]`;
 }
 async function evaluateToolOutput(input, ext = {}) {
-  const emitTrace = bestEffortTrace(hostChargedTrace(ext.trace));
+  const emitTrace = hookTrace(ext.trace);
   const emit = (outcome, fields2) => {
     emitTrace(TraceEvent.HOOK_RAN, {
       hook: HOOK_NAME2,
@@ -50799,7 +50801,7 @@ async function main(read, write, opts = {}) {
     trace: sink,
     env = process.env
   } = opts;
-  const emitTrace = bestEffortTrace(hostChargedTrace(sink));
+  const emitTrace = hookTrace(sink);
   const messages = { ...USER_PROMPT_MESSAGES, ...overrides };
   await runJudgeCli(
     HOOK_NAME3,
@@ -51030,8 +51032,7 @@ async function cliMain3(opts = {}) {
       void 0,
       // All four windows, including the two this scan normally leaves empty: a
       // measured 0 rules a window OUT, where an omitted one leaves the notice
-      // naming candidates it cannot separate. The host window is a real
-      // measurement because the injected trace sink is charged above.
+      // naming candidates it cannot separate.
       {
         cpuMs: timer.cpuMs(),
         redactorMs: timer.redactorMs(),
@@ -51041,7 +51042,7 @@ async function cliMain3(opts = {}) {
   }
 }
 async function runScanCli({ trace: sink, scan: runScan, sessionId }) {
-  const emitTrace = bestEffortTrace(hostChargedTrace(sink));
+  const emitTrace = hookTrace(sink);
   const alertParts = [];
   if (!await ensureSanitizerLoaded()) {
     emitTrace(TraceEvent.SCAN_INVISIBLE_CHARS_RAN, { outcome: "skipped" });
@@ -51254,7 +51255,7 @@ ${tail}`;
 }
 async function cliMain4({ trace: sink } = {}) {
   const timer = startHookTimer();
-  const emitTrace = bestEffortTrace(hostChargedTrace(sink));
+  const emitTrace = hookTrace(sink);
   let sessionId;
   try {
     const payload = await readStdinJson();
@@ -51306,8 +51307,7 @@ async function cliMain4({ trace: sink } = {}) {
       void 0,
       // All four windows, including the two this scan normally leaves empty: a
       // measured 0 rules a window OUT, where an omitted one leaves the notice
-      // naming candidates it cannot separate. The host window is a real
-      // measurement because the injected trace sink is charged above.
+      // naming candidates it cannot separate.
       {
         cpuMs: timer.cpuMs(),
         redactorMs: timer.redactorMs(),

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -49345,10 +49345,15 @@ function bestEffortTrace(sink) {
     }
   };
 }
+function hostChargedTrace(sink) {
+  if (!sink) return trace;
+  return (event, fields, level) => chargeHostExtensionSync(() => sink(event, fields, level));
+}
 var TraceEvent, LEVELS;
 var init_trace = __esm({
   "claude-hooks/lib/trace.mjs"() {
     "use strict";
+    init_hook_timing();
     TraceEvent = Object.freeze({
       HOOK_RAN: "hook_ran",
       SCAN_INVISIBLE_CHARS_RAN: "scan_invisible_chars_ran",
@@ -49510,8 +49515,8 @@ function toolTargetDir(tool, toolInput) {
   const path2 = field && toolInput?.[field];
   return typeof path2 === "string" && path2.startsWith("/") ? dirname7(path2) : void 0;
 }
-async function buildPreToolUseResponse(input, rehydrate = defaultRehydrate, sink = trace) {
-  const emitTrace = bestEffortTrace(sink);
+async function buildPreToolUseResponse(input, rehydrate = defaultRehydrate, sink) {
+  const emitTrace = bestEffortTrace(hostChargedTrace(sink));
   const asks = [];
   const contexts = [];
   const findings = invisibleCharAlert(input.session_id);
@@ -50575,10 +50580,7 @@ function suppressionMessage(cause) {
   return `[SANITIZATION FAILED \u2014 original output suppressed for safety. Hook error: ${cause}]`;
 }
 async function evaluateToolOutput(input, ext = {}) {
-  const hostTrace = ext.trace;
-  const emitTrace = bestEffortTrace(
-    hostTrace ? (event, fields2) => chargeHostExtensionSync(() => hostTrace(event, fields2)) : trace
-  );
+  const emitTrace = bestEffortTrace(hostChargedTrace(ext.trace));
   const emit = (outcome, fields2) => {
     emitTrace(TraceEvent.HOOK_RAN, {
       hook: HOOK_NAME2,
@@ -50794,10 +50796,10 @@ async function main(read, write, opts = {}) {
   const {
     strip = stripAnsiFully3,
     overrides = USER_PROMPT_MESSAGES,
-    trace: sink = trace,
+    trace: sink,
     env = process.env
   } = opts;
-  const emitTrace = bestEffortTrace(sink);
+  const emitTrace = bestEffortTrace(hostChargedTrace(sink));
   const messages = { ...USER_PROMPT_MESSAGES, ...overrides };
   await runJudgeCli(
     HOOK_NAME3,
@@ -51026,12 +51028,20 @@ async function cliMain3(opts = {}) {
       HookEvent.SESSION_START,
       emitHookResponse,
       void 0,
-      { cpuMs: timer.cpuMs() }
+      // All four windows, including the two this scan normally leaves empty: a
+      // measured 0 rules a window OUT, where an omitted one leaves the notice
+      // naming candidates it cannot separate. The host window is a real
+      // measurement because the injected trace sink is charged above.
+      {
+        cpuMs: timer.cpuMs(),
+        redactorMs: timer.redactorMs(),
+        hostMs: timer.hostMs()
+      }
     );
   }
 }
-async function runScanCli({ trace: sink = trace, scan: runScan, sessionId }) {
-  const emitTrace = bestEffortTrace(sink);
+async function runScanCli({ trace: sink, scan: runScan, sessionId }) {
+  const emitTrace = bestEffortTrace(hostChargedTrace(sink));
   const alertParts = [];
   if (!await ensureSanitizerLoaded()) {
     emitTrace(TraceEvent.SCAN_INVISIBLE_CHARS_RAN, { outcome: "skipped" });
@@ -51242,9 +51252,9 @@ function loadedFileMessage({ report, cleaned, reason }, filePath) {
   return `${report}
 ${tail}`;
 }
-async function cliMain4({ trace: sink = trace } = {}) {
+async function cliMain4({ trace: sink } = {}) {
   const timer = startHookTimer();
-  const emitTrace = bestEffortTrace(sink);
+  const emitTrace = bestEffortTrace(hostChargedTrace(sink));
   let sessionId;
   try {
     const payload = await readStdinJson();
@@ -51294,7 +51304,15 @@ async function cliMain4({ trace: sink = trace } = {}) {
       HookEvent.INSTRUCTIONS_LOADED,
       emitHookResponse,
       void 0,
-      { cpuMs: timer.cpuMs() }
+      // All four windows, including the two this scan normally leaves empty: a
+      // measured 0 rules a window OUT, where an omitted one leaves the notice
+      // naming candidates it cannot separate. The host window is a real
+      // measurement because the injected trace sink is charged above.
+      {
+        cpuMs: timer.cpuMs(),
+        redactorMs: timer.redactorMs(),
+        hostMs: timer.hostMs()
+      }
     );
   }
 }

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -49588,7 +49588,7 @@ function assembleResponse({
   return fields;
 }
 async function judgePreToolUseSanitize(event, rehydrate, opts = {}) {
-  const { gates = [], trace: emitTrace = trace } = opts;
+  const { gates = [], trace: sink } = opts;
   const messages = { ...PRE_TOOL_USE_MESSAGES, ...opts.messages };
   const { Decision: Decision3, EventKind: EventKind3 } = controlPlane();
   if (event.event === EventKind3.UNKNOWN)
@@ -49603,7 +49603,7 @@ async function judgePreToolUseSanitize(event, rehydrate, opts = {}) {
     const denyReason = gate(input);
     if (denyReason) return { decision: Decision3.DENY, reason: denyReason };
   }
-  const fields = await buildPreToolUseResponse(input, rehydrate, emitTrace);
+  const fields = await buildPreToolUseResponse(input, rehydrate, sink);
   if (fields === null) return { decision: Decision3.ALLOW };
   const verdict = {
     decision: fields.permissionDecision ?? Decision3.ALLOW
@@ -49664,14 +49664,14 @@ function hookFailureFields(parsedOk, err, opts = {}) {
   );
 }
 async function cliMain(opts = {}) {
-  const { gates = [], trace: emitTrace = trace } = opts;
+  const { gates = [], trace: sink } = opts;
   const messages = { ...PRE_TOOL_USE_MESSAGES, ...opts.messages };
   await runJudgeCli(
     HOOK_NAME,
     (event) => judgePreToolUseSanitize(event, void 0, {
       messages,
       gates,
-      trace: emitTrace
+      trace: sink
     }),
     {
       // The caller's posture, WITHOUT the package: pass through with a warning

--- a/test/claude-hooks-exports.test.mjs
+++ b/test/claude-hooks-exports.test.mjs
@@ -332,7 +332,7 @@ const PUBLISHED_EXPORTS = {
   "lib/trace": [
     "TraceEvent",
     "bestEffortTrace",
-    "hostChargedTrace",
+    "hookTrace",
     "trace",
     "traceThreshold",
   ],

--- a/test/claude-hooks-exports.test.mjs
+++ b/test/claude-hooks-exports.test.mjs
@@ -329,7 +329,13 @@ const PUBLISHED_EXPORTS = {
     "withSlowHookNotice",
     "writeSlowHookNotice",
   ],
-  "lib/trace": ["TraceEvent", "bestEffortTrace", "trace", "traceThreshold"],
+  "lib/trace": [
+    "TraceEvent",
+    "bestEffortTrace",
+    "hostChargedTrace",
+    "trace",
+    "traceThreshold",
+  ],
 };
 
 describe("claude-hooks composition surface resolves through the exports map", () => {

--- a/test/claude-hooks-trace-sink.test.mjs
+++ b/test/claude-hooks-trace-sink.test.mjs
@@ -321,6 +321,26 @@ describe("a host sink's wait is charged to the host window", () => {
       assert.match(additionalContext, /0\.0s was inside redactor round trips/);
       assert.match(additionalContext, /hook name and all four timings/);
     });
+
+  // One hook, unlike the cases above: the wrap order lives inside hookTrace,
+  // which all five share, so a second hook would re-assert the same binder.
+  it("charges a host sink that waits and then THROWS", async () => {
+    freshTraceFile();
+    /** @type {string[]} */
+    const seen = [];
+    // The charge is booked in chargeHostExtensionSync's `finally`, so a sink
+    // that spends its wait and THEN throws is measured before best-effort
+    // swallows the throw. Booked on the success path instead, the sink that
+    // spent the most is the one sink the notice cannot see.
+    const { stderr } = await withCapturedStderr(() =>
+      quietly(HOOKS[0].run, (event, fields, level) => {
+        waitingSink(seen)(event, fields, level);
+        throw new Error("host channel down");
+      }),
+    );
+    assert.deepEqual(seen, [HOOKS[0].event]);
+    assert.match(stderr, /[1-9]\d*\.\ds was inside host extensions/);
+  });
 });
 
 // The other half of the same claim, and the one a wrapper that RESOLVES the

--- a/test/claude-hooks-trace-sink.test.mjs
+++ b/test/claude-hooks-trace-sink.test.mjs
@@ -50,6 +50,8 @@ process.env.CLAUDE_PROJECT_DIR = projectDir;
 process.env._AGENT_SANITIZER_TRACE = "info";
 
 const { TraceEvent } = await import("../claude-hooks/lib/trace.mjs");
+const { SLOW_HOOK_THRESHOLD_MS } =
+  await import("../claude-hooks/lib/hook-timing.mjs");
 const preToolUse = await import("../claude-hooks/pretooluse-sanitize.mjs");
 const sanitizeOutput = await import("../claude-hooks/sanitize-output.mjs");
 const userPrompt = await import("../claude-hooks/sanitize-user-prompt.mjs");
@@ -228,6 +230,86 @@ for (const hook of HOOKS) {
     });
   });
 }
+
+// A host sink that WAITS without computing, which is the shape the slow-hook
+// notice's host window exists to name: `Atomics.wait` blocks this thread and
+// burns no CPU, exactly as a sink writing to an unanswered socket does. Past the
+// budget, so the run it is injected into reports.
+const HOST_SINK_WAIT_MS = SLOW_HOOK_THRESHOLD_MS + 100;
+const waitingSink = () =>
+  Atomics.wait(
+    new Int32Array(new SharedArrayBuffer(4)),
+    0,
+    0,
+    HOST_SINK_WAIT_MS,
+  );
+
+/**
+ * Run `fn` with `process.stderr` collected. Every hook writes the slow-hook
+ * notice there whatever verdict channel it also rides, so it is the one place a
+ * case below can read all five. The `write` PROPERTY is safe to patch here (see
+ * capture-stdout.mjs for why stdout is not): node:test reports on stdout.
+ * @template T
+ * @param {() => Promise<T>} fn
+ * @returns {Promise<{ result: T, stderr: string }>}
+ */
+async function withCapturedStderr(fn) {
+  /** @type {string[]} */
+  const chunks = [];
+  const real = process.stderr.write;
+  // @ts-expect-error -- narrower than the overloaded write signature.
+  process.stderr.write = (chunk) => {
+    chunks.push(String(chunk));
+    return true;
+  };
+  try {
+    return { result: await fn(), stderr: chunks.join("") };
+  } finally {
+    process.stderr.write = real;
+  }
+}
+
+// The two hooks with no verdict to fold a timing notice into: their response
+// envelope is the only route their attribution takes to the model.
+const ENVELOPE_ONLY = new Set([
+  "scan-invisible-chars",
+  "scan-loaded-instructions",
+]);
+
+// Threaded by hand per hook, like the sink itself, so every hook is asserted
+// rather than one standing in for the rest.
+describe("a host sink's wait is charged to the host window", () => {
+  it("drives both envelope-only hooks (non-vacuous)", () => {
+    assert.deepEqual(
+      HOOKS.map(({ name }) => name).filter((name) => ENVELOPE_ONLY.has(name)),
+      [...ENVELOPE_ONLY],
+    );
+  });
+
+  for (const hook of HOOKS)
+    it(`${hook.name} names the host extension, not itself`, async () => {
+      freshTraceFile();
+      const {
+        result: { stdout },
+        stderr,
+      } = await withCapturedStderr(() => quietly(hook.run, waitingSink));
+      // The number, then the verdict: an uncharged host window reads 0.0s and
+      // hands the same wait to the "blocked on a loaded machine" arm, which
+      // sends the reader to their own machine for a cost their sink spent —
+      // and bills the sink's own in-process CPU to the sanitizer.
+      assert.match(stderr, /[1-9]\d*\.\ds was inside host extensions/);
+      assert.match(
+        stderr,
+        /The largest share was spent inside a host extension/,
+      );
+      if (!ENVELOPE_ONLY.has(hook.name)) return;
+      const { additionalContext } = JSON.parse(stdout).hookSpecificOutput;
+      // Every window MEASURED, so the notice rules the empty ones out rather
+      // than listing them as candidates it cannot separate.
+      assert.match(additionalContext, /0\.0s was inside redactor round trips/);
+      assert.match(additionalContext, /hook name and all four timings/);
+    });
+});
 
 // The one hook where a throwing sink costs more than an announcement: its
 // announcement runs BEFORE the auto-clean and the alert write, with no catch

--- a/test/claude-hooks-trace-sink.test.mjs
+++ b/test/claude-hooks-trace-sink.test.mjs
@@ -49,7 +49,7 @@ const projectDir = mkdtempSync(join(tmpdir(), "sanitizer-trace-proj-"));
 process.env.CLAUDE_PROJECT_DIR = projectDir;
 process.env._AGENT_SANITIZER_TRACE = "info";
 
-const { TraceEvent, hostChargedTrace, trace } =
+const { TraceEvent, hookTrace, trace } =
   await import("../claude-hooks/lib/trace.mjs");
 const { SLOW_HOOK_THRESHOLD_MS } =
   await import("../claude-hooks/lib/hook-timing.mjs");
@@ -113,9 +113,12 @@ async function withStdin(payload, fn) {
 /**
  * One entry per hook: how to run it with and without a host sink, and what its
  * announcement looks like.
+ * `envelopeOnly` marks a hook with no verdict to fold a timing notice into, so
+ * its response envelope is the only route its attribution takes to the model.
  * @type {Array<{
  *   name: string,
  *   event: string,
+ *   envelopeOnly?: boolean,
  *   run: (sink?: import("../claude-hooks/lib/trace.mjs").TraceFn) => Promise<void>,
  * }>}
  */
@@ -168,12 +171,14 @@ const HOOKS = [
   {
     name: "scan-invisible-chars",
     event: TraceEvent.SCAN_INVISIBLE_CHARS_RAN,
+    envelopeOnly: true,
     run: (sink) =>
       sink ? scanInvisible.cliMain({ trace: sink }) : scanInvisible.cliMain(),
   },
   {
     name: "scan-loaded-instructions",
     event: TraceEvent.SCAN_LOADED_INSTRUCTIONS_RAN,
+    envelopeOnly: true,
     run: (sink) =>
       withStdin(
         {
@@ -239,12 +244,21 @@ for (const hook of HOOKS) {
 const HOST_SINK_WAIT_MS = SLOW_HOOK_THRESHOLD_MS + 100;
 const block = (ms) =>
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-const waitingSink = () => block(HOST_SINK_WAIT_MS);
+
+/**
+ * A sink that records the events it is handed and then waits.
+ * @param {string[]} seen  filled with each event name as it arrives
+ */
+const waitingSink = (seen) => (event) => {
+  seen.push(event);
+  block(HOST_SINK_WAIT_MS);
+};
 
 /**
  * Run `fn` with `process.stderr` collected. Every hook writes the slow-hook
  * notice there whatever verdict channel it also rides, so it is the one place a
- * case below can read all five. The `write` PROPERTY is safe to patch here (see
+ * case below can read it for all five hooks alike. The `write` PROPERTY is safe
+ * to patch here (see
  * capture-stdout.mjs for why stdout is not): node:test reports on stdout.
  * @template T
  * @param {() => Promise<T>} fn
@@ -271,30 +285,23 @@ async function withCapturedStderr(fn, slowLines = () => false) {
 /** A trace line from the package's own sink, which writes one JSON object. */
 const isTraceLine = (line) => line.includes(`"event":"`);
 
-// The two hooks with no verdict to fold a timing notice into: their response
-// envelope is the only route their attribution takes to the model.
-const ENVELOPE_ONLY = new Set([
-  "scan-invisible-chars",
-  "scan-loaded-instructions",
-]);
-
 // Threaded by hand per hook, like the sink itself, so every hook is asserted
 // rather than one standing in for the rest.
 describe("a host sink's wait is charged to the host window", () => {
-  it("drives both envelope-only hooks (non-vacuous)", () => {
-    assert.deepEqual(
-      HOOKS.map(({ name }) => name).filter((name) => ENVELOPE_ONLY.has(name)),
-      [...ENVELOPE_ONLY],
-    );
-  });
-
   for (const hook of HOOKS)
     it(`${hook.name} names the host extension, not itself`, async () => {
       freshTraceFile();
+      /** @type {string[]} */
+      const seen = [];
       const {
         result: { stdout },
         stderr,
-      } = await withCapturedStderr(() => quietly(hook.run, waitingSink));
+      } = await withCapturedStderr(() => quietly(hook.run, waitingSink(seen)));
+      // The announcement reached the sink, so the wait asserted below is the
+      // sink's and the hook ran its clean path. A hook that faulted before
+      // announcing waits for nothing, and its notice — which this case would
+      // otherwise read as the finding — names no window at all.
+      assert.deepEqual(seen, [hook.event]);
       // The number, then the verdict: an uncharged host window reads 0.0s and
       // hands the same wait to the "blocked on a loaded machine" arm, which
       // sends the reader to their own machine for a cost their sink spent —
@@ -304,7 +311,10 @@ describe("a host sink's wait is charged to the host window", () => {
         stderr,
         /The largest share was spent inside a host extension/,
       );
-      if (!ENVELOPE_ONLY.has(hook.name)) return;
+      if (!hook.envelopeOnly) return;
+      // One envelope: these hooks fold the notice INTO their own response
+      // rather than emitting a second, so a parse that throws here is a real
+      // regression in that merge and not a loose assertion.
       const { additionalContext } = JSON.parse(stdout).hookSpecificOutput;
       // Every window MEASURED, so the notice rules the empty ones out rather
       // than listing them as candidates it cannot separate.
@@ -319,7 +329,7 @@ describe("a host sink's wait is charged to the host window", () => {
 // composer paid.
 describe("the package's own sink is never charged as a host extension", () => {
   it("hands the default back unwrapped, so nothing can charge it", () => {
-    assert.equal(hostChargedTrace(undefined), trace);
+    assert.equal(hookTrace(undefined), trace);
   });
 
   for (const hook of HOOKS)
@@ -332,6 +342,9 @@ describe("the package's own sink is never charged as a host extension", () => {
         () => quietly(hook.run),
         isTraceLine,
       );
+      // The line that blocked, so the budget was spent inside the package's own
+      // sink and not somewhere a faulting hook stopped short of.
+      assert.match(stderr, new RegExp(`"event":"${hook.event}"`));
       assert.match(stderr, /0\.0s was inside host extensions/);
       assert.doesNotMatch(
         stderr,

--- a/test/claude-hooks-trace-sink.test.mjs
+++ b/test/claude-hooks-trace-sink.test.mjs
@@ -49,7 +49,8 @@ const projectDir = mkdtempSync(join(tmpdir(), "sanitizer-trace-proj-"));
 process.env.CLAUDE_PROJECT_DIR = projectDir;
 process.env._AGENT_SANITIZER_TRACE = "info";
 
-const { TraceEvent } = await import("../claude-hooks/lib/trace.mjs");
+const { TraceEvent, hostChargedTrace, trace } =
+  await import("../claude-hooks/lib/trace.mjs");
 const { SLOW_HOOK_THRESHOLD_MS } =
   await import("../claude-hooks/lib/hook-timing.mjs");
 const preToolUse = await import("../claude-hooks/pretooluse-sanitize.mjs");
@@ -236,13 +237,9 @@ for (const hook of HOOKS) {
 // burns no CPU, exactly as a sink writing to an unanswered socket does. Past the
 // budget, so the run it is injected into reports.
 const HOST_SINK_WAIT_MS = SLOW_HOOK_THRESHOLD_MS + 100;
-const waitingSink = () =>
-  Atomics.wait(
-    new Int32Array(new SharedArrayBuffer(4)),
-    0,
-    0,
-    HOST_SINK_WAIT_MS,
-  );
+const block = (ms) =>
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+const waitingSink = () => block(HOST_SINK_WAIT_MS);
 
 /**
  * Run `fn` with `process.stderr` collected. Every hook writes the slow-hook
@@ -253,13 +250,15 @@ const waitingSink = () =>
  * @param {() => Promise<T>} fn
  * @returns {Promise<{ result: T, stderr: string }>}
  */
-async function withCapturedStderr(fn) {
+async function withCapturedStderr(fn, slowLines = () => false) {
   /** @type {string[]} */
   const chunks = [];
   const real = process.stderr.write;
   // @ts-expect-error -- narrower than the overloaded write signature.
   process.stderr.write = (chunk) => {
-    chunks.push(String(chunk));
+    const line = String(chunk);
+    chunks.push(line);
+    if (slowLines(line)) block(HOST_SINK_WAIT_MS);
     return true;
   };
   try {
@@ -268,6 +267,9 @@ async function withCapturedStderr(fn) {
     process.stderr.write = real;
   }
 }
+
+/** A trace line from the package's own sink, which writes one JSON object. */
+const isTraceLine = (line) => line.includes(`"event":"`);
 
 // The two hooks with no verdict to fold a timing notice into: their response
 // envelope is the only route their attribution takes to the model.
@@ -308,6 +310,33 @@ describe("a host sink's wait is charged to the host window", () => {
       // than listing them as candidates it cannot separate.
       assert.match(additionalContext, /0\.0s was inside redactor round trips/);
       assert.match(additionalContext, /hook name and all four timings/);
+    });
+});
+
+// The other half of the same claim, and the one a wrapper that RESOLVES the
+// default sink before the binding breaks: this package's own trace write is the
+// sanitizer's own work, so charging it would blame a composer for a cost no
+// composer paid.
+describe("the package's own sink is never charged as a host extension", () => {
+  it("hands the default back unwrapped, so nothing can charge it", () => {
+    assert.equal(hostChargedTrace(undefined), trace);
+  });
+
+  for (const hook of HOOKS)
+    it(`${hook.name} leaves the host window empty with no sink`, async () => {
+      // No trace FILE, so the package sink writes its line to stderr — where
+      // this case makes that one write block past the budget. Any hook that
+      // charged its own sink would report the wait as a host extension.
+      delete process.env._AGENT_SANITIZER_TRACE_FILE;
+      const { stderr } = await withCapturedStderr(
+        () => quietly(hook.run),
+        isTraceLine,
+      );
+      assert.match(stderr, /0\.0s was inside host extensions/);
+      assert.doesNotMatch(
+        stderr,
+        /The largest share was spent inside a host extension/,
+      );
     });
 });
 


### PR DESCRIPTION
Claimed area: the trace-sink binding in all five hooks, plus the two scanners' `reportSlowHook` context. Fixes #399.

## Summary

Charge a composer's injected trace sink to the host-extension window in every hook, and give both scanners' slow-hook notice all four timings instead of CPU alone.

Only `sanitize-output` bracketed its injected sink in `chargeHostExtensionSync`. `pretooluse-sanitize`, `sanitize-user-prompt` and both scanners bound theirs directly, so a sink that writes over a socket or spawns a subprocess left its wait in the notice's unattributed remainder and its in-process CPU billed to the sanitizer. For the three judge hooks that is worse than an omission: `runJudgeCli` already passes `hostMs`, so the notice printed a measured `0.0s was inside host extensions` for the window that had actually burned the time.

The scanners separately passed `reportSlowHook` only `cpuMs`, which drops `slowHookNotice` to its two-number form — it lists candidates for the wait and commits to none. `hook-timing.mjs:562` already documents the opposite as an invariant ("every caller in this package charges the seams and passes the number, including when it is 0"), and `control-plane.mjs:201` does it. #399 is what that gap looks like from outside: a 1.2s SessionStart scan against 0.0s of CPU, and a notice that could only say it could not tell.

The cold-start dependency wait is already excluded (`awaitLazyDependency` brackets its poll in `excludeProvisioning`), so that reporter's 1.2s is inside the scan itself. This does not make their scan faster — it makes the notice able to say whose second it was.

## Changes

- `lib/trace.mjs`: one new export, `hookTrace(sink)` — the single place a host sink is made best-effort *and* charged, and the place the package's own `trace` is deliberately exempted (that file write is the sanitizer's own work). No hook composes the halves.
- All five hooks bind through it, including `sanitize-output`, whose inline copy it replaces.
- Both scanners pass `cpuMs`, `redactorMs` and `hostMs` to `reportSlowHook`.
- README documents the charge alongside the existing injectable-sink section.
- `plugin/dist/hooks/plugin-hooks.bundle.mjs` rebuilt by the pre-commit hook; `hook-binaries.sha256` is `plugin-dist-autofix.yaml`'s to regenerate.

## Review focus

Read `claude-hooks/lib/trace.mjs` first — `hookTrace` is the whole correctness argument, and its nesting is load-bearing twice over, which the diff cannot show on one screen:

1. The charge is booked in `chargeHostExtensionSync`'s `finally`, *inside* the best-effort bracket, so a sink that spends its wait and then throws is measured before the throw is swallowed.
2. The `if (!sink) return trace` exemption reads the host's own sink. A best-effort wrapper applied first would hand it an always-truthy function, and the package's own write would be charged on every call.

Both are pinned by tests (below). The cross-file invariant worth checking: `judgePreToolUseSanitize` and `cliMain` in `pretooluse-sanitize.mjs` must forward `opts.trace` **unresolved** — substituting the package default there re-breaks (2) from a different file.

The part I am least sure of is the scope call in Decisions below. Second-guess `hostMs: timer.hostMs()` in the two scanners: it is honest only for the host callbacks that actually run inside a charger. Their injectable `scan` seam does not, and neither do `pretooluse-sanitize`'s `gates`/`rehydrate` or `sanitize-user-prompt`'s `strip` — all four predate this PR and are left alone here.

## Tests / verification

- `test/claude-hooks-trace-sink.test.mjs`, one case per hook: drives the real entry point with a host sink that blocks ~1.1s on `Atomics.wait` — a wait with no CPU, the shape the host window exists to name. Each asserts the sink actually received the announcement (so the finding cannot be a fault path), a non-zero host figure, and the host-extension verdict; the two `envelopeOnly` hooks additionally assert their model-facing envelope carries the measured `0.0s` redactor window and asks for all four timings.
- One case per hook for the opposite direction: with **no** sink, the package's own trace write is made to block past the budget, and every hook must still report `0.0s was inside host extensions`.
- One case for a sink that waits and then **throws**, pinning invariant (1) above.
- Non-vacuity, each established by mutation: the waiting-sink cases go red against the unfixed hooks (4 of 5; `sanitize-output` green, it already charged); the no-sink cases go red against the pre-fix `pretooluse-sanitize`; the throwing case reds — alone — when `chargeHostExtensionSync` is mutated to book its charge on the success path instead of in the `finally`.
- `node --test` on trace-sink (28 pass), exports, and the 24-suite pre-commit guard-pair run: 0 failures. `pnpm lint` and `pnpm check` clean. Full `pnpm test` is CI's, per the repo's local test budget.

## Decisions made

- **Scope widened from the two scanners to all four uncharged sinks.** #399 named only the SessionStart notice, but the same binding sits in the two hot-path judge hooks, where it produces a false `0.0s` rather than a missing number. Fixing only the scanners would have left the notice lying on PreToolUse and UserPromptSubmit.
- **One binder, not two exported halves.** `hostChargedTrace` was briefly exported on its own; a half-binding the caller must nest correctly is permanent composition API the moment it merges, so it is now module-private behind `hookTrace`. `bestEffortTrace` stays exported only because it was already published.
- **The three pre-existing uncharged host seams are left alone** (`gates`, `rehydrate`, `strip`, plus the scanners' `scan`). Each is a one-line `chargeHostExtensionSync` away, but none is the defect #399 reports, and charging a documented extension seam changes what its composers' notices say. Under the alternative this PR also closes them and the diff grows a behavior change per seam.

## Checklist

- [x] Commits follow Conventional Commits; the subject reads as a user-facing release note (the notice's wording changes for the scanners).
- [x] `pnpm lint` and `pnpm check` pass locally; targeted `node --test` suites pass.
- [x] No detector changed, so no new negative tests are owed; the existing "announces on the package channel when no sink is supplied" cases stay green, pinning the default path as unchanged.
- [x] No real secrets/tokens in the diff, tests, or description.
- [x] `CHANGELOG.md` and `package.json` version left untouched.