### PR TITLE
fix(output): gate content-block recognition on each field's value shape

### DIFF
--- a/THREAT-MODEL.md
+++ b/THREAT-MODEL.md
@@ -500,12 +500,21 @@ suppression (`suppressToolOutput`) replaces string leaves in place so the
 placeholder still matches the tool's shape, with one exception it must make: an
 Anthropic **content block** is collapsed whole to `{ type: "text", text: … }`
 rather than walked, because rewriting the `type` tag (or a tagged union nested
-under it — `citations[]`, `source`, `cache_control`) produces a block the API
+under it — `citations`, `source`, `cache_control`) produces a block the API
 rejects with a 400, and the invalid block then replays on every later turn, so
 no retry clears it. A block is recognised only when its own keys match that
-tag's schema exactly, so an ordinary object that merely carries a `type` field
+tag's schema exactly **and** each value has that field's shape, so an ordinary
+object that merely carries a `type` field — or an `{ type: "image", source:
+"https://…" }` record whose `source` is a URL rather than the block's object —
 keeps the leaf-wise walk; only the enum-valued tag is preserved, never a string
-from the block itself. In the Claude
+from the block itself. Two residual cases are accepted rather than papered over.
+A tag that PAIRS a block with another block (`tool_use` ↔ `tool_result`, and
+their server-tool twins) is deliberately not recognised: collapsing one orphans
+its partner, which is the same permanent rejection, so those keep the walk and
+#398 stands for them. And the depth/cycle truncation still substitutes the bare
+sentinel string for whatever subtree it cuts, block position or not — the walk
+cannot tell a content position from an ordinary array from inside, and guessing
+would rewrite ordinary arrays of strings into blocks. In the Claude
 Code hooks the entire secret layer is **opt-in**: `secretsEnabled()`
 (`claude-hooks/lib/env-config.mjs`) reads `AGENT_SANITIZER_SECRETS_ENABLED=1`,
 and every secret-layer guarantee below — Layer-4 redaction, rehydration, the

--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=d336348ad98940f963c1292b92682d0adc54cbbcab4e5eb23953ebf621faafdf
-f759d8a222005ccb938b4f1ef5cd67c343e5c9a90c6b464480d529e12a910398  agent-sanitizer-hooks-darwin-arm64
-1917a2b591b60b9c42985bc1ba5c77cf0d03d0c6cce1dc4c50a8bcc5df50c310  agent-sanitizer-hooks-darwin-x64
-f97b0d6513a0ee8696499256894b290c8c1121d29ee3a666652e8c9f70451eae  agent-sanitizer-hooks-linux-arm64
-ef3484144d6710df7f04536c13cbeea2d10368b774eac2e72ddf41fa494bd12c  agent-sanitizer-hooks-linux-x64
+# bundle=94550ed432e7c0df5142ae83c233c39a6bef6608de344c134ec53ed63f01ef50
+d3c42f266906d90277eaa8eafc710f62d8e19ef5d69d6ddac5ecdd903d97d8c0  agent-sanitizer-hooks-darwin-arm64
+8db0bc96cb1507189f901ca2d366c82f2aaa8e06662203909afa9a601876fb5a  agent-sanitizer-hooks-darwin-x64
+a4c545691e2b4bce0ac52cf788f1884284d63a588c5cee837d56ac5372ff6bbc  agent-sanitizer-hooks-linux-arm64
+188c74a209af285e225314fd3c070c1edbe045f26d95d9aee4be1200eee6f1ab  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/hook-binaries.sha256
+++ b/plugin/dist/hooks/hook-binaries.sha256
@@ -4,8 +4,8 @@
 # verified against this file before it is installed.
 # repository=AlexanderMattTurner/agent-sanitizer
 # bun=1.3.11
-# bundle=94550ed432e7c0df5142ae83c233c39a6bef6608de344c134ec53ed63f01ef50
-d3c42f266906d90277eaa8eafc710f62d8e19ef5d69d6ddac5ecdd903d97d8c0  agent-sanitizer-hooks-darwin-arm64
-8db0bc96cb1507189f901ca2d366c82f2aaa8e06662203909afa9a601876fb5a  agent-sanitizer-hooks-darwin-x64
-a4c545691e2b4bce0ac52cf788f1884284d63a588c5cee837d56ac5372ff6bbc  agent-sanitizer-hooks-linux-arm64
-188c74a209af285e225314fd3c070c1edbe045f26d95d9aee4be1200eee6f1ab  agent-sanitizer-hooks-linux-x64
+# bundle=a18f1507446e2109e7332d03865156a4ba6d65de5411b9939afd565c46ccb642
+123899e3a1a0f2c8afc0e4ea596aac78b9762848b1a0fe9c73466d9f05c977b5  agent-sanitizer-hooks-darwin-arm64
+3e78cf645474017b7cb3bf0e68f8dfb4d449486bd0dc679653fab10d0a5b500c  agent-sanitizer-hooks-darwin-x64
+fca58712cc84f148346d938135ef7659dfd6aa3e3f04bfcc31299ba4d9f61209  agent-sanitizer-hooks-linux-arm64
+e116d7a0770cf08db892936e1891476bad6c674e2d7e0ed415d0a97bea749073  agent-sanitizer-hooks-linux-x64

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -11829,7 +11829,7 @@ var require_extend = __commonJS({
     var toStr = Object.prototype.toString;
     var defineProperty = Object.defineProperty;
     var gOPD = Object.getOwnPropertyDescriptor;
-    var isArray = function isArray2(arr) {
+    var isArray2 = function isArray3(arr) {
       if (typeof Array.isArray === "function") {
         return Array.isArray(arr);
       }
@@ -11892,10 +11892,10 @@ var require_extend = __commonJS({
             src = getProperty(target, name50);
             copy = getProperty(options, name50);
             if (target !== copy) {
-              if (deep && copy && (isPlainObject2(copy) || (copyIsArray = isArray(copy)))) {
+              if (deep && copy && (isPlainObject2(copy) || (copyIsArray = isArray2(copy)))) {
                 if (copyIsArray) {
                   copyIsArray = false;
-                  clone = src && isArray(src) ? src : [];
+                  clone = src && isArray2(src) ? src : [];
                 } else {
                   clone = src && isPlainObject2(src) ? src : {};
                 }
@@ -46895,13 +46895,16 @@ function suppressToolOutput(value, message) {
 }
 function isContentBlock(value) {
   if (Array.isArray(value)) return false;
-  const keys = Object.keys(value);
-  if (!keys.includes("type")) return false;
   const schema = CONTENT_BLOCK_SCHEMAS.get(value.type);
-  if (schema === void 0) return false;
-  return schema.required.every((key) => keys.includes(key)) && keys.every(
-    (key) => key === "type" || schema.required.includes(key) || schema.optional.includes(key)
-  );
+  if (schema === void 0 || !Object.hasOwn(value, "type")) return false;
+  const isValidField = (key) => {
+    if (Object.hasOwn(schema.required, key))
+      return schema.required[key](value[key]);
+    if (Object.hasOwn(schema.optional, key))
+      return schema.optional[key](value[key]);
+    return false;
+  };
+  return Object.keys(schema.required).every((key) => Object.hasOwn(value, key)) && Object.keys(value).every((key) => key === "type" || isValidField(key));
 }
 function suppressAt(value, message, depth, seen, memo) {
   if (typeof value === "string") return message;
@@ -46933,7 +46936,7 @@ function suppressAt(value, message, depth, seen, memo) {
     seen.delete(value);
   }
 }
-var FILTER_WARNING, FILTER_WARNING_LABELS, REDACTION_DOCTRINE, MAX_DEPTH, DEPTH_PLACEHOLDER, CYCLE_PLACEHOLDER, CONTENT_BLOCK_SCHEMAS;
+var FILTER_WARNING, FILTER_WARNING_LABELS, REDACTION_DOCTRINE, MAX_DEPTH, DEPTH_PLACEHOLDER, CYCLE_PLACEHOLDER, isString, isRecord, isNullableString, isNullableArray, isArray, CONTENT_BLOCK_SCHEMA_ENTRIES, CONTENT_BLOCK_SCHEMAS;
 var init_output = __esm({
   "src/output.mjs"() {
     "use strict";
@@ -46962,45 +46965,52 @@ var init_output = __esm({
     MAX_DEPTH = 200;
     DEPTH_PLACEHOLDER = `[withheld: structured output nested beyond ${MAX_DEPTH} levels]`;
     CYCLE_PLACEHOLDER = "[withheld: circular reference in structured output]";
-    CONTENT_BLOCK_SCHEMAS = /* @__PURE__ */ new Map([
-      ["text", { required: ["text"], optional: ["citations", "cache_control"] }],
-      ["image", { required: ["source"], optional: ["cache_control"] }],
+    isString = (v) => typeof v === "string";
+    isRecord = (v) => v !== null && typeof v === "object" && !Array.isArray(v);
+    isNullableString = (v) => v === null || isString(v);
+    isNullableArray = (v) => v === null || Array.isArray(v);
+    isArray = (v) => Array.isArray(v);
+    CONTENT_BLOCK_SCHEMA_ENTRIES = [
+      [
+        "text",
+        {
+          required: { text: isString },
+          // A response's text block carries `citations` as an array (or null); a
+          // request's carries none.
+          optional: { citations: isNullableArray, cache_control: isRecord }
+        }
+      ],
+      [
+        "image",
+        { required: { source: isRecord }, optional: { cache_control: isRecord } }
+      ],
       [
         "document",
         {
-          required: ["source"],
-          optional: ["title", "context", "citations", "cache_control"]
+          required: { source: isRecord },
+          // A document's `citations` is the `{ enabled }` toggle, not a list.
+          optional: {
+            title: isNullableString,
+            context: isNullableString,
+            citations: isRecord,
+            cache_control: isRecord
+          }
         }
       ],
       [
         "search_result",
         {
-          required: ["source", "title", "content"],
-          optional: ["citations", "cache_control"]
-        }
-      ],
-      ["thinking", { required: ["thinking", "signature"], optional: [] }],
-      ["redacted_thinking", { required: ["data"], optional: [] }],
-      [
-        "tool_use",
-        { required: ["id", "name", "input"], optional: ["cache_control"] }
-      ],
-      [
-        "server_tool_use",
-        { required: ["id", "name", "input"], optional: ["cache_control"] }
-      ],
-      [
-        "tool_result",
-        {
-          required: ["tool_use_id"],
-          optional: ["content", "is_error", "cache_control"]
+          required: { source: isString, title: isString, content: isArray },
+          optional: { citations: isRecord, cache_control: isRecord }
         }
       ],
       [
-        "web_search_tool_result",
-        { required: ["tool_use_id", "content"], optional: ["cache_control"] }
-      ]
-    ]);
+        "thinking",
+        { required: { thinking: isString, signature: isString }, optional: {} }
+      ],
+      ["redacted_thinking", { required: { data: isString }, optional: {} }]
+    ];
+    CONTENT_BLOCK_SCHEMAS = new Map(CONTENT_BLOCK_SCHEMA_ENTRIES);
   }
 });
 

--- a/plugin/dist/hooks/plugin-hooks.bundle.mjs
+++ b/plugin/dist/hooks/plugin-hooks.bundle.mjs
@@ -46936,7 +46936,7 @@ function suppressAt(value, message, depth, seen, memo) {
     seen.delete(value);
   }
 }
-var FILTER_WARNING, FILTER_WARNING_LABELS, REDACTION_DOCTRINE, MAX_DEPTH, DEPTH_PLACEHOLDER, CYCLE_PLACEHOLDER, isString, isRecord, isNullableString, isNullableArray, isArray, CONTENT_BLOCK_SCHEMA_ENTRIES, CONTENT_BLOCK_SCHEMAS;
+var FILTER_WARNING, FILTER_WARNING_LABELS, REDACTION_DOCTRINE, MAX_DEPTH, DEPTH_PLACEHOLDER, CYCLE_PLACEHOLDER, isString, isRecord, isNullableString, isNullableArray, isNullableRecord, isArray, CONTENT_BLOCK_SCHEMA_ENTRIES, CONTENT_BLOCK_SCHEMAS;
 var init_output = __esm({
   "src/output.mjs"() {
     "use strict";
@@ -46969,6 +46969,7 @@ var init_output = __esm({
     isRecord = (v) => v !== null && typeof v === "object" && !Array.isArray(v);
     isNullableString = (v) => v === null || isString(v);
     isNullableArray = (v) => v === null || Array.isArray(v);
+    isNullableRecord = (v) => v === null || isRecord(v);
     isArray = (v) => Array.isArray(v);
     CONTENT_BLOCK_SCHEMA_ENTRIES = [
       [
@@ -46977,12 +46978,15 @@ var init_output = __esm({
           required: { text: isString },
           // A response's text block carries `citations` as an array (or null); a
           // request's carries none.
-          optional: { citations: isNullableArray, cache_control: isRecord }
+          optional: { citations: isNullableArray, cache_control: isNullableRecord }
         }
       ],
       [
         "image",
-        { required: { source: isRecord }, optional: { cache_control: isRecord } }
+        {
+          required: { source: isRecord },
+          optional: { cache_control: isNullableRecord }
+        }
       ],
       [
         "document",
@@ -46992,8 +46996,8 @@ var init_output = __esm({
           optional: {
             title: isNullableString,
             context: isNullableString,
-            citations: isRecord,
-            cache_control: isRecord
+            citations: isNullableRecord,
+            cache_control: isNullableRecord
           }
         }
       ],
@@ -47001,7 +47005,10 @@ var init_output = __esm({
         "search_result",
         {
           required: { source: isString, title: isString, content: isArray },
-          optional: { citations: isRecord, cache_control: isRecord }
+          optional: {
+            citations: isNullableRecord,
+            cache_control: isNullableRecord
+          }
         }
       ],
       [

--- a/src/output.mjs
+++ b/src/output.mjs
@@ -1144,14 +1144,25 @@ const isArray = (v) => Array.isArray(v);
  * AND every present key's VALUE satisfies its predicate. Gating on the value's
  * shape and not the key name alone is what keeps an ordinary record like
  * `{ type: "image", source: "https://…/x.png" }` out: a real image block's
- * `source` is an object. An unrecognised object is walked as ordinary data, so
- * a schema that is too strict costs a false NEGATIVE (the leaf-wise walk) — the
- * direction this module prefers — while one that is too loose mangles real data.
+ * `source` is an object. An unrecognised object is walked as ordinary data.
+ *
+ * Both directions cost something, and they are not symmetric in the way the
+ * rest of this module's precision rule assumes. Too LOOSE mangles an object
+ * that was never a block. Too STRICT is fail-safe only for those same
+ * non-blocks: for a REAL block it sends the walk over the `type` tag, which is
+ * the permanently-rejected block this collapse exists to prevent. So a
+ * predicate must admit every value the API admits — hence the nullable
+ * variants below, since every optional object-valued field is `object | null`.
  *
  * A block whose tag PAIRS it with another block (`tool_use` ↔ `tool_result`,
  * and their server-tool twins) is deliberately absent: collapsing one to a text
  * block orphans its partner, which the API rejects exactly as permanently as
  * the rewritten tag this collapse exists to prevent. They keep the walk.
+ *
+ * Held as an entry list rather than annotated on the `new Map(...)` below
+ * because only the element-wise annotation typechecks: annotating the map lets
+ * tsc union the entry literals first, and that union's `source?: undefined`
+ * members fail `BlockSchema`'s index signature.
  * @type {[string, BlockSchema][]}
  */
 const CONTENT_BLOCK_SCHEMA_ENTRIES = [
@@ -1201,6 +1212,7 @@ const CONTENT_BLOCK_SCHEMA_ENTRIES = [
   ["redacted_thinking", { required: { data: isString }, optional: {} }],
 ];
 
+/** Tag → schema, keyed for {@link isContentBlock}'s lookup. */
 const CONTENT_BLOCK_SCHEMAS = new Map(CONTENT_BLOCK_SCHEMA_ENTRIES);
 
 /**

--- a/src/output.mjs
+++ b/src/output.mjs
@@ -1103,7 +1103,10 @@ export function composeContext(
  * self-referential value must NOT blow the stack here — that would re-open the
  * very hole suppression exists to close. Past {@link MAX_DEPTH} or on a cycle it
  * substitutes `message` for the offending subtree (already the suppression
- * sentinel, so the placeholder is consistent with the rest of the output).
+ * sentinel, so the placeholder is consistent with the rest of the output). A
+ * recognised block collapses BEFORE either guard and recurses no further, so it
+ * is subject to neither; a truncated subtree that is not itself a block is
+ * still replaced by the bare string, block position or not.
  * @param {any} value
  * @param {string} message
  * @returns {any}
@@ -1113,77 +1116,109 @@ export function suppressToolOutput(value, message) {
 }
 
 /**
- * Own-key schema of every Anthropic content block the suppressor recognises,
- * from the Messages API request shapes
- * (https://docs.claude.com/en/api/messages). A block is recognised only when
- * its own keys match its tag's schema exactly — every `required` key present,
- * no key outside `required` ∪ `optional` ∪ `type`. An unrecognised object is
- * walked as ordinary data, so a schema entry that is wrong or missing costs a
- * false NEGATIVE (the leaf-wise walk) rather than collapsing a legitimate
- * object that merely carries a `type` field.
- * @type {Map<string, { required: string[], optional: string[] }>}
+ * @typedef {(v: any) => boolean} FieldShape  a content-block field's value test
+ * @typedef {{ required: Record<string, FieldShape>, optional: Record<string, FieldShape> }} BlockSchema
  */
-const CONTENT_BLOCK_SCHEMAS = new Map([
-  ["text", { required: ["text"], optional: ["citations", "cache_control"] }],
-  ["image", { required: ["source"], optional: ["cache_control"] }],
+
+/** @type {FieldShape} */
+const isString = (v) => typeof v === "string";
+/** @type {FieldShape} */
+const isRecord = (v) =>
+  v !== null && typeof v === "object" && !Array.isArray(v);
+/** @type {FieldShape} */
+const isNullableString = (v) => v === null || isString(v);
+/** @type {FieldShape} */
+const isNullableArray = (v) => v === null || Array.isArray(v);
+/** @type {FieldShape} */
+const isArray = (v) => Array.isArray(v);
+
+/**
+ * Schema of every Anthropic content block the suppressor recognises, from the
+ * Messages API block shapes (https://docs.claude.com/en/api/messages). A block
+ * is recognised only when its own keys match its tag's schema exactly — every
+ * `required` key present, no key outside `required` ∪ `optional` ∪ `type` —
+ * AND every present key's VALUE satisfies its predicate. Gating on the value's
+ * shape and not the key name alone is what keeps an ordinary record like
+ * `{ type: "image", source: "https://…/x.png" }` out: a real image block's
+ * `source` is an object. An unrecognised object is walked as ordinary data, so
+ * a schema that is too strict costs a false NEGATIVE (the leaf-wise walk) — the
+ * direction this module prefers — while one that is too loose mangles real data.
+ *
+ * A block whose tag PAIRS it with another block (`tool_use` ↔ `tool_result`,
+ * and their server-tool twins) is deliberately absent: collapsing one to a text
+ * block orphans its partner, which the API rejects exactly as permanently as
+ * the rewritten tag this collapse exists to prevent. They keep the walk.
+ * @type {[string, BlockSchema][]}
+ */
+const CONTENT_BLOCK_SCHEMA_ENTRIES = [
+  [
+    "text",
+    {
+      required: { text: isString },
+      // A response's text block carries `citations` as an array (or null); a
+      // request's carries none.
+      optional: { citations: isNullableArray, cache_control: isRecord },
+    },
+  ],
+  [
+    "image",
+    { required: { source: isRecord }, optional: { cache_control: isRecord } },
+  ],
   [
     "document",
     {
-      required: ["source"],
-      optional: ["title", "context", "citations", "cache_control"],
+      required: { source: isRecord },
+      // A document's `citations` is the `{ enabled }` toggle, not a list.
+      optional: {
+        title: isNullableString,
+        context: isNullableString,
+        citations: isRecord,
+        cache_control: isRecord,
+      },
     },
   ],
   [
     "search_result",
     {
-      required: ["source", "title", "content"],
-      optional: ["citations", "cache_control"],
-    },
-  ],
-  ["thinking", { required: ["thinking", "signature"], optional: [] }],
-  ["redacted_thinking", { required: ["data"], optional: [] }],
-  [
-    "tool_use",
-    { required: ["id", "name", "input"], optional: ["cache_control"] },
-  ],
-  [
-    "server_tool_use",
-    { required: ["id", "name", "input"], optional: ["cache_control"] },
-  ],
-  [
-    "tool_result",
-    {
-      required: ["tool_use_id"],
-      optional: ["content", "is_error", "cache_control"],
+      required: { source: isString, title: isString, content: isArray },
+      optional: { citations: isRecord, cache_control: isRecord },
     },
   ],
   [
-    "web_search_tool_result",
-    { required: ["tool_use_id", "content"], optional: ["cache_control"] },
+    "thinking",
+    { required: { thinking: isString, signature: isString }, optional: {} },
   ],
-]);
+  ["redacted_thinking", { required: { data: isString }, optional: {} }],
+];
+
+const CONTENT_BLOCK_SCHEMAS = new Map(CONTENT_BLOCK_SCHEMA_ENTRIES);
 
 /**
  * Whether `value` (already known to be a walkable container) is an Anthropic
  * content block — an object whose `type` tag names a known block shape AND
- * whose own keys match that shape exactly.
+ * whose own keys and values match that shape exactly.
  * @param {any} value
  * @returns {boolean}
  */
 function isContentBlock(value) {
+  // An array with own `type`/`text` properties still occupies an array
+  // position, where a block may not be substituted for the array itself.
   if (Array.isArray(value)) return false;
-  const keys = Object.keys(value);
-  if (!keys.includes("type")) return false;
   const schema = CONTENT_BLOCK_SCHEMAS.get(value.type);
-  if (schema === undefined) return false;
+  if (schema === undefined || !Object.hasOwn(value, "type")) return false;
+  // Object.hasOwn, not a bare index: a bare lookup resolves inherited
+  // Object.prototype members ("toString", "constructor") to real functions,
+  // letting a key outside the schema pass as if it had a predicate.
+  const isValidField = (/** @type {string} */ key) => {
+    if (Object.hasOwn(schema.required, key))
+      return schema.required[key](value[key]);
+    if (Object.hasOwn(schema.optional, key))
+      return schema.optional[key](value[key]);
+    return false;
+  };
   return (
-    schema.required.every((key) => keys.includes(key)) &&
-    keys.every(
-      (key) =>
-        key === "type" ||
-        schema.required.includes(key) ||
-        schema.optional.includes(key),
-    )
+    Object.keys(schema.required).every((key) => Object.hasOwn(value, key)) &&
+    Object.keys(value).every((key) => key === "type" || isValidField(key))
   );
 }
 
@@ -1206,11 +1241,12 @@ function suppressAt(value, message, depth, seen, memo) {
   // walked; an exotic object would be corrupted to an empty clone.
   if (!isWalkableContainer(value)) return value;
   // A content block's `type` tag tells the API how to parse the block, and the
-  // tagged unions under it (`citations[]`, `source`, `cache_control`) are
+  // tagged unions under it (`citations`, `source`, `cache_control`) are
   // validated the same way — so walking a block's keys yields one the API
   // rejects with a 400, permanently: it stays in the transcript and replays on
-  // every later turn. Collapse to the one block shape `message` is legal in.
-  // Only the enum-valued tag survives, never a string from the block itself.
+  // every later turn. Collapse to a text block, which is legal wherever a
+  // recognised block stands (see {@link CONTENT_BLOCK_SCHEMAS} on the paired
+  // tags it excludes for exactly that reason).
   if (isContentBlock(value)) return { type: "text", text: message };
   const cached = memo.get(value, depth);
   if (cached !== undefined) return cached;

--- a/src/output.mjs
+++ b/src/output.mjs
@@ -1129,6 +1129,10 @@ const isRecord = (v) =>
 const isNullableString = (v) => v === null || isString(v);
 /** @type {FieldShape} */
 const isNullableArray = (v) => v === null || Array.isArray(v);
+// The API marks every optional object-valued block field nullable, and an
+// explicit null must not push the block back onto the walk that invalidates it.
+/** @type {FieldShape} */
+const isNullableRecord = (v) => v === null || isRecord(v);
 /** @type {FieldShape} */
 const isArray = (v) => Array.isArray(v);
 
@@ -1157,12 +1161,15 @@ const CONTENT_BLOCK_SCHEMA_ENTRIES = [
       required: { text: isString },
       // A response's text block carries `citations` as an array (or null); a
       // request's carries none.
-      optional: { citations: isNullableArray, cache_control: isRecord },
+      optional: { citations: isNullableArray, cache_control: isNullableRecord },
     },
   ],
   [
     "image",
-    { required: { source: isRecord }, optional: { cache_control: isRecord } },
+    {
+      required: { source: isRecord },
+      optional: { cache_control: isNullableRecord },
+    },
   ],
   [
     "document",
@@ -1172,8 +1179,8 @@ const CONTENT_BLOCK_SCHEMA_ENTRIES = [
       optional: {
         title: isNullableString,
         context: isNullableString,
-        citations: isRecord,
-        cache_control: isRecord,
+        citations: isNullableRecord,
+        cache_control: isNullableRecord,
       },
     },
   ],
@@ -1181,7 +1188,10 @@ const CONTENT_BLOCK_SCHEMA_ENTRIES = [
     "search_result",
     {
       required: { source: isString, title: isString, content: isArray },
-      optional: { citations: isRecord, cache_control: isRecord },
+      optional: {
+        citations: isNullableRecord,
+        cache_control: isNullableRecord,
+      },
     },
   ],
   [

--- a/src/output.mjs
+++ b/src/output.mjs
@@ -1205,6 +1205,10 @@ function isContentBlock(value) {
   // position, where a block may not be substituted for the array itself.
   if (Array.isArray(value)) return false;
   const schema = CONTENT_BLOCK_SCHEMAS.get(value.type);
+  // The own-key check is what blocks a polluted `Object.prototype.type`: the
+  // `value.type` read above resolves through the prototype, so without it
+  // `{ text: "leak" }` would tag itself a text block and be collapsed, dropping
+  // a legitimate field on the fail-closed path.
   if (schema === undefined || !Object.hasOwn(value, "type")) return false;
   // Object.hasOwn, not a bare index: a bare lookup resolves inherited
   // Object.prototype members ("toString", "constructor") to real functions,
@@ -1240,13 +1244,9 @@ function suppressAt(value, message, depth, seen, memo) {
   // Same opaque-leaf rule as sanitizeValueAt: only arrays and plain objects are
   // walked; an exotic object would be corrupted to an empty clone.
   if (!isWalkableContainer(value)) return value;
-  // A content block's `type` tag tells the API how to parse the block, and the
-  // tagged unions under it (`citations`, `source`, `cache_control`) are
-  // validated the same way — so walking a block's keys yields one the API
-  // rejects with a 400, permanently: it stays in the transcript and replays on
-  // every later turn. Collapse to a text block, which is legal wherever a
-  // recognised block stands (see {@link CONTENT_BLOCK_SCHEMAS} on the paired
-  // tags it excludes for exactly that reason).
+  // Walking a block's keys rewrites its `type` tag and the tagged unions under
+  // it, yielding a block the API rejects with a 400 that then replays on every
+  // later turn. Collapse to the one block shape `message` is legal in.
   if (isContentBlock(value)) return { type: "text", text: message };
   const cached = memo.get(value, depth);
   if (cached !== undefined) return cached;

--- a/test/fuzz-coverage.test.mjs
+++ b/test/fuzz-coverage.test.mjs
@@ -163,7 +163,8 @@ const FUZZ_EXEMPT = Object.freeze({
   scanHtmlFragment:
     "has no invariant of its own beyond what the sanitizeHtml round-trip and splice-fidelity properties assert on its output",
   stripAnsiFully: "the ANSI half of applyLayer1, fuzzed through layer1-ansi",
-  suppressToolOutput: "substitutes a sentinel for a subtree and parses nothing",
+  suppressToolOutput:
+    "substitutes a sentinel for a subtree and parses nothing; its content-block recogniser is an exact key/value match against a closed schema map, pinned by the block cases in output.test",
   toUtf16View:
     "converts a view between offset spaces, validated at construction",
   viewMapDefect: "self-check over a view the pipeline built",

--- a/test/output.test.mjs
+++ b/test/output.test.mjs
@@ -1493,6 +1493,20 @@ describe("suppressToolOutput collapses an Anthropic content block", () => {
       "text with cache_control",
       { type: "text", text: "leak", cache_control: { type: "ephemeral" } },
     ],
+    // Every optional object-valued field is nullable in the API schema, so an
+    // explicit null must not push the block back onto the walk.
+    [
+      "text with an explicit null cache_control",
+      { type: "text", text: "leak", cache_control: null },
+    ],
+    [
+      "document with an explicit null citations config",
+      {
+        type: "document",
+        source: { type: "text", media_type: "text/plain", data: "leak" },
+        citations: null,
+      },
+    ],
     [
       "search_result",
       {

--- a/test/output.test.mjs
+++ b/test/output.test.mjs
@@ -1462,7 +1462,7 @@ describe("suppressToolOutput collapses an Anthropic content block", () => {
   // One block per tag the suppressor recognises: rewriting any of these tags
   // (or a tagged union nested in them) yields a block the API rejects with a
   // 400, and the invalid block then replays on every later turn.
-  const BLOCKS = [
+  const BLOCKS_TO_COLLAPSE = [
     ["image", { type: "image", source: IMAGE_SOURCE }],
     [
       "document",
@@ -1504,59 +1504,47 @@ describe("suppressToolOutput collapses an Anthropic content block", () => {
     ],
     ["thinking", { type: "thinking", thinking: "leak", signature: "c2ln" }],
     ["redacted_thinking", { type: "redacted_thinking", data: "leak" }],
-    [
-      "tool_use",
-      { type: "tool_use", id: "toolu_1", name: "leak", input: { q: "leak" } },
-    ],
-    [
-      "server_tool_use",
-      {
-        type: "server_tool_use",
-        id: "srvtoolu_1",
-        name: "web_search",
-        input: { query: "leak" },
-      },
-    ],
-    [
-      "tool_result",
-      {
-        type: "tool_result",
-        tool_use_id: "toolu_1",
-        content: [{ type: "text", text: "leak" }],
-        is_error: false,
-      },
-    ],
-    [
-      "web_search_tool_result",
-      {
-        type: "web_search_tool_result",
-        tool_use_id: "srvtoolu_1",
-        content: [{ type: "web_search_result", url: "leak", title: "leak" }],
-      },
-    ],
   ];
-  for (const [name, block] of BLOCKS)
-    it(`${name} → a single text block carrying the message`, () => {
-      const out = suppressToolOutput([block], MSG);
-      assert.deepEqual(out, [SUPPRESSED_BLOCK]);
-      // The collapse must still withhold everything the walk withheld.
-      assert.ok(!JSON.stringify(out).includes("leak"));
-    });
+  for (const [name, block] of BLOCKS_TO_COLLAPSE)
+    it(`${name} → a single text block carrying the message`, () =>
+      assert.deepStrictEqual(suppressToolOutput([block], MSG), [
+        SUPPRESSED_BLOCK,
+      ]));
 
   it("collapses a bare block passed as the whole tool response", () =>
-    assert.deepEqual(
+    assert.deepStrictEqual(
       suppressToolOutput({ type: "image", source: IMAGE_SOURCE }, MSG),
       SUPPRESSED_BLOCK,
     ));
 
   it("collapses a block nested under an ordinary field", () =>
-    assert.deepEqual(
+    assert.deepStrictEqual(
       suppressToolOutput(
         { content: [{ type: "image", source: IMAGE_SOURCE }], stdout: "leak" },
         MSG,
       ),
       { content: [SUPPRESSED_BLOCK], stdout: MSG },
     ));
+
+  /** `block` wrapped in `depth` nested single-element arrays. */
+  const wrap = (/** @type {number} */ depth) => {
+    /** @type {any} */
+    let nested = { type: "image", source: IMAGE_SOURCE };
+    for (let i = 0; i < depth; i++) nested = [nested];
+    return nested;
+  };
+  /** The value the walk reached at the bottom of `wrap(depth)`'s array chain. */
+  const bottom = (/** @type {number} */ depth) => {
+    let out = suppressToolOutput(wrap(depth), MSG);
+    for (let i = 0; i < depth && Array.isArray(out); i++) out = out[0];
+    return out;
+  };
+
+  it("collapses a block reached at exactly MAX_DEPTH — the collapse runs before the depth guard", () =>
+    assert.deepStrictEqual(bottom(MAX_DEPTH), SUPPRESSED_BLOCK));
+
+  it("truncates to the bare sentinel one level deeper, block or not — the residual case", () =>
+    assert.strictEqual(bottom(MAX_DEPTH + 1), MSG));
 });
 
 describe("suppressToolOutput walks an object that is not a content block", () => {
@@ -1577,11 +1565,50 @@ describe("suppressToolOutput walks an object that is not a content block", () =>
     ],
     [
       "a known tag with a key outside its schema",
-      { type: "image", source: "leak", width: 32 },
-      { type: MSG, source: MSG, width: 32 },
+      { type: "image", source: { data: "leak" }, width: 32 },
+      { type: MSG, source: { data: MSG }, width: 32 },
+    ],
+    // Gated on the value's shape, not the key name: a real image block's
+    // `source` is an object, so this record of a URL is ordinary tool data.
+    [
+      "a known tag whose required value has the wrong shape",
+      { type: "image", source: "https://cdn.example/x.png" },
+      { type: MSG, source: MSG },
+    ],
+    [
+      "a known tag whose optional value has the wrong shape",
+      { type: "text", text: "leak", citations: "leak" },
+      { type: MSG, text: MSG, citations: MSG },
     ],
     ["a non-string tag", { type: 3, text: "leak" }, { type: 3, text: MSG }],
+    // A tag that PAIRS with another block is deliberately not recognised:
+    // collapsing it would orphan its partner, the same permanent-400 class the
+    // collapse exists to prevent. Documented false negative — the tag is still
+    // rewritten here, so widening the schema map must revisit this case.
+    [
+      "a tool_result, whose tag pairs it with a tool_use",
+      { type: "tool_result", tool_use_id: "toolu_1", content: "leak" },
+      { type: MSG, tool_use_id: MSG, content: MSG },
+    ],
+    [
+      "a tool_use, whose tag pairs it with a tool_result",
+      { type: "tool_use", id: "toolu_1", name: "leak", input: { q: "leak" } },
+      { type: MSG, id: MSG, name: MSG, input: { q: MSG } },
+    ],
   ];
   for (const [name, input, expected] of NOT_BLOCKS)
-    it(name, () => assert.deepEqual(suppressToolOutput(input, MSG), expected));
+    it(name, () =>
+      assert.deepStrictEqual(suppressToolOutput(input, MSG), expected),
+    );
+
+  it("an array carrying own block-shaped properties stays an array", () => {
+    /** @type {any} */
+    const arr = ["leak"];
+    arr.type = "text";
+    arr.text = "leak";
+    // Object.keys would report a block's exact key set here, but an array
+    // occupies an array position — substituting a block for it changes the
+    // container's type, not a block's payload.
+    assert.deepStrictEqual(suppressToolOutput(arr, MSG), [MSG]);
+  });
 });

--- a/test/output.test.mjs
+++ b/test/output.test.mjs
@@ -1601,6 +1601,22 @@ describe("suppressToolOutput walks an object that is not a content block", () =>
       assert.deepStrictEqual(suppressToolOutput(input, MSG), expected),
     );
 
+  it("an object whose block tag comes from a polluted prototype is still walked", () => {
+    // The own-key `type` check is the only thing standing between this and a
+    // false collapse: `value.type` reads "text" straight through the prototype.
+    Object.defineProperty(Object.prototype, "type", {
+      value: "text",
+      configurable: true,
+    });
+    try {
+      assert.deepStrictEqual(suppressToolOutput({ text: "leak" }, MSG), {
+        text: MSG,
+      });
+    } finally {
+      delete (/** @type {any} */ (Object.prototype).type);
+    }
+  });
+
   it("an array carrying own block-shaped properties stays an array", () => {
     /** @type {any} */
     const arr = ["leak"];

--- a/test/output.test.mjs
+++ b/test/output.test.mjs
@@ -1507,6 +1507,27 @@ describe("suppressToolOutput collapses an Anthropic content block", () => {
         citations: null,
       },
     ],
+    // A document's/search_result's `citations` is the `{ enabled }` toggle
+    // while a text block's is an array — the one place the schemas diverge, so
+    // it needs a case each or the two predicates are interchangeable.
+    [
+      "document with the { enabled } citations toggle",
+      {
+        type: "document",
+        source: { type: "text", media_type: "text/plain", data: "leak" },
+        citations: { enabled: true },
+      },
+    ],
+    [
+      "search_result with the { enabled } citations toggle",
+      {
+        type: "search_result",
+        source: "leak",
+        title: "leak",
+        content: [{ type: "text", text: "leak" }],
+        citations: { enabled: true },
+      },
+    ],
     [
       "search_result",
       {


### PR DESCRIPTION
Claims `CONTENT_BLOCK_SCHEMAS` / `isContentBlock` in `src/output.mjs`. Follow-up to #401 (merged as 2.57.2), which landed the content-block collapse for #398. This carries the hardening that review of #401 produced but that did not make it into the merge — the adversarial pass, plus the two findings its reviewers left on the merged commit.

## What & why

Recognise a content block by each field's **value shape**, not its key name alone; stop recognising the four tags that pair a block with another block; and name the guard that keeps a polluted prototype from faking a tag.

**Key names alone are not a block.** `source`, `title` and `content` are generic field names, so `{ type: "image", source: "https://cdn/x.png" }` — an ordinary record of a URL — matched the image schema and was collapsed, losing its fields. A real image block's `source` is an object. Each schema field now carries a predicate on its value (`text` a string, `source` an object, `citations` an array for a text block but the `{ enabled }` object for a document), and a mismatch falls back to the leaf-wise walk. This is the repo's own rule: gate on the value's shape, not the name.

**Collapsing a paired block re-creates the bug it fixes.** `tool_use`, `server_tool_use`, `tool_result` and `web_search_tool_result` carry an id binding them to a partner block. Replacing one with a text block orphans that partner, and the API rejects the request exactly as permanently as the rewritten `type` tag #398 is about. They are dropped from the schema map and keep the walk, so **#398 still stands for those four tags** — a negative test says so in the open rather than trading one instance of the bug for another. (This is also the answer to Codex's P1 on #401 about `web_fetch_tool_result` / `code_execution_tool_result`: both are `tool_use_id`-paired, so they are excluded by the same rule, not by oversight.)

**The own-key `type` check was an unnamed, unpinned security guard.** It reads as redundant beside the schema-map miss, so a cleanup would delete it — and nothing went red when it did: every negative case decided on the map lookup instead. With `Object.prototype.type` polluted, `value.type` resolves through the prototype, so `{ text: "leak" }` would tag itself a text block and be collapsed, dropping a legitimate field on the fail-closed path. The invariant is now stated at the enforcement point and a test kills the mutant.

## Partitions

Three commits, one concern, read in order:

1. `e02029c` — value-shape predicates; drop the pairing-bearing tags.
2. `040df29` — name and pin the prototype-pollution guard; trim the collapse comment to the 5-line cap.

## Review focus

`src/output.mjs` — `CONTENT_BLOCK_SCHEMAS` and `isContentBlock`. Two things worth checking against the API docs rather than the diff:

- **The predicates themselves.** Too strict is fail-safe (that tag falls back to the walk); too loose collapses an object that isn't a block. The one I'd check first is `document.citations`, which is the `{ enabled }` toggle object while `text.citations` is an array — the two tags genuinely differ.
- **`isValidField` looks up predicates with `Object.hasOwn`**, mirroring `mapFilterWarning`'s guard in the same file: a bare index would resolve `toString`/`constructor` to real functions and let a key outside the schema pass as if it had a predicate.

## How it was tested

- `node --test test/output.test.mjs` → 174/174. The negative table covers unknown tag, missing required key, extra key, **wrong-shaped required value**, **wrong-shaped optional value**, non-string tag, and the two pairing-bearing tags — each asserting the walk still runs. Separate cases pin the `Array.isArray` guard (an array carrying own `type`/`text` properties stays an array) and the prototype guard.
- Non-vacuity, both new guards: dropping `!Object.hasOwn(value, "type")` reds exactly the pollution test (`# fail 1`); short-circuiting `isContentBlock` to `false` reds the collapse suite. Green with them.
- Depth-boundary cases either side of `MAX_DEPTH` pin the collapse's position before the depth guard: a block reached at exactly `MAX_DEPTH` collapses; one level deeper the subtree truncates to the bare sentinel.
- `pnpm check`, `pnpm lint`, `pnpm format:check` clean. `build-hook-binaries.mjs --check` reproduces the manifest byte-for-byte after the rebase; `plugin-hooks.bundle.mjs` conflicted on the rebase and was regenerated with the repo's tooling, never resolved by hand.
- `test/fuzz-coverage.test.mjs`'s exemption justification for `suppressToolOutput` moves in the same commit as the recogniser it describes, per the SSOT-contract rule.

## Decisions made

- **`tool_result` and friends keep the walk rather than preserving their pairing keys.** The alternative — keep `id`/`tool_use_id` and suppress only the payload — puts attacker-chosen strings back into a fail-closed placeholder. Leaving #398 unfixed for four rare tags is the cheaper failure.
- **Recognition stays context-free rather than positional.** Codex's other P1 on #401 asked for envelope/position context instead of matching every walked object. The value-shape gate answers the concrete misclassification it named (`{ type: "image", source: "…" }`); true positional context would mean threading a "this is a content position" bit through the walk, which the walk cannot know from the inside — `tool_response` is the tool's own schema, not a message body.
- **The schema map still covers the Messages API shapes only.** MCP tool results use their own block shapes (`{ type: "image", data, mimeType }`, `resource`, `resource_link`); nothing in this tree records which shape `tool_response` carries for an MCP result, so adding them would be unverified recall traded against the precision rule.
